### PR TITLE
Only allow proxy for macOS and add test for iOS test with xCode build

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Description
+
+### Why is this change needed?
+<!-- Explain the motivation for this change. What problem does it solve? -->
+
+### What does this change do?
+<!-- Provide a clear description of what your PR changes -->
+
+## Additional Context
+<!-- Add any other context, screenshots, or information about the PR here -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,3 @@
-## Description
-
 ### Why is this change needed?
 <!-- Explain the motivation for this change. What problem does it solve? -->
 
-### What does this change do?
-<!-- Provide a clear description of what your PR changes -->
-
-## Additional Context
-<!-- Add any other context, screenshots, or information about the PR here -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,10 +33,13 @@ jobs:
       - name: Build for iOS Simulator
         run: |
           echo "Building for iOS Simulator..."
-          swift build --product FluidAudio \
-            --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) \
-            --triple arm64-apple-ios16.0-simulator \
-            -Xswiftc -target -Xswiftc arm64-apple-ios16.0-simulator
+          # List available simulators first
+          xcrun simctl list devices available | head -20
+          # Build for generic iOS Simulator
+          xcodebuild -scheme FluidAudio \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath .build/ios-simulator \
+            build
       
       - name: Clean build artifacts
         run: rm -rf .build .swiftpm
@@ -44,10 +47,10 @@ jobs:
       - name: Build for iOS Device
         run: |
           echo "Building for iOS Device..."
-          swift build --product FluidAudio \
-            --sdk $(xcrun --sdk iphoneos --show-sdk-path) \
-            --triple arm64-apple-ios16.0 \
-            -Xswiftc -target -Xswiftc arm64-apple-ios16.0
+          xcodebuild -scheme FluidAudio \
+            -destination 'generic/platform=iOS' \
+            -derivedDataPath .build/ios-device \
+            build
 
   build-and-test-macos:
     name: Build and Test Swift Package (macOS)
@@ -103,24 +106,14 @@ jobs:
         run: |
           rm -rf .swiftpm .build
 
-      - name: Build iOS library using Swift PM (simulator)
+      - name: Build iOS library using xcodebuild (simulator)
         run: |
           set -e
-          echo "Building FluidAudio library for iOS Simulator using Swift Package Manager..."
-          swift build --product FluidAudio \
-            --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) \
-            --triple arm64-apple-ios16.0-simulator \
-            -Xswiftc -target -Xswiftc arm64-apple-ios16.0-simulator
-
-      - name: Clean up build artifacts
-        run: |
-          rm -rf .swiftpm .build
-
-      - name: Build iOS library (simulator with xcodebuild)
-        run: |
-          set -e
-          echo "Building FluidAudio library for iOS Simulator with xcodebuild..."
-          xcodebuild -scheme FluidAudio -destination 'platform=iOS Simulator,name=Any iOS Simulator Device' build
+          echo "Building FluidAudio library for iOS Simulator using xcodebuild..."
+          xcodebuild -scheme FluidAudio \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath .build/ios-simulator \
+            build
 
       - name: Clean up build artifacts
         run: |
@@ -130,4 +123,4 @@ jobs:
         run: |
           set -e
           echo "Building FluidAudio library for iOS Device..."
-          xcodebuild -scheme FluidAudio -destination 'platform=iOS,name=Any iOS Device' build
+          xcodebuild -scheme FluidAudio -destination 'generic/platform=iOS' build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,7 +107,8 @@ jobs:
         run: |
           set -e
           echo "Building FluidAudio library for iOS Simulator using Swift Package Manager..."
-          swift build --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) \
+          swift build --product FluidAudio \
+            --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) \
             --triple arm64-apple-ios16.0-simulator \
             -Xswiftc -target -Xswiftc arm64-apple-ios16.0-simulator
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  cross-platform-build:
+    name: Cross-Platform Build Check
+    runs-on: macos-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Check Swift version
+        run: swift --version
+      
+      - name: Build for macOS
+        run: |
+          echo "Building for macOS..."
+          swift build --product FluidAudio
+      
+      - name: Clean build artifacts
+        run: rm -rf .build .swiftpm
+      
+      - name: Build for iOS Simulator
+        run: |
+          echo "Building for iOS Simulator..."
+          swift build --product FluidAudio \
+            --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) \
+            --triple arm64-apple-ios16.0-simulator \
+            -Xswiftc -target -Xswiftc arm64-apple-ios16.0-simulator
+      
+      - name: Clean build artifacts
+        run: rm -rf .build .swiftpm
+      
+      - name: Build for iOS Device
+        run: |
+          echo "Building for iOS Device..."
+          swift build --product FluidAudio \
+            --sdk $(xcrun --sdk iphoneos --show-sdk-path) \
+            --triple arm64-apple-ios16.0 \
+            -Xswiftc -target -Xswiftc arm64-apple-ios16.0
+
   build-and-test-macos:
     name: Build and Test Swift Package (macOS)
     runs-on: macos-latest
