### PR TITLE
Fix melspectrogram typo

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: opened
 
 jobs:
   claude-review:

--- a/Sources/FluidAudio/ASR/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/AsrManager.swift
@@ -182,11 +182,11 @@ public final class AsrManager {
         // Zero-copy: chain mel-spectrogram outputs directly to encoder inputs
         if let provider = ZeroCopyFeatureProvider.chain(
             from: melspectrogramOutput,
-            outputName: "melspectogram",
+            outputName: "melspectrogram",
             to: "audio_signal"
         ) {
             // Also need to chain the length
-            if let melLength = melspectrogramOutput.featureValue(for: "melspectogram_length") {
+            if let melLength = melspectrogramOutput.featureValue(for: "melspectrogram_length") {
                 let features = [
                     "audio_signal": provider.featureValue(for: "audio_signal")!,
                     "length": melLength,
@@ -197,10 +197,10 @@ public final class AsrManager {
 
         // Fallback to copying if zero-copy fails
         let melspectrogram = try extractFeatureValue(
-            from: melspectrogramOutput, key: "melspectogram",
+            from: melspectrogramOutput, key: "melspectrogram",
             errorMessage: "Invalid mel-spectrogram output")
         let melspectrogramLength = try extractFeatureValue(
-            from: melspectrogramOutput, key: "melspectogram_length",
+            from: melspectrogramOutput, key: "melspectrogram_length",
             errorMessage: "Invalid mel-spectrogram length output")
 
         return try createFeatureProvider(features: [

--- a/Sources/FluidAudio/ASR/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/AsrModels.swift
@@ -40,7 +40,7 @@ extension AsrModels {
     }
 
     public enum ModelNames {
-        public static let melspectrogram = "Melspectogram.mlmodelc"
+        public static let melspectrogram = "Melspectrogram_v2.mlmodelc"
         public static let encoder = "ParakeetEncoder_v2.mlmodelc"
         public static let decoder = "ParakeetDecoder.mlmodelc"
         public static let joint = "RNNTJoint.mlmodelc"

--- a/Sources/FluidAudio/ASR/StreamingAsrManager.swift
+++ b/Sources/FluidAudio/ASR/StreamingAsrManager.swift
@@ -365,7 +365,7 @@ public struct StreamingAsrConfig: Sendable {
 
     public init(
         confirmationThreshold: Float = 0.85,
-        chunkDuration: TimeInterval = 1.0,
+        chunkDuration: TimeInterval = 10.0,
         enableDebug: Bool = false
     ) {
         self.confirmationThreshold = confirmationThreshold

--- a/Sources/FluidAudio/ASR/StreamingAsrManager.swift
+++ b/Sources/FluidAudio/ASR/StreamingAsrManager.swift
@@ -342,10 +342,24 @@ public struct StreamingAsrConfig: Sendable {
     /// Enable debug logging
     public let enableDebug: Bool
 
-    /// Default configuration - optimized for Melspectrogram_v2
+    /// Default configuration with balanced settings
     public static let `default` = StreamingAsrConfig(
         confirmationThreshold: 0.85,
-        chunkDuration: 1.0,  // 1 second chunks - balance of latency and context
+        chunkDuration: 10.0,  // 10 second chunks - model limitation
+        enableDebug: false
+    )
+
+    /// Low latency configuration with faster updates
+    public static let lowLatency = StreamingAsrConfig(
+        confirmationThreshold: 0.75,
+        chunkDuration: 10.0,  // 10 second chunks - model limitation
+        enableDebug: false
+    )
+
+    /// High accuracy configuration with conservative confirmation
+    public static let highAccuracy = StreamingAsrConfig(
+        confirmationThreshold: 0.9,
+        chunkDuration: 10.0,  // 10 second chunks - model limitation
         enableDebug: false
     )
 
@@ -360,8 +374,8 @@ public struct StreamingAsrConfig: Sendable {
     }
 
     /// Custom configuration with specified chunk duration
-    /// - Note: With Melspectrogram_v2, chunks as short as 0.01s (160 samples) are supported
-    /// - Default uses 1.0s for optimal balance of latency and ASR accuracy
+    /// - Note: The underlying model currently works best with 10s chunks
+    /// - Shorter chunk support is still being validated
     public static func custom(
         chunkDuration: TimeInterval,
         confirmationThreshold: Float = 0.85,

--- a/Sources/FluidAudio/ASR/StreamingAsrManager.swift
+++ b/Sources/FluidAudio/ASR/StreamingAsrManager.swift
@@ -342,31 +342,16 @@ public struct StreamingAsrConfig: Sendable {
     /// Enable debug logging
     public let enableDebug: Bool
 
-    /// Default configuration with balanced settings
-    // Limtiation in the underlying model only supporting 10s. We are working to support other durations.
+    /// Default configuration - optimized for Melspectrogram_v2
     public static let `default` = StreamingAsrConfig(
         confirmationThreshold: 0.85,
-        chunkDuration: 10.0,
-        enableDebug: false
-    )
-
-    /// Low latency configuration with faster updates
-    public static let lowLatency = StreamingAsrConfig(
-        confirmationThreshold: 0.75,
-        chunkDuration: 10.0,
-        enableDebug: false
-    )
-
-    /// High accuracy configuration with conservative confirmation
-    public static let highAccuracy = StreamingAsrConfig(
-        confirmationThreshold: 0.9,
-        chunkDuration: 10.0,
+        chunkDuration: 1.0,  // 1 second chunks - balance of latency and context
         enableDebug: false
     )
 
     public init(
         confirmationThreshold: Float = 0.85,
-        chunkDuration: TimeInterval = 10.0,
+        chunkDuration: TimeInterval = 1.0,
         enableDebug: Bool = false
     ) {
         self.confirmationThreshold = confirmationThreshold
@@ -375,8 +360,8 @@ public struct StreamingAsrConfig: Sendable {
     }
 
     /// Custom configuration with specified chunk duration
-    /// - Note: For TDT decoder, chunk sizes below 5.0s may result in empty transcriptions
-    // Limtiation in the underlying model only supporting 10s. We are working to support other durations.
+    /// - Note: With Melspectrogram_v2, chunks as short as 0.01s (160 samples) are supported
+    /// - Default uses 1.0s for optimal balance of latency and ASR accuracy
     public static func custom(
         chunkDuration: TimeInterval,
         confirmationThreshold: Float = 0.85,

--- a/Sources/FluidAudio/ASR/StreamingAsrManager.swift
+++ b/Sources/FluidAudio/ASR/StreamingAsrManager.swift
@@ -345,21 +345,21 @@ public struct StreamingAsrConfig: Sendable {
     /// Default configuration with balanced settings
     public static let `default` = StreamingAsrConfig(
         confirmationThreshold: 0.85,
-        chunkDuration: 10.0,  // 10 second chunks - model limitation
+        chunkDuration: 10.0,  // 10 second chunks for now
         enableDebug: false
     )
 
     /// Low latency configuration with faster updates
     public static let lowLatency = StreamingAsrConfig(
         confirmationThreshold: 0.75,
-        chunkDuration: 10.0,  // 10 second chunks - model limitation
+        chunkDuration: 10.0,  // 10 second chunks for now, need to fix streaming impl
         enableDebug: false
     )
 
     /// High accuracy configuration with conservative confirmation
     public static let highAccuracy = StreamingAsrConfig(
         confirmationThreshold: 0.9,
-        chunkDuration: 10.0,  // 10 second chunks - model limitation
+        chunkDuration: 10.0,  // 10 second chunks for now, need to fix streaming impl
         enableDebug: false
     )
 

--- a/Sources/FluidAudio/Diarizer/EmbeddingExtractor.swift
+++ b/Sources/FluidAudio/Diarizer/EmbeddingExtractor.swift
@@ -162,7 +162,7 @@ public class EmbeddingExtractor {
             // Extract directly from the view
             var embedding = [Float](repeating: 0, count: embeddingDim)
             let ptr = embeddingView.dataPointer.assumingMemoryBound(to: Float.self)
-            embedding.withUnsafeMutableBufferPointer { buffer in
+            _ = embedding.withUnsafeMutableBufferPointer { buffer in
                 // Use optimized memory copy
                 memcpy(buffer.baseAddress!, ptr, embeddingDim * MemoryLayout<Float>.size)
             }

--- a/Sources/FluidAudio/Diarizer/SpeakerOperations.swift
+++ b/Sources/FluidAudio/Diarizer/SpeakerOperations.swift
@@ -498,8 +498,8 @@ extension SpeakerManager {
     ) -> Bool {
         return queue.sync(flags: .barrier) {
             // Get speaker info from database
-            guard var fromSpeakerInfo = speakerDatabase[fromSpeakerId],
-                var toSpeakerInfo = speakerDatabase[toSpeakerId]
+            guard let fromSpeakerInfo = speakerDatabase[fromSpeakerId],
+                let toSpeakerInfo = speakerDatabase[toSpeakerId]
             else {
                 logger.warning("One or both speakers not found: from=\(fromSpeakerId), to=\(toSpeakerId)")
                 return false

--- a/Sources/FluidAudio/Diarizer/SpeakerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/SpeakerTypes.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Speaker profile representation for tracking speakers across audio
 /// This represents a speaker's identity, not a specific segment
 @available(macOS 13.0, iOS 16.0, *)
-public final class Speaker: Identifiable, Codable, Sendable, Equatable, Hashable {
+public final class Speaker: Identifiable, Codable, Equatable, Hashable {
     public let id: String
     public var name: String
     public var currentEmbedding: [Float]

--- a/Sources/FluidAudio/Shared/ANEMemoryUtils.swift
+++ b/Sources/FluidAudio/Shared/ANEMemoryUtils.swift
@@ -26,14 +26,33 @@ public enum ANEMemoryUtils {
         dataType: MLMultiArrayDataType,
         zeroClear: Bool = true
     ) throws -> MLMultiArray {
-        // Calculate total elements
-        let totalElements = shape.map { $0.intValue }.reduce(1, *)
-
         // Calculate element size
         let elementSize = getElementSize(for: dataType)
 
+        // Calculate total elements from shape
+        let totalElements = shape.map { $0.intValue }.reduce(1, *)
+
+        // For very large arrays, use standard strides to avoid excessive memory overhead
+        // ANE optimization is beneficial for smaller tensors but counterproductive for large test arrays
+        let strides: [NSNumber]
+        if totalElements > 100_000 {
+            // Use standard row-major strides for large arrays
+            var standardStrides: [Int] = []
+            var currentStride = 1
+            for i in (0..<shape.count).reversed() {
+                standardStrides.insert(currentStride, at: 0)
+                currentStride *= shape[i].intValue
+            }
+            strides = standardStrides.map { NSNumber(value: $0) }
+        } else {
+            // Use ANE-optimized strides for smaller arrays
+            strides = calculateOptimalStrides(for: shape)
+        }
+
+        let actualElements = totalElements
+
         // Align the allocation size to ANE requirements
-        let bytesNeeded = totalElements * elementSize
+        let bytesNeeded = actualElements * elementSize
         // Ensure at least one alignment unit is allocated even for empty arrays
         let alignedBytes = max(aneAlignment, ((bytesNeeded + aneAlignment - 1) / aneAlignment) * aneAlignment)
 
@@ -55,7 +74,7 @@ public enum ANEMemoryUtils {
             dataPointer: pointer,
             shape: shape,
             dataType: dataType,
-            strides: calculateOptimalStrides(for: shape),
+            strides: strides,
             deallocator: { bytes in
                 bytes.deallocate()
             }

--- a/Sources/FluidAudio/Shared/ANEMemoryUtils.swift
+++ b/Sources/FluidAudio/Shared/ANEMemoryUtils.swift
@@ -31,7 +31,7 @@ public enum ANEMemoryUtils {
 
         // Calculate optimal strides for ANE
         let strides = calculateOptimalStrides(for: shape)
-        
+
         // Calculate actual elements needed based on strides (accounts for padding)
         // The total elements needed is the stride of the first dimension times the first dimension size
         let totalElementsNeeded: Int

--- a/Sources/FluidAudioCLI/Commands/DownloadCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/DownloadCommand.swift
@@ -68,7 +68,7 @@ enum DownloadCommand {
                 let modelsDir = FileManager.default.homeDirectoryForCurrentUser
                     .appendingPathComponent("Library/Application Support/FluidAudio/Models")
                 let modelNames = [
-                    "Melspectogram.mlmodelc",
+                    "Melspectogram_v2.mlmodelc",
                     "ParakeetEncoder_v2.mlmodelc",
                     "ParakeetDecoder.mlmodelc",
                     "RNNTJoint.mlmodelc",

--- a/Tests/FluidAudioTests/AsrManagerTests.swift
+++ b/Tests/FluidAudioTests/AsrManagerTests.swift
@@ -191,8 +191,8 @@ final class AsrManagerTests: XCTestCase {
         lengthArray[0] = NSNumber(value: 100)
 
         let melOutput = try MLDictionaryFeatureProvider(dictionary: [
-            "melspectogram": MLFeatureValue(multiArray: melArray),
-            "melspectogram_length": MLFeatureValue(multiArray: lengthArray),
+            "melspectrogram": MLFeatureValue(multiArray: melArray),
+            "melspectrogram_length": MLFeatureValue(multiArray: lengthArray),
         ])
 
         let encoderInput = try manager.prepareEncoderInput(melOutput)
@@ -292,8 +292,8 @@ final class AsrManagerTests: XCTestCase {
         }
 
         let melOutput = try MLDictionaryFeatureProvider(dictionary: [
-            "melspectogram": MLFeatureValue(multiArray: melArray),
-            "melspectogram_length": MLFeatureValue(multiArray: lengthArray),
+            "melspectrogram": MLFeatureValue(multiArray: melArray),
+            "melspectrogram_length": MLFeatureValue(multiArray: lengthArray),
         ])
 
         let encoderInput = try manager.prepareEncoderInput(melOutput)

--- a/Tests/FluidAudioTests/AsrModelsTests.swift
+++ b/Tests/FluidAudioTests/AsrModelsTests.swift
@@ -10,7 +10,7 @@ final class AsrModelsTests: XCTestCase {
     // MARK: - Model Names Tests
 
     func testModelNames() {
-        XCTAssertEqual(AsrModels.ModelNames.melspectrogram, "Melspectogram_v2.mlmodelc")
+        XCTAssertEqual(AsrModels.ModelNames.melspectrogram, "Melspectrogram_v2.mlmodelc")
         XCTAssertEqual(AsrModels.ModelNames.encoder, "ParakeetEncoder_v2.mlmodelc")
         XCTAssertEqual(AsrModels.ModelNames.decoder, "ParakeetDecoder.mlmodelc")
         XCTAssertEqual(AsrModels.ModelNames.joint, "RNNTJoint.mlmodelc")

--- a/Tests/FluidAudioTests/AsrModelsTests.swift
+++ b/Tests/FluidAudioTests/AsrModelsTests.swift
@@ -10,7 +10,7 @@ final class AsrModelsTests: XCTestCase {
     // MARK: - Model Names Tests
 
     func testModelNames() {
-        XCTAssertEqual(AsrModels.ModelNames.melspectrogram, "Melspectogram.mlmodelc")
+        XCTAssertEqual(AsrModels.ModelNames.melspectrogram, "Melspectogram_v2.mlmodelc")
         XCTAssertEqual(AsrModels.ModelNames.encoder, "ParakeetEncoder_v2.mlmodelc")
         XCTAssertEqual(AsrModels.ModelNames.decoder, "ParakeetDecoder.mlmodelc")
         XCTAssertEqual(AsrModels.ModelNames.joint, "RNNTJoint.mlmodelc")


### PR DESCRIPTION
Uses new v2 model with fixes to the melspectrogram typo but also updated the model to support shorter chunks (won't fail now) but we still need to update the code to support the shorter chunks. The current streaming implementation has issues here, its not properly implemented 