### PR TITLE
Memory leak in deallocator for ANE

### DIFF
--- a/Sources/FluidAudio/Shared/ANEMemoryUtils.swift
+++ b/Sources/FluidAudio/Shared/ANEMemoryUtils.swift
@@ -1,5 +1,6 @@
 import Accelerate
 import CoreML
+import Darwin
 import Foundation
 import Metal
 
@@ -66,7 +67,8 @@ public enum ANEMemoryUtils {
             dataType: dataType,
             strides: strides,
             deallocator: { bytes in
-                bytes.deallocate()
+                // `posix_memalign` requires `free` for cleanup; `deallocate()` would trap.
+                Darwin.free(bytes)
             }
         )
 


### PR DESCRIPTION
### Why is this change needed?
<!-- Explain the motivation for this change. What problem does it solve? -->

From a developer

```
"Thread 19 crashed inside objc_retain while CoreML was trying to access an MLFeatureValue / MLMultiArray during async prediction. The crash is a SIGSEGV / KERN_INVALID_ADDRESS at an address that is not mapped → classic use-after-free / accessing deallocated memory.

Load of the backtrace shows CoreML code paths (- [MLFeatureValue multiArrayValue], MLE5InputPortBinder bindMemoryObjectForFeatureValue:, MLE5ExecutionStreamOperation … prepareAsyncSubmissionForInputFeatures:) — i.e. CoreML is preparing inputs for an async execution and tried to retain an Objective-C object that was already freed.

So: you passed a feature value / multiarray to CoreML, CoreML used it asynchronously, but the Swift/ObjC object backing that data was deallocated earlier (or concurrently mutated in an unsafe way). That triggered an invalid pointer dereference when CoreML tried to retain/read it."

```