### PR TITLE
Add logs for ASR loading and compiling time for better tracking

### DIFF
--- a/Sources/FluidAudio/ASR/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/AsrManager.swift
@@ -177,7 +177,15 @@ public final class AsrManager {
         configuration: MLModelConfiguration
     ) async throws -> MLModel {
         do {
-            return try MLModel(contentsOf: path, configuration: configuration)
+            // Log host environment information once per process
+            await SystemInfo.logOnce(using: logger)
+            // Measure Core ML model initialization time for ASR components
+            let start = Date()
+            let model = try MLModel(contentsOf: path, configuration: configuration)
+            let elapsed = Date().timeIntervalSince(start) * 1000
+            let formatted = String(format: "%.2f", elapsed)
+            logger.info("Compiled ASR model \(name) in \(formatted) ms")
+            return model
         } catch {
             logger.error("Failed to load \(name) model: \(error)")
 

--- a/Sources/FluidAudio/ASR/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/AsrManager.swift
@@ -177,14 +177,7 @@ public final class AsrManager {
         configuration: MLModelConfiguration
     ) async throws -> MLModel {
         do {
-            // Log host environment information once per process
-            await SystemInfo.logOnce(using: logger)
-            // Measure Core ML model initialization time for ASR components
-            let start = Date()
             let model = try MLModel(contentsOf: path, configuration: configuration)
-            let elapsed = Date().timeIntervalSince(start) * 1000
-            let formatted = String(format: "%.2f", elapsed)
-            logger.info("Compiled ASR model \(name) in \(formatted) ms")
             return model
         } catch {
             logger.error("Failed to load \(name) model: \(error)")

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -153,8 +153,6 @@ public class DownloadUtils {
 
         // Load each model
         var models: [String: MLModel] = [:]
-        // Log host environment once per process (use local logger category)
-        await SystemInfo.logOnce(using: logger)
         for name in modelNames {
             let modelPath = repoPath.appendingPathComponent(name)
             guard FileManager.default.fileExists(atPath: modelPath.path) else {

--- a/Sources/FluidAudio/Shared/SystemInfo.swift
+++ b/Sources/FluidAudio/Shared/SystemInfo.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OSLog
+
 #if canImport(Darwin)
 import Darwin
 #endif
@@ -42,7 +43,8 @@ public enum SystemInfo {
         }()
 
         // Chip / CPU brand if available
-        let chip = sysctlString("machdep.cpu.brand_string")
+        let chip =
+            sysctlString("machdep.cpu.brand_string")
             ?? sysctlString("hw.model")
             ?? "UnknownChip"
 
@@ -55,7 +57,8 @@ public enum SystemInfo {
         // Rosetta translation status (best-effort)
         let translated = isRunningTranslated()
 
-        return "\(osName) \(osVersionString), arch=\(arch), chip=\(chip), cores=\(coresActive)/\(coresTotal), mem=\(mem), rosetta=\(translated)"
+        return
+            "\(osName) \(osVersionString), arch=\(arch), chip=\(chip), cores=\(coresActive)/\(coresTotal), mem=\(mem), rosetta=\(translated)"
     }
 
     /// Logs the environment exactly once per process using the provided logger.

--- a/Sources/FluidAudio/Shared/SystemInfo.swift
+++ b/Sources/FluidAudio/Shared/SystemInfo.swift
@@ -1,0 +1,108 @@
+import Foundation
+import OSLog
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// System information utilities and one-time environment reporting.
+public enum SystemInfo {
+    /// Collects a concise set of host and OS details.
+    public static func summary() -> String {
+        let pinfo = ProcessInfo.processInfo
+
+        // OS name by platform
+        #if os(macOS)
+        let osName = "macOS"
+        #elseif os(iOS)
+        let osName = "iOS"
+        #elseif os(tvOS)
+        let osName = "tvOS"
+        #elseif os(watchOS)
+        let osName = "watchOS"
+        #else
+        let osName = "UnknownOS"
+        #endif
+
+        // Version (human-readable string typically includes build)
+        let osVersionString = pinfo.operatingSystemVersionString
+
+        // Architecture (compile-time slice used at runtime)
+        let arch: String = {
+            #if arch(arm64)
+            return "arm64"
+            #elseif arch(x86_64)
+            return "x86_64"
+            #elseif arch(arm)
+            return "arm"
+            #elseif arch(i386)
+            return "i386"
+            #else
+            return "unknown"
+            #endif
+        }()
+
+        // Chip / CPU brand if available
+        let chip = sysctlString("machdep.cpu.brand_string")
+            ?? sysctlString("hw.model")
+            ?? "UnknownChip"
+
+        // CPU and memory
+        let coresTotal = pinfo.processorCount
+        let coresActive = pinfo.activeProcessorCount
+        let memBytes = pinfo.physicalMemory
+        let mem = ByteCountFormatter.string(fromByteCount: Int64(memBytes), countStyle: .binary)
+
+        // Rosetta translation status (best-effort)
+        let translated = isRunningTranslated()
+
+        return "\(osName) \(osVersionString), arch=\(arch), chip=\(chip), cores=\(coresActive)/\(coresTotal), mem=\(mem), rosetta=\(translated)"
+    }
+
+    /// Logs the environment exactly once per process using the provided logger.
+    public static func logOnce(using logger: AppLogger) async {
+        await SystemInfoReporter.shared.logIfNeeded(logger: logger)
+    }
+
+    // MARK: - Private helpers
+
+    private static func sysctlString(_ key: String) -> String? {
+        #if canImport(Darwin)
+        var size: size_t = 0
+        guard sysctlbyname(key, nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [CChar](repeating: 0, count: Int(size))
+        let result = buffer.withUnsafeMutableBufferPointer { ptr in
+            sysctlbyname(key, ptr.baseAddress, &size, nil, 0)
+        }
+        guard result == 0 else { return nil }
+        return String(cString: buffer)
+        #else
+        return nil
+        #endif
+    }
+
+    private static func isRunningTranslated() -> Bool {
+        #if canImport(Darwin)
+        if #available(macOS 11.0, *) {
+            var translated: Int32 = 0
+            var size = MemoryLayout<Int32>.size
+            if sysctlbyname("sysctl.proc_translated", &translated, &size, nil, 0) == 0 {
+                return translated == 1
+            }
+        }
+        #endif
+        return false
+    }
+}
+
+// MARK: - One-time reporter
+
+actor SystemInfoReporter {
+    static let shared = SystemInfoReporter()
+    private var didLog = false
+
+    func logIfNeeded(logger: AppLogger) {
+        guard !didLog else { return }
+        didLog = true
+        logger.info("Host environment: \(SystemInfo.summary())")
+    }
+}

--- a/Sources/FluidAudioCLI/main.swift
+++ b/Sources/FluidAudioCLI/main.swift
@@ -57,6 +57,11 @@ guard arguments.count > 1 else {
 // Mirror OSLog messages to console when running CLI
 AppLogger.enableConsoleOutput(true)
 
+// Log system information once at application startup
+Task {
+    await SystemInfo.logOnce(using: cliLogger)
+}
+
 let command = arguments[1]
 let semaphore = DispatchSemaphore(value: 0)
 


### PR DESCRIPTION
### Why is this change needed?
<!-- Explain the motivation for this change. What problem does it solve? -->

Better way of tracking, note that we should also need mobius compare script to track the first time compare, just tracking later ones isn't too helpful 

```swift
[21:15:38.521] [INFO] [DownloadUtils] Found parakeet-tdt-0.6b-v3-coreml locally, no download needed
[21:15:38.521] [INFO] [DownloadUtils] Host environment: macOS Version 26.0 (Build 25A5338b), arch=arm64, chip=Apple M4 Pro, cores=12/12, mem=48 GB, rosetta=false
[21:15:38.608] [INFO] [DownloadUtils] Loaded model: MelEncoder.mlmodelc
[21:15:38.608] [INFO] [DownloadUtils] Compiled ASR model MelEncoder.mlmodelc in 86.63 ms
[21:15:38.608] [INFO] [AsrModels] Loaded MelEncoder.mlmodelc with compute units: MLComputeUnits(rawValue: 3)
[21:15:38.608] [INFO] [DownloadUtils] Found parakeet-tdt-0.6b-v3-coreml locally, no download needed
[21:15:38.615] [INFO] [DownloadUtils] Loaded model: Decoder.mlmodelc
[21:15:38.615] [INFO] [DownloadUtils] Compiled ASR model Decoder.mlmodelc in 6.55 ms
[21:15:38.615] [INFO] [AsrModels] Loaded Decoder.mlmodelc with compute units: MLComputeUnits(rawValue: 3)
[21:15:38.615] [INFO] [DownloadUtils] Found parakeet-tdt-0.6b-v3-coreml locally, no download needed
[21:15:38.621] [INFO] [DownloadUtils] Loaded model: JointDecision.mlmodelc
[21:15:38.621] [INFO] [AsrModels] Loaded JointDecision.mlmodelc with compute units: MLComputeUnits(rawValue: 3)
[21:15:38.621] [INFO] [DownloadUtils] Compiled ASR model JointDecision.mlmodelc in 5.50 ms
[21:15:38.625] [INFO] [AsrModels] Loaded vocabulary with 8192 tokens from /Users/brandonweng/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml/parakeet_v3_vocab.json
[21:15:38.625] [INFO] [AsrModels] Successfully loaded all ASR models with optimized compute units
[21:15:38.626] [INFO] [ASR] Initializing AsrManager with provided models
[21:15:38.626] [INFO] [ASR] Token duration optimization model loaded successfully
[21:15:38.626] [INFO] [ASR] AsrManager initialized successfully with provided models
[21:15:38.626] [INFO] [Transcribe] ASR Manager initialized successfully
[21:15:38.626] [INFO] [MLArrayCache] Pre-warming cache with 3 shapes
[21:15:38.650] [DEBUG] [AudioConverter] Audio conversion: 14215676 samples → 4738559 samples, ratio: 0.3333333567816261
[21:15:38.651] [INFO] [Transcribe] Processing 296.16s of audio (4738559 samples)
```