### PR TITLE
docs: add Sortformer diarization section to README

### DIFF
--- a/Documentation/Diarization/Sortformer.md
+++ b/Documentation/Diarization/Sortformer.md
@@ -9,6 +9,12 @@ Sortformer is an end-to-end neural speaker diarization model that answers "who s
 - 4 fixed speaker slots (no clustering required)
 - ~80ms frame resolution (8x subsampling of 10ms mel frames)
 - CoreML-optimized for Apple Silicon
+- Licensed under [NVIDIA Open Model License](https://developer.nvidia.com/open-model-license) (no restrictions)
+
+**Limitations:**
+- 4 speaker maximum — cannot handle 5+ speakers (will miss or merge them)
+- Does not remember speakers across recordings (no persistent speaker embeddings)
+- May miss quiet or distant speech (trained to ignore background conversations)
 
 ## Sortformer vs DiarizerManager (Pyannote-based)
 

--- a/README.md
+++ b/README.md
@@ -347,7 +347,13 @@ swift run fluidaudio diarization-benchmark --mode offline --auto-download \
 
 `offline_results.json` contains DER/JER/RTFx along with timing breakdowns for segmentation, embedding extraction, and VBx clustering. CI now runs this workflow on every PR to ensure the offline models stay healthy and the Hugging Face assets remain accessible.
 
-### Streaming/Online Speaker Diarization
+### Sortformer (End-to-End Neural Diarization)
+
+End-to-end neural diarization using [NVIDIA's Sortformer](https://arxiv.org/abs/2409.06656). No separate VAD, segmentation, or clustering needed. Limited to 4 speakers and does not remember speakers across recordings. Licensed under NVIDIA Open Model License (no restrictions).
+
+See [Documentation/Diarization/Sortformer.md](Documentation/Diarization/Sortformer.md) for usage, comparison with Pyannote, streaming config, and architecture details.
+
+### Streaming/Online Speaker Diarization (Pyannote)
 
 Use this if you need to show speaker labels while the transcription is happening, in most use cases, offline should be more than enough.
 


### PR DESCRIPTION
## Summary
- Add Sortformer (end-to-end neural diarization) section to README
- Cover licensing: NVIDIA Open Model License (no restrictions)
- Document limitations: 4 speaker max, no cross-recording speaker memory, may miss quiet speech
- Include usage example and comparison table (Sortformer vs Pyannote)
- Link to full Sortformer docs