### PR TITLE
Remove some unnecessary async annotations

### DIFF
--- a/Tests/FluidAudioTests/BasicInitializationTests.swift
+++ b/Tests/FluidAudioTests/BasicInitializationTests.swift
@@ -47,14 +47,14 @@ final class CoreMLDiarizerTests: XCTestCase {
         XCTAssertFalse(manager.isAvailable, "Manager should not be available before initialization")
     }
 
-    func testNotInitializedErrors() async {
+    func testNotInitializedErrors() {
         let testSamples = Array(repeating: Float(0.5), count: 16000)
         let config = DiarizerConfig()
         let manager = DiarizerManager(config: config)
 
         // Test diarization fails when not initialized
         do {
-            _ = try await manager.performCompleteDiarization(testSamples, sampleRate: 16000)
+            _ = try manager.performCompleteDiarization(testSamples, sampleRate: 16000)
             XCTFail("Should have thrown notInitialized error")
         } catch DiarizerError.notInitialized {
             // Expected error
@@ -151,12 +151,12 @@ final class CoreMLDiarizerTests: XCTestCase {
         XCTAssertFalse(manager.validateEmbedding(smallEmbedding), "Small magnitude embedding should fail validation")
     }
 
-    func testCleanup() async {
+    func testCleanup() {
         let config = DiarizerConfig()
         let manager = DiarizerManager(config: config)
 
         // Test cleanup doesn't crash
-        await manager.cleanup()
+        manager.cleanup()
         XCTAssertFalse(manager.isAvailable, "Manager should not be available after cleanup")
     }
 
@@ -254,13 +254,13 @@ final class CoreMLBackendIntegrationTests: XCTestCase {
             let testSamples = Array(repeating: Float(0.5), count: 16000)
 
             do {
-                let result = try await diarizer.performCompleteDiarization(testSamples, sampleRate: 16000)
+                let result = try diarizer.performCompleteDiarization(testSamples, sampleRate: 16000)
                 print("✅ CoreML diarization completed, found \(result.segments.count) segments")
             } catch {
                 print("ℹ️  Segmentation test completed (may need more realistic audio): \(error)")
             }
 
-            await diarizer.cleanup()
+            diarizer.cleanup()
 
         } catch {
             // This is expected in test environment - models might not download


### PR DESCRIPTION
`performCompleteDiarization` and `cleanup` do not perform any asynchronous work and it is difficult to imagine any reason they would ever want to.

Fundamentally, performing diarization is not an asynchronous operation - it's just a calculation, and you don't need to wait arbitrarily long on external systems such as the network or filesystem.

There are some async operations you can build around diarization, such as processing an async stream of samples, or concurrently processing multiple audio buffers (as shown in `compareSpeakers` which now uses `async let`), and loading the model makes sense to do asynchronously, but the computation itself is synchronous and it's important to make it available in synchronous contexts.