### PR TITLE
Add Speakmac to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[Starling](https://github.com/Ryandonofrio3/Starling)** | Open Source, fully local voice-to-text transcription with auto-paste at your cursor. |
 | **[BoltAI](https://boltai.com/)** | Write content 10x faster using parakeet models |
 | **[Voxeoflow](https://www.voxeoflow.app)** | Mac dictation app with real-time translation. Lightning-fast transcription in over 100 languages, instantly translated to your target language. |
+| **[Speakmac](https://speakmac.app)** | Mac app that lets you type anywhere on your Mac using your voice. Fully local, private dictation built on FluidAudio. |
 
 ## Installation
 


### PR DESCRIPTION
This PR adds Speakmac to the FluidAudio showcase table as a Mac dictation app built on FluidAudio. 

Checkout: www.speakmac.app