### PR TITLE
Add WhisKey to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[Voxeoflow](https://www.voxeoflow.app)** | Mac dictation app with real-time translation. Lightning-fast transcription in over 100 languages, instantly translated to your target language. |
 | **[Speakmac](https://speakmac.app)** | Mac app that lets you type anywhere on your Mac using your voice. Fully local, private dictation built on FluidAudio. |
 | **[SamScribe](https://github.com/Steven-Weng/SamScribe)** | An open-source macOS app that captures and transcribes audio from your microphone and meeting applications (Zoom, Teams, Chrome) in real-time, with cross-session speaker recognition. |
-| **[WhisKey](https://whiskey.asktobuild.app/)** | Privacy-first voice dictation keyboard for iOS and macOS. On-device transcription with 12+ languages. Uses speaker diarization. |
+| **[WhisKey](https://whiskey.asktobuild.app/)** | Privacy-first voice dictation keyboard for iOS and macOS. On-device transcription with 12+ languages, AI meeting summaries, and mindmap generation. Great for daily use and vibe-coding. Uses speaker diarization. |
 
 ## Installation
 


### PR DESCRIPTION
  ## Summary
  - Add WhisKey to the showcase table in README.md

  ## About WhisKey
  Privacy-first voice dictation keyboard for iOS and macOS featuring on-device transcription with 12+ languages, AI meeting summaries, and mindmap generation. Uses FluidAudio's speaker diarization.

  Website: https://whiskey.asktobuild.app/