### PR TITLE
fix: Swift 6 Sendable compliance for AVAudioConverter closures (Xcode 26 SDK)

### DIFF
--- a/Sources/FluidAudio/Shared/AudioConverter.swift
+++ b/Sources/FluidAudio/Shared/AudioConverter.swift
@@ -149,13 +149,15 @@ final public class AudioConverter {
         var aggregated: [Float] = []
         aggregated.reserveCapacity(Int(estimatedOutputFrames))
 
-        // Provide input once, then signal end-of-stream
-        var provided = false
+        // Provide input once, then signal end-of-stream.
+        // nonisolated(unsafe) is safe here because AVAudioConverter calls input blocks synchronously.
+        nonisolated(unsafe) var provided = false
+        nonisolated(unsafe) let inputBuffer = buffer
         let inputBlock: AVAudioConverterInputBlock = { _, status in
             if !provided {
                 provided = true
                 status.pointee = .haveData
-                return buffer
+                return inputBuffer
             } else {
                 status.pointee = .endOfStream
                 return nil


### PR DESCRIPTION
## Summary

Fixes Swift 6 build errors that occur with Xcode 26 SDK due to new `@Sendable` annotations on `AVAudioConverterInputBlock`.

## Problem

Starting with **Xcode 26 SDK**, Apple added `NS_SWIFT_SENDABLE` to several AVFAudio types:

| Type | Change |
|------|--------|
| `AVAudioConverter` | Added `NS_SWIFT_SENDABLE` |
| `AVAudioConverterInputBlock` | **Typedef now includes `NS_SWIFT_SENDABLE`** |
| `AVAudioFile` | Added `NS_SWIFT_SENDABLE` |
| `AVAudioFormat` | Added `NS_SWIFT_SENDABLE` |

Source: [AVFAudio-iOS-xcode26.0-b1 (.NET MAUI SDK diff)](https://github.com/dotnet/macios/wiki/AVFAudio-iOS-xcode26.0-b1)

This causes build failures because closures passed to `AVAudioConverter.convert(to:error:withInputFrom:)` capture:
- Mutable variables (`var provided`, `var inputComplete`)
- Non-Sendable types (`AVAudioPCMBuffer`, `AVAudioFile`)

### Build errors on Xcode 26:
```
error: capture of 'provided' with non-sendable type 'Bool' in a @Sendable closure
error: capture of 'buffer' with non-sendable type 'AVAudioPCMBuffer' in a @Sendable closure
```

### Why CI passes:
GitHub Actions uses `macos-15` runners with Xcode 16, which doesn't have these `@Sendable` annotations yet.

## Solution

Use `nonisolated(unsafe)` on captured variables. This is safe because:

1. **AVAudioConverter calls input blocks synchronously** on the same thread
2. No actual concurrency occurs - the closure executes inline during `convert()` call
3. `nonisolated(unsafe)` tells Swift "I'm handling thread safety myself" (which we are)

## Changes

- `AudioConverter.swift`: Add `nonisolated(unsafe)` to `provided` and `inputBuffer`
- `StreamingAudioSourceFactory.swift`: Add `nonisolated(unsafe)` to captured state variables

## Test plan

- [x] Build succeeds on Xcode 26 (macOS 26 SDK)
- [x] Build succeeds on Xcode 16 (backward compatible)
- [x] No runtime behavior changes (same synchronous execution)