### PR TITLE
fix: remove Tokenizer from ParakeetEOU required models

### DIFF
--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -155,7 +155,6 @@ public enum ModelNames {
         public static let decoder = "decoder"
         public static let joint = "joint_decision"
         public static let vocab = "vocab.json"
-        public static let tokenizer = "tokenizer.model"
 
         public static let preprocessorFile = preprocessor + ".mlmodelc"
         public static let encoderFile = encoder + ".mlmodelc"
@@ -168,7 +167,6 @@ public enum ModelNames {
             decoderFile,
             jointFile,
             vocab,
-            tokenizer,
         ]
     }
 


### PR DESCRIPTION
ModelNames.swift: Remove tokenizer.model from ParakeetEOU.requiredModels
   The tokenizer.model file doesn't exist in the HuggingFace repo and isn't
   used by StreamingEouAsrManager.loadModels() which uses vocab.json instead.