### PR TITLE
Fix Float16 compatibility for macOS deployment targets

### DIFF
--- a/Sources/FluidAudio/ASR/ANEOptimizer.swift
+++ b/Sources/FluidAudio/ASR/ANEOptimizer.swift
@@ -169,10 +169,9 @@ public enum ANEOptimizer {
             dataType: .float16
         )
 
-        // Convert using Accelerate
+        // Convert using Accelerate with platform-specific handling
         let sourcePtr = input.dataPointer.bindMemory(to: Float.self, capacity: input.count)
-        let destPtr = float16Array.dataPointer.bindMemory(to: Float16.self, capacity: input.count)
-
+        
         var sourceBuffer = vImage_Buffer(
             data: sourcePtr,
             height: 1,
@@ -180,11 +179,14 @@ public enum ANEOptimizer {
             rowBytes: input.count * MemoryLayout<Float>.stride
         )
 
+        // Use UInt16 as storage type for cross-platform compatibility
+        let destPtr = float16Array.dataPointer.bindMemory(to: UInt16.self, capacity: input.count)
+        
         var destBuffer = vImage_Buffer(
             data: destPtr,
             height: 1,
             width: vImagePixelCount(input.count),
-            rowBytes: input.count * MemoryLayout<Float16>.stride
+            rowBytes: input.count * MemoryLayout<UInt16>.stride
         )
 
         vImageConvert_PlanarFtoPlanar16F(&sourceBuffer, &destBuffer, 0)


### PR DESCRIPTION
Issue: 'Float16' unavailable on macOS during Archiving macOS app. 

<img width="4176" height="2494" alt="Xcode 2025-08-02 19 39 22" src="https://github.com/user-attachments/assets/8309b5d0-60b1-46e6-b6ba-249d6f8b4f90" />


- ✅ Archive builds now work without errors