### PR TITLE
Fix BNNS identity tensor rejection on iOS 26 with mimi_decoder_v3

### DIFF
--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -273,7 +273,7 @@ public enum ModelNames {
         public static let condStep = "cond_step"
         public static let flowlmStep = "flowlm_step"
         public static let flowDecoder = "flow_decoder"
-        public static let mimiDecoder = "mimi_decoder_v2"
+        public static let mimiDecoder = "mimi_decoder_v3"
 
         public static let condStepFile = condStep + ".mlmodelc"
         public static let flowlmStepFile = flowlmStep + ".mlmodelc"

--- a/Sources/FluidAudioTTS/TextToSpeech/PocketTTS/Assets/PocketTtsConstantsLoader.swift
+++ b/Sources/FluidAudioTTS/TextToSpeech/PocketTTS/Assets/PocketTtsConstantsLoader.swift
@@ -7,6 +7,12 @@ public struct PocketTtsConstantsBundle: Sendable {
     public let bosEmbedding: [Float]
     public let textEmbedTable: [Float]
     public let tokenizer: SentencePieceTokenizer
+    /// Latent normalization mean [32].
+    public let embMean: [Float]
+    /// Latent normalization std [32].
+    public let embStd: [Float]
+    /// Quantizer projection weight [512, 32] (flattened row-major).
+    public let quantizerWeight: [Float]
 }
 
 /// Pre-loaded voice conditioning data.
@@ -43,6 +49,22 @@ public enum PocketTtsConstantsLoader {
             name: "text_embed_table"
         )
 
+        let embMean = try loadFloatArray(
+            from: constantsDir.appendingPathComponent("emb_mean.bin"),
+            expectedCount: PocketTtsConstants.latentDim,
+            name: "emb_mean"
+        )
+        let embStd = try loadFloatArray(
+            from: constantsDir.appendingPathComponent("emb_std.bin"),
+            expectedCount: PocketTtsConstants.latentDim,
+            name: "emb_std"
+        )
+        let quantizerWeight = try loadFloatArray(
+            from: constantsDir.appendingPathComponent("quantizer_weight.bin"),
+            expectedCount: PocketTtsConstants.quantizerDim * PocketTtsConstants.latentDim,
+            name: "quantizer_weight"
+        )
+
         let tokenizerURL = constantsDir.appendingPathComponent("tokenizer.model")
         guard FileManager.default.fileExists(atPath: tokenizerURL.path) else {
             throw LoadError.fileNotFound("tokenizer.model")
@@ -60,7 +82,10 @@ public enum PocketTtsConstantsLoader {
         return PocketTtsConstantsBundle(
             bosEmbedding: bosEmb,
             textEmbedTable: embedTable,
-            tokenizer: tokenizer
+            tokenizer: tokenizer,
+            embMean: embMean,
+            embStd: embStd,
+            quantizerWeight: quantizerWeight
         )
     }
 

--- a/Sources/FluidAudioTTS/TextToSpeech/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
+++ b/Sources/FluidAudioTTS/TextToSpeech/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
@@ -48,41 +48,39 @@ extension PocketTtsSynthesizer {
         ]
     }
 
-    /// CoreML output key names for the Mimi decoder model.
+    /// CoreML output key names for the Mimi decoder model (v3).
     enum MimiKeys {
-        static let audioOutput = "var_821"
+        static let audioOutput = "var_1445"
     }
 
     /// Mimi decoder streaming state key mappings (input name → output name).
     ///
-    /// 26 state tensors including 3 zero-length tensors (res{0,1,2}_conv1_prev)
-    /// whose input and output names are identical pass-throughs.
+    /// v3: 23 state tensors with all distinct output names, fixing BNNS
+    /// identity tensor rejection on iOS 26 (issue #294).
+    /// Zero-length tensors (res{0,1,2}_conv1_prev) are excluded.
     static let mimiStateMapping: [(input: String, output: String)] = [
-        ("upsample_partial", "var_82"),
-        ("attn0_cache", "var_262"),
-        ("attn0_offset", "var_840"),
+        ("upsample_partial", "y_end_1"),
+        ("attn0_cache", "new_cache_1_internal_tensor_assign_2"),
+        ("attn0_offset", "var_402"),
         ("attn0_end_offset", "new_end_offset_1"),
-        ("attn1_cache", "var_479"),
-        ("attn1_offset", "var_843"),
+        ("attn1_cache", "new_cache_internal_tensor_assign_2"),
+        ("attn1_offset", "var_825"),
         ("attn1_end_offset", "new_end_offset"),
-        ("conv0_prev", "var_607"),
-        ("conv0_first", "conv0_first"),
-        ("convtr0_partial", "var_634"),
-        ("res0_conv0_prev", "var_660"),
-        ("res0_conv0_first", "res0_conv0_first"),
-        ("res0_conv1_prev", "res0_conv1_prev"),
-        ("res0_conv1_first", "res0_conv1_first"),
-        ("convtr1_partial", "var_700"),
-        ("res1_conv0_prev", "var_726"),
-        ("res1_conv0_first", "res1_conv0_first"),
-        ("res1_conv1_prev", "res1_conv1_prev"),
-        ("res1_conv1_first", "res1_conv1_first"),
-        ("convtr2_partial", "var_766"),
-        ("res2_conv0_prev", "var_792"),
-        ("res2_conv0_first", "res2_conv0_first"),
-        ("res2_conv1_prev", "res2_conv1_prev"),
-        ("res2_conv1_first", "res2_conv1_first"),
-        ("conv_final_prev", "var_824"),
-        ("conv_final_first", "conv_final_first"),
+        ("conv0_prev", "var_998"),
+        ("conv0_first", "var_1006"),
+        ("convtr0_partial", "var_1048"),
+        ("res0_conv0_prev", "var_1105"),
+        ("res0_conv0_first", "var_1113"),
+        ("res0_conv1_first", "var_1134"),
+        ("convtr1_partial", "var_1178"),
+        ("res1_conv0_prev", "var_1235"),
+        ("res1_conv0_first", "var_1243"),
+        ("res1_conv1_first", "var_1264"),
+        ("convtr2_partial", "var_1308"),
+        ("res2_conv0_prev", "var_1365"),
+        ("res2_conv0_first", "var_1373"),
+        ("res2_conv1_first", "var_1394"),
+        ("conv_final_prev", "var_1450"),
+        ("conv_final_first", "var_1458"),
     ]
 }

