### PR TITLE
Add Flowstay to Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[VoiceTypr](https://github.com/moinulmoin/voicetypr)** | Open-source voice-to-text dictation for macOS and Windows. Uses Parakeet ASR. |
 | **[Summit AI Notes](https://summitnotes.app/)** | Local meeting transcription and summarization with speaker identification. Supports 100+ languages. |
 | **[Ora](https://futurelab.studio/ora)** | Local voice assistant for macOS with speech recognition and text-to-speech. |
+| **[Flowstay](https://flowstay.app)** | Easy text-to-speech, local post-processing and Claude Code integration for MacOS. Free forever. |
 
 ## Installation
 


### PR DESCRIPTION
Adds [Flowstay](https://flowstay.app) to the Showcase table in the README.

Flowstay provides easy text-to-speech, local post-processing and Claude Code integration for macOS.