### PR TITLE
docs: fix broken links, correct product name, and fix typos

### DIFF
--- a/Documentation/Benchmarks.md
+++ b/Documentation/Benchmarks.md
@@ -237,7 +237,7 @@ Peak memory usage (process-wide): 1.503 GB
 
 ## Voice Activity Detection
 
-Model is nearly identical to the base model in terms of quality, perforamnce wise we see an up to ~3.5x improvement compared to the silero Pytorch VAD model with the 256ms batch model (8 chunks of 32ms)
+Model is nearly identical to the base model in terms of quality, performance wise we see an up to ~3.5x improvement compared to the silero Pytorch VAD model with the 256ms batch model (8 chunks of 32ms)
 
 ![VAD/speed.png](VAD/speed.png)
 ![VAD/correlation.png](VAD/correlation.png)
@@ -320,7 +320,7 @@ swift run -c release fluidaudiocli parakeet-eou --benchmark --chunk-size 160 --u
 
 The offline version uses the community-1 model, the online version uses the legacy speaker-diarization-3.1 model.
 
-### Offline diarzing pipeline
+### Offline diarization pipeline
 
 For slightly ~1.2% worse DER we default to a higher step ratio segmentation duration than the baseline community-1 pipeline. This allows us to get nearly ~2x the speed (as expected because we're processing 1/2 of the embeddings). For highly critical use cases, one may should use step ratio = 0.1 and minSegmentDurationSeconds = 0.0
 
@@ -331,7 +331,7 @@ StepRatio = 0.2, minSegmentDurationSeconds= 1.0
 Average DER: 15.07% | Median DER: 10.70% | Average JER: 39.40% | Median JER: 40.95% (collar=0.25s, ignoreOverlap=True)
 Average RTFx: 122.06 (from 232 clips)
 Completed. New results: 232, Skipped existing: 0, Total attempted: 232
-Step Ratio 2, min turation 1.0
+Step Ratio 2, min duration 1.0
 
 
 StepRatio = 0.1, minSegmentDurationSeconds= 0
@@ -341,7 +341,7 @@ Completed. New results: 232, Skipped existing: 0, Total attempted: 232
 Step Ratio 1, min duration 0 (edited) 
 ```
 
-Note that the baseline pytorch version is ~11% DER, we lost some precision dropping down to fp16 precision in order to run most of the emebdding model on neural engine. But as a result, we significantly out perform the baseline `mps` backend as well. the pyannote-community-1 on cpu is ~1.5-2 RTFx, on mps, it's ~20-25 RTFx.
+Note that the baseline pytorch version is ~11% DER, we lost some precision dropping down to fp16 precision in order to run most of the embedding model on neural engine. But as a result, we significantly out perform the baseline `mps` backend as well. the pyannote-community-1 on cpu is ~1.5-2 RTFx, on mps, it's ~20-25 RTFx.
 
 ### Streaming/online Diarization
 

--- a/Documentation/TTS/Kokoro.md
+++ b/Documentation/TTS/Kokoro.md
@@ -99,12 +99,12 @@ PocketTTS cannot support phoneme-level features because it has no phoneme stage 
 
 ### App/Library Development (Xcode & SwiftPM)
 
-When adding FluidAudio to your Xcode project or Package.swift, select the **`FluidAudioWithTTS`** product:
+When adding FluidAudio to your Xcode project or Package.swift, select the **`FluidAudioTTS`** product:
 
 **Xcode:**
 1. File > Add Package Dependencies
 2. Enter FluidAudio repository URL
-3. Choose **`FluidAudioWithTTS`**
+3. Choose **`FluidAudioTTS`**
 4. Add it to your app target
 
 **Package.swift:**
@@ -116,7 +116,7 @@ targets: [
     .target(
         name: "YourTarget",
         dependencies: [
-            .product(name: "FluidAudioWithTTS", package: "FluidAudio")
+            .product(name: "FluidAudioTTS", package: "FluidAudio")
         ]
     )
 ]

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
             path: "Sources/MachTaskSelfWrapper",
             publicHeadersPath: "include"
         ),
-        // TTS targets are always available for FluidAudioWithTTS product
+        // TTS targets are always available for FluidAudioTTS product
         .binaryTarget(
             name: "ESpeakNG",
             path: "Frameworks/ESpeakNG.xcframework"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[Whisper Mate](https://whisper.marksdo.com)** | Transcribes movies and audio locally; records and transcribes in real time from speakers or system apps. Uses speaker diarization. |
 | **[Altic/Fluid Voice](https://github.com/altic-dev/Fluid-oss)** | Lightweight Fully free and Open Source Voice to Text dictation for macOS built using FluidAudio. Never pay for dictation apps |
 | **[Paraspeech](https://paraspeech.com)** | AI powered voice to text. Fully offline. No subscriptions. |
-| **[mac-whisper-speedtest](https://github.com/anvanvan/mac-whisper-speedtest)** | Comparison of different local ASR, including one of the first verions of FluidAudio's ASR models |
+| **[mac-whisper-speedtest](https://github.com/anvanvan/mac-whisper-speedtest)** | Comparison of different local ASR, including one of the first versions of FluidAudio's ASR models |
 | **[Starling](https://github.com/Ryandonofrio3/Starling)** | Open Source, fully local voice-to-text transcription with auto-paste at your cursor. |
 | **[BoltAI](https://boltai.com/)** | Write content 10x faster using parakeet models |
 | **[Voxeoflow](https://www.voxeoflow.app)** | Mac dictation app with real-time translation. Lightning-fast transcription in over 100 languages, instantly translated to your target language. |
@@ -118,13 +118,6 @@ FluidAudio provides two library products:
 // Add TTS support (includes GPL ESpeakNG):
 .product(name: "FluidAudioTTS", package: "FluidAudio")
 ```
-
-**In Xcode:**
-1. Add the FluidAudio package to your project
-2. In the "Add Package" dialog, select your desired product:
-   - `FluidAudio` for core features only
-   - `FluidAudioWithTTS` if you need text-to-speech
-3. Add the selected product to your app target
 
 **CocoaPods:** We recommend using [cocoapods-spm](https://github.com/trinhngocthuyen/cocoapods-spm) for better SPM integration, but if needed, you can also use our podspec: `pod 'FluidAudio', '~> 0.7.8'`
 
@@ -222,7 +215,7 @@ swift run fluidaudio transcribe audio.wav
 
 - Guides
   - [Audio Conversion for Inference](Documentation/Guides/AudioConversion.md)
-  - Manual model download & loading options: [ASR](Documentation/ASR/ManualModelLoading.md), [Diarizer](Documentation/SpeakerDiarization.md#manual-model-loading), [VAD](Documentation/VAD/GettingStarted.md#manual-model-loading)
+  - Manual model download & loading options: [ASR](Documentation/ASR/ManualModelLoading.md), [Diarizer](Documentation/Diarization/GettingStarted.md#manual-model-loading), [VAD](Documentation/VAD/GettingStarted.md#manual-model-loading)
   - Routing Hugging Face (or compatible) requests through a proxy? Set `https_proxy` before running the download helpers (see [Documentation/API.md](Documentation/API.md:9)).
   - [Kokoro TTS arm64 build requirements](Documentation/TTS/README.md#arm64-only-builds)
 - Models
@@ -230,11 +223,11 @@ swift run fluidaudio transcribe audio.wav
     - [Getting Started](Documentation/ASR/GettingStarted.md)
     - [Last Chunk Handling](Documentation/ASR/LastChunkHandling.md)
   - Speaker Diarization
-    - [Speaker Diarization Guide](Documentation/SpeakerDiarization.md)
+    - [Speaker Diarization Guide](Documentation/Diarization/GettingStarted.md)
   - VAD: [Getting Started](Documentation/VAD/GettingStarted.md)
     - [Segmentation](Documentation/VAD/Segmentation.md)
     - [Model Conversion Code](https://github.com/FluidInference/mobius)
-- [Benchmarks]([Documentation/Benchmarks.md])
+- [Benchmarks](Documentation/Benchmarks.md)
 - [API Reference](Documentation/API.md)
 - [Command Line Guide](Documentation/CLI.md)
 
@@ -304,7 +297,7 @@ swift run fluidaudio transcribe audio.wav --model-version v2
 
 ### Offline Speaker Diarization Pipeline
 
-Pyannote Community-1 pipeline (powerset segmentation + WeSpeaker + VBx) for offline speaker diarization. Use this for most use cases, see Benchmarkds.md for benchmarks.
+Pyannote Community-1 pipeline (powerset segmentation + WeSpeaker + VBx) for offline speaker diarization. Use this for most use cases, see Benchmarks.md for benchmarks.
 
 ```swift
 import FluidAudio
@@ -368,7 +361,7 @@ Task {
 }
 ```
 
-For diarization streaming see [Documentation/SpeakerDiarization.md](Documentation/SpeakerDiarization.md)
+For diarization streaming see [Documentation/Diarization/GettingStarted.md](Documentation/Diarization/GettingStarted.md)
 
 ```bash
 swift run fluidaudio diarization-benchmark --single-file ES2004a \
@@ -572,7 +565,7 @@ This project builds upon the excellent work of the [sherpa-onnx](https://github.
 
 Pyannote: <https://github.com/pyannote/pyannote-audio>
 
-Wewpeaker: <https://github.com/wenet-e2e/wespeaker>
+WeSpeaker: <https://github.com/wenet-e2e/wespeaker>
 
 Parakeet-mlx: <https://github.com/senstella/parakeet-mlx>
 


### PR DESCRIPTION
## Summary

- **Fix 3 broken `SpeakerDiarization.md` links** — `Documentation/SpeakerDiarization.md` no longer exists after the Documentation folder reorganization. Updated all references to point to `Documentation/Diarization/GettingStarted.md`
- **Fix malformed Benchmarks link** — Extra brackets in `[Benchmarks]([Documentation/Benchmarks.md])` made the link non-functional
- **Fix `FluidAudioWithTTS` → `FluidAudioTTS`** — The README (duplicate "In Xcode" block), Kokoro docs, and a Package.swift comment referenced `FluidAudioWithTTS`, but the actual product defined in Package.swift is `FluidAudioTTS`. Users following these instructions would get build failures
- **Remove duplicate "In Xcode" instruction block** — README had two "In Xcode" sections (lines 106-111 and 122-127) with conflicting product names
- **Fix typos** in README and Benchmarks.md: `verions` → `versions`, `Benchmarkds` → `Benchmarks`, `Wewpeaker` → `WeSpeaker`, `perforamnce` → `performance`, `diarzing` → `diarization`, `turation` → `duration`, `emebdding` → `embedding`

## Files Changed

- `README.md` — Broken links, duplicate block removal, typos
- `Documentation/TTS/Kokoro.md` — Product name correction
- `Documentation/Benchmarks.md` — Typos
- `Package.swift` — Comment correction

## Test plan

- [x] Verified `Documentation/Diarization/GettingStarted.md` exists and has `## Manual Model Loading` section
- [x] Verified `FluidAudioTTS` matches the product name in Package.swift line 16
- [x] All link targets confirmed to exist in the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)