### PR TITLE
Add a models parameter to DiarizerManager.initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,10 +148,10 @@ import FluidAudio
 // Initialize and process audio
 Task {
     let diarizer = DiarizerManager()
-    try await diarizer.initialize()
+    diarizer.initialize(models: try await .downloadIfNeeded())
 
     let audioSamples: [Float] = // your 16kHz audio data
-    let result = try await diarizer.performCompleteDiarization(audioSamples, sampleRate: 16000)
+    let result = try diarizer.performCompleteDiarization(audioSamples, sampleRate: 16000)
 
     for segment in result.segments {
         print("\(segment.speakerId): \(segment.startTimeSeconds)s - \(segment.endTimeSeconds)s")

--- a/Sources/FluidAudio/DiarizationModels.swift
+++ b/Sources/FluidAudio/DiarizationModels.swift
@@ -1,0 +1,299 @@
+import CoreML
+import OSLog
+
+/// Models required for diarization.
+///
+internal struct DiarizationModels {
+
+    private static var SegmentationModelFileName: String { "pyannote_segmentation.mlmodelc" }
+    private static var EmbeddingModelFileName: String { "wespeaker.mlmodelc" }
+
+    // ML models
+    internal var segmentationModel: MLModel
+    internal var embeddingModel: MLModel
+    internal var paths: ModelPaths
+
+    // Timing tracking
+    internal var downloadTime: Duration
+    internal var compilationTime: Duration
+
+    private init(
+        segmentationModel: MLModel,
+        embeddingModel: MLModel,
+        paths: ModelPaths,
+        downloadTime: Duration,
+        compilationTime: Duration
+    ) {
+        self.segmentationModel = segmentationModel
+        self.embeddingModel = embeddingModel
+        self.paths = paths
+        self.downloadTime = downloadTime
+        self.compilationTime = compilationTime
+    }
+}
+
+// ---------------------------
+// MARK: - Downloading models.
+// ---------------------------
+
+extension DiarizationModels {
+
+    private static var HuggingFaceRepoPath: String { "bweng/speaker-diarization-coreml" }
+
+    /// Download the models, if needed, to a directory managed by the framework.
+    ///
+    public static func download(
+        logger: Logger
+    ) async throws -> DiarizationModels {
+
+        let directory: URL
+        #if os(iOS)
+            // Use Documents directory on iOS for better compatibility with sandboxing
+            let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+            directory = documents.appendingPathComponent("FluidAudio/models/diarization", isDirectory: true)
+        #else
+            // Use Application Support on macOS
+            let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            directory = appSupport.appendingPathComponent("SpeakerKitModels/coreml", isDirectory: true)
+        #endif
+
+        return try await download(to: directory, logger: logger)
+    }
+
+    /// Download the models, if needed, to the given directory.
+    ///
+    public static func download(
+        to modelsDirectory: URL,
+        logger: Logger
+    ) async throws -> DiarizationModels {
+
+        try deleteNoncompiledModels(modelsDirectory: modelsDirectory, logger)
+
+        try FileManager.default.createDirectory(
+            at: modelsDirectory,
+            withIntermediateDirectories: true
+        )
+
+        var modelPaths: ModelPaths!
+        let downloadTime = try await ContinuousClock().measure {
+            modelPaths = try await downloadModelsIfNeeded(to: modelsDirectory, logger)
+        }
+
+        var models: (segmentation: MLModel, embedding: MLModel)!
+        let compilationTime = try await ContinuousClock().measure {
+            models = try await loadModelsWithAutoRecovery(
+                segmentationURL: modelPaths.segmentationPath,
+                embeddingURL: modelPaths.embeddingPath
+            )
+        }
+
+        return DiarizationModels(
+            segmentationModel: models.segmentation,
+            embeddingModel: models.embedding,
+            paths: modelPaths,
+            downloadTime: downloadTime,
+            compilationTime: compilationTime
+        )
+    }
+
+    /// Deletes the existing segmentation and embedding models in the given directory
+    /// if they are not compiled.
+    ///
+    private static func deleteNoncompiledModels(
+        modelsDirectory: URL,
+        _ logger: Logger
+    ) throws {
+
+        let segmentationModelPath = modelsDirectory
+            .appendingPathComponent(SegmentationModelFileName, isDirectory: true)
+        let embeddingModelPath = modelsDirectory
+            .appendingPathComponent(EmbeddingModelFileName, isDirectory: true)
+
+        if FileManager.default.fileExists(atPath: segmentationModelPath.path)
+            && !DownloadUtils.isModelCompiled(at: segmentationModelPath)
+        {
+            logger.info("Removing broken segmentation model")
+            try FileManager.default.removeItem(at: segmentationModelPath)
+        }
+
+        if FileManager.default.fileExists(atPath: embeddingModelPath.path)
+            && !DownloadUtils.isModelCompiled(at: embeddingModelPath)
+        {
+            logger.info("Removing broken embedding model")
+            try FileManager.default.removeItem(at: embeddingModelPath)
+        }
+    }
+
+    /// Download required models for diarization to the given directory.
+    ///
+    /// If compiled models already exist, they will not be redownloaded.
+    ///
+    private static func downloadModelsIfNeeded(
+        to modelsDirectory: URL,
+        _ logger: Logger
+    ) async throws -> ModelPaths {
+
+        logger.info("Checking for existing diarization models")
+
+        let segmentationModelPath = modelsDirectory
+            .appendingPathComponent(SegmentationModelFileName, isDirectory: true)
+        let embeddingModelPath = modelsDirectory
+            .appendingPathComponent(EmbeddingModelFileName, isDirectory: true)
+
+        // Check if models already exist and are compiled.
+
+        let segmentationExists =
+            FileManager.default.fileExists(atPath: segmentationModelPath.path)
+            && DownloadUtils.isModelCompiled(at: segmentationModelPath)
+        let embeddingExists =
+            FileManager.default.fileExists(atPath: embeddingModelPath.path)
+            && DownloadUtils.isModelCompiled(at: embeddingModelPath)
+
+        if segmentationExists && embeddingExists {
+            logger.info("Valid models already exist, skipping download")
+            return ModelPaths(
+                segmentationPath: segmentationModelPath,
+                embeddingPath: embeddingModelPath
+            )
+        }
+
+        logger.info("Downloading missing or invalid diarization models from Hugging Face")
+
+        // Download models if needed.
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+
+            if !segmentationExists {
+                group.addTask {
+                    logger.info("Downloading segmentation model bundle from Hugging Face")
+                    try await DownloadUtils.downloadMLModelBundle(
+                        repoPath: HuggingFaceRepoPath,
+                        modelName: SegmentationModelFileName,
+                        outputPath: segmentationModelPath
+                    )
+                    logger.info("Downloaded segmentation model bundle from Hugging Face")
+                }
+            }
+
+            if !embeddingExists {
+                group.addTask {
+                    logger.info("Downloading embedding model bundle from Hugging Face")
+                    try await DownloadUtils.downloadMLModelBundle(
+                        repoPath: HuggingFaceRepoPath,
+                        modelName: EmbeddingModelFileName,
+                        outputPath: embeddingModelPath
+                    )
+                    logger.info("Downloaded embedding model bundle from Hugging Face")
+                }
+            }
+
+            try await group.waitForAll()
+        }
+
+        logger.info("Successfully ensured diarization models are available")
+
+        return ModelPaths(
+            segmentationPath: segmentationModelPath,
+            embeddingPath: embeddingModelPath
+        )
+    }
+
+    /// Loads the models at the given local locations.
+    ///
+    /// If the models fail to load, they will be deleted and redownloaded, up to the given
+    /// number of retry attempts.
+    ///
+    private static func loadModelsWithAutoRecovery(
+        segmentationURL: URL,
+        embeddingURL: URL,
+        maxRetries: Int = 2
+    ) async throws -> (segmentation: MLModel, embedding: MLModel) {
+
+        assert(segmentationURL.isFileURL, "This should be a file URL to a downloaded model")
+        assert(embeddingURL.isFileURL, "This should be a file URL to a downloaded model")
+
+        let config = MLModelConfiguration()
+        config.computeUnits = .cpuAndNeuralEngine
+
+        async let segmentationModel = DownloadUtils.withAutoRecovery {
+            try MLModel(contentsOf: segmentationURL, configuration: config)
+        } recovery: {
+            try await DownloadUtils.performModelRecovery(
+                modelPaths: [segmentationURL],
+                downloadAction: {
+                    try await DownloadUtils.downloadMLModelBundle(
+                        repoPath: HuggingFaceRepoPath,
+                        modelName: SegmentationModelFileName,
+                        outputPath: segmentationURL
+                    )
+                }
+            )
+        }
+
+        async let embeddingModel = DownloadUtils.withAutoRecovery {
+            try MLModel(contentsOf: embeddingURL, configuration: config)
+        } recovery: {
+            try await DownloadUtils.performModelRecovery(
+                modelPaths: [embeddingURL],
+                downloadAction: {
+                    try await DownloadUtils.downloadMLModelBundle(
+                        repoPath: HuggingFaceRepoPath,
+                        modelName: EmbeddingModelFileName,
+                        outputPath: embeddingURL
+                    )
+                }
+            )
+        }
+
+        return (segmentation: try await segmentationModel, embedding: try await embeddingModel)
+    }
+}
+
+// -----------------------------
+// MARK: - Predownloaded models.
+// -----------------------------
+
+extension DiarizationModels {
+
+    /// Loads the models from the given local files.
+    ///
+    /// If the models fail to load, no recovery will be attempted. No models are downloaded.
+    ///
+    public static func load(
+        localSegmentationModel: URL,
+        localEmbeddingModel: URL
+    ) throws -> DiarizationModels {
+
+        guard localEmbeddingModel.isFileURL, localEmbeddingModel.isFileURL else {
+            throw LoadingErrors.notAFileURL
+        }
+
+        let config = MLModelConfiguration()
+        config.computeUnits = .cpuAndNeuralEngine
+
+        var segmentationModel: MLModel!
+        var embeddingModel: MLModel!
+        let compilationTime = try ContinuousClock().measure {
+            segmentationModel = try MLModel(contentsOf: localSegmentationModel, configuration: config)
+            embeddingModel    = try MLModel(contentsOf: localEmbeddingModel, configuration: config)
+        }
+
+        return DiarizationModels(
+            segmentationModel: segmentationModel,
+            embeddingModel: embeddingModel,
+            paths: ModelPaths(segmentationPath: localSegmentationModel, embeddingPath: localEmbeddingModel),
+            downloadTime: .zero,
+            compilationTime: compilationTime
+        )
+    }
+
+    private enum LoadingErrors: Error, CustomStringConvertible {
+        case notAFileURL
+
+        var description: String {
+            switch self {
+            case .notAFileURL: "The given URL is not a file URL"
+            }
+        }
+    }
+}

--- a/Sources/FluidAudio/DiarizerManager.swift
+++ b/Sources/FluidAudio/DiarizerManager.swift
@@ -114,6 +114,15 @@ public struct PipelineTimings: Sendable, Codable {
     }
 }
 
