### PR TITLE
Use independent Melspec and Encoder models for iPhones 

### DIFF
--- a/Sources/FluidAudio/ASR/ANEOptimizer.swift
+++ b/Sources/FluidAudio/ASR/ANEOptimizer.swift
@@ -43,8 +43,12 @@ public enum ANEOptimizer {
 
     /// Configure optimal compute units for each model type
     public static func optimalComputeUnits(for modelType: ModelType) -> MLComputeUnits {
-        // Testing shows CPU+ANE is fastest for all models, including fused mel encoder
-        return .cpuAndNeuralEngine
+        #if os(iOS)
+            return .cpuAndGPU
+        #else
+            // Testing shows CPU+ANE is fastest for all models on macOS, including fused mel encoder
+            return .cpuAndNeuralEngine
+        #endif
     }
 
     /// Create zero-copy memory view between models

--- a/Sources/FluidAudio/ASR/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/AsrManager.swift
@@ -15,6 +15,7 @@ public final class AsrManager {
     internal let config: ASRConfig
     private let audioConverter: AudioConverter = AudioConverter()
 
+    internal var preprocessorModel: MLModel?
     internal var melEncoderModel: MLModel?
     internal var decoderModel: MLModel?
     internal var jointModel: MLModel?
@@ -65,7 +66,17 @@ public final class AsrManager {
     }
 
     public var isAvailable: Bool {
-        return melEncoderModel != nil && decoderModel != nil && jointModel != nil
+        let baseReady = melEncoderModel != nil && decoderModel != nil && jointModel != nil
+
+        if let asrModels, asrModels.usesSplitFrontend {
+            return baseReady && preprocessorModel != nil
+        }
+
+        if preprocessorModel != nil {
+            return baseReady
+        }
+
+        return baseReady
     }
 
     /// Initialize ASR Manager with pre-loaded models
@@ -74,6 +85,7 @@ public final class AsrManager {
         logger.info("Initializing AsrManager with provided models")
 
         self.asrModels = models
+        self.preprocessorModel = models.preprocessor
         self.melEncoderModel = models.melEncoder
         self.decoderModel = models.decoder
         self.jointModel = models.joint
@@ -219,6 +231,7 @@ public final class AsrManager {
     }
 
     public func cleanup() {
+        preprocessorModel = nil
         melEncoderModel = nil
         decoderModel = nil
         jointModel = nil

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -32,19 +32,32 @@ public enum ModelNames {
     /// ASR model names
     public enum ASR {
         public static let melEncoder = "MelEncoder"
+        public static let preprocessor = "Preprocessor"
+        public static let encoder = "Encoder"
         public static let decoder = "Decoder"
         public static let joint = "JointDecision"
         public static let vocabulary = "parakeet_v3_vocab.json"
 
         public static let melEncoderFile = melEncoder + ".mlmodelc"
+        public static let preprocessorFile = preprocessor + ".mlmodelc"
+        public static let encoderFile = encoder + ".mlmodelc"
         public static let decoderFile = decoder + ".mlmodelc"
         public static let jointFile = joint + ".mlmodelc"
 
-        public static let requiredModels: Set<String> = [
-            melEncoderFile,
-            decoderFile,
-            jointFile,
-        ]
+        #if os(iOS)
+            public static let requiredModels: Set<String> = [
+                preprocessorFile,
+                encoderFile,
+                decoderFile,
+                jointFile,
+            ]
+        #else
+            public static let requiredModels: Set<String> = [
+                melEncoderFile,
+                decoderFile,
+                jointFile,
+            ]
+        #endif
     }
 
     /// VAD model names


### PR DESCRIPTION
### Why is this change needed?
Compile time Metrics on iPhone 16 Pro Max:

Before, 20,000ms (5mins+) to compile encoder and processor

```
Updating content for activity 34DE0CCF-64A6-455F-BE25-20AFCB9CFDC4
Updating content for activity 34DE0CCF-64A6-455F-BE25-20AFCB9CFDC4
Loaded model: MelEncoder.mlmodelc
Compiled ASR model MelEncoder.mlmodelc in 20018.84 ms
Updating content for activity 34DE0CCF-64A6-455F-BE25-20AFCB9CFDC4
Loaded model: Decoder.mlmodelc
Compiled ASR model Decoder.mlmodelc in 116.61 ms
Loaded model: JointDecision.mlmodelc
Compiled ASR model JointDecision.mlmodelc in 122.83 ms
Successfully downloaded ASR models
```

After: 
```
Loaded model: Encoder.mlmodelc
Compiled ASR model Encoder.mlmodelc in 3361.23 ms
Found parakeet-tdt-0.6b-v3-coreml locally, no download needed
Updating content for activity 18AB8F87-3186-4EE1-BE7D-C2F5893E29E6
Loaded model: Decoder.mlmodelc
Compiled ASR model Decoder.mlmodelc in 88.49 ms
Found parakeet-tdt-0.6b-v3-coreml locally, no download needed
Loaded model: JointDecision.mlmodelc
Compiled ASR model JointDecision.mlmodelc in 48.46 ms
Successfully downloaded ASR models
Loading ASR models from: /var/mobile/Containers/Data/Application/94B9177E-C7FC-465C-82E9-7BF21F0F971A/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml
Found parakeet-tdt-0.6b-v3-coreml locally, no download needed
Loaded model: Preprocessor.mlmodelc
Compiled ASR model Preprocessor.mlmodelc in 9.15 ms
Loaded Preprocessor.mlmodelc with compute units: MLComputeUnits(rawValue: 2)
Found parakeet-tdt-0.6b-v3-coreml locally, no download needed
Loaded model: Encoder.mlmodelc
Compiled ASR model Encoder.mlmodelc in 162.05 ms
Loaded Encoder.mlmodelc with compute units: MLComputeUnits(rawValue: 1)
Found parakeet-tdt-0.6b-v3-coreml locally, no download needed
Loaded model: Decoder.mlmodelc
Compiled ASR model Decoder.mlmodelc in 8.11 ms
Loaded Decoder.mlmodelc with compute units: MLComputeUnits(rawValue: 1)
Found parakeet-tdt-0.6b-v3-coreml locally, no download needed
Loaded model: JointDecision.mlmodelc
Compiled ASR model JointDecision.mlmodelc in 7.97 ms
Loaded JointDecision.mlmodelc with compute units: MLComputeUnits(rawValue: 1)
Loaded vocabulary with 8192 tokens from /var/mobile/Containers/Data/Application/94B9177E-C7FC-465C-82E9-7BF21F0F971A/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml/parakeet_v3_vocab.json
Successfully loaded all ASR models with optimized compute units
Initializing AsrManager with provided models
Token duration optimization model loaded successfully

```