### PR TITLE
fix: Add architecture guard for Float16 on macOS

### DIFF
--- a/Sources/FluidAudio/Diarizer/Sortformer/SortformerModelInference.swift
+++ b/Sources/FluidAudio/Diarizer/Sortformer/SortformerModelInference.swift
@@ -250,13 +250,19 @@ extension SortformerModels {
             .scalars
         {
             chunkEmbeddings = fp32
-        } else if #available(macOS 15.0, iOS 18.0, *),
-            let fp16 = output.featureValue(for: "chunk_pre_encoder_embs_out")?.shapedArrayValue(of: Float16.self)?
-                .scalars
-        {
-            chunkEmbeddings = fp16.map { Float($0) }
         } else {
+            #if arch(arm64)
+            if #available(macOS 15.0, iOS 18.0, *),
+                let fp16 = output.featureValue(for: "chunk_pre_encoder_embs_out")?.shapedArrayValue(of: Float16.self)?
+                    .scalars
+            {
+                chunkEmbeddings = fp16.map { Float($0) }
+            } else {
+                throw SortformerError.inferenceFailed("Missing chunk_pre_encoder_embs_out")
+            }
+            #else
             throw SortformerError.inferenceFailed("Missing chunk_pre_encoder_embs_out")
+            #endif
         }
 
         return MainModelOutput(


### PR DESCRIPTION
## Summary
- Adds `#if arch(arm64)` guard around Float16 code path in SortformerModelInference.swift

## Problem
Float16 is only available on arm64 (Apple Silicon), not x86_64 (Intel). The existing `#available(macOS 15.0, iOS 18.0, *)` check only guards OS version, not CPU architecture. This caused universal binary builds to fail with:

```
'Float16' is unavailable in macOS
Conformance of 'Float16' to 'MLShapedArrayScalar' is unavailable in macOS
```

## Solution
Wrap the Float16 code path with `#if arch(arm64)` compile-time directive so x86_64 builds succeed.

## Test plan
- [x] Built universal binary (arm64 + x86_64) successfully with this fix

Fixes #269