### PR TITLE
docs: add Evaluated Models section for models tried but not shipped

### DIFF
--- a/Documentation/Models.md
+++ b/Documentation/Models.md
@@ -44,7 +44,7 @@ TDT models process audio in chunks (~15s with overlap) as batch operations. Fast
 | Model | Description | Context |
 |-------|-------------|---------|
 | **Kokoro TTS** | Text-to-speech synthesis (82M params), 48 voices, minimal RAM usage on iOS. Generates all frames at once via flow matching over mel spectrograms + Vocos vocoder. Requires espeak for phonemization. | First TTS backend added. |
-| **PocketTTS** | Second TTS backend (~155M params). Upgrade over Kokoro with much better dynamic audio chunking. No espeak dependency. | |
+| **PocketTTS** | Second TTS backend (~155M params). Upgrade over Kokoro with much better dynamic audio chunking. No espeak dependency. | Improvement over Kokoro TTS: simpler chunking, dynammic inputs & longer token counts |
 
 ## Evaluated Models (Not Shipped)
 


### PR DESCRIPTION
## Summary

Add documentation for models we converted and tested but haven't shipped yet — provides transparency on what we've explored.

### ASR Models Documented
- **Nemotron Speech Streaming 0.6B** — In development, strong performance (1.99% WER)
- **Qwen3-ASR-0.6B** — In development, encoder-decoder architecture
- **Canary 1B v2** — Too large for mobile
- **Hybrid CTC-TDT 110M** — Superseded by separate CTC models

### TTS Models Documented
- **Kokoro Chinese (MLX)** — Pure Swift MLX inference, experimental
- **Kitten TTS** — Superseded by PocketTTS

## Test plan
- [x] Documentation renders correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)