### PR TITLE
Fix ComputeUnits override for ASR

### DIFF
--- a/Sources/FluidAudio/ASR/ANEOptimizer.swift
+++ b/Sources/FluidAudio/ASR/ANEOptimizer.swift
@@ -94,25 +94,8 @@ public enum ANEOptimizer {
 
     /// Configure optimal compute units for each model type
     public static func optimalComputeUnits(for modelType: ModelType) -> MLComputeUnits {
-        switch modelType {
-        case .melSpectrogram:
-            // FFT operations run better on CPU/GPU
-            return .cpuAndGPU
-        case .encoder:
-            // Transformer/attention benefits from Neural Engine
-            return .cpuAndNeuralEngine
-        case .decoder:
-            // LSTM operations optimized for Neural Engine
-            return .cpuAndNeuralEngine
-        case .joint:
-            // Small dense layers perfect for Neural Engine
-            if #available(macOS 14.0, iOS 17.0, *) {
-                // Use Neural Engine exclusively for small models
-                return .all  // Will prefer NE for small ops
-            } else {
-                return .cpuAndNeuralEngine
-            }
-        }
+        // Testing shows CPU+ANE is fastest for all models, including melspectrogram
+        return .cpuAndNeuralEngine
     }
 
     /// Create zero-copy memory view between models

