### PR TITLE
Migrate ANE optimizer away from singelton

### DIFF
--- a/FluidAudio.podspec
+++ b/FluidAudio.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "FluidAudio"
-  spec.version      = "0.4.1"
+  spec.version      = "0.5.0"
   spec.summary      = "Speaker diarization, voice-activity-detection and transcription with CoreML"
   spec.description  = <<-DESC
                        Fluid Audio is a Swift SDK for fully local, low-latency audio AI on Apple devices,

--- a/Sources/FluidAudio/Diarizer/DiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/DiarizerManager.swift
@@ -17,7 +17,7 @@ public final class DiarizerManager {
     public let segmentationProcessor = SegmentationProcessor()
     public var embeddingExtractor: EmbeddingExtractor?
     private let audioValidation = AudioValidation()
-    private let memoryOptimizer = ANEMemoryOptimizer.shared
+    private let memoryOptimizer = ANEMemoryOptimizer()
 
     // Speaker manager for consistent speaker tracking
     public let speakerManager: SpeakerManager

--- a/Sources/FluidAudio/Diarizer/EmbeddingExtractor.swift
+++ b/Sources/FluidAudio/Diarizer/EmbeddingExtractor.swift
@@ -7,7 +7,7 @@ import OSLog
 public class EmbeddingExtractor {
     private let wespeakerModel: MLModel
     private let logger = AppLogger(category: "EmbeddingExtractor")
-    private let memoryOptimizer = ANEMemoryOptimizer.shared
+    private let memoryOptimizer = ANEMemoryOptimizer()
 
     // Pre-allocated ANE-aligned buffers
     private var waveformBuffer: MLMultiArray?

--- a/Sources/FluidAudio/Diarizer/SegmentationProcessor.swift
+++ b/Sources/FluidAudio/Diarizer/SegmentationProcessor.swift
@@ -8,7 +8,7 @@ import OSLog
 public struct SegmentationProcessor {
 
     private let logger = AppLogger(category: "Segmentation")
-    private let memoryOptimizer = ANEMemoryOptimizer.shared
+    private let memoryOptimizer = ANEMemoryOptimizer()
 
     public init() {}
 

--- a/Sources/FluidAudio/Shared/ANEMemoryOptimizer.swift
+++ b/Sources/FluidAudio/Shared/ANEMemoryOptimizer.swift
@@ -5,18 +5,15 @@ import Metal
 
 /// ANE-optimized memory management for speaker diarization pipeline
 @available(macOS 13.0, iOS 16.0, *)
-public class ANEMemoryOptimizer {
+public final class ANEMemoryOptimizer {
     // Use shared ANE constants
     public static let aneAlignment = ANEMemoryUtils.aneAlignment
     public static let aneTileSize = ANEMemoryUtils.aneTileSize
 
-    /// Shared instance for resource management
-    public static let shared = ANEMemoryOptimizer()
-
     private var bufferPool: [String: MLMultiArray] = [:]
     private let bufferLock = NSLock()
 
-    private init() {}
+    public init() {}
 
     /// Create ANE-aligned MLMultiArray with optimized memory layout
     public func createAlignedArray(

--- a/Sources/FluidAudioCLI/Commands/VadBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/VadBenchmark.swift
@@ -411,6 +411,7 @@ struct VadBenchmark {
     ) async throws -> VadBenchmarkResult {
         logger.info("Running VAD benchmark on \(testFiles.count) files...")
 
+        let memoryOptimizer = ANEMemoryOptimizer()
         let startTime = Date()
         var predictions: [Int] = []
         var groundTruth: [Int] = []
@@ -472,7 +473,7 @@ struct VadBenchmark {
 
             // Periodic buffer pool cleanup every 10 files to prevent ANE memory buildup
             if (index + 1) % 10 == 0 {
-                ANEMemoryOptimizer.shared.clearBufferPool()
+                memoryOptimizer.clearBufferPool()
             }
         }
 

--- a/Tests/FluidAudioTests/ANEMemoryOptimizerTests.swift
+++ b/Tests/FluidAudioTests/ANEMemoryOptimizerTests.swift
@@ -10,7 +10,7 @@ final class ANEMemoryOptimizerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        optimizer = ANEMemoryOptimizer.shared
+        optimizer = ANEMemoryOptimizer()
     }
 
     override func tearDown() {

--- a/Tests/FluidAudioTests/ArraySliceTests.swift
+++ b/Tests/FluidAudioTests/ArraySliceTests.swift
@@ -61,7 +61,7 @@ final class ArraySliceTests: XCTestCase {
     }
 
     func testANEMemoryOptimizerWithArraySlice() throws {
-        let optimizer = ANEMemoryOptimizer.shared
+        let optimizer = ANEMemoryOptimizer()
 
         // Create test data
         let fullArray = [Float](repeating: 0.5, count: 1000)

--- a/Tests/FluidAudioTests/DiarizerMemoryTests.swift
+++ b/Tests/FluidAudioTests/DiarizerMemoryTests.swift
@@ -13,7 +13,7 @@ final class DiarizerMemoryTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        optimizer = ANEMemoryOptimizer.shared
+        optimizer = ANEMemoryOptimizer()
         config = DiarizerConfig()
         segmentationProcessor = SegmentationProcessor()
     }

--- a/Tests/FluidAudioTests/EmbeddingExtractorMemoryTests.swift
+++ b/Tests/FluidAudioTests/EmbeddingExtractorMemoryTests.swift
@@ -18,7 +18,7 @@ final class EmbeddingExtractorMemoryTests: XCTestCase {
 
     func testANEBufferAlignment() throws {
         // Test that buffers created for embedding extraction are ANE-aligned
-        let optimizer = ANEMemoryOptimizer.shared
+        let optimizer = ANEMemoryOptimizer()
 
         // Test waveform buffer creation
         let waveformBuffer = try optimizer.createAlignedArray(
@@ -44,7 +44,7 @@ final class EmbeddingExtractorMemoryTests: XCTestCase {
     }
 
     func testBufferPoolingForMasks() throws {
-        let optimizer = ANEMemoryOptimizer.shared
+        let optimizer = ANEMemoryOptimizer()
 
         // Test that mask buffers of different sizes are pooled correctly
         let sizes = [100, 500, 1000, 2000]
@@ -74,7 +74,7 @@ final class EmbeddingExtractorMemoryTests: XCTestCase {
     }
 
     func testMemoryStressWithMultipleMasks() throws {
-        let optimizer = ANEMemoryOptimizer.shared
+        let optimizer = ANEMemoryOptimizer()
 
         // Simulate processing many speakers with different mask sizes
         autoreleasepool {
@@ -105,7 +105,7 @@ final class EmbeddingExtractorMemoryTests: XCTestCase {
     }
 
     func testZeroCopyFeatureProvider() throws {
-        let optimizer = ANEMemoryOptimizer.shared
+        let optimizer = ANEMemoryOptimizer()
 
         // Create aligned buffers
         let waveformBuffer = try optimizer.createAlignedArray(
@@ -152,7 +152,7 @@ final class EmbeddingExtractorMemoryTests: XCTestCase {
     }
 
     func testConcurrentBufferAccess() {
-        let optimizer = ANEMemoryOptimizer.shared
+        let optimizer = ANEMemoryOptimizer()
         let expectation = XCTestExpectation(description: "Concurrent access")
         expectation.expectedFulfillmentCount = 10
 

--- a/Tests/FluidAudioTests/RandomAccessCollectionTests.swift
+++ b/Tests/FluidAudioTests/RandomAccessCollectionTests.swift
@@ -143,7 +143,7 @@ final class RandomAccessCollectionTests: XCTestCase {
     // MARK: - ANEMemoryOptimizer Tests
 
     func testANEOptimizerWithContiguousArray() throws {
-        let optimizer = ANEMemoryOptimizer.shared
+        let optimizer = ANEMemoryOptimizer()
 
         let audio = ContiguousArray<Float>(repeating: 0.5, count: 1000)
         let destination = try optimizer.createAlignedArray(
@@ -159,7 +159,7 @@ final class RandomAccessCollectionTests: XCTestCase {
     }
 
     func testANEOptimizerWithCustomCollection() throws {
-        let optimizer = ANEMemoryOptimizer.shared
+        let optimizer = ANEMemoryOptimizer()
 
         let audioData = [Float](repeating: 0.3, count: 500)
         let customBuffer = CustomAudioBuffer(audioData)
@@ -177,7 +177,7 @@ final class RandomAccessCollectionTests: XCTestCase {
     }
 
     func testANEOptimizerWithLazyCollection() throws {
-        let optimizer = ANEMemoryOptimizer.shared
+        let optimizer = ANEMemoryOptimizer()
 
         // Lazy collection that transforms values
         let baseData = [Float](repeating: 0.25, count: 100)

--- a/Tests/FluidAudioTests/SegmentationProcessorEdgeCaseTests.swift
+++ b/Tests/FluidAudioTests/SegmentationProcessorEdgeCaseTests.swift
@@ -15,7 +15,7 @@ final class SegmentationProcessorEdgeCaseTests: XCTestCase {
 
     override func tearDown() {
         processor = nil
-        ANEMemoryOptimizer.shared.clearBufferPool()
+        ANEMemoryOptimizer().clearBufferPool()
         super.tearDown()
     }
 


### PR DESCRIPTION
### Why is this change needed?
<!-- Explain the motivation for this change. What problem does it solve? -->

Preparing for Swift 6 migration, singletons are generally not recommended 