--- a/Sources/FluidAudioTTS/TextToSpeech/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudioTTS/TextToSpeech/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -141,10 +141,10 @@ public struct PocketTtsSynthesizer {
                 )
 
                 // Mimi state is continuous across chunks
-                // (denormalize + quantize baked into mimi_decoder model)
                 let frameSamples = try await runMimiDecoder(
                     latent: latent,
                     state: &mimiState,
+                    constants: constants,
                     model: mimiModel
                 )
                 audioChunks.append(frameSamples)

--- a/Sources/FluidAudioTTS/TextToSpeech/PocketTTS/PocketTtsConstants.swift
+++ b/Sources/FluidAudioTTS/TextToSpeech/PocketTTS/PocketTtsConstants.swift
@@ -11,6 +11,7 @@ public enum PocketTtsConstants {
     // MARK: - Model dimensions
 
     public static let latentDim: Int = 32
+    public static let quantizerDim: Int = 512
     public static let transformerDim: Int = 1024
     public static let vocabSize: Int = 4001
     public static let embeddingDim: Int = 1024


### PR DESCRIPTION
## Summary
- Fixes BNNS graph compile error on iOS 26 where 11 mimi_decoder_v2 state tensors were used as both input and output (`conv0_first as both an input and output`)
- Switches to `mimi_decoder_v3` which has all distinct `var_*` output names (no identity collisions)
- Moves denormalize + quantize from baked-in-model to Swift runtime: `denorm = latent * emb_std + emb_mean`, `quantized = matmul(denorm, quantizer_weight.T)`
- State mapping reduced from 26 → 23 entries (zero-length tensors excluded)

## Test plan
- [x] `swift build` passes
- [x] Download pipeline verified: `fluidaudiocli tts --backend pocket` downloads v3 from HuggingFace and generates audio
- [x] PyTorch vs CoreML v3 spectral similarity: 0.965 log-mel cosine sim
- [x] Both outputs transcribe to exact input text with >0.96 confidence
- [ ] Test on iOS 26 device to confirm BNNS no longer rejects the model

Closes #294