### PR TITLE
[Performance] Eliminate some copies of the sample buffer

### DIFF
--- a/Sources/FluidAudio/DiarizerManager.swift
+++ b/Sources/FluidAudio/DiarizerManager.swift
@@ -368,15 +368,19 @@ public final class DiarizerManager: @unchecked Sendable {
         }
     }
 
-    private func getSegments(audioChunk: [Float], chunkSize: Int = 160_000) throws -> [[[Float]]] {
+    private func getSegments(audioChunk: ArraySlice<Float>, chunkSize: Int = 160_000) throws -> [[[Float]]] {
         guard let segmentationModel = self.segmentationModel else {
             throw DiarizerError.notInitialized
         }
 
         let audioArray = try MLMultiArray(
-            shape: [1, 1, NSNumber(value: chunkSize)], dataType: .float32)
-        for i in 0..<min(audioChunk.count, chunkSize) {
-            audioArray[i] = NSNumber(value: audioChunk[i])
+            shape: [1, 1, NSNumber(value: chunkSize)],
+            dataType: .float32
+        )
+        var offset = 0
+        for sample in audioChunk.prefix(chunkSize) {
+            audioArray[offset] = NSNumber(value: sample)
+            offset &+= 1
         }
 
         let input = try MLDictionaryFeatureProvider(dictionary: ["audio": audioArray])
@@ -463,7 +467,7 @@ public final class DiarizerManager: @unchecked Sendable {
     }
 
     private func getEmbedding(
-        audioChunk: [Float],
+        audioChunk: ArraySlice<Float>,
         binarizedSegments: [[[Float]]],
         slidingWindowFeature: SlidingWindowFeature,
         embeddingModel: MLModel,
@@ -497,12 +501,6 @@ public final class DiarizerManager: @unchecked Sendable {
             }
         }
 
-        // Flatten audio tensor to shape (numSpeakers, 160000)
-        var audioBatch: [[Float]] = []
-        for _ in 0..<numSpeakers {
-            audioBatch.append(audioTensor)
-        }
-
         // Transpose mask shape to (numSpeakers, 589)
         var cleanMasks: [[Float]] = Array(
             repeating: Array(repeating: 0.0, count: numFrames), count: numSpeakers)
@@ -524,8 +522,8 @@ public final class DiarizerManager: @unchecked Sendable {
         }
 
         for s in 0..<numSpeakers {
-            for i in 0..<chunkSize {
-                waveformArray[s * chunkSize + i] = NSNumber(value: audioBatch[s][i])
+            for i in 0..<min(chunkSize, audioTensor.count) {
+                waveformArray[s * chunkSize + i] = NSNumber(value: audioTensor[audioTensor.startIndex + i])
             }
         }
 
@@ -896,7 +894,7 @@ public final class DiarizerManager: @unchecked Sendable {
         // Process in 10-second chunks
         for chunkStart in stride(from: 0, to: samples.count, by: chunkSize) {
             let chunkEnd = min(chunkStart + chunkSize, samples.count)
-            let chunk = Array(samples[chunkStart..<chunkEnd])
+            let chunk = samples[chunkStart..<chunkEnd]
             let chunkOffset = Double(chunkStart) / Double(sampleRate)
 
             let (chunkSegments, chunkTimings) = try await processChunkWithSpeakerTracking(
@@ -947,7 +945,7 @@ public final class DiarizerManager: @unchecked Sendable {
 
     /// Process a single chunk with speaker tracking and timing
     private func processChunkWithSpeakerTracking(
-        _ chunk: [Float],
+        _ chunk: ArraySlice<Float>,
         chunkOffset: Double,
         speakerDB: inout [String: [Float]],
         sampleRate: Int = 16000
@@ -957,7 +955,9 @@ public final class DiarizerManager: @unchecked Sendable {
         let chunkSize = sampleRate * 10  // 10 seconds
         var paddedChunk = chunk
         if chunk.count < chunkSize {
-            paddedChunk += Array(repeating: 0.0, count: chunkSize - chunk.count)
+            var padded = Array(repeating: 0.0 as Float, count: chunk.count)
+            padded.replaceSubrange(0..<chunk.count, with: chunk)
+            paddedChunk = padded[...]
         }
 
         // Step 1: Get segmentation (when speakers are active)


### PR DESCRIPTION
The sample buffer can be rather large, and it would be nice to avoid copying it.

---

In `performCompleteDiarization`, there is a loop which splits the provided sample array in to 10-second chunks. Unfortunately, because later functions require an `Array` as input, each of these chunks are copies from the provided array in to fresh storage.

We can change the other functions to support `ArraySlice`s as input instead (any Array can trivially be converted to an ArraySlice using `array[...]`). Some small adjustments are required because they sometimes assume the input starts at index 0, which when using slices it now might not.

Ultimately, the sample buffer might be copied in `processChunkWithSpeakerTracking` if it needs padding. I've rewritten that copy to minimise reallocations, but in a later PR I'd like to have it provided externally, so it can be hoisted out of the loop in `performCompleteDiarization` and can be allocated once and reused.

---

Additionally, in `getEmbedding`, the audio chunk is copied in to a tensor of shape `(numspeakers, 10 * 16_000)`, where each row of `numspeakers` is an identical copy of the audio chunk. That data then gets copied in to the `waveformArray` and is never used again.

We can just eliminate all of that and access the audio chunk directly, without any copies.