### PR TITLE
docs: add platform wrappers section for React Native and Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ FluidAudio provides two library products:
 
 > **Note:** The Kokoro TTS tooling currently ships arm64-only dependencies. See the [arm64 build requirements](Documentation/TTS/README.md#arm64-only-builds) guide if you hit linker errors targeting x86_64.
 
-### Platform Wrappers
+### Other Frameworks
 
 Building with a different framework? Use one of our official wrappers:
 


### PR DESCRIPTION
## Summary
- Adds a "Platform Wrappers" section to the Installation area of the README
- Links to official wrapper packages for developers using other frameworks:
  - **React Native / Expo**: [@fluidinference/react-native-fluidaudio](https://github.com/FluidInference/react-native-fluidaudio)
  - **Rust / Tauri**: [fluidaudio-rs](https://github.com/FluidInference/fluidaudio-rs)

## Preview

| Platform | Package | Install |
|----------|---------|---------|
| **React Native / Expo** | @fluidinference/react-native-fluidaudio | `npm install @fluidinference/react-native-fluidaudio` |
| **Rust / Tauri** | fluidaudio-rs | `cargo add fluidaudio-rs` |

🤖 Generated with [Claude Code](https://claude.ai/code)