### PR TITLE
Adjust Kokoro pauses and tail trim for TTS parity

### DIFF
--- a/Sources/FluidAudioTTS/TextToSpeech/Kokoro/Pipeline/Preprocess/KokoroChunker.swift
+++ b/Sources/FluidAudioTTS/TextToSpeech/Kokoro/Pipeline/Preprocess/KokoroChunker.swift
@@ -22,6 +22,20 @@ enum KokoroChunker {
     private static let logger = AppLogger(subsystem: "com.fluidaudio.tts", category: "KokoroChunker")
     private static let decimalDigits = CharacterSet.decimalDigits
     private static let apostropheCharacters: Set<Character> = ["'", "’", "ʼ", "‛", "‵", "′"]
+    private static func pauseAfterMs(for text: String) -> Int {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let last = trimmed.last else { return 60 }
+        switch last {
+        case ".", "?", "!":
+            return 220
+        case ",", ";", ":":
+            return 140
+        case "-", "—":
+            return 80
+        default:
+            return 60
+        }
+    }
 
     private static func isWordCharacter(_ character: Character) -> Bool {
         if character.isLetter || character.isNumber || apostropheCharacters.contains(character) {
@@ -292,13 +306,14 @@ enum KokoroChunker {
             let textValue = chunkAtoms.reduce(into: "") { partial, atom in
                 partial = appendSegment(partial, with: atom)
             }.trimmingCharacters(in: .whitespacesAndNewlines)
+            let pauseAfter = pauseAfterMs(for: textValue)
             chunks.append(
                 TextChunk(
                     words: chunkWords,
                     atoms: chunkAtoms,
                     phonemes: chunkPhonemes,
                     totalFrames: 0,
-                    pauseAfterMs: 0,
+                    pauseAfterMs: pauseAfter,
                     text: textValue
                 )
             )

--- a/wav_compare/PROGRESS.md
+++ b/wav_compare/PROGRESS.md
@@ -1,0 +1,15 @@
+# wav_compare Progress Log
+
+## 2024-11-25
+- Context: focusing on af_heart p0/p1/p2 parity with Python Kokoro reference.
+- Changes implemented:
+  - Softer trailing-silence trim in `KokoroSynthesizer.swift` (threshold 0.003, keep ~120ms tail).
+  - Punctuation-based pauses in `KokoroChunker.swift` (220ms after `.?!`, 140ms after `,;:`, 80ms after `-`, 60ms default).
+- Current cosine distances (speed 1.0):
+  - p0: 0.2056 (ref 6.60s, FA 5.99s)
+  - p1: 0.2231 (ref 6.52s, FA 5.25s)
+  - p2: 0.0842 (ref 2.73s, FA 1.99s)
+- Speed sweeps (0.94–1.10) increased distance; best remains speed 1.0.
+- Next possible tweaks (if needed):
+  - Add a bit more tail padding for p0/p1.
+  - Slightly longer punctuation pauses for single-sentence prompts if we want durations closer to refs.


### PR DESCRIPTION
## Summary\n- add punctuation-aware pause defaults to KokoroChunker for more natural cadence\n- relax trailing silence trim to keep ~120ms tails and lower threshold\n- add wav_compare/PROGRESS.md logging current af_heart p0/p1/p2 metrics\n\n## Testing\n- swift run -c release fluidaudio tts '<p0/p1/p2 text>' --voice af_heart --output wav_compare/p?-af_heart-fa-final.wav\n- swift run -c release fluidaudio compare-audio wav_compare/p?-af_heart-ref.wav wav_compare/p?-af_heart-fa-final.wav\n