### PR TITLE
fix: vocabulary loading ignores custom model directory

### DIFF
--- a/Sources/FluidAudio/ASR/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/AsrManager.swift
@@ -269,7 +269,6 @@ public final class AsrManager {
         decoderState = freshState
     }
 
-
     private func loadModel(
         path: URL,
         name: String,

--- a/Sources/FluidAudio/ASR/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/AsrManager.swift
@@ -64,9 +64,6 @@ public final class AsrManager {
 
         // Optimization models will be loaded during initialize()
 
-        // Load vocabulary once during initialization
-        self.vocabulary = loadVocabulary()
-
         // Pre-warm caches if possible
         Task {
             await sharedMLArrayCache.prewarm(shapes: [
@@ -92,6 +89,7 @@ public final class AsrManager {
         self.encoderModel = models.encoder
         self.decoderModel = models.decoder
         self.jointModel = models.joint
+        self.vocabulary = models.vocabulary
 
         logger.info("Token duration optimization model loaded successfully")
 
@@ -270,46 +268,7 @@ public final class AsrManager {
 
         decoderState = freshState
     }
-    private func loadVocabulary() -> [Int: String] {
-        let applicationSupportURL = FileManager.default.urls(
-            for: .applicationSupportDirectory, in: .userDomainMask
-        ).first!
-        let appDirectory = applicationSupportURL.appendingPathComponent(
-            "FluidAudio", isDirectory: true
-        )
-        .appendingPathComponent("Models", isDirectory: true)
-        .appendingPathComponent("parakeet-tdt-0.6b-v2-coreml", isDirectory: true)
-        let vocabPath = appDirectory.appendingPathComponent("parakeet_vocab.json")
 
-        if !FileManager.default.fileExists(atPath: vocabPath.path) {
-            logger.warning(
-                "Vocabulary file not found at \(vocabPath.path). Please ensure parakeet_vocab.json is downloaded with the models."
-            )
-            return [:]
-        }
-
-        do {
-            let data = try Data(contentsOf: vocabPath)
-            let jsonDict = try JSONSerialization.jsonObject(with: data) as? [String: String] ?? [:]
-
-            var vocabulary: [Int: String] = [:]
-
-            for (key, value) in jsonDict {
-                if let tokenId = Int(key) {
-                    vocabulary[tokenId] = value
-                }
-            }
-
-            logger.info(
-                "Loaded vocabulary with \(vocabulary.count) tokens from \(vocabPath.path)")
-            return vocabulary
-        } catch {
-            logger.error(
-                "Failed to load or parse vocabulary file at \(vocabPath.path): \(error.localizedDescription)"
-            )
-            return [:]
-        }
-    }
 
     private func loadModel(
         path: URL,
@@ -482,11 +441,6 @@ public final class AsrManager {
         text: String, timings: [TokenTiming]
     ) {
         guard !tokenIds.isEmpty else { return ("", []) }
-
-        // Fallback: if vocabulary is empty (failed to load during init), try loading it now
-        if vocabulary.isEmpty {
-            vocabulary = loadVocabulary()
-        }
 
         // Debug: print token mappings
         if config.enableDebug {

--- a/Sources/FluidAudio/ASR/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/AsrModels.swift
@@ -147,7 +147,6 @@ extension AsrModels {
         }
     }
 
-
     public static func loadFromCache(
         configuration: MLModelConfiguration? = nil
     ) async throws -> AsrModels {

--- a/Sources/FluidAudio/ASR/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/AsrModels.swift
@@ -9,6 +9,7 @@ public struct AsrModels: Sendable {
     public let decoder: MLModel
     public let joint: MLModel
     public let configuration: MLModelConfiguration
+    public let vocabulary: [Int: String]
 
     private static let logger = Logger(subsystem: "com.fluidinfluence.asr", category: "AsrModels")
 
@@ -17,13 +18,15 @@ public struct AsrModels: Sendable {
         encoder: MLModel,
         decoder: MLModel,
         joint: MLModel,
-        configuration: MLModelConfiguration
+        configuration: MLModelConfiguration,
+        vocabulary: [Int: String]
     ) {
         self.melspectrogram = melspectrogram
         self.encoder = encoder
         self.decoder = decoder
         self.joint = joint
         self.configuration = configuration
+        self.vocabulary = vocabulary
     }
 }
 
@@ -104,12 +107,46 @@ extension AsrModels {
             encoder: encoderModel,
             decoder: decoderModel,
             joint: jointModel,
-            configuration: config
+            configuration: config,
+            vocabulary: try loadVocabulary(from: directory)
         )
 
         logger.info("Successfully loaded all ASR models with optimized compute units")
         return asrModels
     }
+
+    private static func loadVocabulary(from directory: URL) throws -> [Int: String] {
+        let vocabPath = repoPath(from: directory).appendingPathComponent(ModelNames.vocabulary)
+
+        if !FileManager.default.fileExists(atPath: vocabPath.path) {
+            logger.warning(
+                "Vocabulary file not found at \(vocabPath.path). Please ensure parakeet_vocab.json is downloaded with the models."
+            )
+            throw AsrModelsError.modelNotFound(ModelNames.vocabulary, vocabPath)
+        }
+
+        do {
+            let data = try Data(contentsOf: vocabPath)
+            let jsonDict = try JSONSerialization.jsonObject(with: data) as? [String: String] ?? [:]
+
+            var vocabulary: [Int: String] = [:]
+
+            for (key, value) in jsonDict {
+                if let tokenId = Int(key) {
+                    vocabulary[tokenId] = value
+                }
+            }
+
+            logger.info("Loaded vocabulary with \(vocabulary.count) tokens from \(vocabPath.path)")
+            return vocabulary
+        } catch {
+            logger.error(
+                "Failed to load or parse vocabulary file at \(vocabPath.path): \(error.localizedDescription)"
+            )
+            throw AsrModelsError.loadingFailed("Vocabulary parsing failed")
+        }
+    }
+
 
     public static func loadFromCache(
         configuration: MLModelConfiguration? = nil


### PR DESCRIPTION
AsrManager.loadVocabulary() used hardcoded paths, ignoring custom directories specified in AsrModels.downloadAndLoad(to: customDirectory). This would cause the transcription to fail when using custom directory configurations. 
<img width="382" height="204" alt="CleanShot 2025-08-03 at 09 22 46@2x" src="https://github.com/user-attachments/assets/22ac854c-1110-45b1-a5c5-e54ef88a45eb" />


**Fix:** Move vocabulary loading into AsrModels.load() to respect the same directory path used for ML models.