### PR TITLE
Fix token timing for parakeet-tdt-v2

### DIFF
--- a/Sources/FluidAudio/ASR/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/AsrManager.swift
@@ -316,6 +316,10 @@ public final class AsrManager {
         }
     }
 
+    internal func normalizedTimingToken(_ token: String) -> String {
+        token.replacingOccurrences(of: "▁", with: " ")
+    }
+
     internal func convertTokensWithExistingTimings(
         _ tokenIds: [Int], timings: [TokenTiming]
     ) -> (
@@ -349,7 +353,7 @@ public final class AsrManager {
         let adjustedTimings = tokenInfos.compactMap { info in
             info.timing.map { timing in
                 TokenTiming(
-                    token: info.token.replacingOccurrences(of: "▁", with: ""),
+                    token: normalizedTimingToken(info.token),
                     tokenId: info.tokenId,
                     startTime: timing.startTime,
                     endTime: timing.endTime,

--- a/Sources/FluidAudio/ASR/AsrTranscription.swift
+++ b/Sources/FluidAudio/ASR/AsrTranscription.swift
@@ -298,8 +298,9 @@ extension AsrManager {
             // Validate that end time is after start time
             let validatedEndTime = max(endTime, startTime + 0.001)  // Minimum 1ms gap
 
-            // Get token text from vocabulary if available
-            let tokenText = vocabulary[tokenId] ?? "token_\(tokenId)"
+            // Get token text from vocabulary if available and normalize for timing display
+            let rawToken = vocabulary[tokenId] ?? "token_\(tokenId)"
+            let tokenText = normalizedTimingToken(rawToken)
 
             // Use actual confidence score from TDT decoder
             let tokenConfidence = data.confidence

--- a/Sources/FluidAudioCLI/Commands/ASR/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/TranscribeCommand.swift
@@ -185,7 +185,8 @@ enum TranscribeCommand {
                     let start = String(format: "%.3f", timing.startTime)
                     let end = String(format: "%.3f", timing.endTime)
                     let confidence = String(format: "%.3f", timing.confidence)
-                    return "[\(index)] '\(timing.token)' (id: \(timing.tokenId), start: \(start)s, end: \(end)s, conf: \(confidence))"
+                    return
+                        "[\(index)] '\(timing.token)' (id: \(timing.tokenId), start: \(start)s, end: \(end)s, conf: \(confidence))"
                 }.joined(separator: ", ")
                 logger.debug("Token timings (count: \(tokenTimings.count)): \(debugDump)")
             }

--- a/Sources/FluidAudioCLI/Commands/ASR/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/TranscribeCommand.swift
@@ -180,6 +180,16 @@ enum TranscribeCommand {
                 logger.info("  Confidence: \(String(format: "%.3f", result.confidence))")
             }
 
+            if let tokenTimings = result.tokenTimings, !tokenTimings.isEmpty {
+                let debugDump = tokenTimings.enumerated().map { index, timing in
+                    let start = String(format: "%.3f", timing.startTime)
+                    let end = String(format: "%.3f", timing.endTime)
+                    let confidence = String(format: "%.3f", timing.confidence)
+                    return "[\(index)] '\(timing.token)' (id: \(timing.tokenId), start: \(start)s, end: \(end)s, conf: \(confidence))"
+                }.joined(separator: ", ")
+                logger.debug("Token timings (count: \(tokenTimings.count)): \(debugDump)")
+            }
+
             // Cleanup
             asrManager.cleanup()
 


### PR DESCRIPTION
### Why is this change needed?
<!-- Explain the motivation for this change. What problem does it solve? -->

Before:

V3: 
`[23:59:52.122] [DEBUG] [FluidAudio.Transcribe] Token timings (count: 5): [0] ' Go' (id: 4285, start: 0.640s, end: 0.960s, conf: 0.985), [1] ' a' (id: 279, start: 0.960s, end: 1.280s, conf: 0.699), [2] 'he' (id: 388, start: 1.280s, end: 1.520s, conf: 1.000), [3] 'ad' (id: 319, start: 1.520s, end: 1.920s, conf: 1.000), [4] '.' (id: 7883, start: 1.920s, end: 2.000s, conf: 0.682)`

V2
`[00:01:05.185] [DEBUG] [FluidAudio.Transcribe] Token timings (count: 6): [0] '▁G' (id: 219, start: 0.640s, end: 0.880s, conf: 0.983), [1] 'o' (id: 822, start: 0.880s, end: 1.040s, conf: 1.000), [2] '▁a' (id: 3, start: 1.040s, end: 1.280s, conf: 0.961), [3] 'he' (id: 546, start: 1.280s, end: 1.360s, conf: 1.000), [4] 'ad' (id: 103, start: 1.360s, end: 1.520s, conf: 1.000), [5] '.' (id: 841, start: 1.520s, end: 1.600s, conf: 0.951)`

After:

v3:
`[00:02:42.981] [DEBUG] [FluidAudio.Transcribe] Token timings (count: 5): [0] ' Go' (id: 4285, start: 0.640s, end: 0.960s, conf: 0.985), [1] ' a' (id: 279, start: 0.960s, end: 1.280s, conf: 0.699), [2] 'he' (id: 388, start: 1.280s, end: 1.520s, conf: 1.000), [3] 'ad' (id: 319, start: 1.520s, end: 1.920s, conf: 1.000), [4] '.' (id: 7883, start: 1.920s, end: 2.000s, conf: 0.682)`


V2:
`[00:03:33.396] [DEBUG] [FluidAudio.Transcribe] Token timings (count: 6): [0] ' G' (id: 219, start: 0.640s, end: 0.880s, conf: 0.983), [1] 'o' (id: 822, start: 0.880s, end: 1.040s, conf: 1.000), [2] ' a' (id: 3, start: 1.040s, end: 1.280s, conf: 0.961), [3] 'he' (id: 546, start: 1.280s, end: 1.360s, conf: 1.000), [4] 'ad' (id: 103, start: 1.360s, end: 1.520s, conf: 1.000), [5] '.' (id: 841, start: 1.520s, end: 1.600s, conf: 0.951)`