### PR TITLE
Content skipping bug fix

### DIFF
--- a/Sources/FluidAudio/ASR/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/ChunkProcessor.swift
@@ -15,22 +15,25 @@ struct ChunkProcessor {
     }
 
     // Stateless chunking aligned with CoreML reference:
-    // - process ~14.96s of audio per window (239,360 samples) to stay under encoder limit
-    // - 2.0s overlap (32,000 samples) to give the decoder slack when merging windows
+    // - process ~14.96s of audio per window (frame-aligned) to stay under encoder limit
+    // - 2.0s overlap (frame-aligned) to give the decoder slack when merging windows
     private let sampleRate: Int = 16000
     private let overlapSeconds: Double = 2.0
 
     private var maxModelSamples: Int { 240_000 }  // CoreML encoder capacity (15 seconds)
     private var chunkSamples: Int {
         // Match CoreML reference chunk length (239,840 samples ≈ 14.99s)
-        max(maxModelSamples - ASRConstants.melHopSize, ASRConstants.samplesPerEncoderFrame)
+        let raw = max(maxModelSamples - ASRConstants.melHopSize, ASRConstants.samplesPerEncoderFrame)
+        return raw / ASRConstants.samplesPerEncoderFrame * ASRConstants.samplesPerEncoderFrame
     }
     private var overlapSamples: Int {
         let requested = Int(overlapSeconds * Double(sampleRate))
-        return min(requested, chunkSamples / 2)
+        let capped = min(requested, chunkSamples / 2)
+        return capped / ASRConstants.samplesPerEncoderFrame * ASRConstants.samplesPerEncoderFrame
     }
     private var strideSamples: Int {
-        max(chunkSamples - overlapSamples, ASRConstants.samplesPerEncoderFrame)
+        let raw = max(chunkSamples - overlapSamples, ASRConstants.samplesPerEncoderFrame)
+        return raw / ASRConstants.samplesPerEncoderFrame * ASRConstants.samplesPerEncoderFrame
     }
 
     func process(


### PR DESCRIPTION
- Fixed a bug where some content got skipped in longer videos. 
    - Cause: Chunk sizes were not divisible by the encoder frame size which caused the merging to skip some audio because the remainder was not accounted for in the integer division.
    - Solution: Made it so that 14.96 seconds of audio was collected i(nstead of 14.99 seconds) to ensure that the start of every chunk is aligned with the start of every frame.
- Resolve #212 