### PR TITLE
add @available(iOS 17.0, *) for VBxClustering and OfflineEmbeddingExt…

### DIFF
--- a/Sources/FluidAudio/Diarizer/Offline/Clustering/VBxClustering.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Clustering/VBxClustering.swift
@@ -22,7 +22,7 @@ import os.signpost
 ///
 /// The implementation includes warm-start initialization from initial hard cluster
 /// assignments and supports PLDA whitening transformation of input features.
-@available(iOS 17.0, *)
+@available(macOS 14.0, iOS 17.0, *)
 struct VBxClustering {
     private let config: OfflineDiarizerConfig
     private let pldaTransform: PLDATransform

--- a/Sources/FluidAudio/Diarizer/Offline/Extraction/OfflineEmbeddingExtractor.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Extraction/OfflineEmbeddingExtractor.swift
@@ -53,7 +53,7 @@ private struct OfflineChunkBatchInfo: Sendable {
     }
 }
 
-@available(iOS 17.0, *)
+@available(macOS 14.0, iOS 17.0, *)
 struct OfflineEmbeddingExtractor {
     private let fbankModel: MLModel
     private let embeddingModel: MLModel


### PR DESCRIPTION
Although right now it dropped iOS 16 support, with this change, users can still change the package.swift to work on iOS 16.

