### PR TITLE
fix: replace legacy FileHandle.write with throwing write(contentsOf:)

### DIFF
--- a/Sources/FluidAudio/Diarizer/Offline/Extraction/OfflineEmbeddingExtractor.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Extraction/OfflineEmbeddingExtractor.swift
@@ -760,10 +760,16 @@ struct OfflineEmbeddingExtractor {
         return secondsMs + attosecondsMs
     }
 
+    private static let profilingLogger = AppLogger(category: "OfflineEmbedding")
+
     private static func emitProfileLog(_ message: String) {
         let line = "[Profiling] \(message)\n"
         if let data = line.data(using: .utf8) {
-            FileHandle.standardError.write(data)
+            do {
+                try FileHandle.standardError.write(contentsOf: data)
+            } catch {
+                profilingLogger.warning("Failed to write profiling log: \(error.localizedDescription)")
+            }
         }
     }
 

--- a/Sources/FluidAudio/Diarizer/Offline/Segmentation/OfflineSegmentationProcessor.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Segmentation/OfflineSegmentationProcessor.swift
@@ -565,10 +565,16 @@ extension OfflineSegmentationProcessor {
         return secondsMs + attosecondsMs
     }
 
+    private static let profilingLogger = AppLogger(category: "OfflineSegmentation")
+
     fileprivate static func emitProfileLog(_ message: String) {
         let line = "[Profiling] \(message)\n"
         if let data = line.data(using: .utf8) {
-            FileHandle.standardError.write(data)
+            do {
+                try FileHandle.standardError.write(contentsOf: data)
+            } catch {
+                profilingLogger.warning("Failed to write profiling log: \(error.localizedDescription)")
+            }
         }
     }
 }

--- a/Sources/FluidAudio/Shared/AppLogger.swift
+++ b/Sources/FluidAudio/Shared/AppLogger.swift
@@ -118,7 +118,11 @@ public struct AppLogger: Sendable {
         case .fault: levelLabel = "FAULT"
         }
         let line = "[\(timestamp)] [\(levelLabel)] [FluidAudio.\(category)] \(message)\n"
-        FileHandle.standardError.write(Data(line.utf8))
+        do {
+            try FileHandle.standardError.write(contentsOf: Data(line.utf8))
+        } catch {
+            print("Failed to write to stderr: \(error.localizedDescription)")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Replace `FileHandle.write(_:)` with `write(contentsOf:)` to fix intermittent crashes during diarization
- `FileHandle.write(_:)` is legacy Objective-C API that throws `NSException` (uncatchable in Swift)
- `write(contentsOf:)` throws Swift `Error` that can be properly caught
- Falls back to stdout via `print()` on failure

#261


## Files Changed
- `OfflineEmbeddingExtractor.swift` - emitProfileLog
- `OfflineSegmentationProcessor.swift` - emitProfileLog  
- `AppLogger.swift` - legacySink write

## Test plan
- [x] Build passes
- [ ] Test diarization in sandboxed environment where stderr may be unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)