@@ -65,10 +103,22 @@ jobs:
         run: |
           rm -rf .swiftpm .build
 
-      - name: Build iOS library (simulator)
+      - name: Build iOS library using Swift PM (simulator)
         run: |
           set -e
-          echo "Building FluidAudio library for iOS Simulator..."
+          echo "Building FluidAudio library for iOS Simulator using Swift Package Manager..."
+          swift build --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) \
+            --triple arm64-apple-ios16.0-simulator \
+            -Xswiftc -target -Xswiftc arm64-apple-ios16.0-simulator
+
+      - name: Clean up build artifacts
+        run: |
+          rm -rf .swiftpm .build
+
+      - name: Build iOS library (simulator with xcodebuild)
+        run: |
+          set -e
+          echo "Building FluidAudio library for iOS Simulator with xcodebuild..."
           xcodebuild -scheme FluidAudio -destination 'platform=iOS Simulator,name=Any iOS Simulator Device' build
 
       - name: Clean up build artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# FluidAudio - Agent Development Guide
+
+## Build & Test Commands
+```bash
+swift build                                    # Build project
+swift build -c release                        # Release build
+swift test                                     # Run all tests
+swift test --filter CITests                   # Run single test class
+swift test --filter CITests.testPackageImports # Run single test method
+swift format --in-place --recursive --configuration .swift-format Sources/ Tests/
+```
+
+## Critical Rules
+- **NEVER** use `@unchecked Sendable` - implement proper thread safety with actors/MainActor
+- **NEVER** create dummy/mock models or synthetic audio data - use real models only
+- **NEVER** create simplified versions - implement full solutions or consult first
+
+## Code Style (swift-format config)
+- Line length: 120 chars, 4-space indentation
+- Import order: `import CoreML`, `import Foundation`, `import OSLog` (OrderedImports rule)
+- Naming: lowerCamelCase for variables/functions, UpperCamelCase for types
+- Error handling: Use proper Swift error handling, no force unwrapping in production
+- Documentation: Triple-slash comments (`///`) for public APIs
+- Thread safety: Use actors, `@MainActor`, or proper locking - never `@unchecked Sendable`

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -19,6 +19,7 @@ public class DownloadUtils {
     }()
 
     private static func configureProxySettings() -> [String: Any]? {
+        #if os(macOS)
         var proxyConfig: [String: Any] = [:]
         var hasProxyConfig = false
 
@@ -39,9 +40,14 @@ public class DownloadUtils {
         }
 
         return hasProxyConfig ? proxyConfig : nil
+        #else
+        // Proxy configuration not available on iOS
+        return nil
+        #endif
     }
 
     private static func parseProxyURL(_ proxyURLString: String, type: String) -> [String: Any]? {
+        #if os(macOS)
         guard let proxyURL = URL(string: proxyURLString),
             let host = proxyURL.host,
             let port = proxyURL.port
@@ -70,6 +76,10 @@ public class DownloadUtils {
 
         logger.info("Configured \(type) proxy: \(host):\(port)")
         return config
+        #else
+        // Proxy configuration not available on iOS
+        return nil
+        #endif
     }
 
     /// Download progress callback

--- a/Sources/FluidAudioCLI/Commands/AsrBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/AsrBenchmark.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import AVFoundation
 import FluidAudio
 import OSLog
@@ -902,3 +903,4 @@ extension ASRBenchmark {
         )
     }
 }
+#endif

--- a/Sources/FluidAudioCLI/Commands/AsrBenchmarkTypes.swift
+++ b/Sources/FluidAudioCLI/Commands/AsrBenchmarkTypes.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  AsrBenchmarkTypes.swift
 //  FluidAudio
@@ -129,3 +130,4 @@ public struct LibriSpeechFile {
     public let audioPath: URL
     public let transcript: String
 }
+#endif

--- a/Sources/FluidAudioCLI/Commands/DiarizationBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/DiarizationBenchmark.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import AVFoundation
 import FluidAudio
 import Foundation
@@ -1088,3 +1089,4 @@ enum StreamDiarizationBenchmark {
         }
     }
 }
+#endif

--- a/Sources/FluidAudioCLI/Commands/DownloadCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/DownloadCommand.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import FluidAudio
 import Foundation
 
@@ -126,3 +127,4 @@ enum DownloadCommand {
         )
     }
 }
+#endif

--- a/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 import AVFoundation
 import FluidAudio
 
@@ -117,3 +118,4 @@ enum ProcessCommand {
         )
     }
 }
+#endif


### PR DESCRIPTION
## Description

### Why is this change needed?
[breaks builds for iOS](https://github.com/FluidInference/FluidAudio/issues/74)

### What does this change do?
Only build the proxy components for macOS, not iOS 