### PR TITLE
Simplify and enhance debug logs with timestamp and service prefix

### DIFF
--- a/Sources/FluidAudio/Shared/AppLogger.swift
+++ b/Sources/FluidAudio/Shared/AppLogger.swift
@@ -35,10 +35,6 @@ public struct AppLogger {
 
     // MARK: - Public API
 
-    public static func enableConsoleOutput(_ enabled: Bool = true, minimumLevel: Level = .debug) {
-        Task { await LogConsole.shared.update(enabled: enabled, minimumLevel: minimumLevel) }
-    }
-
     public func debug(_ message: String) {
         log(.debug, message)
     }
@@ -97,37 +93,15 @@ public struct AppLogger {
 actor LogConsole {
     static let shared = LogConsole()
 
-    private var enabled: Bool = {
-        #if DEBUG
-        // Enable console output for debug builds by default
-        return true
-        #else
-        // Allow environment variable to toggle without code changes for non-debug builds
-        if let env = ProcessInfo.processInfo.environment["FLUIDAUDIO_LOG_TO_CONSOLE"],
-            env == "1" || env.lowercased() == "true"
-        {
-            return true
-        }
-        return false
-        #endif
-    }()
-
-    private var minimumLevel: AppLogger.Level = .info
     private let dateFormatter: DateFormatter = {
         let df = DateFormatter()
         df.dateFormat = "HH:mm:ss.SSS"
         return df
     }()
 
-    func update(enabled: Bool, minimumLevel: AppLogger.Level) {
-        self.enabled = enabled
-        self.minimumLevel = minimumLevel
-    }
-
     func write(level: AppLogger.Level, category: String, message: String) {
-        guard enabled, level.rawValue >= minimumLevel.rawValue else { return }
         let timestamp = dateFormatter.string(from: Date())
-        let line = "[\(timestamp)] [\(label(for: level))] [\(category)] \(message)\n"
+        let line = "[\(timestamp)] [\(label(for: level))] [FluidAudio.\(category)] \(message)\n"
         if let data = line.data(using: .utf8) {
             FileHandle.standardError.write(data)
         }

--- a/Sources/FluidAudioCLI/main.swift
+++ b/Sources/FluidAudioCLI/main.swift
@@ -54,8 +54,7 @@ guard arguments.count > 1 else {
     exit(1)
 }
 
-// Mirror OSLog messages to console when running CLI
-AppLogger.enableConsoleOutput(true)
+// Debug builds automatically mirror OSLog messages to console
 
 // Log system information once at application startup
 Task {


### PR DESCRIPTION
### Why is this change needed?
<!-- Explain the motivation for this change. What problem does it solve? -->

Logs from Xcode:

Before
```
Pre-warming cache with 3 shapes
ASR models already present at: /var/mobile/Containers/Data/Application/63ADC44D-9106-4C33-BAD7-A660BDA2AA5A/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml
Loading ASR models from: /var/mobile/Containers/Data/Application/63ADC44D-9106-4C33-BAD7-A660BDA2AA5A/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml
[19:06:34.814] [INFO] [AsrModels] Downloading ASR models to: /var/mobile/Containers/Data/Application/63ADC44D-9106-4C33-BAD7-A660BDA2AA5A/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml
Host environment: iOS Version 26.0 (Build 23A341), arch=arm64, chip=D17AP, cores=6/6, mem=3.58 GB, rosetta=false
[19:06:34.817] [INFO] [MLArrayCache] Pre-warming cache with 3 shapes
[19:06:34.817] [INFO] [AsrModels] ASR models already present at: /var/mobile/Containers/Data/Application/63ADC44D-9106-4C33-BAD7-A660BDA2AA5A/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml
[19:06:34.817] [INFO] [AsrModels] Loading ASR models from: /var/mobile/Containers/Data/Application/63ADC44D-9106-4C33-BAD7-A660BDA2AA5A/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml
[19:06:34.817] [INFO] [DownloadUtils] Host environment: iOS V
```

AFter
```
[19:29:20.402] [INFO] [FluidAudio.MLArrayCache] Pre-warming cache with 3 shapes
[19:29:20.405] [INFO] [FluidAudio.AsrModels] ASR models already present at: /var/mobile/Containers/Data/Application/8F5B0F77-74D8-436C-A85A-51B7143F2CE3/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml
[19:29:20.405] [INFO] [FluidAudio.AsrModels] Loading ASR models from: /var/mobile/Containers/Data/Application/8F5B0F77-74D8-436C-A85A-51B7143F2CE3/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml
[19:29:20.405] [INFO] [FluidAudio.AsrModels] Downloading ASR models to: /var/mobile/Containers/Data/Application/8F5B0F77-74D8-436C-A85A-51B7143F2CE3/Library/Application Support/FluidAudio/Models/parakeet-tdt-0.6b-v3-coreml
[19:29:20.405] [INFO] [FluidAudio.DownloadUtils] Host environment: iOS Version 26.0 (Build 23A341), arch=arm64, chip=D17AP, cores=6/6, mem=3.58 GB, rosetta=false
[19:29:20.405] [INFO] [FluidAudio.DownloadUtils] Found parakeet-tdt-0.6b-v3-coreml locally, no download needed
```