### PR TITLE
docs: add documentation badge linking to docs.fluidinference.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Swift](https://img.shields.io/badge/Swift-5.9+-orange.svg)](https://swift.org)
 [![Platform](https://img.shields.io/badge/Platform-macOS%20%7C%20iOS-blue.svg)](https://developer.apple.com)
+[![Documentation](https://img.shields.io/badge/Documentation-docs.fluidinference.com-008574.svg)](https://docs.fluidinference.com/introduction)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Chat-7289da.svg)](https://discord.gg/WNsvaCtmDe)
 [![Hugging Face Models](https://img.shields.io/badge/Hugging%20Face%20Models-100k%2B%20downloads-brightgreen?logo=huggingface)](https://huggingface.co/FluidInference)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/FluidInference/FluidAudio)


### PR DESCRIPTION
## Summary
- Add documentation badge to README linking to https://docs.fluidinference.com/introduction
- Uses brand teal color (#008574)

## Test plan
- [ ] Verify badge renders correctly in README
- [ ] Verify link opens docs site