### PR TITLE
Fix ML cache race condition

### DIFF
--- a/Sources/FluidAudio/ASR/MLArrayCache.swift
+++ b/Sources/FluidAudio/ASR/MLArrayCache.swift
@@ -27,7 +27,11 @@ actor MLArrayCache {
 
         // Check if we have a cached array
         if var arrays = cache[key], !arrays.isEmpty {
-            return arrays.removeLast()
+            // Never return the same buffer twice while it is still in use; keep the trimmed bucket so we only
+            // hand out arrays that callers have explicitly returned to the cache.
+            let array = arrays.removeLast()
+            cache[key] = arrays
+            return array
         }
 
         return try ANEOptimizer.createANEAlignedArray(shape: shape, dataType: dataType)

--- a/Tests/FluidAudioTests/MLArrayCacheTests.swift
+++ b/Tests/FluidAudioTests/MLArrayCacheTests.swift
@@ -241,6 +241,18 @@ final class MLArrayCacheTests: XCTestCase {
         XCTAssertNotNil(finalArray)
     }
 
+    func testGetArrayDoesNotReuseActiveBuffer() async throws {
+        let shape: [NSNumber] = [1, 64]
+
+        let array1 = try await cache.getArray(shape: shape, dataType: .float32)
+        let array2 = try await cache.getArray(shape: shape, dataType: .float32)
+
+        XCTAssertFalse(array1 === array2, "Cache should not hand out the same array while it is still borrowed")
+
+        await cache.returnArray(array1)
+        await cache.returnArray(array2)
+    }
+
     // Removed performance test - can cause timing issues
 
     // MARK: - Global Cache Tests
@@ -255,4 +267,5 @@ final class MLArrayCacheTests: XCTestCase {
         // Return to shared cache
         await sharedMLArrayCache.returnArray(array)
     }
+
 }


### PR DESCRIPTION
### Why is this change needed?
<!-- Explain the motivation for this change. What problem does it solve? -->

From discord:

```text
One more crash, when running a 1 hour recording,
...

Thread 21 Crashed:
0   libobjc.A.dylib                          0x19c0c8104 objc_release + 16
1   libobjc.A.dylib                          0x19c0cfc74 AutoreleasePoolPage::releaseUntil(objc_object) + 204
2   libobjc.A.dylib                          0x19c0cc140 objc_autoreleasePoolPop + 244
3   libswift_Concurrency.dylib               0x294c08094 swift::runJobInEstablishedExecutorContext(swift::Job) + 484
4   libswift_Concurrency.dylib               0x294c093c4 swift_job_runImpl(swift::Job, swift::SerialExecutorRef) + 156
5   libdispatch.dylib                        0x19c362fc8 _dispatch_root_queue_drain + 364
6   libdispatch.dylib                        0x19c363784 _dispatch_worker_thread2 + 180
7   libsystem_pthread.dylib                  0x19c508e10 _pthread_wqthread + 232
8   libsystem_pthread.dylib                  0x19c507b9c start_wqthread + 8


AI report:**
Short diagnosis (the likely cause)
The crash is an EXC_BAD_ACCESS (SIGSEGV) triggered while CoreML is trying to objc_retain an object returned by -[MLFeatureValue multiArrayValue]. That means CoreML tried to retain an object whose memory is already invalid (zombie / freed / corrupted). In plain terms: you handed CoreML an MLFeatureValue / MLMultiArray (or memory backing it) that was deallocated or not properly retained when CoreML used it asynchronously.

Evidence:
    •    Crash occurs in Thread 16 inside objc_retain -> -[MLFeatureValue multiArrayValue] -> CoreML input-port binding.
    •    The CoreML engine is doing an async prediction (prepareAsyncSubmissionForInputFeatures / submitPredictionRequest: in the stack). Async + temporary / non-retained buffers very commonly cause this exact class of crash.
    •    No obvious corruption earlier in trace — CoreML is the one failing to retain a valid object.

```
