### PR TITLE
fix: MachTaskSelfWrapper module import and remove unused preprocessorFile from requiredModels

### DIFF
--- a/FluidAudio.podspec
+++ b/FluidAudio.podspec
@@ -52,6 +52,7 @@ Pod::Spec.new do |spec|
     mach.source_files = "Sources/MachTaskSelfWrapper/**/*.{c,h}"
     mach.public_header_files = "Sources/MachTaskSelfWrapper/include/MachTaskSelf.h"
     mach.header_mappings_dir = "Sources/MachTaskSelfWrapper"
+    mach.module_map = "Sources/MachTaskSelfWrapper/include/module.modulemap"
   end
 
   spec.subspec "Core" do |core|

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -150,19 +150,16 @@ public enum ModelNames {
 
     /// Parakeet EOU streaming model names
     public enum ParakeetEOU {
-        public static let preprocessor = "parakeet_eou_preprocessor"
         public static let encoder = "streaming_encoder"
         public static let decoder = "decoder"
         public static let joint = "joint_decision"
         public static let vocab = "vocab.json"
 
-        public static let preprocessorFile = preprocessor + ".mlmodelc"
         public static let encoderFile = encoder + ".mlmodelc"
         public static let decoderFile = decoder + ".mlmodelc"
         public static let jointFile = joint + ".mlmodelc"
 
         public static let requiredModels: Set<String> = [
-            preprocessorFile,
             encoderFile,
             decoderFile,
             jointFile,

--- a/Sources/MachTaskSelfWrapper/include/module.modulemap
+++ b/Sources/MachTaskSelfWrapper/include/module.modulemap
@@ -1,0 +1,4 @@
+module MachTaskSelfWrapper {
+    header "MachTaskSelf.h"
+    export *
+}


### PR DESCRIPTION
Fix MachTaskSelfWrapper module import and remove unused preprocessorFile from requiredModels

This patch fixes two issues in FluidAudio 0.9.1:

1. MachTaskSelfWrapper module import error
   Swift code cannot `import MachTaskSelfWrapper` because the C library lacks a
   module.modulemap file. This adds the modulemap and configures it in the podspec.

2. preprocessorFile in ParakeetEOU.requiredModels
   The preprocessor model is no longer used (replaced by native Swift NeMoMelSpectrogram
   in StreamingEouAsrManager), but it's still listed in requiredModels. This causes
   model download validation to fail since the file doesn't exist in the HuggingFace repo.