### PR TITLE
fix: apply vocabulary rescoring for chunked long audio path

### DIFF
--- a/Sources/FluidAudio/ASR/AsrTranscription.swift
+++ b/Sources/FluidAudio/ASR/AsrTranscription.swift
@@ -55,7 +55,7 @@ extension AsrManager {
 
         // ChunkProcessor handles stateless chunked transcription for long audio
         let processor = ChunkProcessor(audioSamples: audioSamples)
-        return try await processor.process(
+        var result = try await processor.process(
             using: self,
             startTime: startTime,
             progressHandler: { [weak self] progress in
@@ -63,6 +63,13 @@ extension AsrManager {
                 await self.progressEmitter.report(progress: progress)
             }
         )
+
+        // Auto-apply vocabulary rescoring when configured
+        if vocabBoostingEnabled {
+            result = await applyVocabularyRescoring(result: result, audioSamples: audioSamples)
+        }
+
+        return result
     }
 
     internal func executeMLInferenceWithTimings(


### PR DESCRIPTION
The short-audio path in transcribeWithState() ran applyVocabularyRescoring after transcription, but the long-audio ChunkProcessor path returned directly without it. This meant vocab boosting silently did nothing on audio longer than ~15s. Wire up the same rescoring call after ChunkProcessor returns.
