### PR TITLE
fix: PocketTTS iOS 17 compatibility — remove scaled_dot_product_attention

### DIFF
--- a/mobius/models/tts/pocket_tts/coreml/CONVERSION.md
+++ b/mobius/models/tts/pocket_tts/coreml/CONVERSION.md
@@ -1,0 +1,307 @@
+# PocketTTS CoreML Conversion Guide
+
+How the PocketTTS PyTorch model is converted to a pure CoreML pipeline with zero PyTorch runtime dependency.
+
+---
+
+## Architecture Overview
+
+PocketTTS uses a **flow-matching language model** architecture:
+
+```
+Text → Tokenize → Embed → [Voice Embed] → Transformer (KV Cache) → Flow Decode → Mimi Decode → Audio
+```
+
+The pipeline is split into **4 CoreML models** plus numpy/sentencepiece for preprocessing:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Pure Python (no PyTorch)                  │
+│  SentencePiece tokenization → numpy embedding lookup        │
+│  safetensors voice loading → numpy array ops                │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────────┐
+│  cond_step.mlpackage          (KV cache prefill)            │
+│  Input:  1 conditioning token [1, 1, 1024]                  │
+│  Output: updated KV caches [2, 1, 200, 16, 64] x6          │
+│  Called: 141 times (125 voice + 16 text tokens)             │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────────┐
+│  flowlm_step.mlpackage       (autoregressive generation)    │
+│  Input:  latent frame [1, 1, 32] + KV caches               │
+│  Output: transformer_out [1, 1, 1024] + EOS logit + caches │
+│  Called: ~20-50 times per utterance                          │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────────┐
+│  flow_decoder.mlpackage   (flow decoding, 8 LSD steps)  │
+│  Input:  transformer_out [1, 1024] + latent [1, 32] + s, t │
+│  Output: velocity [1, 32]                                   │
+│  Called: 8 times per generation step                         │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────────┐
+│  mimi_decoder.mlpackage   (audio synthesis)              │
+│  Input:  quantized latent [1, 512, 1] + streaming state     │
+│  Output: audio frame [1, 1, 1920] (80ms at 24kHz)           │
+│  Called: once per generation step                            │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+                   audio.wav
+```
+
+---
+
+## Model Conversion Process
+
+Each model follows the same pattern:
+1. Load original PocketTTS PyTorch weights
+2. Create a `Traceable*` wrapper with explicit inputs (no dynamic control flow)
+3. `torch.jit.trace` the wrapper
+4. `coremltools.convert` to `.mlpackage`
+
+### 1. Conditioning Step (`cond_step.mlpackage`)
+
+**Source:** `traceable_cond_step.py` → `convert_cond_step.py`
+
+Processes one conditioning token (text or voice embedding) through the 6-layer transformer, updating the KV cache. This is the **prefill** stage — called once per conditioning token before generation begins.
+
+**Why a separate model?** The original model processes all conditioning at once with variable-length input. CoreML's scatter op doesn't support dynamic shapes, so we process one token at a time with a fixed-shape cache.
+
+**Architecture:**
+- 6 transformer layers (same weights as the generation step model)
+- No `input_linear` — conditioning is already 1024d
+- No BOS handling, no EOS output
+- Streaming attention with circular KV cache (max 200 positions)
+- RoPE positional encoding
+
+**Inputs:**
+| Name | Shape | Description |
+|------|-------|-------------|
+| `conditioning` | `[1, 1, 1024]` | One pre-embedded conditioning token |
+| `cache0`–`cache5` | `[2, 1, 200, 16, 64]` | KV caches (key + value) per layer |
+| `position0`–`position5` | `[1]` | Current write position per layer |
+
+**Outputs:** Updated caches and positions (12 tensors total).
+
+### 2. Generation Step (`flowlm_step.mlpackage`)
+
+**Source:** `traceable_flowlm_step.py` → `convert_flowlm_step.py`
+
+The autoregressive backbone. Takes one latent frame, runs it through the transformer (attending to the prefilled KV cache), and outputs the transformer hidden state + EOS logit.
+
+**Architecture:**
+- `input_linear`: projects 32d latent → 1024d
+- 6 transformer layers (shared weights with cond_step)
+- `out_norm` + `out_eos`: EOS prediction head
+- NaN input → BOS embedding substitution (first frame)
+- Streaming attention with circular KV cache
+
+**Inputs:**
+| Name | Shape | Description |
+|------|-------|-------------|
+| `sequence` | `[1, 1, 32]` | Latent frame (NaN for BOS) |
+| `bos_emb` | `[32]` | BOS embedding constant |
+| `cache0`–`cache5` | `[2, 1, 200, 16, 64]` | KV caches |
+| `position0`–`position5` | `[1]` | Current positions |
+
+**Outputs:**
+| Name | Shape | Description |
+|------|-------|-------------|
+| `input` | `[1, 1, 1024]` | Transformer hidden state |
+| EOS logit | `[1, 1, 1]` | EOS probability (threshold: -4.0) |
+| Updated caches/positions | | 12 tensors |
+
+### 3. Flow Decoder (`flow_decoder.mlpackage`)
+
+**Source:** `traceable_flow_decoder.py` → `convert_flow_decoder.py`
+
+Lagrangian Self-Distillation (LSD) flow decoder. Converts transformer output to a 32d audio latent via 8 iterative denoising steps.
+
+**Architecture:**
+- `SimpleMLPAdaLN` network conditioned on transformer output and time
+- Takes **two** time inputs: start time `s` and end time `t`
+- Averages time embeddings: `time_emb = (embed(s) + embed(t)) / 2`
+
+**Critical detail:** Both `s` and `t` must be passed correctly:
+```
+Step 0: s=0.000, t=0.125
+Step 1: s=0.125, t=0.250
+...
+Step 7: s=0.875, t=1.000
+```
+
+**Inputs:**
+| Name | Shape | Description |
+|------|-------|-------------|
+| `transformer_out` | `[1, 1024]` | Hidden state from generation step |
+| `latent` | `[1, 32]` | Current noise/latent |
+| `s` | `[1, 1]` | Start time |
+| `t` | `[1, 1]` | End time |
+
+**Output:** Velocity field `[1, 32]`. Applied as: `latent = latent + velocity * dt`
+
+### 4. Mimi Decoder (`mimi_decoder.mlpackage`)
+
+**Source:** Converted separately (streaming convolutional decoder).
+
+Converts quantized latent `[1, 512, 1]` to audio `[1, 1, 1920]` (80ms at 24kHz). Uses streaming state for causal convolutions and attention.
+
+**State:** 26 tensors tracking convolutional history, attention caches, and partial upsampling buffers. Initialized from `mimi_init_state.npz`.
+
+---
+
+## Constants Export
+
+**Script:** `export_constants.py`
+
+Extracts model constants from PyTorch and saves as numpy files. This is a one-time operation requiring PyTorch.
+
+| File | Shape | Description |
+|------|-------|-------------|
+| `bos_emb.npy` | `[32]` | Beginning-of-sequence embedding |
+| `emb_mean.npy` | `[32]` | Latent normalization mean |
+| `emb_std.npy` | `[32]` | Latent normalization std |
+| `quantizer_weight.npy` | `[512, 32, 1]` | Quantizer projection (1D conv kernel) |
+| `text_embed_table.npy` | `[4001, 1024]` | Text token embedding table |
+| `mimi_init_state.npz` | 26 tensors | Mimi decoder initial streaming state |
+| `tokenizer.model` | — | SentencePiece tokenizer (copied from HuggingFace) |
+| `alba.safetensors` | `[1, 125, 1024]` | Pre-encoded voice conditioning |
+
+Total: ~28 MB
+
+---
+
+## Generation Pipeline (`generate_coreml_v4.py`)
+
+Zero PyTorch dependency. Imports: `numpy`, `sentencepiece`, `safetensors`, `coremltools`, `scipy`.
+
+### Step-by-step:
+
+```
+1. Text preparation (string ops)
+   - Normalize whitespace, capitalize first letter, add period
+   - Pad short texts with spaces for better prosody
+   → prepared_text, frames_after_eos
+
+2. Tokenize (SentencePiece)
+   sp.encode(prepared_text) → token_ids [N]
+
+3. Embed text (numpy lookup)
+   text_embed_table[token_ids] → text_emb [1, 16, 1024]
+
+4. Load voice (safetensors)
+   load_file("alba.safetensors")["audio_prompt"] → voice_emb [1, 125, 1024]
+
+5. Combine conditioning (voice FIRST, then text)
+   concat(voice_emb, text_emb) → combined [1, 141, 1024]
+
+6. KV cache prefill (cond_step.mlpackage × 141)
+   For each token in combined:
+     cond_step.predict(token, caches, positions) → updated caches
+   → positions now at 141
+
+7. Autoregressive generation loop:
+   a. flowlm_step.predict(latent, bos_emb, caches, positions)
+      → transformer_out [1, 1, 1024], eos_logit, updated caches
+
+   b. Check EOS (logit > -4.0 → stop after frames_after_eos extra frames)
+
+   c. Flow decode (flow_decoder × 8 LSD steps):
+      latent = randn(1, 32) * sqrt(0.7)
+      for i in 0..7:
+        velocity = flow_decoder.predict(transformer_out, latent, s=i/8, t=(i+1)/8)
+        latent += velocity * (1/8)
+
+   d. Denormalize: latent * emb_std + emb_mean
+
+   e. Quantize: dot(latent, quantizer_weight.T) → [1, 512, 1]
+
+   f. Mimi decode: mimi_decoder.predict(quantized, state) → audio [1, 1, 1920]
+
+   g. Update sequence for next step: latent reshaped to [1, 1, 32]
+
+8. Concatenate audio frames, normalize, save as WAV (24kHz, 16-bit)
+```
+
+### Critical ordering detail
+
+Conditioning must be **voice first, then text** — matching the original model's processing order:
+1. `get_state_for_audio_prompt()` fills positions 0–124 with voice
+2. `_run_flow_lm_and_increment_step()` fills positions 125–140 with text
+
+Reversing this order (text first) produces cosine similarity of only 0.6–0.9 in the KV cache vs the reference, causing unintelligible output.
+
+---
+
+## Disk & Memory Footprint
+
+| Model | Disk | RAM (loaded) |
+|-------|------|-------------|
+| flowlm_step | 289 MB | ~50 MB |
+| cond_step | 253 MB | ~45 MB |
+| flow_decoder | 37 MB | ~7 MB |
+| mimi_decoder | 20 MB | ~5 MB |
+| Constants | 28 MB | ~28 MB |
+| **Total** | **627 MB** | **~135 MB** |
+
+Note: cond_step and flowlm_step share the same transformer weights (289 MB each on disk) but are separate CoreML models because they have different input/output signatures.
+
+---
+
+## Environment Setup
+
+The conversion scripts require the upstream PocketTTS PyTorch package. It's installed as an editable dependency via `uv`.
+
+```bash
+cd models/tts/pocket_tts
+
+# Clone the upstream PocketTTS repo (provides the pocket_tts/ Python package)
+git clone https://github.com/kyutai-labs/pocket-tts.git pocket_tts_upstream
+cp -r pocket_tts_upstream/pocket_tts ./pocket_tts
+rm -rf pocket_tts_upstream
+
+# Install dependencies (requires uv: https://docs.astral.sh/uv/)
+uv sync --extra coreml
+
+# Verify
+.venv/bin/python -c "from pocket_tts import TTSModel; print('OK')"
+```
+
+The `.python-version` file pins Python 3.10 (required for `pocket_tts` type syntax).
+
+## Reproducing the Conversion
+
+Requires PyTorch (one-time only):
+
+```bash
+# 1. Export constants
+.venv/bin/python coreml/convert_assets/export_constants.py
+
+# 2. Convert models (each creates an .mlpackage)
+.venv/bin/python coreml/convert_models/convert/convert_cond_step.py
+.venv/bin/python coreml/convert_models/convert/convert_flowlm_step.py
+.venv/bin/python coreml/convert_models/convert/convert_flow_decoder.py
+# mimi_decoder requires a custom functional wrapper (see convert_mimi_decoder.py)
+
+# 3. Run generation (no PyTorch needed after conversion)
+.venv/bin/python coreml/generate_coreml_v4.py
+```
+
+---
+
+## Porting to Swift
+
+All components map to native Swift/Apple frameworks:
+
+| Python | Swift |
+|--------|-------|
+| SentencePiece | swift-sentencepiece or bundled C lib |
+| numpy array ops | `[Float]` + Accelerate/vDSP |
+| safetensors | Simple binary parser (~50 lines) |
+| coremltools inference | `MLModel.prediction(from:)` (native, faster) |
+| scipy WAV write | AVFoundation |
+
+The 4 `.mlpackage` files and constants bundle directly into an Xcode project.

--- a/mobius/models/tts/pocket_tts/coreml/TRIALS.md
+++ b/mobius/models/tts/pocket_tts/coreml/TRIALS.md
@@ -1,0 +1,145 @@
+# PocketTTS CoreML Conversion — Trial Log
+
+Chronological record of all attempts, failures, and fixes to port PocketTTS from PyTorch to pure CoreML.
+
+---
+
+## Phase 1: Monolithic Conversion Attempts
+
+### Trial 1 — Full model trace (`convert_pocket_tts.py`)
+**Approach:** Trace the entire PocketTTS model as one CoreML model.
+**Result:** Failed. The model has dynamic control flow (autoregressive loop, EOS checking, variable-length generation) that `torch.jit.trace` cannot capture. CoreML requires static compute graphs.
+
+### Trial 2 — ONNX intermediate (`convert_via_onnx.py`)
+**Approach:** Export to ONNX first, then convert ONNX to CoreML.
+**Result:** Failed. Same dynamic control flow issues. ONNX export also choked on the streaming KV cache scatter operations.
+
+### Trial 3 — Split into submodels (`convert_pocket_tts_v2.py`, `v3`, `v4`)
+**Approach:** Split the pipeline into separate traceable modules:
+- Text encoder
+- Flow decoder
+- Mimi decoder
+- EOS detector
+
+**Result:** Partial success. Individual components converted but the orchestration between them still required PyTorch for KV cache management, text preparation, and conditioning.
+
+---
+
+## Phase 2: Step-Based Architecture
+
+### Trial 4 — Traceable FlowLM backbone (`traceable_flowlm.py`)
+**Approach:** Create a traceable wrapper for the full transformer backbone that takes `text_embeddings` as a fixed-size input and manages KV cache internally.
+**Result:** Converted successfully to `flowlm_backbone_v2.mlpackage`, but required fixed `text_embeddings` shape `[1, 100, 1024]`. This forced zero-padding for shorter inputs, which corrupted the KV cache (see Trial 7).
+
+### Trial 5 — Flexible text_embeddings shape
+**Approach:** Use `ct.RangeDim` to allow variable-length `text_embeddings` input `[1, (1-200), 1024]`.
+**Result:** Failed. CoreML's `scatter_along_axis` op threw `AssertionError` with dynamic shapes. The scatter operation in the streaming KV cache requires static dimensions.
+
+### Trial 6 — Fixed T_text=150 (`convert_flowlm.py`)
+**Approach:** Fix `text_embeddings` to `[1, 150, 1024]` — large enough for any voice+text combination.
+**Result:** Converted to `flowlm_backbone_v3.mlpackage`. But still required zero-padding shorter conditioning sequences.
+
+---
+
+## Phase 3: Flow Decoder Fix
+
+### Trial 7 — Flow decoder time values bug
+**Bug:** The `TraceableFlowDecoder` was passing wrong time values to `SimpleMLPAdaLN`:
+- `s` (start time) was hardcoded to `0` instead of `i/N`
+- `t` (end time) received `lsd_step * dt` (the start value) instead of `(lsd_step + 1) * dt`
+
+**Symptom:** CoreML generation produced gibberish audio despite transformer outputs matching PyTorch exactly. The 8-step LSD flow decoding was computing wrong velocity fields at every step.
+
+**Root cause:** `SimpleMLPAdaLN.forward(c, s, t, x)` takes TWO time conditions and averages their embeddings. With `s=0` always, the flow trajectory was wrong.
+
+**Fix:** Updated `traceable_flow_decoder.py` to accept explicit `s` and `t` inputs:
+```python
+# Before (wrong):
+s = torch.zeros_like(t)  # always 0
+velocity = self.flow_net(transformer_out, s, t, latent)
+
+# After (correct):
+def forward(self, transformer_out, latent, s, t):
+    velocity = self.flow_net(transformer_out, s, t, latent)
+```
+
+And the generation loop:
+```python
+# Before (wrong):
+t_np = np.array([[lsd_step * dt]])  # this is s, not t!
+
+# After (correct):
+s_np = np.array([[lsd_step * dt]])
+t_np = np.array([[(lsd_step + 1) * dt]])
+```
+
+**Result:** CoreML generation now produced correct speech. Whisper transcribed output as "Hello, this is Pure CoreML Text to Speech Generation." — matching PyTorch reference.
+
+---
+
+## Phase 4: Eliminating PyTorch from Setup
+
+### Trial 8 — Zero-padding conditioning corruption
+**Approach:** Use `flowlm_backbone_v3.mlpackage` (T_text=150) with zero-padded conditioning. Pad the 141-token conditioning sequence (125 voice + 16 text) with 9 zeros to fill the fixed 150-slot input.
+
+**Result:** Failed. Zero-padded tokens are NOT ignored — they pass through LayerNorm (which has bias terms) and FFN layers, producing non-zero KV cache entries. The model wrote KV entries at positions 0-149 instead of 0-140, advancing the position counter to 150 instead of 141. Generation started at the wrong position, producing garbage.
+
+**Key insight:** You cannot zero-pad conditioning tokens. Each padded token creates a real (non-zero) KV cache entry because LayerNorm bias + FFN bias transform zeros into non-zero activations.
+
+### Trial 9 — Conditioning step model (`traceable_cond_step.py`, v1)
+**Approach:** Create a separate CoreML model that processes ONE conditioning token at a time. Feed all 141 tokens sequentially, no padding needed.
+
+**Result:** Positions now correct (141), EOS triggered at step 21. But audio quality was wrong — Whisper transcribed as "Third is... Yes." instead of expected text.
+
+**Root cause:** The attention implementation in `traceable_cond_step.py` differed from the verified `traceable_flowlm_step.py`:
+
+| Aspect | Step model (correct) | Cond step v1 (wrong) |
+|--------|---------------------|----------------------|
+| QKV split | `.reshape(B, T, 3, H, D)` slicing | `.chunk(3, dim=-1)` then `.view()` |
+| NaN handling | `torch.where(isnan, zeros, keys)` | None |
+| Masking | Boolean mask + `F.scaled_dot_product_attention` | Float mask + manual softmax + `-1e9` |
+| RoPE | `torch.exp(ds * (-math.log(10000) * 2/D))` | `1.0 / (10000 ** (2*indices/D))` |
+
+While mathematically equivalent, these code paths trace to different CoreML ops, and the missing NaN→0 replacement caused NaN propagation through attention.
+
+### Trial 10 — Conditioning step model (v2, fixed attention)
+**Approach:** Copy the exact `_apply_rope_tensor` and `_streaming_attention` methods from the verified `traceable_flowlm_step.py` into `traceable_cond_step.py`.
+
+**Result:** Reconverted `cond_step.mlpackage`. Still produced "Third is... Yes."
+
+**Root cause discovered via verification script:** The **conditioning order** was wrong.
+
+### Trial 11 — Conditioning order fix (voice-first)
+**Bug:** `generate_coreml_v4.py` concatenated `[text_emb, voice_emb]` (text first), but the original PocketTTS model processes **voice first** then text:
+1. `get_state_for_audio_prompt("alba")` → fills KV cache with 125 voice tokens (positions 0-124)
+2. `_run_flow_lm_and_increment_step(text_tokens)` → adds 16 text tokens (positions 125-140)
+
+**Verification:** Wrote a comparison script that ran both orders through the PyTorch cond_step model and compared KV caches against the original model:
+
+| Order | Max diff | Cosine sim |
+|-------|----------|-----------|
+| Voice-first | 0.000007 | 1.000 |
+| Text-first | 4.33–9.11 | 0.60–0.90 |
+
+**Fix:**
+```python
+# Before (wrong):
+combined = np.concatenate([text_emb, voice_emb], axis=1)
+
+# After (correct):
+combined = np.concatenate([voice_emb, text_emb], axis=1)
+```
+
+**Result:** Correct speech output. Whisper: "Hello, this is Pure CoreML Text to Speech Generation." Duration: 3.52s, 44 frames, EOS at step 41. Zero PyTorch dependency confirmed.
+
+---
+
+## Summary of Bugs Found
+
+| # | Bug | Symptom | Fix |
+|---|-----|---------|-----|
+| 1 | Flow decoder `s` hardcoded to 0 | Gibberish audio | Pass explicit `s = i/N` |
+| 2 | Flow decoder `t` off by one | Gibberish audio | Pass `t = (i+1)/N` |
+| 3 | Zero-padding conditioning | Wrong position (150 vs 141) | Use per-token cond_step model |
+| 4 | Attention implementation mismatch | Wrong KV cache content | Copy exact code from verified step model |
+| 5 | Conditioning order (text-first vs voice-first) | "Third is... Yes." | Swap to voice-first, then text |

--- a/mobius/models/tts/pocket_tts/coreml/convert_assets/export_constants.py
+++ b/mobius/models/tts/pocket_tts/coreml/convert_assets/export_constants.py
@@ -1,0 +1,88 @@
+"""One-time export of model constants as .npy files.
+
+Exports:
+- bos_emb.npy         [32]        BOS embedding
+- emb_mean.npy        [32]        Latent normalization mean
+- emb_std.npy         [32]        Latent normalization std
+- quantizer_weight.npy [512, 32]  Quantizer output projection
+- text_embed_table.npy [4001, 1024] Text token embedding table
+
+Run once, then the generation script can load these without PyTorch.
+"""
+import numpy as np
+import sys
+import os
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_COREML_DIR = os.path.dirname(_SCRIPT_DIR)
+_PROJECT_DIR = os.path.dirname(_COREML_DIR)
+sys.path.insert(0, _PROJECT_DIR)  # for: from pocket_tts import ...
+sys.path.insert(0, os.path.join(_COREML_DIR, "convert_models", "traceable"))  # for: from traceable_* import ...
+
+OUTPUT_DIR = os.path.join(_COREML_DIR, "constants")
+
+
+def export():
+    import torch
+    from pocket_tts import TTSModel
+
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    print("Loading model...")
+    model = TTSModel.load_model(lsd_decode_steps=8)
+    model.eval()
+
+    # FlowLM constants
+    flow_lm = model.flow_lm
+
+    bos_emb = flow_lm.bos_emb.data.numpy().astype(np.float32)
+    print(f"bos_emb: {bos_emb.shape}")
+    np.save(os.path.join(OUTPUT_DIR, "bos_emb.npy"), bos_emb)
+
+    emb_mean = flow_lm.emb_mean.numpy().astype(np.float32)
+    print(f"emb_mean: {emb_mean.shape}")
+    np.save(os.path.join(OUTPUT_DIR, "emb_mean.npy"), emb_mean)
+
+    emb_std = flow_lm.emb_std.numpy().astype(np.float32)
+    print(f"emb_std: {emb_std.shape}")
+    np.save(os.path.join(OUTPUT_DIR, "emb_std.npy"), emb_std)
+
+    # Quantizer weight
+    q_weight = model.mimi.quantizer.output_proj.weight.detach().numpy().astype(np.float32)
+    print(f"quantizer_weight: {q_weight.shape}")
+    np.save(os.path.join(OUTPUT_DIR, "quantizer_weight.npy"), q_weight)
+
+    # Text embedding table
+    embed_table = flow_lm.conditioner.embed.weight.detach().numpy().astype(np.float32)
+    print(f"text_embed_table: {embed_table.shape}")
+    np.save(os.path.join(OUTPUT_DIR, "text_embed_table.npy"), embed_table)
+
+    # Also export the Mimi decoder init state
+    from pocket_tts.modules.stateful_module import init_states
+
+    state = init_states(model.mimi.decoder, batch_size=1, sequence_length=256)
+    state.update(init_states(model.mimi.decoder_transformer, batch_size=1, sequence_length=256))
+    if hasattr(model.mimi, "upsample"):
+        state.update(init_states(model.mimi.upsample, batch_size=1, sequence_length=256))
+
+    mimi_state_np = {}
+    for mod_name, mod_state in state.items():
+        for key, tensor in mod_state.items():
+            mimi_state_np[key] = tensor.numpy().astype(np.float32)
+    np.savez(os.path.join(OUTPUT_DIR, "mimi_init_state.npz"), **mimi_state_np)
+    print(f"mimi_init_state: {len(mimi_state_np)} tensors")
+
+    print(f"\nAll constants saved to {OUTPUT_DIR}/")
+
+    # Print sizes
+    total = 0
+    for f in os.listdir(OUTPUT_DIR):
+        path = os.path.join(OUTPUT_DIR, f)
+        size = os.path.getsize(path)
+        total += size
+        print(f"  {f}: {size / 1024:.1f} KB")
+    print(f"  TOTAL: {total / 1024:.1f} KB")
+
+
+if __name__ == "__main__":
+    export()

--- a/mobius/models/tts/pocket_tts/coreml/convert_models/convert/convert_cond_step.py
+++ b/mobius/models/tts/pocket_tts/coreml/convert_models/convert/convert_cond_step.py
@@ -1,0 +1,82 @@
+"""Convert conditioning step model to CoreML."""
+import torch
+import numpy as np
+import coremltools as ct
+import sys
+import os
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_CONVERT_MODELS_DIR = os.path.dirname(_SCRIPT_DIR)
+_COREML_DIR = os.path.dirname(_CONVERT_MODELS_DIR)
+_PROJECT_DIR = os.path.dirname(_COREML_DIR)
+sys.path.insert(0, _PROJECT_DIR)  # for: from pocket_tts import ...
+sys.path.insert(0, os.path.join(_CONVERT_MODELS_DIR, "traceable"))  # for: from traceable_* import ...
+
+from traceable_cond_step import TraceableCondStep
+
+
+def convert():
+    print("Loading model...")
+    from pocket_tts import TTSModel
+    model = TTSModel.load_model(lsd_decode_steps=8)
+    model.eval()
+
+    cond_step = TraceableCondStep.from_flowlm(model.flow_lm, max_seq_len=512)
+    cond_step.eval()
+
+    # Example inputs
+    conditioning = torch.randn(1, 1, 1024)
+    cache = torch.full((2, 1, 512, 16, 64), float('nan'))
+    pos = torch.zeros(1)
+
+    example_inputs = (
+        conditioning,
+        cache, pos, cache.clone(), pos.clone(),
+        cache.clone(), pos.clone(), cache.clone(), pos.clone(),
+        cache.clone(), pos.clone(), cache.clone(), pos.clone(),
+    )
+
+    print("Tracing...")
+    with torch.no_grad():
+        traced = torch.jit.trace(cond_step, example_inputs)
+
+    print("Converting to CoreML...")
+    inputs = [ct.TensorType(name="conditioning", shape=(1, 1, 1024))]
+    for i in range(6):
+        inputs.append(ct.TensorType(name=f"cache{i}", shape=(2, 1, 512, 16, 64)))
+        inputs.append(ct.TensorType(name=f"position{i}", shape=(1,)))
+
+    mlmodel = ct.convert(
+        traced,
+        inputs=inputs,
+        minimum_deployment_target=ct.target.iOS17,
+        compute_precision=ct.precision.FLOAT32,
+    )
+
+    output_path = "cond_step.mlpackage"
+    mlmodel.save(output_path)
+    print(f"Saved to {output_path}")
+
+    # Print outputs
+    spec = mlmodel.get_spec()
+    print("\n=== OUTPUTS ===")
+    for out in spec.description.output:
+        if out.type.HasField('multiArrayType'):
+            print(f"  {out.name}: {list(out.type.multiArrayType.shape)}")
+
+    # Quick test
+    print("\nTesting...")
+    coreml_model = ct.models.MLModel(output_path, compute_units=ct.ComputeUnit.CPU_AND_GPU)
+    test_inputs = {
+        'conditioning': np.random.randn(1, 1, 1024).astype(np.float32),
+    }
+    for i in range(6):
+        test_inputs[f'cache{i}'] = np.zeros((2, 1, 512, 16, 64), dtype=np.float32)
+        test_inputs[f'position{i}'] = np.array([0.0], dtype=np.float32)
+    out = coreml_model.predict(test_inputs)
+    print(f"Output keys: {len(out)}")
+    print("Done!")
+
+
+if __name__ == "__main__":
+    convert()

--- a/mobius/models/tts/pocket_tts/coreml/convert_models/convert/convert_flow_decoder_v2.py
+++ b/mobius/models/tts/pocket_tts/coreml/convert_models/convert/convert_flow_decoder_v2.py
@@ -1,0 +1,81 @@
+"""Convert traceable flow decoder to CoreML."""
+import torch
+import numpy as np
+import coremltools as ct
+import sys
+import os
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_CONVERT_MODELS_DIR = os.path.dirname(_SCRIPT_DIR)
+_COREML_DIR = os.path.dirname(_CONVERT_MODELS_DIR)
+_PROJECT_DIR = os.path.dirname(_COREML_DIR)
+sys.path.insert(0, _PROJECT_DIR)  # for: from pocket_tts import ...
+sys.path.insert(0, os.path.join(_CONVERT_MODELS_DIR, "traceable"))  # for: from traceable_* import ...
+
+from traceable_flow_decoder import TraceableFlowDecoder
+
+
+def convert_flow_decoder():
+    print("Loading model...")
+    from pocket_tts import TTSModel
+    model = TTSModel.load_model(lsd_decode_steps=8)
+    model.eval()
+
+    print("Creating traceable flow decoder...")
+    flow_decoder = TraceableFlowDecoder.from_flowlm(model.flow_lm)
+    flow_decoder.eval()
+
+    print("Creating example inputs...")
+    transformer_out = torch.randn(1, 1024)
+    latent = torch.randn(1, 32)
+    s = torch.tensor([[0.0]])
+    t = torch.tensor([[0.125]])
+
+    print("Tracing model...")
+    with torch.no_grad():
+        traced = torch.jit.trace(flow_decoder, (transformer_out, latent, s, t))
+
+    print("Converting to CoreML...")
+    mlmodel = ct.convert(
+        traced,
+        inputs=[
+            ct.TensorType(name="transformer_out", shape=(1, 1024)),
+            ct.TensorType(name="latent", shape=(1, 32)),
+            ct.TensorType(name="s", shape=(1, 1)),
+            ct.TensorType(name="t", shape=(1, 1)),
+        ],
+        minimum_deployment_target=ct.target.iOS17,
+        compute_precision=ct.precision.FLOAT32,
+    )
+
+    output_path = "flow_decoder.mlpackage"
+    print(f"Saving to {output_path}...")
+    mlmodel.save(output_path)
+
+    # Test
+    print("\nTesting CoreML model...")
+    coreml_model = ct.models.MLModel(output_path, compute_units=ct.ComputeUnit.CPU_AND_GPU)
+
+    test_transformer = np.random.randn(1, 1024).astype(np.float32)
+    test_latent = np.random.randn(1, 32).astype(np.float32)
+    test_s = np.array([[0.0]], dtype=np.float32)
+    test_t = np.array([[0.125]], dtype=np.float32)
+
+    outputs = coreml_model.predict({
+        'transformer_out': test_transformer,
+        'latent': test_latent,
+        's': test_s,
+        't': test_t,
+    })
+
+    print(f"Output keys: {list(outputs.keys())}")
+    velocity = list(outputs.values())[0]
+    print(f"Velocity shape: {velocity.shape}")
+    print(f"Velocity range: [{velocity.min():.4f}, {velocity.max():.4f}]")
+
+    print("\nDone!")
+    return output_path
+
+
+if __name__ == "__main__":
+    convert_flow_decoder()

--- a/mobius/models/tts/pocket_tts/coreml/convert_models/convert/convert_flowlm_step.py
+++ b/mobius/models/tts/pocket_tts/coreml/convert_models/convert/convert_flowlm_step.py
@@ -1,0 +1,113 @@
+"""Convert FlowLM step model to CoreML."""
+import torch
+import numpy as np
+import coremltools as ct
+import sys
+import os
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_CONVERT_MODELS_DIR = os.path.dirname(_SCRIPT_DIR)
+_COREML_DIR = os.path.dirname(_CONVERT_MODELS_DIR)
+_PROJECT_DIR = os.path.dirname(_COREML_DIR)
+sys.path.insert(0, _PROJECT_DIR)  # for: from pocket_tts import ...
+sys.path.insert(0, os.path.join(_CONVERT_MODELS_DIR, "traceable"))  # for: from traceable_* import ...
+
+from traceable_flowlm_step import TraceableFlowLMStep
+
+
+def convert_flowlm_step():
+    print("Loading model...")
+    from pocket_tts import TTSModel
+    model = TTSModel.load_model(lsd_decode_steps=8)
+    model.eval()
+
+    print("Creating traceable step model...")
+    max_seq_len = 512
+    step_model = TraceableFlowLMStep.from_flowlm(model.flow_lm, max_seq_len=max_seq_len)
+    step_model.eval()
+
+    print("Creating example inputs...")
+    B = 1
+    T = 1
+    H = 16
+    D = 64
+
+    sequence = torch.randn(B, T, 32)
+    bos_emb = model.flow_lm.bos_emb.data
+
+    # Create example caches and positions
+    caches = []
+    positions = []
+    for i in range(6):
+        cache = torch.zeros(2, B, max_seq_len, H, D)
+        # Fill some positions with data (simulating voice/text conditioning)
+        cache[:, :, :136, :, :] = torch.randn(2, B, 136, H, D)
+        caches.append(cache)
+        positions.append(torch.tensor([136.0]))
+
+    print("Tracing model...")
+    with torch.no_grad():
+        traced = torch.jit.trace(step_model, (
+            sequence, bos_emb,
+            caches[0], positions[0],
+            caches[1], positions[1],
+            caches[2], positions[2],
+            caches[3], positions[3],
+            caches[4], positions[4],
+            caches[5], positions[5],
+        ))
+
+    print("Converting to CoreML...")
+    inputs = [
+        ct.TensorType(name="sequence", shape=(1, 1, 32)),
+        ct.TensorType(name="bos_emb", shape=(32,)),
+    ]
+    for i in range(6):
+        inputs.append(ct.TensorType(name=f"cache{i}", shape=(2, 1, max_seq_len, H, D)))
+        inputs.append(ct.TensorType(name=f"position{i}", shape=(1,)))
+
+    mlmodel = ct.convert(
+        traced,
+        inputs=inputs,
+        minimum_deployment_target=ct.target.iOS17,
+        compute_precision=ct.precision.FLOAT32,
+    )
+
+    output_path = "flowlm_step.mlpackage"
+    print(f"Saving to {output_path}...")
+    mlmodel.save(output_path)
+
+    # Test
+    print("\nTesting CoreML model...")
+    coreml_model = ct.models.MLModel(output_path, compute_units=ct.ComputeUnit.CPU_AND_GPU)
+
+    # Create test inputs
+    test_seq = np.random.randn(1, 1, 32).astype(np.float32)
+    test_bos = bos_emb.numpy().astype(np.float32)
+
+    test_caches = {}
+    test_positions = {}
+    for i in range(6):
+        cache = np.zeros((2, 1, max_seq_len, H, D), dtype=np.float32)
+        cache[:, :, :136, :, :] = np.random.randn(2, 1, 136, H, D).astype(np.float32)
+        test_caches[f'cache{i}'] = cache
+        test_positions[f'position{i}'] = np.array([136.0], dtype=np.float32)
+
+    outputs = coreml_model.predict({
+        'sequence': test_seq,
+        'bos_emb': test_bos,
+        **test_caches,
+        **test_positions,
+    })
+
+    print(f"Output keys: {list(outputs.keys())}")
+    for k, v in outputs.items():
+        if isinstance(v, np.ndarray):
+            print(f"  {k}: shape={v.shape}, range=[{v.min():.4f}, {v.max():.4f}]")
+
+    print("\nDone!")
+    return output_path
+
+
+if __name__ == "__main__":
+    convert_flowlm_step()

--- a/mobius/models/tts/pocket_tts/coreml/convert_models/convert/convert_mimi_decoder.py
+++ b/mobius/models/tts/pocket_tts/coreml/convert_models/convert/convert_mimi_decoder.py
@@ -1,0 +1,77 @@
+"""Convert Mimi streaming decoder to CoreML.
+
+NOTE: The Mimi decoder uses in-place state mutations (state[:] = ...) in its
+streaming convolution layers (StreamingConv1d, StreamingConvTranspose1d).
+coremltools cannot convert these in-place operations directly.
+
+The existing mimi_decoder.mlpackage was converted using a custom traceable
+wrapper that rewrites all streaming ops as functional (returning new tensors
+instead of mutating in place). This requires rewriting the forward pass of:
+  - StreamingConv1d.forward()       (conv.py)
+  - StreamingConvTranspose1d.forward()  (conv.py)
+  - MimiTransformerLayer attention cache updates  (mimi_transformer.py)
+
+The model has 26 streaming state tensors (see traceable_mimi_decoder.py for
+the full list) and produces 1920 audio samples per frame at 24kHz.
+
+To regenerate mimi_decoder.mlpackage:
+1. Create a functional TraceableMimiDecoder that avoids all in-place ops
+2. Trace with sequence_length=256 for attention caches
+3. Convert with compute_precision=FLOAT32, target=macOS15
+
+Input:  latent [1, 512, 1]  +  26 state tensors
+Output: audio  [1, 1, 1920] +  26 updated state tensors
+"""
+import sys
+import os
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_CONVERT_MODELS_DIR = os.path.dirname(_SCRIPT_DIR)
+_COREML_DIR = os.path.dirname(_CONVERT_MODELS_DIR)
+_PROJECT_DIR = os.path.dirname(_COREML_DIR)
+sys.path.insert(0, _PROJECT_DIR)  # for: from pocket_tts import ...
+sys.path.insert(0, os.path.join(_CONVERT_MODELS_DIR, "traceable"))  # for: from traceable_* import ...
+
+
+def convert():
+    """Reference conversion — requires functional Mimi wrapper (see docstring)."""
+    import torch
+    import numpy as np
+    import coremltools as ct
+    from pocket_tts import TTSModel
+    from pocket_tts.modules.stateful_module import init_states
+
+    print("Loading model...")
+    model = TTSModel.load_model(lsd_decode_steps=8)
+    model.eval()
+
+    # Show the state structure for reference
+    print("\nMimi decoder streaming state:")
+    state = init_states(model.mimi.decoder, batch_size=1, sequence_length=256)
+    state.update(
+        init_states(model.mimi.decoder_transformer, batch_size=1, sequence_length=256)
+    )
+    if hasattr(model.mimi, "upsample"):
+        state.update(
+            init_states(model.mimi.upsample, batch_size=1, sequence_length=256)
+        )
+
+    total_params = 0
+    for mod_name, mod_state in state.items():
+        for key, tensor in mod_state.items():
+            total_params += tensor.numel()
+            print(f"  {mod_name}.{key}: {list(tensor.shape)}")
+
+    print(f"\nTotal state elements: {total_params:,}")
+    print(f"State tensors: {sum(len(s) for s in state.values())}")
+
+    print(
+        "\nERROR: Direct conversion not supported due to in-place state mutations."
+    )
+    print("The existing mimi_decoder.mlpackage uses a custom functional wrapper.")
+    print("See this file's docstring for details on how to regenerate it.")
+    return None
+
+
+if __name__ == "__main__":
+    convert()

--- a/mobius/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_cond_step.py
+++ b/mobius/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_cond_step.py
@@ -1,0 +1,261 @@
+"""Traceable conditioning step for CoreML - fills KV cache one token at a time.
+
+Unlike the FlowLM step model (which takes 32d latents via input_linear),
+this takes 1024d conditioning embeddings directly (text or voice).
+No BOS handling, no EOS output - just fills the KV cache.
+"""
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+from typing import Tuple
+import math
+import sys
+import os
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(_SCRIPT_DIR)))
+sys.path.insert(0, _PROJECT_DIR)  # for: from pocket_tts import ...
+
+
+class TraceableCondStep(nn.Module):
+    """Processes one conditioning token through the transformer, updating KV cache.
+
+    Input: conditioning [1, 1, 1024] (pre-embedded text or voice token)
+    Output: updated KV caches and positions
+    """
+
+    def __init__(self, max_seq_len: int = 200):
+        super().__init__()
+        self.num_layers = 6
+        self.embed_dim = 1024
+        self.num_heads = 16
+        self.head_dim = 64
+        self.max_seq_len = max_seq_len
+        self.rope_max_period = 10000.0
+
+        for i in range(self.num_layers):
+            setattr(self, f'attn{i}_in_proj', nn.Linear(1024, 3 * 1024, bias=False))
+            setattr(self, f'attn{i}_out_proj', nn.Linear(1024, 1024, bias=False))
+            setattr(self, f'norm{i}_1', nn.LayerNorm(1024, eps=1e-5))
+            setattr(self, f'norm{i}_2', nn.LayerNorm(1024, eps=1e-5))
+            setattr(self, f'linear{i}_1', nn.Linear(1024, 4096, bias=False))
+            setattr(self, f'linear{i}_2', nn.Linear(4096, 1024, bias=False))
+
+        self.out_norm = nn.LayerNorm(1024, eps=1e-5)
+
+    @classmethod
+    def from_flowlm(cls, flow_lm_model, max_seq_len: int = 200) -> "TraceableCondStep":
+        wrapper = cls(max_seq_len)
+
+        # Copy transformer layers (same weights as step model, no input_linear)
+        for i, layer in enumerate(flow_lm_model.transformer.layers):
+            getattr(wrapper, f'attn{i}_in_proj').weight.data.copy_(layer.self_attn.in_proj.weight.data)
+            getattr(wrapper, f'attn{i}_out_proj').weight.data.copy_(layer.self_attn.out_proj.weight.data)
+            getattr(wrapper, f'norm{i}_1').weight.data.copy_(layer.norm1.weight.data)
+            getattr(wrapper, f'norm{i}_1').bias.data.copy_(layer.norm1.bias.data)
+            getattr(wrapper, f'norm{i}_2').weight.data.copy_(layer.norm2.weight.data)
+            getattr(wrapper, f'norm{i}_2').bias.data.copy_(layer.norm2.bias.data)
+            getattr(wrapper, f'linear{i}_1').weight.data.copy_(layer.linear1.weight.data)
+            getattr(wrapper, f'linear{i}_2').weight.data.copy_(layer.linear2.weight.data)
+
+        wrapper.out_norm.weight.data.copy_(flow_lm_model.out_norm.weight.data)
+        wrapper.out_norm.bias.data.copy_(flow_lm_model.out_norm.bias.data)
+
+        return wrapper
+
+    def _apply_rope_tensor(self, q: torch.Tensor, k: torch.Tensor, offset: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Apply rotary position embeddings with tensor offset.
+
+        Uses interleaved pairs: (q[..., 0], q[..., 1]), (q[..., 2], q[..., 3]), etc.
+        Identical to TraceableFlowLMStep._apply_rope_tensor.
+        """
+        B, T, H, D = q.shape
+        Bk, Tk, Hk, Dk = k.shape
+        D_float = float(self.head_dim)
+        half_d = self.head_dim // 2
+
+        # Compute RoPE frequencies
+        ds = torch.arange(half_d, device=q.device, dtype=torch.float32)
+        freqs = torch.exp(ds * (-math.log(self.rope_max_period) * 2.0 / D_float))
+
+        # Position indices
+        ts = torch.arange(T, device=q.device, dtype=torch.float32)
+        offset_f = offset.float() if offset.dtype != torch.float32 else offset
+        ts = ts + offset_f.view(B, 1)
+        ts = ts.view(B, T, 1, 1)
+
+        # View as interleaved pairs
+        q_complex = q.view(B, T, H, half_d, 2)
+        k_complex = k.view(Bk, Tk, Hk, half_d, 2)
+
+        # Extract real and imaginary parts
+        qr = q_complex[..., 0].float()
+        qi = q_complex[..., 1].float()
+        kr = k_complex[..., 0].float()
+        ki = k_complex[..., 1].float()
+
+        # Compute rotation angles
+        rotr = torch.cos(freqs * ts)
+        roti = torch.sin(freqs * ts)
+
+        # Apply complex rotation
+        qor = qr * rotr - qi * roti
+        qoi = qr * roti + qi * rotr
+        kor = kr * rotr - ki * roti
+        koi = kr * roti + ki * rotr
+
+        # Stack back to original shape
+        dtype = q.dtype
+        qo = torch.stack([qor.to(dtype), qoi.to(dtype)], dim=-1)
+        ko = torch.stack([kor.to(dtype), koi.to(dtype)], dim=-1)
+
+        return qo.view(B, T, H, D), ko.view(Bk, Tk, Hk, Dk)
+
+    def _streaming_attention(
+        self,
+        x: torch.Tensor,
+        in_proj: nn.Linear,
+        out_proj: nn.Linear,
+        cache: torch.Tensor,
+        position: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Streaming attention with fixed-size KV cache.
+
+        Identical to TraceableFlowLMStep._streaming_attention.
+        """
+        B, T, _ = x.shape
+        H = self.num_heads
+        D = self.head_dim
+        max_len = cache.shape[2]
+        max_len_float = float(max_len)
+
+        pos_float = position.float() if position.dtype != torch.float32 else position
+
+        # Project to Q, K, V
+        qkv = in_proj(x).reshape(B, T, 3, H, D)
+        q, k, v = qkv[:, :, 0], qkv[:, :, 1], qkv[:, :, 2]
+
+        # Apply RoPE
+        q, k = self._apply_rope_tensor(q, k, pos_float)
+
+        # Update cache
+        new_cache = cache.clone()
+        write_base_float = pos_float.view(B, 1, 1, 1)
+        write_offsets_float = torch.arange(T, device=x.device, dtype=torch.float32).view(1, T, 1, 1)
+        write_indices_float = write_base_float + write_offsets_float
+        write_indices_float = write_indices_float - torch.floor(write_indices_float / max_len_float) * max_len_float
+        write_indices = write_indices_float.long().expand(B, T, H, D)
+
+        new_cache[0] = new_cache[0].scatter(1, write_indices, k)
+        new_cache[1] = new_cache[1].scatter(1, write_indices, v)
+
+        # Full cache attention
+        keys = new_cache[0]
+        values = new_cache[1]
+
+        # Replace NaN with 0 for attention (NaN * 0 weight = NaN, but 0 * 0 = 0)
+        # The mask will ensure these positions don't contribute to the output
+        keys = torch.where(torch.isnan(keys), torch.zeros_like(keys), keys)
+        values = torch.where(torch.isnan(values), torch.zeros_like(values), values)
+
+        q = q.permute(0, 2, 1, 3)
+        keys = keys.permute(0, 2, 1, 3)
+        values = values.permute(0, 2, 1, 3)
+
+        # Create attention mask
+        q_offsets = torch.arange(T, device=x.device, dtype=torch.float32).view(1, T, 1)
+        q_positions = pos_float.view(B, 1, 1) + q_offsets
+        k_positions = torch.arange(max_len, device=x.device, dtype=torch.float32).view(1, 1, max_len)
+
+        valid_len = pos_float.view(B, 1, 1) + float(T)
+        valid_mask = k_positions < valid_len
+        causal_mask = k_positions <= q_positions
+
+        attn_mask = valid_mask & causal_mask
+        attn_mask = attn_mask.unsqueeze(1)
+
+        # Manual attention (avoids scaled_dot_product_attention op for iOS 17 compat)
+        scale = 1.0 / (q.shape[-1] ** 0.5)
+        attn_weights = torch.matmul(q, keys.transpose(-2, -1)) * scale
+        attn_weights = attn_weights.masked_fill(~attn_mask, float("-inf"))
+        attn_weights = torch.softmax(attn_weights, dim=-1)
+        attn_output = torch.matmul(attn_weights, values)
+
+        attn_output = attn_output.permute(0, 2, 1, 3).reshape(B, T, self.embed_dim)
+        output = out_proj(attn_output)
+
+        new_position = pos_float + float(T)
+
+        return output, new_cache, new_position
+
+    def forward(
+        self,
+        conditioning: torch.Tensor,  # [B, 1, 1024] pre-embedded conditioning token
+        cache0: torch.Tensor, position0: torch.Tensor,
+        cache1: torch.Tensor, position1: torch.Tensor,
+        cache2: torch.Tensor, position2: torch.Tensor,
+        cache3: torch.Tensor, position3: torch.Tensor,
+        cache4: torch.Tensor, position4: torch.Tensor,
+        cache5: torch.Tensor, position5: torch.Tensor,
+    ):
+        """Process one conditioning token through transformer.
+
+        No input_linear (conditioning is already 1024d).
+        No BOS handling. No EOS output.
+        """
+        x = conditioning  # [B, 1, 1024]
+
+        caches = [cache0, cache1, cache2, cache3, cache4, cache5]
+        positions = [position0, position1, position2, position3, position4, position5]
+        new_caches = []
+        new_positions = []
+
+        for i in range(self.num_layers):
+            residual = x
+            x_norm = getattr(self, f'norm{i}_1')(x)
+            attn_out, new_cache, new_pos = self._streaming_attention(
+                x_norm,
+                getattr(self, f'attn{i}_in_proj'),
+                getattr(self, f'attn{i}_out_proj'),
+                caches[i],
+                positions[i]
+            )
+            x = residual + attn_out
+
+            residual = x
+            x_norm = getattr(self, f'norm{i}_2')(x)
+            ffn_out = getattr(self, f'linear{i}_2')(F.gelu(getattr(self, f'linear{i}_1')(x_norm)))
+            x = residual + ffn_out
+
+            new_caches.append(new_cache)
+            new_positions.append(new_pos)
+
+        return (
+            new_caches[0], new_positions[0],
+            new_caches[1], new_positions[1],
+            new_caches[2], new_positions[2],
+            new_caches[3], new_positions[3],
+            new_caches[4], new_positions[4],
+            new_caches[5], new_positions[5],
+        )
+
+
+if __name__ == "__main__":
+    from pocket_tts import TTSModel
+    model = TTSModel.load_model(lsd_decode_steps=8)
+    model.eval()
+
+    cond_step = TraceableCondStep.from_flowlm(model.flow_lm, max_seq_len=200)
+    cond_step.eval()
+    print(f"Created conditioning step model")
+
+    # Test
+    cond = torch.randn(1, 1, 1024)
+    cache = torch.full((2, 1, 200, 16, 64), float('nan'))
+    pos = torch.zeros(1)
+    with torch.no_grad():
+        out = cond_step(cond, cache, pos, cache.clone(), pos.clone(),
+                        cache.clone(), pos.clone(), cache.clone(), pos.clone(),
+                        cache.clone(), pos.clone(), cache.clone(), pos.clone())
+    print(f"Output: {len(out)} tensors")
+    print(f"New position: {out[1].item()}")

--- a/mobius/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_flow_decoder.py
+++ b/mobius/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_flow_decoder.py
@@ -1,0 +1,99 @@
+"""Traceable Flow Decoder with variable time step for LSD decoding."""
+import torch
+import torch.nn as nn
+from typing import Tuple
+
+
+class TraceableFlowDecoder(nn.Module):
+    """Flow decoder that takes time interval as input for LSD decoding.
+
+    For LSD (Lagrangian Self Distillation) with N steps:
+    - Start with noise z_0
+    - For i in [0, 1, ..., N-1]:
+        s = i / N      (start time)
+        t = (i+1) / N  (end time)
+        velocity = flow_net(transformer_out, s, t, z_i)
+        z_{i+1} = z_i + velocity * (1/N)
+    - Final latent = z_N
+    """
+
+    def __init__(self, flow_net, ldim: int = 32):
+        super().__init__()
+        self.flow_net = flow_net
+        self.ldim = ldim
+
+    @classmethod
+    def from_flowlm(cls, flow_lm) -> "TraceableFlowDecoder":
+        return cls(flow_lm.flow_net, flow_lm.ldim)
+
+    def forward(
+        self,
+        transformer_out: torch.Tensor,  # [B, 1024]
+        latent: torch.Tensor,  # [B, 32] current latent estimate
+        s: torch.Tensor,  # [B, 1] start time of interval
+        t: torch.Tensor,  # [B, 1] end time of interval
+    ) -> torch.Tensor:
+        """Single flow step.
+
+        Args:
+            transformer_out: Conditioning from FlowLM backbone [B, 1024]
+            latent: Current latent estimate [B, 32]
+            s: Start time [B, 1], range [0, 1)
+            t: End time [B, 1], range (0, 1]
+
+        Returns:
+            velocity: Flow direction [B, 32]
+        """
+        # Get flow direction with both time endpoints
+        velocity = self.flow_net(transformer_out, s, t, latent)
+
+        return velocity
+
+
+def test_traceable_flow_decoder():
+    print("Loading model...")
+    import sys
+    import os
+    _script_dir = os.path.dirname(os.path.abspath(__file__))
+    _project_dir = os.path.dirname(os.path.dirname(os.path.dirname(_script_dir)))
+    sys.path.insert(0, _project_dir)
+
+    from pocket_tts import TTSModel
+    model = TTSModel.load_model(lsd_decode_steps=8)
+    model.eval()
+
+    print("Creating traceable flow decoder...")
+    flow_decoder = TraceableFlowDecoder.from_flowlm(model.flow_lm)
+    flow_decoder.eval()
+
+    print("Testing forward pass...")
+    transformer_out = torch.randn(1, 1024)
+    latent = torch.randn(1, 32)
+    s = torch.tensor([[0.0]])
+    t = torch.tensor([[0.125]])
+
+    with torch.no_grad():
+        velocity = flow_decoder(transformer_out, latent, s, t)
+
+    print(f"Velocity shape: {velocity.shape}")
+    print(f"Velocity range: [{velocity.min().item():.4f}, {velocity.max().item():.4f}]")
+
+    print("\nTesting full LSD decoding...")
+    num_steps = 8
+    latent = torch.randn(1, 32)
+    dt = 1.0 / num_steps
+
+    for step in range(num_steps):
+        s = torch.tensor([[step * dt]])
+        t = torch.tensor([[(step + 1) * dt]])
+        with torch.no_grad():
+            velocity = flow_decoder(transformer_out, latent, s, t)
+        latent = latent + velocity * dt
+        print(f"  Step {step}: s={s.item():.3f}, t={t.item():.3f}, latent range [{latent.min().item():.4f}, {latent.max().item():.4f}]")
+
+    print(f"\nFinal latent shape: {latent.shape}")
+    print("Done!")
+
+
+if __name__ == "__main__":
+    test_traceable_flow_decoder()

--- a/mobius/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_flowlm_step.py
+++ b/mobius/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_flowlm_step.py
@@ -1,0 +1,355 @@
+"""Traceable FlowLM step for CoreML - audio frame generation only.
+
+This is the "step" model used after text/voice conditioning is in the KV cache.
+It does NOT concatenate text embeddings - it just processes the audio latent frames.
+"""
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+from typing import Tuple
+import math
+import sys
+import os
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(_SCRIPT_DIR)))
+sys.path.insert(0, _PROJECT_DIR)  # for: from pocket_tts import ...
+
+
+class TraceableFlowLMStep(nn.Module):
+    """FlowLM backbone for step-by-step generation (no text concatenation).
+
+    Use this after text/voice conditioning is already in the KV cache.
+    """
+
+    def __init__(self, max_seq_len: int = 200):
+        super().__init__()
+
+        self.num_layers = 6
+        self.embed_dim = 1024
+        self.num_heads = 16
+        self.head_dim = 64
+        self.max_seq_len = max_seq_len
+        self.rope_max_period = 10000.0
+
+        # Input projection (ldim=32 -> dim=1024)
+        self.input_linear = nn.Linear(32, 1024, bias=False)
+
+        # Transformer layers
+        for i in range(self.num_layers):
+            # Attention
+            setattr(self, f'attn{i}_in_proj', nn.Linear(1024, 3 * 1024, bias=False))
+            setattr(self, f'attn{i}_out_proj', nn.Linear(1024, 1024, bias=False))
+
+            # Norms
+            setattr(self, f'norm{i}_1', nn.LayerNorm(1024, eps=1e-5))
+            setattr(self, f'norm{i}_2', nn.LayerNorm(1024, eps=1e-5))
+
+            # FFN
+            hidden_dim = 4096
+            setattr(self, f'linear{i}_1', nn.Linear(1024, hidden_dim, bias=False))
+            setattr(self, f'linear{i}_2', nn.Linear(hidden_dim, 1024, bias=False))
+
+        # Output norm
+        self.out_norm = nn.LayerNorm(1024, eps=1e-5)
+
+        # EOS prediction
+        self.out_eos = nn.Linear(1024, 1)
+
+    @classmethod
+    def from_flowlm(cls, flow_lm_model, max_seq_len: int = 200) -> "TraceableFlowLMStep":
+        """Create traceable step model from original FlowLM model."""
+        wrapper = cls(max_seq_len)
+
+        # Copy input linear
+        wrapper.input_linear.weight.data.copy_(flow_lm_model.input_linear.weight.data)
+
+        # Copy transformer layers
+        for i, layer in enumerate(flow_lm_model.transformer.layers):
+            # Attention
+            getattr(wrapper, f'attn{i}_in_proj').weight.data.copy_(layer.self_attn.in_proj.weight.data)
+            getattr(wrapper, f'attn{i}_out_proj').weight.data.copy_(layer.self_attn.out_proj.weight.data)
+
+            # Norms
+            getattr(wrapper, f'norm{i}_1').weight.data.copy_(layer.norm1.weight.data)
+            getattr(wrapper, f'norm{i}_1').bias.data.copy_(layer.norm1.bias.data)
+            getattr(wrapper, f'norm{i}_2').weight.data.copy_(layer.norm2.weight.data)
+            getattr(wrapper, f'norm{i}_2').bias.data.copy_(layer.norm2.bias.data)
+
+            # FFN
+            getattr(wrapper, f'linear{i}_1').weight.data.copy_(layer.linear1.weight.data)
+            getattr(wrapper, f'linear{i}_2').weight.data.copy_(layer.linear2.weight.data)
+
+        # Output norm
+        wrapper.out_norm.weight.data.copy_(flow_lm_model.out_norm.weight.data)
+        wrapper.out_norm.bias.data.copy_(flow_lm_model.out_norm.bias.data)
+
+        # EOS
+        wrapper.out_eos.weight.data.copy_(flow_lm_model.out_eos.weight.data)
+        wrapper.out_eos.bias.data.copy_(flow_lm_model.out_eos.bias.data)
+
+        return wrapper
+
+    def _apply_rope_tensor(self, q: torch.Tensor, k: torch.Tensor, offset: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Apply rotary position embeddings with tensor offset.
+
+        Uses interleaved pairs: (q[..., 0], q[..., 1]), (q[..., 2], q[..., 3]), etc.
+        """
+        B, T, H, D = q.shape
+        Bk, Tk, Hk, Dk = k.shape
+        D_float = float(self.head_dim)
+        half_d = self.head_dim // 2
+
+        # Compute RoPE frequencies
+        ds = torch.arange(half_d, device=q.device, dtype=torch.float32)
+        freqs = torch.exp(ds * (-math.log(self.rope_max_period) * 2.0 / D_float))
+
+        # Position indices
+        ts = torch.arange(T, device=q.device, dtype=torch.float32)
+        offset_f = offset.float() if offset.dtype != torch.float32 else offset
+        ts = ts + offset_f.view(B, 1)
+        ts = ts.view(B, T, 1, 1)
+
+        # View as interleaved pairs
+        q_complex = q.view(B, T, H, half_d, 2)
+        k_complex = k.view(Bk, Tk, Hk, half_d, 2)
+
+        # Extract real and imaginary parts
+        qr = q_complex[..., 0].float()
+        qi = q_complex[..., 1].float()
+        kr = k_complex[..., 0].float()
+        ki = k_complex[..., 1].float()
+
+        # Compute rotation angles
+        rotr = torch.cos(freqs * ts)
+        roti = torch.sin(freqs * ts)
+
+        # Apply complex rotation
+        qor = qr * rotr - qi * roti
+        qoi = qr * roti + qi * rotr
+        kor = kr * rotr - ki * roti
+        koi = kr * roti + ki * rotr
+
+        # Stack back to original shape
+        dtype = q.dtype
+        qo = torch.stack([qor.to(dtype), qoi.to(dtype)], dim=-1)
+        ko = torch.stack([kor.to(dtype), koi.to(dtype)], dim=-1)
+
+        return qo.view(B, T, H, D), ko.view(Bk, Tk, Hk, Dk)
+
+    def _streaming_attention(
+        self,
+        x: torch.Tensor,
+        in_proj: nn.Linear,
+        out_proj: nn.Linear,
+        cache: torch.Tensor,
+        position: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Streaming attention with fixed-size KV cache."""
+        B, T, _ = x.shape
+        H = self.num_heads
+        D = self.head_dim
+        max_len = cache.shape[2]
+        max_len_float = float(max_len)
+
+        pos_float = position.float() if position.dtype != torch.float32 else position
+
+        # Project to Q, K, V
+        qkv = in_proj(x).reshape(B, T, 3, H, D)
+        q, k, v = qkv[:, :, 0], qkv[:, :, 1], qkv[:, :, 2]
+
+        # Apply RoPE
+        q, k = self._apply_rope_tensor(q, k, pos_float)
+
+        # Update cache
+        new_cache = cache.clone()
+        write_base_float = pos_float.view(B, 1, 1, 1)
+        write_offsets_float = torch.arange(T, device=x.device, dtype=torch.float32).view(1, T, 1, 1)
+        write_indices_float = write_base_float + write_offsets_float
+        write_indices_float = write_indices_float - torch.floor(write_indices_float / max_len_float) * max_len_float
+        write_indices = write_indices_float.long().expand(B, T, H, D)
+
+        new_cache[0] = new_cache[0].scatter(1, write_indices, k)
+        new_cache[1] = new_cache[1].scatter(1, write_indices, v)
+
+        # Full cache attention
+        keys = new_cache[0]
+        values = new_cache[1]
+
+        # Replace NaN with 0 for attention (NaN * 0 weight = NaN, but 0 * 0 = 0)
+        # The mask will ensure these positions don't contribute to the output
+        keys = torch.where(torch.isnan(keys), torch.zeros_like(keys), keys)
+        values = torch.where(torch.isnan(values), torch.zeros_like(values), values)
+
+        q = q.permute(0, 2, 1, 3)
+        keys = keys.permute(0, 2, 1, 3)
+        values = values.permute(0, 2, 1, 3)
+
+        # Create attention mask
+        q_offsets = torch.arange(T, device=x.device, dtype=torch.float32).view(1, T, 1)
+        q_positions = pos_float.view(B, 1, 1) + q_offsets
+        k_positions = torch.arange(max_len, device=x.device, dtype=torch.float32).view(1, 1, max_len)
+
+        valid_len = pos_float.view(B, 1, 1) + float(T)
+        valid_mask = k_positions < valid_len
+        causal_mask = k_positions <= q_positions
+
+        attn_mask = valid_mask & causal_mask
+        attn_mask = attn_mask.unsqueeze(1)
+
+        # Manual attention (avoids scaled_dot_product_attention op for iOS 17 compat)
+        scale = 1.0 / (q.shape[-1] ** 0.5)
+        attn_weights = torch.matmul(q, keys.transpose(-2, -1)) * scale
+        attn_weights = attn_weights.masked_fill(~attn_mask, float("-inf"))
+        attn_weights = torch.softmax(attn_weights, dim=-1)
+        attn_output = torch.matmul(attn_weights, values)
+
+        attn_output = attn_output.permute(0, 2, 1, 3).reshape(B, T, self.embed_dim)
+        output = out_proj(attn_output)
+
+        new_position = pos_float + float(T)
+
+        return output, new_cache, new_position
+
+    def forward(
+        self,
+        sequence: torch.Tensor,  # [B, T, 32] input latents
+        bos_emb: torch.Tensor,  # [32] BOS embedding
+        cache0: torch.Tensor, position0: torch.Tensor,
+        cache1: torch.Tensor, position1: torch.Tensor,
+        cache2: torch.Tensor, position2: torch.Tensor,
+        cache3: torch.Tensor, position3: torch.Tensor,
+        cache4: torch.Tensor, position4: torch.Tensor,
+        cache5: torch.Tensor, position5: torch.Tensor,
+    ):
+        """Forward pass for step generation.
+
+        Args:
+            sequence: [B, T, 32] input latents (NaN for BOS)
+            bos_emb: [32] BOS embedding
+            cache0-5: [2, B, max_seq_len, 16, 64] KV caches (pre-filled with text/voice)
+            position0-5: [B] current positions
+
+        Returns:
+            transformer_out: [B, T, 1024]
+            is_eos: [B, T, 1]
+            new_cache0-5, new_position0-5
+        """
+        # Replace NaN values with BOS embedding
+        sequence = torch.where(torch.isnan(sequence), bos_emb, sequence)
+
+        # Project input (NO text concatenation - text is already in KV cache)
+        x = self.input_linear(sequence)  # [B, T, 1024]
+
+        caches = [cache0, cache1, cache2, cache3, cache4, cache5]
+        positions = [position0, position1, position2, position3, position4, position5]
+        new_caches = []
+        new_positions = []
+
+        # Transformer layers
+        for i in range(self.num_layers):
+            residual = x
+            x_norm = getattr(self, f'norm{i}_1')(x)
+            attn_out, new_cache, new_pos = self._streaming_attention(
+                x_norm,
+                getattr(self, f'attn{i}_in_proj'),
+                getattr(self, f'attn{i}_out_proj'),
+                caches[i],
+                positions[i]
+            )
+            x = residual + attn_out
+
+            residual = x
+            x_norm = getattr(self, f'norm{i}_2')(x)
+            ffn_out = getattr(self, f'linear{i}_2')(F.gelu(getattr(self, f'linear{i}_1')(x_norm)))
+            x = residual + ffn_out
+
+            new_caches.append(new_cache)
+            new_positions.append(new_pos)
+
+        # Output
+        x = self.out_norm(x)
+        is_eos = self.out_eos(x)
+
+        return (
+            x,
+            is_eos,
+            new_caches[0], new_positions[0],
+            new_caches[1], new_positions[1],
+            new_caches[2], new_positions[2],
+            new_caches[3], new_positions[3],
+            new_caches[4], new_positions[4],
+            new_caches[5], new_positions[5],
+        )
+
+
+def test_traceable_step():
+    """Test the step model matches original FlowLM."""
+    print("Loading PocketTTS model...")
+    from pocket_tts import TTSModel
+    model = TTSModel.load_model(lsd_decode_steps=8)
+    model.eval()
+
+    print("Creating traceable step model...")
+    step_model = TraceableFlowLMStep.from_flowlm(model.flow_lm, max_seq_len=200)
+    step_model.eval()
+
+    # Initialize with voice state
+    print("\nLoading voice state...")
+    voice_state = model.get_state_for_audio_prompt("alba")
+    model._expand_kv_cache(voice_state, sequence_length=200)
+
+    # Process text tokens first to fill KV cache
+    print("Processing text tokens...")
+    from pocket_tts.models.tts_model import prepare_text_prompt
+    prepared_text, _ = prepare_text_prompt("Hello world")
+    tokenized = model.flow_lm.conditioner.prepare(prepared_text)
+    text_tokens = tokenized.tokens
+    model._run_flow_lm_and_increment_step(model_state=voice_state, text_tokens=text_tokens)
+
+    # Extract KV cache from voice state
+    print("Extracting KV cache...")
+    caches = []
+    positions = []
+
+    for i in range(6):
+        key = f'transformer.layers.{i}.self_attn'
+        layer_state = voice_state[key]
+
+        # Extract cache [2, B, max_len, H, D]
+        cache = layer_state['cache']  # Already [2, B, max_len, H, D]
+        caches.append(cache)
+
+        # Position is the LENGTH of current_end (number of elements processed)
+        current_end = layer_state['current_end']
+        pos = torch.tensor([float(len(current_end))])
+        positions.append(pos)
+
+    print(f"Position: {positions[0].item()}")
+
+    # Test forward pass
+    print("\nTesting forward pass...")
+    bos_emb = model.flow_lm.bos_emb.data
+    sequence = torch.full((1, 1, 32), float('nan'))
+
+    with torch.no_grad():
+        outputs = step_model(
+            sequence, bos_emb,
+            caches[0], positions[0],
+            caches[1], positions[1],
+            caches[2], positions[2],
+            caches[3], positions[3],
+            caches[4], positions[4],
+            caches[5], positions[5],
+        )
+
+    transformer_out = outputs[0]
+    is_eos = outputs[1]
+    print(f"Transformer output shape: {transformer_out.shape}")
+    print(f"Transformer output range: [{transformer_out.min():.4f}, {transformer_out.max():.4f}]")
+    print(f"EOS output: {is_eos.item():.4f}")
+    print("Done!")
+
+
+if __name__ == "__main__":
+    test_traceable_step()

--- a/mobius/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_mimi_decoder.py
+++ b/mobius/models/tts/pocket_tts/coreml/convert_models/traceable/traceable_mimi_decoder.py
@@ -1,0 +1,149 @@
+"""Traceable Mimi streaming decoder for CoreML conversion.
+
+Flattens the stateful Mimi decoder into explicit input/output tensors
+so it can be traced with torch.jit.trace and converted to CoreML.
+
+Input:  latent [1, 512, 1] + 26 state tensors
+Output: audio [1, 1, 1920] + 26 updated state tensors
+"""
+import torch
+import torch.nn as nn
+
+
+# Ordered list of (state_name, shape) for the 26 Mimi streaming state tensors.
+# Must match the manifest.json order used by the Swift loader.
+MIMI_STATE_SPEC = [
+    ("upsample_partial", [1, 512, 16]),
+    ("attn0_cache", [2, 1, 8, 256, 64]),
+    ("attn0_offset", [1]),
+    ("attn0_end_offset", [1]),
+    ("attn1_cache", [2, 1, 8, 256, 64]),
+    ("attn1_offset", [1]),
+    ("attn1_end_offset", [1]),
+    ("conv0_prev", [1, 512, 6]),
+    ("conv0_first", [1]),
+    ("convtr0_partial", [1, 256, 6]),
+    ("res0_conv0_prev", [1, 256, 2]),
+    ("res0_conv0_first", [1]),
+    ("res0_conv1_prev", [1, 128, 0]),
+    ("res0_conv1_first", [1]),
+    ("convtr1_partial", [1, 128, 5]),
+    ("res1_conv0_prev", [1, 128, 2]),
+    ("res1_conv0_first", [1]),
+    ("res1_conv1_prev", [1, 64, 0]),
+    ("res1_conv1_first", [1]),
+    ("convtr2_partial", [1, 64, 4]),
+    ("res2_conv0_prev", [1, 64, 2]),
+    ("res2_conv0_first", [1]),
+    ("res2_conv1_prev", [1, 32, 0]),
+    ("res2_conv1_first", [1]),
+    ("conv_final_prev", [1, 64, 2]),
+    ("conv_final_first", [1]),
+]
+
+
+class TraceableMimiDecoder(nn.Module):
+    """Wrapper that exposes Mimi's streaming state as flat tensor I/O."""
+
+    def __init__(self, mimi_model):
+        super().__init__()
+        self.mimi = mimi_model
+
+        # Build the mapping from flat state list to nested model_state dict.
+        # init_states() returns {module_name: {key: tensor}}.
+        from pocket_tts.modules.stateful_module import init_states
+        self._nested_state = init_states(self.mimi.decoder, batch_size=1, sequence_length=1)
+        # Also add decoder_transformer and upsample states
+        self._nested_state.update(
+            init_states(self.mimi.decoder_transformer, batch_size=1, sequence_length=1)
+        )
+        if hasattr(self.mimi, 'upsample'):
+            self._nested_state.update(
+                init_states(self.mimi.upsample, batch_size=1, sequence_length=1)
+            )
+
+    @classmethod
+    def from_tts_model(cls, tts_model) -> "TraceableMimiDecoder":
+        return cls(tts_model.mimi)
+
+    def _pack_state(self, flat_tensors: tuple) -> dict:
+        """Convert flat tensor tuple into nested model_state dict."""
+        state = {}
+        # Rebuild nested structure from init_states template
+        idx = 0
+        for module_name, module_state in self._nested_state.items():
+            state[module_name] = {}
+            for key in module_state:
+                state[module_name][key] = flat_tensors[idx]
+                idx += 1
+        return state
+
+    def _unpack_state(self, state: dict) -> tuple:
+        """Extract flat tensor tuple from nested model_state dict."""
+        tensors = []
+        for module_name, module_state in self._nested_state.items():
+            for key in module_state:
+                tensors.append(state[module_name][key])
+        return tuple(tensors)
+
+    def forward(self, latent, *state_tensors):
+        """
+        Args:
+            latent: [1, 512, 1] quantized latent frame
+            *state_tensors: 26 flat state tensors
+
+        Returns:
+            audio: [1, 1, 1920] decoded audio frame
+            *updated_states: 26 updated state tensors
+        """
+        model_state = self._pack_state(state_tensors)
+        audio = self.mimi.decode_from_latent(latent, model_state)
+        updated = self._unpack_state(model_state)
+        return (audio,) + updated
+
+
+def test_traceable_mimi():
+    import sys
+    import os
+    _script_dir = os.path.dirname(os.path.abspath(__file__))
+    _project_dir = os.path.dirname(os.path.dirname(os.path.dirname(_script_dir)))
+    sys.path.insert(0, _project_dir)
+
+    from pocket_tts import TTSModel
+    from pocket_tts.modules.stateful_module import init_states
+
+    print("Loading model...")
+    model = TTSModel.load_model(lsd_decode_steps=8)
+    model.eval()
+
+    print("Creating traceable Mimi decoder...")
+    traceable = TraceableMimiDecoder.from_tts_model(model)
+    traceable.eval()
+
+    # Build initial state
+    print("Building initial state...")
+    state = init_states(model.mimi.decoder, batch_size=1, sequence_length=1)
+    state.update(init_states(model.mimi.decoder_transformer, batch_size=1, sequence_length=1))
+    if hasattr(model.mimi, 'upsample'):
+        state.update(init_states(model.mimi.upsample, batch_size=1, sequence_length=1))
+
+    flat_state = traceable._unpack_state(state)
+    print(f"State tensors: {len(flat_state)}")
+    for i, t in enumerate(flat_state):
+        print(f"  [{i}] shape={list(t.shape)}")
+
+    # Test forward pass
+    print("\nTesting forward pass...")
+    latent = torch.randn(1, 512, 1)
+    with torch.no_grad():
+        outputs = traceable(latent, *flat_state)
+
+    audio = outputs[0]
+    print(f"Audio shape: {audio.shape}")
+    print(f"Audio range: [{audio.min().item():.4f}, {audio.max().item():.4f}]")
+    print(f"Updated state tensors: {len(outputs) - 1}")
+    print("Done!")
+
+
+if __name__ == "__main__":
+    test_traceable_mimi()

--- a/mobius/models/tts/pocket_tts/coreml/generate_coreml_v4.py
+++ b/mobius/models/tts/pocket_tts/coreml/generate_coreml_v4.py
@@ -1,0 +1,293 @@
+"""Pure CoreML TTS generation — zero PyTorch dependency.
+
+Dependencies: numpy, sentencepiece, safetensors, coremltools, scipy
+NO torch import anywhere.
+
+Pipeline:
+1. Text prep (string ops)
+2. Tokenize (sentencepiece)
+3. Embed text (numpy lookup)
+4. Load voice (safetensors)
+5. KV cache prefill (CoreML backbone)
+6. Autoregressive generation (CoreML step + flow_decoder + mimi)
+"""
+import os
+import re
+import numpy as np
+import sentencepiece as sp
+import coremltools as ct
+import scipy.io.wavfile as wavfile
+from safetensors.numpy import load_file
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CONST_DIR = os.path.join(SCRIPT_DIR, "constants")
+
+# Backbone model output key names (mapped from step model outputs)
+# Conditioning step model output key names
+COND_CACHE_KEYS = [
+    "new_cache_1_internal_tensor_assign_2",
+    "new_cache_3_internal_tensor_assign_2",
+    "new_cache_5_internal_tensor_assign_2",
+    "new_cache_7_internal_tensor_assign_2",
+    "new_cache_9_internal_tensor_assign_2",
+    "new_cache_internal_tensor_assign_2",
+]
+COND_POS_KEYS = [
+    "var_445", "var_864", "var_1283", "var_1702", "var_2121", "var_2365",
+]
+
+# Generation step model output key names
+STEP_CACHE_KEYS = [
+    "new_cache_1_internal_tensor_assign_2",
+    "new_cache_3_internal_tensor_assign_2",
+    "new_cache_5_internal_tensor_assign_2",
+    "new_cache_7_internal_tensor_assign_2",
+    "new_cache_9_internal_tensor_assign_2",
+    "new_cache_internal_tensor_assign_2",
+]
+STEP_POS_KEYS = [
+    "var_458", "var_877", "var_1296", "var_1715", "var_2134", "var_2553",
+]
+
+
+def prepare_text_prompt(text: str):
+    """Normalize text for TTS (pure string ops, no PyTorch)."""
+    text = text.strip()
+    text = re.sub(r'\r\n|\r', '\n', text)
+    text = re.sub(r'  +', ' ', text)
+
+    if text and text[0].isalpha():
+        text = text[0].upper() + text[1:]
+
+    if text and text[-1] not in '.!?':
+        text += '.'
+
+    word_count = len(text.split())
+    if word_count < 5:
+        text = ' ' * 8 + text
+        frames_after_eos = 3
+    else:
+        frames_after_eos = 1
+
+    return text, frames_after_eos
+
+
+def generate_v4(text: str, voice: str = "alba", output_path: str = "coreml_v4.wav", seed: int = 42):
+    """Generate audio using pure CoreML — no PyTorch."""
+    print(f"Text: '{text}'")
+    print(f"Voice: {voice}")
+    print(f"Seed: {seed}")
+
+    # 1. Text preparation
+    prepared_text, frames_after_eos = prepare_text_prompt(text)
+    frames_after_eos += 2
+    print(f"Prepared: '{prepared_text}' (frames_after_eos={frames_after_eos})")
+
+    # 2. Tokenize
+    tokenizer = sp.SentencePieceProcessor()
+    tokenizer.load(os.path.join(CONST_DIR, "tokenizer.model"))
+    token_ids = tokenizer.encode(prepared_text)
+    print(f"Tokens: {len(token_ids)} ids")
+
+    # 3. Embed text (numpy lookup)
+    embed_table = np.load(os.path.join(CONST_DIR, "text_embed_table.npy"))
+    text_emb = embed_table[token_ids]  # [T_text, 1024]
+    text_emb = text_emb[np.newaxis, :, :]  # [1, T_text, 1024]
+    print(f"Text embeddings: {text_emb.shape}")
+
+    # 4. Load voice conditioning
+    voice_path = os.path.join(CONST_DIR, f"{voice}.safetensors")
+    voice_data = load_file(voice_path)
+    voice_emb = voice_data['audio_prompt']  # [1, V, 1024]
+    print(f"Voice embeddings: {voice_emb.shape}")
+
+    # 5. Load constants
+    bos_emb = np.load(os.path.join(CONST_DIR, "bos_emb.npy"))
+    emb_mean = np.load(os.path.join(CONST_DIR, "emb_mean.npy"))
+    emb_std = np.load(os.path.join(CONST_DIR, "emb_std.npy"))
+    q_weight = np.load(os.path.join(CONST_DIR, "quantizer_weight.npy"))  # [512, 32, 1]
+    mimi_state_npz = dict(np.load(os.path.join(CONST_DIR, "mimi_init_state.npz")))
+
+    # 6. Load CoreML models
+    print("\nLoading CoreML models...")
+    coreml_cond = ct.models.MLModel(
+        os.path.join(SCRIPT_DIR, 'cond_step.mlpackage'),
+        compute_units=ct.ComputeUnit.CPU_AND_GPU
+    )
+    coreml_step = ct.models.MLModel(
+        os.path.join(SCRIPT_DIR, 'flowlm_step.mlpackage'),
+        compute_units=ct.ComputeUnit.CPU_AND_GPU
+    )
+    coreml_flow = ct.models.MLModel(
+        os.path.join(SCRIPT_DIR, 'flow_decoder.mlpackage'),
+        compute_units=ct.ComputeUnit.CPU_AND_GPU
+    )
+    coreml_mimi = ct.models.MLModel(
+        os.path.join(SCRIPT_DIR, 'mimi_decoder.mlpackage'),
+        compute_units=ct.ComputeUnit.CPU_AND_GPU
+    )
+
+    # 7. Combine conditioning: voice first, then text (matches original model order)
+    combined = np.concatenate([voice_emb, text_emb], axis=1)  # [1, V+T, 1024]
+    cond_len = combined.shape[1]
+    print(f"Conditioning: {cond_len} tokens (voice={voice_emb.shape[1]}, text={text_emb.shape[1]})")
+
+    # 8. Initialize empty KV caches
+    caches = {}
+    positions = {}
+    for i in range(6):
+        caches[f'cache{i}'] = np.zeros((2, 1, 512, 16, 64), dtype=np.float32)
+        positions[f'position{i}'] = np.array([0.0], dtype=np.float32)
+
+    # 9. Prefill: process each conditioning token one at a time (no padding needed)
+    print(f"Prefilling KV cache ({cond_len} tokens)...")
+    for tok_idx in range(cond_len):
+        cond_token = combined[:, tok_idx:tok_idx + 1, :]  # [1, 1, 1024]
+        cond_inputs = {
+            'conditioning': cond_token.astype(np.float32),
+            **caches,
+            **positions,
+        }
+        cond_out = coreml_cond.predict(cond_inputs)
+
+        for i in range(6):
+            caches[f'cache{i}'] = cond_out[COND_CACHE_KEYS[i]]
+            positions[f'position{i}'] = cond_out[COND_POS_KEYS[i]]
+
+    start_pos = positions['position0'][0]
+    print(f"KV cache filled to position: {start_pos}")
+
+    # 10. Autoregressive generation loop (pure CoreML)
+    gen_len_sec = len(text.split()) * 1 + 2.0
+    max_gen_len = int(gen_len_sec * 12.5)
+    print(f"\nGenerating (max {max_gen_len} frames)...")
+
+    np.random.seed(seed)
+
+    audio_chunks = []
+    eos_step = None
+    sequence = np.full((1, 1, 32), float('nan'), dtype=np.float32)
+    num_lsd_steps = 8
+    dt = 1.0 / num_lsd_steps
+    temp = 0.7
+
+    # Initialize Mimi state
+    coreml_mimi_state = {}
+    for k, v in mimi_state_npz.items():
+        coreml_mimi_state[k] = v.astype(np.float32)
+    # Add offset scalars
+    coreml_mimi_state.setdefault('attn0_offset', np.array([0.0], dtype=np.float32))
+    coreml_mimi_state.setdefault('attn0_end_offset', np.array([0.0], dtype=np.float32))
+    coreml_mimi_state.setdefault('attn1_offset', np.array([0.0], dtype=np.float32))
+    coreml_mimi_state.setdefault('attn1_end_offset', np.array([0.0], dtype=np.float32))
+
+    for step in range(max_gen_len):
+        # Step model
+        step_inputs = {
+            'sequence': sequence,
+            'bos_emb': bos_emb,
+            **caches,
+            **positions,
+        }
+        step_out = coreml_step.predict(step_inputs)
+
+        transformer_out = step_out['input']  # [1, 1, 1024]
+        eos_logit = step_out['var_2582']  # [1, 1, 1]
+
+        # Update caches/positions
+        for i in range(6):
+            caches[f'cache{i}'] = step_out[STEP_CACHE_KEYS[i]]
+            positions[f'position{i}'] = step_out[STEP_POS_KEYS[i]]
+
+        # EOS check
+        is_eos = eos_logit.flatten()[0] > -4.0
+        if is_eos and eos_step is None:
+            eos_step = step
+            print(f"  EOS at step {step}")
+        if eos_step is not None and step >= eos_step + frames_after_eos:
+            break
+
+        # Flow decode (LSD 8 steps)
+        transformer_out_flat = transformer_out.reshape(1, 1024)
+        latent = np.random.randn(1, 32).astype(np.float32) * (temp ** 0.5)
+
+        for lsd_step in range(num_lsd_steps):
+            s_np = np.array([[lsd_step * dt]], dtype=np.float32)
+            t_np = np.array([[(lsd_step + 1) * dt]], dtype=np.float32)
+            flow_out = coreml_flow.predict({
+                'transformer_out': transformer_out_flat,
+                'latent': latent,
+                's': s_np,
+                't': t_np,
+            })
+            velocity = list(flow_out.values())[0]
+            latent = latent + velocity * dt
+
+        # Denormalize + quantize
+        latent_denorm = latent * emb_std.reshape(1, -1) + emb_mean.reshape(1, -1)
+        # q_weight is [512, 32, 1] (1D conv kernel), squeeze to [512, 32]
+        w = q_weight.squeeze(-1)  # [512, 32]
+        quantized = np.dot(latent_denorm, w.T).reshape(1, 512, 1)
+
+        # Mimi decode
+        mimi_inputs = {'latent': quantized.astype(np.float32), **coreml_mimi_state}
+        mimi_out = coreml_mimi.predict(mimi_inputs)
+
+        audio_frame = mimi_out['var_1445']
+        audio_chunks.append(audio_frame)
+
+        # Update Mimi state
+        coreml_mimi_state['upsample_partial'] = mimi_out['y_end_1']
+        coreml_mimi_state['attn0_cache'] = mimi_out['new_cache_1_internal_tensor_assign_2']
+        coreml_mimi_state['attn0_offset'] = mimi_out['var_402']
+        coreml_mimi_state['attn0_end_offset'] = mimi_out['new_end_offset_1']
+        coreml_mimi_state['attn1_cache'] = mimi_out['new_cache_internal_tensor_assign_2']
+        coreml_mimi_state['attn1_offset'] = mimi_out['var_825']
+        coreml_mimi_state['attn1_end_offset'] = mimi_out['new_end_offset']
+        coreml_mimi_state['conv0_prev'] = mimi_out['var_998']
+        coreml_mimi_state['conv0_first'] = mimi_out['var_1006']
+        coreml_mimi_state['convtr0_partial'] = mimi_out['var_1048']
+        coreml_mimi_state['res0_conv0_prev'] = mimi_out['var_1105']
+        coreml_mimi_state['res0_conv0_first'] = mimi_out['var_1113']
+        coreml_mimi_state['res0_conv1_prev'] = mimi_out['cast_13']
+        coreml_mimi_state['res0_conv1_first'] = mimi_out['var_1134']
+        coreml_mimi_state['convtr1_partial'] = mimi_out['var_1178']
+        coreml_mimi_state['res1_conv0_prev'] = mimi_out['var_1235']
+        coreml_mimi_state['res1_conv0_first'] = mimi_out['var_1243']
+        coreml_mimi_state['res1_conv1_prev'] = mimi_out['cast_18']
+        coreml_mimi_state['res1_conv1_first'] = mimi_out['var_1264']
+        coreml_mimi_state['convtr2_partial'] = mimi_out['var_1308']
+        coreml_mimi_state['res2_conv0_prev'] = mimi_out['var_1365']
+        coreml_mimi_state['res2_conv0_first'] = mimi_out['var_1373']
+        coreml_mimi_state['res2_conv1_prev'] = mimi_out['cast_23']
+        coreml_mimi_state['res2_conv1_first'] = mimi_out['var_1394']
+        coreml_mimi_state['conv_final_prev'] = mimi_out['var_1450']
+        coreml_mimi_state['conv_final_first'] = mimi_out['var_1458']
+
+        # Update sequence for next step
+        sequence = latent.reshape(1, 1, 32)
+
+        if step % 20 == 0:
+            print(f"  Step {step}...")
+
+    print(f"Generated {len(audio_chunks)} frames")
+
+    # Concatenate and save
+    audio = np.concatenate(audio_chunks, axis=-1)
+    audio = audio[0, 0]
+    audio = audio / (np.abs(audio).max() + 1e-8) * 0.9
+
+    sample_rate = 24000
+    wavfile.write(output_path, sample_rate, (audio * 32767).astype(np.int16))
+
+    print(f"\nSaved to {output_path}")
+    print(f"Duration: {len(audio) / sample_rate:.2f}s")
+    return output_path
+
+
+if __name__ == "__main__":
+    generate_v4(
+        "Hello, this is pure CoreML text to speech generation.",
+        voice="alba",
+        output_path="coreml_v4.wav",
+    )


### PR DESCRIPTION
## Summary
- Replace `F.scaled_dot_product_attention` with manual matmul+softmax attention in traceable wrappers to fix BNNS crash on iOS
- Retarget all conversion scripts from macOS 15 / iOS 18 (spec 9) to iOS 17 (spec 8)
- Update `generate_coreml_v4.py` with new output tensor names from reconverted models

## Problem
Three PocketTTS CoreML models (`cond_step`, `flowlm_step`, `flow_decoder_v2`) were converted targeting spec 9, which includes the fused `scaled_dot_product_attention` op. This op crashes Apple's BNNS library on iOS.

## Fix
- Decomposed SDPA into manual `Q×K^T / √d → mask → softmax → ×V` in `traceable_cond_step.py` (5 ops) and `traceable_flowlm_step.py` (6 ops)
- Changed `minimum_deployment_target` from `ct.target.macOS15` to `ct.target.iOS17` in all 3 convert scripts
- All reconverted models verified: spec 8, zero SDPA ops
- Full inference produces identical output (WER 0 on both short and long sentences)

## Test plan
- [x] Reconverted all 3 models (cond_step, flowlm_step, flow_decoder_v2)
- [x] Verified zero SDPA ops in all 4 models
- [x] Python inference test passes (3.52s audio, EOS at step 41)
- [x] Swift TTS test: short sentence — WER 0, 5.52s audio
- [x] Swift TTS test: long sentence — WER 0, 5.76s audio
- [x] iOS build succeeds (`xcodebuild -destination 'generic/platform=iOS'`)
- [ ] Upload reconverted models to HuggingFace
- [ ] iOS device test by croqueteer