--- a/Tests/FluidAudioTests/ANEOptimizerTests.swift
+++ b/Tests/FluidAudioTests/ANEOptimizerTests.swift
@@ -86,9 +86,10 @@ final class ANEOptimizerTests: XCTestCase {
     // MARK: - Compute Unit Selection Tests
 
     func testOptimalComputeUnits() {
+        // All models use CPU+ANE for optimal performance
         XCTAssertEqual(
             ANEOptimizer.optimalComputeUnits(for: .melSpectrogram),
-            .cpuAndGPU
+            .cpuAndNeuralEngine
         )
 
         XCTAssertEqual(
@@ -101,17 +102,10 @@ final class ANEOptimizerTests: XCTestCase {
             .cpuAndNeuralEngine
         )
 
-        if #available(macOS 14.0, iOS 17.0, *) {
-            XCTAssertEqual(
-                ANEOptimizer.optimalComputeUnits(for: .joint),
-                .all
-            )
-        } else {
-            XCTAssertEqual(
-                ANEOptimizer.optimalComputeUnits(for: .joint),
-                .cpuAndNeuralEngine
-            )
-        }
+        XCTAssertEqual(
+            ANEOptimizer.optimalComputeUnits(for: .joint),
+            .cpuAndNeuralEngine
+        )
     }
 
     // MARK: - Zero-Copy View Tests (Removed - causes crashes with memory operations)

--- a/Tests/FluidAudioTests/AsrModelsTests.swift
+++ b/Tests/FluidAudioTests/AsrModelsTests.swift
@@ -23,14 +23,8 @@ final class AsrModelsTests: XCTestCase {
         let config = AsrModels.defaultConfiguration()
 
         XCTAssertTrue(config.allowLowPrecisionAccumulationOnGPU)
-
-        // Check compute units based on environment
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        if isCI {
-            XCTAssertEqual(config.computeUnits, .cpuAndNeuralEngine)
-        } else {
-            XCTAssertEqual(config.computeUnits, .all)
-        }
+        // Should always use CPU+ANE for optimal performance
+        XCTAssertEqual(config.computeUnits, .cpuAndNeuralEngine)
     }
 
     // MARK: - Directory Tests
@@ -282,7 +276,7 @@ final class AsrModelsTests: XCTestCase {
     func testPerformanceProfiles() {
         // Test low latency profile
         let lowLatencyConfig = AsrModels.PerformanceProfile.lowLatency.configuration
-        XCTAssertEqual(lowLatencyConfig.computeUnits, .cpuAndGPU)
+        XCTAssertEqual(lowLatencyConfig.computeUnits, .cpuAndNeuralEngine)
         XCTAssertTrue(lowLatencyConfig.allowLowPrecisionAccumulationOnGPU)
 
         let lowLatencyOptions = AsrModels.PerformanceProfile.lowLatency.predictionOptions
@@ -290,11 +284,11 @@ final class AsrModelsTests: XCTestCase {
 
         // Test balanced profile
         let balancedConfig = AsrModels.PerformanceProfile.balanced.configuration
-        XCTAssertEqual(balancedConfig.computeUnits, .all)
+        XCTAssertEqual(balancedConfig.computeUnits, .cpuAndNeuralEngine)
 
         // Test high accuracy profile
         let accuracyConfig = AsrModels.PerformanceProfile.highAccuracy.configuration
-        XCTAssertEqual(accuracyConfig.computeUnits, .all)
+        XCTAssertEqual(accuracyConfig.computeUnits, .cpuAndNeuralEngine)
         XCTAssertFalse(accuracyConfig.allowLowPrecisionAccumulationOnGPU)
 
         // Test streaming profile
@@ -331,15 +325,8 @@ final class AsrModelsTests: XCTestCase {
     func testPlatformAwareDefaultConfiguration() {
         let config = AsrModels.defaultConfiguration()
         
-        let isCI = ProcessInfo.processInfo.environment["CI"] != nil
-        
-        if isCI {
-            // CI environment should use CPU+ANE
-            XCTAssertEqual(config.computeUnits, .cpuAndNeuralEngine)
-        } else {
-            // Should use all compute units by default
-            XCTAssertEqual(config.computeUnits, .all)
-        }
+        // Should always use CPU+ANE for optimal performance
+        XCTAssertEqual(config.computeUnits, .cpuAndNeuralEngine)
     }
     
     func testOptimalComputeUnitsRespectsPlatform() {

--- a/Tests/FluidAudioTests/AsrModelsTests.swift
+++ b/Tests/FluidAudioTests/AsrModelsTests.swift
@@ -220,7 +220,7 @@ final class AsrModelsTests: XCTestCase {
         if isCI {
             XCTAssertEqual(melConfig.computeUnits, .cpuOnly)
         } else {
-            XCTAssertEqual(melConfig.computeUnits, .cpuAndGPU)
+            XCTAssertEqual(melConfig.computeUnits, .cpuAndNeuralEngine)
         }
         XCTAssertTrue(melConfig.allowLowPrecisionAccumulationOnGPU)
 
@@ -244,8 +244,6 @@ final class AsrModelsTests: XCTestCase {
         let jointConfig = AsrModels.optimizedConfiguration(for: .joint)
         if isCI {
             XCTAssertEqual(jointConfig.computeUnits, .cpuOnly)
-        } else if #available(macOS 14.0, iOS 17.0, *) {
-            XCTAssertEqual(jointConfig.computeUnits, .all)
         } else {
             XCTAssertEqual(jointConfig.computeUnits, .cpuAndNeuralEngine)
         }
@@ -356,19 +354,9 @@ final class AsrModelsTests: XCTestCase {
         for modelType in modelTypes {
             let computeUnits = ANEOptimizer.optimalComputeUnits(for: modelType)
             
-            // Should use model-specific optimization
-            switch modelType {
-            case .melSpectrogram:
-                XCTAssertEqual(computeUnits, .cpuAndGPU)
-            case .encoder, .decoder:
-                XCTAssertEqual(computeUnits, .cpuAndNeuralEngine)
-            case .joint:
-                if #available(macOS 14.0, iOS 17.0, *) {
-                    XCTAssertEqual(computeUnits, .all)
-                } else {
-                    XCTAssertEqual(computeUnits, .cpuAndNeuralEngine)
-                }
-            }
+            // All models should use CPU+ANE for optimal performance
+            XCTAssertEqual(computeUnits, .cpuAndNeuralEngine,
+                          "Model type \(modelType) should use CPU+ANE")
         }
     }
 }


### PR DESCRIPTION
https://github.com/FluidInference/FluidAudio/issues/53

Ideally users should be able to configure each model but honestly from our benchmark tests, anything other than ANE was tested and the performance is not ideal  