### PR TITLE
Fix VAD threshold overriding per segment

### DIFF
--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -52,11 +52,11 @@ Voice activity detection using the Silero VAD Core ML model with 256 ms unified 
 - `VadManager.sampleRate = 16000`
 
 **Configuration (`VadConfig`):**
-- `threshold: Float` — Decision threshold (0.0–1.0). Default: `0.85`.
+- `defaultThreshold: Float` — Baseline decision threshold (0.0–1.0) used when segmentation does not override. Default: `0.85`.
 - `debugMode: Bool` — Extra logging for benchmarking and troubleshooting. Default: `false`.
 - `computeUnits: MLComputeUnits` — Core ML compute target. Default: `.cpuAndNeuralEngine`.
 
-Recommended threshold ranges depend on your acoustic conditions:
+Recommended `defaultThreshold` ranges depend on your acoustic conditions:
 - Clean speech: 0.7–0.9
 - Noisy/mixed content: 0.3–0.6 (higher recall, more false positives)
 

--- a/Documentation/VAD/GettingStarted.md
+++ b/Documentation/VAD/GettingStarted.md
@@ -83,7 +83,7 @@ import FluidAudio
 
 Task {
     let manager = try await VadManager(
-        config: VadConfig(threshold: 0.75)
+        config: VadConfig(defaultThreshold: 0.75)
     )
 
     // Convert any supported file to 16 kHz mono Float32

--- a/Documentation/VAD/Segmentation.md
+++ b/Documentation/VAD/Segmentation.md
@@ -81,3 +81,9 @@ public struct VadSegmentationConfig: Sendable {
     }
 }
 ```
+
+The entry threshold for hysteresis defaults to `VadConfig.defaultThreshold`, set when you construct a
+`VadManager`. If you provide a `negativeThreshold`, the streaming helpers derive an entry threshold
+by adding `negativeThresholdOffset` (clamped to 1.0), allowing per-request tuning without rebuilding
+the manager. To change the baseline entry threshold globally, create the manager with a different
+`defaultThreshold`.

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ import FluidAudio
 
 Task {
     let manager = try await VadManager(
-        config: VadConfig(threshold: 0.75)
+        config: VadConfig(defaultThreshold: 0.75)
     )
 
     let audioURL = URL(fileURLWithPath: "path/to/audio.wav")

--- a/Sources/FluidAudio/VAD/VadManager+SpeechSegmentation.swift
+++ b/Sources/FluidAudio/VAD/VadManager+SpeechSegmentation.swift
@@ -27,7 +27,12 @@ extension VadManager {
         guard !vadResults.isEmpty, totalSamples > 0 else { return [] }
 
         let probabilities = vadResults.map { $0.probability }
-        let threshold = self.config.threshold
+        // If the caller pins the negative threshold, derive a matching entry threshold via the offset.
+        let thresholdOverride: Float? = {
+            guard let negative = config.negativeThreshold else { return nil }
+            return min(1.0, negative + config.negativeThresholdOffset)
+        }()
+        let threshold = thresholdOverride ?? self.config.defaultThreshold
         let rawSegments = detectSpeechSampleRanges(
             probabilities: probabilities,
             audioLengthSamples: totalSamples,

--- a/Sources/FluidAudio/VAD/VadManager+Streaming.swift
+++ b/Sources/FluidAudio/VAD/VadManager+Streaming.swift
@@ -41,7 +41,12 @@ extension VadManager {
         nextState.modelState = modelState
         nextState.processedSamples += chunkSampleCount
 
-        let threshold = self.config.threshold
+        // If the caller pins the negative threshold, derive a matching entry threshold via the offset.
+        let thresholdOverride: Float? = {
+            guard let negative = config.negativeThreshold else { return nil }
+            return min(1.0, negative + config.negativeThresholdOffset)
+        }()
+        let threshold = thresholdOverride ?? self.config.defaultThreshold
         let negativeThreshold = config.effectiveNegativeThreshold(baseThreshold: threshold)
         let speechPadSamples = Int(config.speechPadding * Double(Self.sampleRate))
         let minSilenceSamples = Int(config.minSilenceDuration * Double(Self.sampleRate))

--- a/Sources/FluidAudio/VAD/VadManager.swift
+++ b/Sources/FluidAudio/VAD/VadManager.swift
@@ -188,7 +188,7 @@ public actor VadManager {
 
         return VadResult(
             probability: rawProbability,
-            isVoiceActive: rawProbability >= config.threshold,
+            isVoiceActive: rawProbability >= config.defaultThreshold,
             processingTime: processingTime,
             outputState: outputState
         )

--- a/Sources/FluidAudio/VAD/VadTypes.swift
+++ b/Sources/FluidAudio/VAD/VadTypes.swift
@@ -2,18 +2,19 @@ import CoreML
 import Foundation
 
 public struct VadConfig: Sendable {
-    public var threshold: Float
+    /// Baseline model probability threshold used when no segmentation override is provided.
+    public var defaultThreshold: Float
     public var debugMode: Bool
     public var computeUnits: MLComputeUnits
 
     public static let `default` = VadConfig()
 
     public init(
-        threshold: Float = 0.85,
+        defaultThreshold: Float = 0.85,
         debugMode: Bool = false,
         computeUnits: MLComputeUnits = .cpuAndNeuralEngine
     ) {
-        self.threshold = threshold
+        self.defaultThreshold = defaultThreshold
         self.debugMode = debugMode
         self.computeUnits = computeUnits
     }

--- a/Sources/FluidAudioCLI/Commands/VadAnalyzeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/VadAnalyzeCommand.swift
@@ -87,7 +87,7 @@ enum VadAnalyzeCommand {
             let samples = try AudioConverter().resampleAudioFile(path: audioPath)
             let manager = try await VadManager(
                 config: VadConfig(
-                    threshold: options.threshold ?? VadConfig.default.threshold,
+                    defaultThreshold: options.threshold ?? VadConfig.default.defaultThreshold,
                     debugMode: options.debug
                 )
             )

--- a/Sources/FluidAudioCLI/Commands/VadBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/VadBenchmark.swift
@@ -77,7 +77,7 @@ struct VadBenchmark {
         // Use VadManager with the trained model
         let vadManager = try await VadManager(
             config: VadConfig(
-                threshold: vadThreshold,
+                defaultThreshold: vadThreshold,
                 debugMode: debugMode
             ))
 

--- a/Tests/FluidAudioTests/VadTests.swift
+++ b/Tests/FluidAudioTests/VadTests.swift
@@ -17,7 +17,7 @@ final class VadTests: XCTestCase {
     func testVadModelLoading() async throws {
         // Test loading the VAD model
         let config = VadConfig(
-            threshold: 0.5,
+            defaultThreshold: 0.5,
             debugMode: true
         )
 
@@ -38,7 +38,7 @@ final class VadTests: XCTestCase {
     func testVadProcessing() async throws {
         // Test processing audio through the model
         let config = VadConfig(
-            threshold: 0.5,
+            defaultThreshold: 0.5,
             debugMode: true
         )
 
@@ -81,7 +81,7 @@ final class VadTests: XCTestCase {
 
     func testVadBatchProcessing() async throws {
         let config = VadConfig(
-            threshold: 0.5,
+            defaultThreshold: 0.5,
             debugMode: false
         )
 
@@ -123,7 +123,7 @@ final class VadTests: XCTestCase {
     }
 
     func testVadStateReset() async throws {
-        let config = VadConfig(threshold: 0.1)
+        let config = VadConfig(defaultThreshold: 0.1)
         let vad: VadManager
         do {
             vad = try await VadManager(config: config)
@@ -147,7 +147,7 @@ final class VadTests: XCTestCase {
 
     func testVadPaddingAndTruncation() async throws {
         let config = VadConfig(
-            threshold: 0.5,
+            defaultThreshold: 0.5,
             debugMode: true
         )
 
@@ -407,11 +407,11 @@ final class VadTests: XCTestCase {
         let chunk = (0..<chunkSize).map { _ in Float.random(in: -0.1...0.1) }
 
         // Test with low threshold
-        let lowThresholdVad = try await VadManager(config: VadConfig(threshold: 0.1))
+        let lowThresholdVad = try await VadManager(config: VadConfig(defaultThreshold: 0.1))
         let lowResult = try await lowThresholdVad.processChunk(chunk)
 
         // Test with high threshold
-        let highThresholdVad = try await VadManager(config: VadConfig(threshold: 0.9))
+        let highThresholdVad = try await VadManager(config: VadConfig(defaultThreshold: 0.9))
         let highResult = try await highThresholdVad.processChunk(chunk)
 
         // With same input, low threshold should be more likely to detect voice
@@ -425,11 +425,11 @@ final class VadTests: XCTestCase {
     }
 
     func testVadConfigurationAccessibility() async throws {
-        let config = VadConfig(threshold: 0.3, debugMode: true)
+        let config = VadConfig(defaultThreshold: 0.3, debugMode: true)
         let vad = try await VadManager(config: config)
 
         let currentConfig = await vad.currentConfig
-        XCTAssertEqual(currentConfig.threshold, 0.3, "Should maintain configured threshold")
+        XCTAssertEqual(currentConfig.defaultThreshold, 0.3, "Should maintain configured threshold")
         XCTAssertEqual(currentConfig.debugMode, true, "Should maintain debug mode")
     }
 


### PR DESCRIPTION
### Why is this change needed?
<!-- Explain the motivation for this change. What problem does it solve? -->

https://github.com/FluidInference/FluidAudio/pull/153 <-- from this PR, but thought it would be easier for me to just clean it up entirely. 

Rename the actor level threshold to "defaultThreshold" and actually allow overriding per segment. 

previously the end speech (negative threshold) wasn't being used either 