### PR TITLE
Exclude framework in the CLI build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,8 +29,8 @@ let package = Package(
                 "ESpeakNG"
             ],
             path: "Sources/FluidAudio",
-            exclude: []
-        ),
+            exclude: ["Frameworks"]
+	),
         .executableTarget(
             name: "FluidAudioCLI",
             dependencies: ["FluidAudio"],


### PR DESCRIPTION
### Why is this change needed?
<!-- Explain the motivation for this change. What problem does it solve? -->

Still able to run, just without the annoying long logs about ESSpeak 

```bash
swift run fluidaudio tts "I can't believe we finally made it to the summit after climbing for twelve exhausting hours through wind and rain, but wow, this view of the endless mountain ranges stretching to the horizon makes every single difficult step completely worth the journey." --output journey.wav
Building for debugging...
[1/1] Write swift-version--58304C5D6DBC2206.txt
Build of product 'fluidaudio' complete! (0.15s)
[11:51:20.807] [INFO] [FluidAudio.Main] Host environment: macOS Version 26.1 (Build 25B5057f), arch=arm64, chip=Apple M4 Pro, cores=12/12, mem=48 GB, rosetta=false
[11:51:20.807] [INFO] [FluidAudio.DownloadUtils] Found kokoro locally, no download needed
[11:51:21.964] [INFO] [FluidAudio.DownloadUtils] Compiled model kokoro_21_5s.mlmodelc in 1155.83 ms :: macOS Version 26.1 (Build 25B5057f), arch=arm64, chip=Apple M4 Pro, cores=12/12, mem=48 GB, rosetta=false
[11:51:23.278] [INFO] [FluidAudio.DownloadUtils] Compiled model kokoro_21_15s.mlmodelc in 1313.98 ms :: macOS Version 26.1 (Build 25B5057f), arch=arm64, chip=Apple M4 Pro, cores=12/12, mem=48 GB, rosetta=false
[11:51:23.894] [INFO] [FluidAudio.TtsModels] Warm-up completed for 5s in 0.47s
[11:51:23.894] [INFO] [FluidAudio.TtsModels] Warm-up completed for 15s in 0.61s
[11:51:23.896] [INFO] [FluidAudio.KokoroVocabulary] Loaded 114 vocabulary entries from integer map
[11:51:25.610] [INFO] [FluidAudio.KokoroSynthesizer] Loaded lexicon cache: 177676 entries
[11:51:25.660] [NOTICE] [FluidAudio.TtSManager] TtSManager initialized with provided models
[11:51:25.665] [INFO] [FluidAudio.KokoroSynthesizer] Starting synthesis: 'I can't believe we finally made it to the summit after climbing for twelve exhausting hours through wind and rain but wow this view of the endless mountain ranges stretching to the horizon makes every single difficult step completely worth the journey.'
[11:51:25.665] [INFO] [FluidAudio.KokoroSynthesizer] Input length: 252 characters
[11:51:25.665] [INFO] [FluidAudio.KokoroSynthesizer] Variant preference requested: automatic
[11:51:25.667] [INFO] [FluidAudio.EspeakG2P] Found eSpeak data at: /Users/brandonweng/code/FluidAudio-version-updates/.build/arm64-apple-macosx/debug/ESpeakNG.framework/Resources/espeak-ng-data.bundle/espeak-ng-data
[11:51:25.872] [INFO] [FluidAudio.EspeakG2P] Found eSpeak data at: /Users/brandonweng/code/FluidAudio-version-updates/.build/arm64-apple-macosx/debug/ESpeakNG.framework/Resources/espeak-ng-data.bundle/espeak-ng-data
[11:51:25.872] [INFO] [FluidAudio.EspeakG2P] Using eSpeak NG data from framework: /Users/brandonweng/code/FluidAudio-version-updates/.build/arm64-apple-macosx/debug/ESpeakNG.framework/Resources/espeak-ng-data.bundle/espeak-ng-data
[11:51:25.933] [DEBUG] [FluidAudio.KokoroSynthesizer] Tokenized 234 ids; first 32: [0, 156, 25, 16, 53, 156, 72, 56, 62, 16, 44, 83, 54, 156, 51, 64, 16, 65, 51, 16, 48, 156, 25, 56, 42, 54, 51, 16, 55, 157, 24, 46]
[11:51:25.933] [NOTICE] [FluidAudio.KokoroSynthesizer] Promoting chunk to Kokoro 15s variant: token count 234 exceeds short threshold=71 (short capacity=124, long capacity=249)
[11:51:25.933] [DEBUG] [FluidAudio.KokoroSynthesizer] Tokenized 18 ids; first 32: [0, 65, 156, 87, 123, 119, 16, 81, 51, 16, 82, 156, 87, 123, 56, 51, 4, 0]
[11:51:25.933] [INFO] [FluidAudio.KokoroSynthesizer] Text split into 2 chunks
[11:51:25.970] [DEBUG] [FluidAudio.KokoroSynthesizer] Reusing cached voice embedding: af_heart, dim=256, l2norm=2.242
[11:51:25.970] [DEBUG] [FluidAudio.KokoroSynthesizer] Reusing cached voice embedding: af_heart, dim=256, l2norm=2.242
[11:51:25.971] [INFO] [FluidAudio.KokoroSynthesizer] Starting audio inference across 2 chunk(s)
[11:51:25.971] [INFO] [FluidAudio.KokoroSynthesizer] Processing chunk 1/2: 39 words
[11:51:25.971] [INFO] [FluidAudio.KokoroSynthesizer] Chunk 1 text: 'I can't believe we finally made it to the summit after climbing for twelve exhausting hours through wind and rain but wow this view of the endless mountain ranges stretching to the horizon makes every single difficult step completely'
[11:51:25.971] [INFO] [FluidAudio.KokoroSynthesizer] Chunk 1 using Kokoro 15s model
[11:51:25.971] [INFO] [FluidAudio.KokoroSynthesizer] Processing chunk 2/2: 3 words
[11:51:25.971] [INFO] [FluidAudio.KokoroSynthesizer] Chunk 2 text: 'worth the journey.'
[11:51:25.971] [INFO] [FluidAudio.KokoroSynthesizer] Chunk 2 using Kokoro 5s model
[11:51:25.971] [DEBUG] [FluidAudio.KokoroSynthesizer] input_ids length (234) below targetTokens=249 for chunk 'I can't believe we finally made it to the summit after climbing for twelve exhausting hours through wind and rain but wow this view of the endless mountain ranges stretching to the horizon makes every single difficult step completely' — padding with zeros
[11:51:25.971] [DEBUG] [FluidAudio.KokoroSynthesizer] input_ids length (18) below targetTokens=124 for chunk 'worth the journey.' — padding
```