### PR TITLE
docs: add Sortformer production notes and TTS pronunciation feature support

### DIFF
--- a/Documentation/Diarization/Sortformer.md
+++ b/Documentation/Diarization/Sortformer.md
@@ -25,6 +25,16 @@ Sortformer is an end-to-end neural speaker diarization model that answers "who s
 | More than 4 speakers | No | Yes |
 | Remembering speakers across meetings | No | Yes |
 
+## Production Notes
+
+Benchmark DER does not always reflect real-world performance. Key things to know:
+
+- **Noisy environments**: Sortformer's main strength. It handles background noise significantly better than pyannote.
+- **4 speaker hard limit**: Sortformer has 4 fixed speaker slots. It will not work with 5+ speakers — it will miss or merge them.
+- **Heavy crosstalk (5+ people)**: Does not work well when many people talk over each other. The 4-slot design breaks down.
+- **Benchmark tuning**: Pyannote with aggressive tuning can score lower DER than Sortformer on specific datasets (e.g. AMI), but those configs often don't generalize to real audio. Sortformer's 32% DER is more representative of actual production performance on meetings with 4 or fewer speakers.
+- **Missed speech**: The most common error type. Sortformer is trained to ignore background conversations, so quiet or distant speech may be missed.
+
 ## Architecture
 
 ### Processing Pipeline


### PR DESCRIPTION
## Summary

- **Sortformer**: Add production notes — benchmark DER vs real-world, 4-speaker hard limit, 5+ speaker crosstalk issues, noisy environment advantage
- **Kokoro**: Add pipeline diagram (espeak G2P flow), pronunciation control docs (SSML, custom lexicon, markdown syntax), expanded comparison table
- **PocketTTS**: Add pipeline diagram (SentencePiece flow), feature support table explaining what can/cannot be added and why (no phoneme stage = no pronunciation control without retraining)

## Test plan

- [ ] Review Sortformer production notes for accuracy
- [ ] Verify Kokoro pipeline diagram matches actual code flow
- [ ] Confirm PocketTTS feature limitations are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)