### PR TITLE
docs: add Transcriper and VoiceTypr to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[hongbomiao.com](https://github.com/hongbo-miao/hongbomiao.com)** | A personal R&D lab that facilitates knowledge sharing. Uses Parakeet ASR. |
 | **[Hex](https://github.com/kitlangton/Hex)** | macOS app that lets you press-and-hold a hotkey to record your voice, transcribe it, and paste into any application. Uses Parakeet ASR. |
 | **[Super Voice Assistant](https://github.com/ykdojo/super-voice-assistant)** | Open-source macOS voice assistant with local transcription. Uses Parakeet ASR. |
+| **[VoiceTypr](https://github.com/moinulmoin/voicetypr)** | Open-source voice-to-text dictation for macOS and Windows. Uses Parakeet ASR. |
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Added [VoiceTypr](https://github.com/moinulmoin/voicetypr) — Open-source voice-to-text dictation app using FluidAudio Swift sidecar for Parakeet ASR on macOS ([Package.swift](https://github.com/moinulmoin/voicetypr/blob/main/sidecar/parakeet-swift/Package.swift))