### PR TITLE
docs: add Parakeet EOU and Sortformer demo videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Want to convert your own model? Check [möbius](https://github.com/FluidInferenc
 | **[Spokenly Real-time ASR](https://www.youtube.com/watch?v=9fXKKkyL8JE)** | Video demonstration of FluidAudio's transcription accuracy and speed |
 | **[Senko Integration](https://x.com/hamza_q_/status/1970228971657928995)** | Python Speaker diarization on Mac using FluidAudio's segmentation model |
 | **[Mobile TTS](https://x.com/sach1n/status/1977817056507793521)** | Voice on mobile video using FluidAudio's Kokoro and Silero models |
+| **[Parakeet Realtime EOU](https://x.com/sach1n/status/2003210626659680762)** | FluidAudio CoreML: NVIDIA's Parakeet streaming ASR with end-of-utterance detection |
+| **[Sortformer Diarization](https://x.com/Alex_tra_memory/status/2010530705667661843)** | FluidAudio CoreML: NVIDIA Sortformer for speaker diarization with overlapping speech |
 
 ## Showcase
 


### PR DESCRIPTION
## Summary
Adds two new video demos showcasing FluidAudio capabilities:

| Demo | Description |
|------|-------------|
| **[Parakeet Realtime EOU](https://x.com/sach1n/status/2003210626659680762)** | NVIDIA's Parakeet streaming ASR with end-of-utterance detection on CoreML |
| **[Sortformer Diarization](https://x.com/Alex_tra_memory/status/2010530705667661843)** | NVIDIA Sortformer for speaker diarization with overlapping speech support |

### Credits
- Parakeet EOU: @sach1n, @fluidinference for CoreML conversion
- Sortformer: @SGD2718 for Swift implementation & model conversion, @sach1n for video demo

🤖 Generated with [Claude Code](https://claude.ai/code)