+extension Duration {
+
+    /// Converts this duration to a Foundation TimeInterval - i.e. a `Double` number of seconds.
+    ///
+    internal var timeInterval: TimeInterval {
+        self / .seconds(1)
+    }
+}
+
 /// Complete diarization result with consistent speaker IDs and embeddings
 public struct DiarizationResult: Sendable {
     public let segments: [TimedSpeakerSegment]
@@ -168,10 +177,10 @@ public struct SpeakerEmbedding: Sendable {
 }
 
 public struct ModelPaths: Sendable {
-    public let segmentationPath: String
-    public let embeddingPath: String
+    public let segmentationPath: URL
+    public let embeddingPath: URL
 
-    public init(segmentationPath: String, embeddingPath: String) {
+    public init(segmentationPath: URL, embeddingPath: URL) {
         self.segmentationPath = segmentationPath
         self.embeddingPath = embeddingPath
     }
@@ -252,124 +261,51 @@ public final class DiarizerManager {
     private let logger = Logger(subsystem: "com.fluidinfluence.diarizer", category: "Diarizer")
     private let config: DiarizerConfig
 
-    // ML models
-    private var segmentationModel: MLModel?
-    private var embeddingModel: MLModel?
-
-    // Timing tracking
-    private var modelDownloadTime: TimeInterval = 0
-    private var modelCompilationTime: TimeInterval = 0
+    private var models: DiarizationModels?
 
     public init(config: DiarizerConfig = .default) {
         self.config = config
     }
 
     public var isAvailable: Bool {
-        return segmentationModel != nil && embeddingModel != nil
+        models != nil
     }
 
     /// Get the initialization timing data
     public var initializationTimings: (downloadTime: TimeInterval, compilationTime: TimeInterval) {
-        return (modelDownloadTime, modelCompilationTime)
+        models.map { ($0.downloadTime.timeInterval, $0.compilationTime.timeInterval) } ?? (0, 0)
     }
 
     public func initialize() async throws {
-        let initStartTime = Date()
+
         logger.info("Initializing diarization system")
 
-        try await cleanupBrokenModels()
+        let initializeDuration = try await ContinuousClock().measure {
+            if let customDirectory = config.modelCacheDirectory {
+                let subdir = customDirectory.appendingPathComponent("coreml", isDirectory: true)
+                self.models = try await .download(to: subdir, logger: logger)
+            } else {
+                self.models = try await .download(logger: logger)
+            }
+        }
 
-        let downloadStartTime = Date()
-        let modelPaths = try await downloadModels()
-        self.modelDownloadTime = Date().timeIntervalSince(downloadStartTime)
-
-        let segmentationURL = URL(fileURLWithPath: modelPaths.segmentationPath)
-        let embeddingURL = URL(fileURLWithPath: modelPaths.embeddingPath)
-
-        let compilationStartTime = Date()
-        try await loadModelsWithAutoRecovery(
-            segmentationURL: segmentationURL, embeddingURL: embeddingURL)
-        self.modelCompilationTime = Date().timeIntervalSince(compilationStartTime)
-
-        let totalInitTime = Date().timeIntervalSince(initStartTime)
+        func format(_ d: Duration) -> String {
+            d.formatted(.time(pattern: .minuteSecond(padMinuteToLength: 0, fractionalSecondsLength: 3)))
+        }
         logger.info(
-            "Diarization system initialized successfully in \(String(format: "%.2f", totalInitTime))s (download: \(String(format: "%.2f", self.modelDownloadTime))s, compilation: \(String(format: "%.2f", self.modelCompilationTime))s)"
+            "Diarization system initialized successfully in \(format(initializeDuration)) (download: \(format(self.models!.downloadTime)), compilation: \(format(self.models!.compilationTime))"
         )
     }
 
-    /// Load models with automatic recovery on compilation failures
-    private func loadModelsWithAutoRecovery(
-        segmentationURL: URL, embeddingURL: URL, maxRetries: Int = 2
-    ) async throws {
-        let config: MLModelConfiguration = MLModelConfiguration()
-        config.computeUnits = .cpuAndNeuralEngine
-
-        let modelPaths = [
-            (url: segmentationURL, name: "segmentation"),
-            (url: embeddingURL, name: "embedding")
-        ]
-
-        let models = try await DownloadUtils.loadModelsWithAutoRecovery(
-            modelPaths: modelPaths,
-            config: config,
-            maxRetries: maxRetries,
-            recoveryAction: {
-                try await self.performModelRecovery(
-                    segmentationURL: segmentationURL, 
-                    embeddingURL: embeddingURL
-                )
-            }
-        )
-
-        self.segmentationModel = models[0]
-        self.embeddingModel = models[1]
-    }
-
-    /// Perform model recovery by deleting and re-downloading corrupted models
-    private func performModelRecovery(segmentationURL: URL, embeddingURL: URL) async throws {
-        try await DownloadUtils.performModelRecovery(
-            modelPaths: [segmentationURL, embeddingURL],
-            downloadAction: {
-                // Re-download segmentation model
-                try await DownloadUtils.downloadMLModelBundle(
-                    repoPath: "FluidInference/speaker-diarization-coreml",
-                    modelName: "pyannote_segmentation.mlmodelc",
-                    outputPath: segmentationURL
-                )
-
-                // Re-download embedding model
-                try await DownloadUtils.downloadMLModelBundle(
-                    repoPath: "FluidInference/speaker-diarization-coreml",
-                    modelName: "wespeaker.mlmodelc",
-                    outputPath: embeddingURL
-                )
-            }
-        )
-    }
-
-    private func cleanupBrokenModels() async throws {
-        let modelsDirectory = getModelsDirectory()
-        let segmentationModelPath = modelsDirectory.appendingPathComponent(
-            "pyannote_segmentation.mlmodelc")
-        let embeddingModelPath = modelsDirectory.appendingPathComponent("wespeaker.mlmodelc")
-
-        if FileManager.default.fileExists(atPath: segmentationModelPath.path)
-            && !DownloadUtils.isModelCompiled(at: segmentationModelPath)
-        {
-            logger.info("Removing broken segmentation model")
-            try FileManager.default.removeItem(at: segmentationModelPath)
-        }
-
-        if FileManager.default.fileExists(atPath: embeddingModelPath.path)
-            && !DownloadUtils.isModelCompiled(at: embeddingModelPath)
-        {
-            logger.info("Removing broken embedding model")
-            try FileManager.default.removeItem(at: embeddingModelPath)
-        }
+    /// Download required models for diarization
+    public func downloadModels() async throws -> ModelPaths {
+        try await initialize()
+        return models!.paths
     }
 
     private func getSegments(audioChunk: ArraySlice<Float>, chunkSize: Int = 160_000) throws -> [[[Float]]] {
-        guard let segmentationModel = self.segmentationModel else {
+
+        guard let models else {
             throw DiarizerError.notInitialized
         }
 
@@ -388,7 +324,7 @@ public final class DiarizerManager {
 
         let input = try MLDictionaryFeatureProvider(dictionary: ["audio": audioArray])
 
-        let output = try segmentationModel.prediction(from: input)
+        let output = try models.segmentationModel.prediction(from: input)
 
         guard let segmentOutput = output.featureValue(for: "segments")?.multiArrayValue else {
             throw DiarizerError.processingFailed("Missing segments output from segmentation model")
@@ -613,111 +549,6 @@ public final class DiarizerManager {
         annotation[finalSegment] = currentSpeaker  // Use raw speaker index
     }
 
-    // MARK: - Model Management
-
-    /// Download required models for diarization
-    public func downloadModels() async throws -> ModelPaths {
-        logger.info("Checking for existing diarization models")
-
-        let modelsDirectory = getModelsDirectory()
-
-        let segmentationModelPath = modelsDirectory.appendingPathComponent(
-            "pyannote_segmentation.mlmodelc"
-        ).path
-        let embeddingModelPath = modelsDirectory.appendingPathComponent("wespeaker.mlmodelc").path
-
-        let segmentationURL = URL(fileURLWithPath: segmentationModelPath)
-        let embeddingURL = URL(fileURLWithPath: embeddingModelPath)
-
-        // Check if models already exist and are valid
-        let segmentationExists =
-            FileManager.default.fileExists(atPath: segmentationModelPath)
-            && DownloadUtils.isModelCompiled(at: segmentationURL)
-        let embeddingExists =
-            FileManager.default.fileExists(atPath: embeddingModelPath)
-            && DownloadUtils.isModelCompiled(at: embeddingURL)
-
-        if segmentationExists && embeddingExists {
-            logger.info("Valid models already exist, skipping download")
-            return ModelPaths(
-                segmentationPath: segmentationModelPath, embeddingPath: embeddingModelPath)
-        }
-
-        logger.info("Downloading missing or invalid diarization models from Hugging Face")
-
-        // Download segmentation model if needed
-        if !segmentationExists {
-            logger.info("Downloading segmentation model bundle from Hugging Face")
-            try await DownloadUtils.downloadMLModelBundle(
-                repoPath: "FluidInference/speaker-diarization-coreml",
-                modelName: "pyannote_segmentation.mlmodelc",
-                outputPath: segmentationURL
-            )
-            logger.info("Downloaded segmentation model bundle from Hugging Face")
-        }
-
-        // Download embedding model if needed
-        if !embeddingExists {
-            logger.info("Downloading embedding model bundle from Hugging Face")
-            try await DownloadUtils.downloadMLModelBundle(
-                repoPath: "FluidInference/speaker-diarization-coreml",
-                modelName: "wespeaker.mlmodelc",
-                outputPath: embeddingURL
-            )
-            logger.info("Downloaded embedding model bundle from Hugging Face")
-        }
-
-        logger.info("Successfully ensured diarization models are available")
-        return ModelPaths(
-            segmentationPath: segmentationModelPath, embeddingPath: embeddingModelPath)
-    }
-
-
-    /// Compile a model
-    private func compileModel(at sourceURL: URL, outputPath: URL) async throws -> URL {
-        logger.info("Compiling model from \(sourceURL.lastPathComponent)")
-
-        // Remove existing compiled model if it exists
-        if FileManager.default.fileExists(atPath: outputPath.path) {
-            try FileManager.default.removeItem(at: outputPath)
-        }
-
-        // Compile the model
-        let compiledModelURL = try await MLModel.compileModel(at: sourceURL)
-
-        // Move to the desired location
-        try FileManager.default.moveItem(at: compiledModelURL, to: outputPath)
-
-        // Clean up the source file
-        try? FileManager.default.removeItem(at: sourceURL)
-
-        logger.info("Successfully compiled model to \(outputPath.lastPathComponent)")
-        return outputPath
-    }
-
-    private func getModelsDirectory() -> URL {
-        let directory: URL
-
-        if let customDirectory = config.modelCacheDirectory {
-            directory = customDirectory.appendingPathComponent("coreml", isDirectory: true)
-        } else {
-            #if os(iOS)
-            // Use Documents directory on iOS for better compatibility with sandboxing
-            let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
-            directory = documents.appendingPathComponent("FluidAudio/models/diarization", isDirectory: true)
-            #else
-            // Use Application Support on macOS
-            let appSupport = FileManager.default.urls(
-                for: .applicationSupportDirectory, in: .userDomainMask
-            ).first!
-            directory = appSupport.appendingPathComponent(
-                "SpeakerKitModels/coreml", isDirectory: true)
-            #endif
-        }
-
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        return directory.standardizedFileURL
-    }
 
     // MARK: - Audio Analysis
 
@@ -880,7 +711,7 @@ public final class DiarizerManager {
     public func performCompleteDiarization(_ samples: [Float], sampleRate: Int = 16000) throws
         -> DiarizationResult
     {
-        guard segmentationModel != nil, embeddingModel != nil else {
+        guard let models else {
             throw DiarizerError.notInitialized
         }
 
@@ -922,8 +753,8 @@ public final class DiarizerManager {
         let totalProcessingTime = Date().timeIntervalSince(processingStartTime)
 
         let timings = PipelineTimings(
-            modelDownloadSeconds: self.modelDownloadTime,
-            modelCompilationSeconds: self.modelCompilationTime,
+            modelDownloadSeconds: models.downloadTime.timeInterval,
+            modelCompilationSeconds: models.compilationTime.timeInterval,
             audioLoadingSeconds: 0,  // Will be set by CLI
             segmentationSeconds: segmentationTime,
             embeddingExtractionSeconds: embeddingTime,
@@ -972,7 +803,7 @@ public final class DiarizerManager {
         let embeddingStartTime = Date()
 
         // Step 2: Get embeddings using same segmentation results
-        guard let embeddingModel = self.embeddingModel else {
+        guard let models else {
             throw DiarizerError.notInitialized
         }
 
@@ -980,7 +811,7 @@ public final class DiarizerManager {
             audioChunk: paddedChunk,
             binarizedSegments: binarizedSegments,
             slidingWindowFeature: slidingFeature,
-            embeddingModel: embeddingModel,
+            embeddingModel: models.embeddingModel,
             sampleRate: sampleRate
         )
 
@@ -1213,8 +1044,7 @@ public final class DiarizerManager {
 
     /// Clean up resources
     public func cleanup() {
-        segmentationModel = nil
-        embeddingModel = nil
+        models = nil
         logger.info("Diarization resources cleaned up")
     }
 }

--- a/Sources/FluidAudio/DiarizerModels.swift
+++ b/Sources/FluidAudio/DiarizerModels.swift
@@ -110,7 +110,7 @@ extension DiarizerModels {
             d.formatted(.time(pattern: .minuteSecond(padMinuteToLength: 0, fractionalSecondsLength: 3)))
         }
         logger.info(
-            "Models loaded successfully in \(format(downloadTime + compilationTime)) (download: \(format(downloadTime)), compilation: \(format(compilationTime))"
+            "Models loaded successfully in \(format(downloadTime + compilationTime)) (download: \(format(downloadTime)), compilation: \(format(compilationTime)))"
         )
 
         return DiarizerModels(

--- a/Sources/FluidAudioCLI/Models/CLIModels.swift
+++ b/Sources/FluidAudioCLI/Models/CLIModels.swift
@@ -83,7 +83,6 @@
             case numClusters
             case minActivityThreshold
             case debugMode
-            case modelCacheDirectory
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -94,7 +93,6 @@
             try container.encode(numClusters, forKey: .numClusters)
             try container.encode(minActivityThreshold, forKey: .minActivityThreshold)
             try container.encode(debugMode, forKey: .debugMode)
-            try container.encodeIfPresent(modelCacheDirectory, forKey: .modelCacheDirectory)
         }
 
         public init(from decoder: Decoder) throws {
@@ -106,8 +104,6 @@
             let minActivityThreshold = try container.decode(
                 Float.self, forKey: .minActivityThreshold)
             let debugMode = try container.decode(Bool.self, forKey: .debugMode)
-            let modelCacheDirectory = try container.decodeIfPresent(
-                URL.self, forKey: .modelCacheDirectory)
 
             self.init(
                 clusteringThreshold: clusteringThreshold,
@@ -115,8 +111,7 @@
                 minDurationOff: minDurationOff,
                 numClusters: numClusters,
                 minActivityThreshold: minActivityThreshold,
-                debugMode: debugMode,
-                modelCacheDirectory: modelCacheDirectory
+                debugMode: debugMode
             )
         }
     }

--- a/Tests/FluidAudioTests/BasicInitializationTests.swift
+++ b/Tests/FluidAudioTests/BasicInitializationTests.swift
@@ -34,7 +34,6 @@ final class BasicInitializationTests: XCTestCase {
         XCTAssertEqual(defaultConfig.minDurationOff, 0.5, accuracy: 0.01)
         XCTAssertEqual(defaultConfig.numClusters, -1)
         XCTAssertFalse(defaultConfig.debugMode)
-        XCTAssertNil(defaultConfig.modelCacheDirectory)
     }
 }
 
@@ -367,7 +366,7 @@ final class CoreMLBackendIntegrationTests: XCTestCase {
         let diarizer = DiarizerManager(config: config)
 
         do {
-            try await diarizer.initialize()
+            diarizer.initialize(models: try await .downloadIfNeeded())
             XCTAssertTrue(diarizer.isAvailable, "Should be available after successful initialization")
             print("✅ CoreML diarizer initialized successfully!")
 
@@ -395,7 +394,7 @@ final class CoreMLBackendIntegrationTests: XCTestCase {
 
         do {
             // Initialize to download models
-            try await manager.initialize()
+            manager.initialize(models: try await .downloadIfNeeded())
 
             // Get model paths (this is implementation specific)
             // For CoreML, we'll test that the manager initializes properly

--- a/Tests/FluidAudioTests/BasicInitializationTests.swift
+++ b/Tests/FluidAudioTests/BasicInitializationTests.swift
@@ -191,11 +191,14 @@ final class CoreMLDiarizerTests: XCTestCase {
         do {
             let modelPaths = try await manager.downloadModels()
 
-            XCTAssertFalse(modelPaths.segmentationPath.isEmpty, "Segmentation path should not be empty")
-            XCTAssertFalse(modelPaths.embeddingPath.isEmpty, "Embedding path should not be empty")
+            XCTAssertFalse(modelPaths.segmentationPath.absoluteString.isEmpty, "Segmentation path should not be empty")
+            XCTAssertFalse(modelPaths.embeddingPath.absoluteString.isEmpty, "Embedding path should not be empty")
 
             // Verify CoreML model directories
-            XCTAssertTrue(modelPaths.segmentationPath.contains("coreml"), "CoreML models should be in coreml directory")
+            XCTAssertTrue(modelPaths.segmentationPath.isFileURL)
+            XCTAssertTrue(modelPaths.embeddingPath.isFileURL)
+            XCTAssertTrue(modelPaths.segmentationPath.absoluteString.contains("coreml"), "CoreML models should be in coreml directory")
+            XCTAssertTrue(modelPaths.embeddingPath.absoluteString.contains("coreml"), "CoreML models should be in coreml directory")
 
         } catch {
             // This may fail in test environment without network access - that's expected

--- a/Tests/FluidAudioTests/BasicInitializationTests.swift
+++ b/Tests/FluidAudioTests/BasicInitializationTests.swift
@@ -1,3 +1,6 @@
+import Foundation
+import CoreML
+import System
 import XCTest
 @testable import FluidAudio
 
@@ -182,28 +185,143 @@ final class CoreMLDiarizerTests: XCTestCase {
             XCTFail("Unexpected error: \(error)")
         }
     }
+}
 
-    func testModelDownloadPaths() async {
-        let config = DiarizerConfig()
-        let manager = DiarizerManager(config: config)
+// MARK: - Model Loading Tests
 
-        // Test model download (this might fail in CI/test environment, but should return valid paths)
-        do {
-            let modelPaths = try await manager.downloadModels()
+extension CoreMLDiarizerTests {
 
-            XCTAssertFalse(modelPaths.segmentationPath.absoluteString.isEmpty, "Segmentation path should not be empty")
-            XCTAssertFalse(modelPaths.embeddingPath.absoluteString.isEmpty, "Embedding path should not be empty")
+    /// Tests that we can download model files to a user-specified directory and load them from there.
+    ///
+    func testModelDownloadCustomPath() async throws {
 
-            // Verify CoreML model directories
-            XCTAssertTrue(modelPaths.segmentationPath.isFileURL)
-            XCTAssertTrue(modelPaths.embeddingPath.isFileURL)
-            XCTAssertTrue(modelPaths.segmentationPath.absoluteString.contains("coreml"), "CoreML models should be in coreml directory")
-            XCTAssertTrue(modelPaths.embeddingPath.absoluteString.contains("coreml"), "CoreML models should be in coreml directory")
+        XCTExpectFailure("Download might fail in CI environment", strict: false)
 
-        } catch {
-            // This may fail in test environment without network access - that's expected
-            print("Model download failed (expected in test environment): \(error)")
-        }
+        // Create a temporary directory.
+
+        let downloadDir = URL.temporaryDirectory.appendingPathComponent("\(Self.self)-testModelDownloadPaths", isDirectory: true)
+        try? FileManager.default.removeItem(at: downloadDir)
+        try FileManager.default.createDirectory(at: downloadDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: downloadDir) }
+
+        // Download the models to that directory.
+
+        let models = try await DiarizerModels.downloadIfNeeded(to: downloadDir)
+
+        // Check that the model paths point to that directory.
+
+        let (downloadedSegmentationModel, downloadedEmbeddingModel) = (models.paths.segmentationPath, models.paths.embeddingPath)
+
+        XCTAssert(downloadedSegmentationModel.absoluteString.starts(with: downloadDir.absoluteString))
+        XCTAssert(downloadedEmbeddingModel.absoluteString.starts(with: downloadDir.absoluteString))
+
+        // Check that the model files are actually there.
+
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: FilePath(downloadedSegmentationModel)!.string, isDirectory: &isDirectory))
+        XCTAssertTrue(isDirectory.boolValue)
+
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: FilePath(downloadedSegmentationModel.appendingPathComponent("coremldata.bin", isDirectory: false))!.string, isDirectory: &isDirectory))
+        XCTAssertFalse(isDirectory.boolValue)
+
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: FilePath(downloadedEmbeddingModel)!.string, isDirectory: &isDirectory))
+        XCTAssertTrue(isDirectory.boolValue)
+
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: FilePath(downloadedEmbeddingModel.appendingPathComponent("coremldata.bin", isDirectory: false))!.string, isDirectory: &isDirectory))
+        XCTAssertFalse(isDirectory.boolValue)
+
+        // Consume the models object; we don't need it any more.
+
+        let _ = consume models
+
+        // Load the downloaded models using the predownloaded loader function.
+        // We already know that the models are there; it's enough to just check that this works to load them.
+
+        let _ = try DiarizerModels.load(
+            localSegmentationModel: downloadedSegmentationModel,
+            localEmbeddingModel: downloadedEmbeddingModel
+        )
+    }
+
+    /// Tests that we can download model files to a framework-managed directory and load them from there.
+    ///
+    func testModelDownloadDefaultPath() async throws {
+
+        XCTExpectFailure("Download might fail in CI environment", strict: false)
+
+        // Download the models to the framework-managed directory.
+
+        let models = try await DiarizerModels.downloadIfNeeded()
+
+        // Check that the model paths point to that directory.
+
+        let (downloadedSegmentationModel, downloadedEmbeddingModel) = (models.paths.segmentationPath, models.paths.embeddingPath)
+
+        #if os(iOS)
+            XCTAssert(downloadedSegmentationModel.pathComponents.suffix(4) == ["FluidAudio", "models", "diarization", "pyannote_segmentation.mlmodelc"])
+            XCTAssert(downloadedEmbeddingModel.pathComponents.suffix(4) == ["FluidAudio", "models", "diarization", "wespeaker.mlmodelc"])
+        #else
+            XCTAssert(downloadedSegmentationModel.pathComponents.suffix(3) == ["SpeakerKitModels", "coreml", "pyannote_segmentation.mlmodelc"])
+            XCTAssert(downloadedEmbeddingModel.pathComponents.suffix(3) == ["SpeakerKitModels", "coreml", "wespeaker.mlmodelc"])
+        #endif
+
+        // Check that the model files are actually there.
+
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: FilePath(downloadedSegmentationModel)!.string, isDirectory: &isDirectory))
+        XCTAssertTrue(isDirectory.boolValue)
+
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: FilePath(downloadedSegmentationModel.appendingPathComponent("coremldata.bin", isDirectory: false))!.string, isDirectory: &isDirectory))
+        XCTAssertFalse(isDirectory.boolValue)
+
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: FilePath(downloadedEmbeddingModel)!.string, isDirectory: &isDirectory))
+        XCTAssertTrue(isDirectory.boolValue)
+
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: FilePath(downloadedEmbeddingModel.appendingPathComponent("coremldata.bin", isDirectory: false))!.string, isDirectory: &isDirectory))
+        XCTAssertFalse(isDirectory.boolValue)
+
+        // Consume the models object; we don't need it any more.
+
+        let _ = consume models
+
+        // Load the downloaded models using the predownloaded loader function.
+        // We already know that the models are there; it's enough to just check that this works to load them.
+
+        let _ = try DiarizerModels.load(
+            localSegmentationModel: downloadedSegmentationModel,
+            localEmbeddingModel: downloadedEmbeddingModel
+        )
+    }
+
+    /// Tests that we can load model files with a user-specified configuration.
+    ///
+    func testModelLoadingCustomConfig() async throws {
+
+        XCTExpectFailure("Download might fail in CI environment", strict: false)
+
+        // Create a custom configuration.
+
+        let customConfig = MLModelConfiguration()
+        customConfig.modelDisplayName = "My custom name"
+        customConfig.computeUnits = .cpuOnly
+
+        // Download the models to the framework-managed directory.
+
+        let models = try await DiarizerModels.downloadIfNeeded(configuration: customConfig)
+
+        XCTAssertEqual(models.segmentationModel.configuration.modelDisplayName, customConfig.modelDisplayName)
+        XCTAssertEqual(models.segmentationModel.configuration.computeUnits, customConfig.computeUnits)
+
+        XCTAssertEqual(models.embeddingModel.configuration.modelDisplayName, customConfig.modelDisplayName)
+        XCTAssertEqual(models.embeddingModel.configuration.computeUnits, customConfig.computeUnits)
     }
 }
 

--- a/Tests/FluidAudioTests/CITests.swift
+++ b/Tests/FluidAudioTests/CITests.swift
@@ -33,7 +33,6 @@ final class CITests: XCTestCase {
         XCTAssertEqual(defaultConfig.numClusters, -1)
         XCTAssertEqual(defaultConfig.minActivityThreshold, 10.0, accuracy: 0.01)
         XCTAssertFalse(defaultConfig.debugMode)
-        XCTAssertNil(defaultConfig.modelCacheDirectory)
     }
 
     func testDiarizerConfigCustom() {
@@ -43,8 +42,7 @@ final class CITests: XCTestCase {
             minDurationOff: 1.0,
             numClusters: 3,
             minActivityThreshold: 15.0,
-            debugMode: true,
-            modelCacheDirectory: URL(fileURLWithPath: "/tmp/test")
+            debugMode: true
         )
 
         XCTAssertEqual(customConfig.clusteringThreshold, 0.8, accuracy: 0.01)
@@ -53,7 +51,6 @@ final class CITests: XCTestCase {
         XCTAssertEqual(customConfig.numClusters, 3)
         XCTAssertEqual(customConfig.minActivityThreshold, 15.0, accuracy: 0.01)
         XCTAssertTrue(customConfig.debugMode)
-        XCTAssertNotNil(customConfig.modelCacheDirectory)
     }
 
     // MARK: - Data Structure Tests

--- a/Tests/FluidAudioTests/CITests.swift
+++ b/Tests/FluidAudioTests/CITests.swift
@@ -177,12 +177,12 @@ final class CITests: XCTestCase {
 
     func testModelPathsStructure() {
         let modelPaths = ModelPaths(
-            segmentationPath: "/path/to/segmentation.mlmodelc",
-            embeddingPath: "/path/to/embedding.mlmodelc"
+            segmentationPath: URL(fileURLWithPath: "/path/to/segmentation.mlmodelc"),
+            embeddingPath: URL(fileURLWithPath: "/path/to/embedding.mlmodelc")
         )
 
-        XCTAssertEqual(modelPaths.segmentationPath, "/path/to/segmentation.mlmodelc")
-        XCTAssertEqual(modelPaths.embeddingPath, "/path/to/embedding.mlmodelc")
+        XCTAssertEqual(modelPaths.segmentationPath.absoluteString, "file:///path/to/segmentation.mlmodelc")
+        XCTAssertEqual(modelPaths.embeddingPath.absoluteString, "file:///path/to/embedding.mlmodelc")
     }
 
     // MARK: - Backend Enum Tests


### PR DESCRIPTION
Only the last commit is new.

Builds on #25 by adding a `models` parameter to `DiarizerManager.initialize`. 

The `DiarizerModels` type gives users APIs to download models, including to custom directories, and load models that are bundled with the app or downloaded from elsewhere. Models can also be loaded with user-specified options, such as the compute units to use.

This unlocks some new use-cases but comes with some minor API changes. IMO, it is actually quite nice to let users know that initialising the diarization manager might involve a download, so I feel the extra clarity is worth the extra characters.

The `DiarizerModels` APIs make the previous `DiarizerManager.downloadModels` and `DiarizerConfig.modelCacheDirectory` APIs obsolete, so they have also been removed.