### PR TITLE
fix: replace force-unwraps with guard in tdtDecodeWithTimings

### DIFF
--- a/Sources/FluidAudio/ASR/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/AsrManager.swift
@@ -305,15 +305,18 @@ public final class AsrManager {
         globalFrameOffset: Int = 0
     ) async throws -> TdtHypothesis {
         // Route to appropriate decoder based on model version
-        switch asrModels!.version {
+        guard let models = asrModels, let decoder_ = decoderModel, let joint = jointModel else {
+            throw ASRError.notInitialized
+        }
+        switch models.version {
         case .v2:
             let decoder = TdtDecoderV2(config: config)
             return try await decoder.decodeWithTimings(
                 encoderOutput: encoderOutput,
                 encoderSequenceLength: encoderSequenceLength,
                 actualAudioFrames: actualAudioFrames,
-                decoderModel: decoderModel!,
-                jointModel: jointModel!,
+                decoderModel: decoder_,
+                jointModel: joint,
                 decoderState: &decoderState,
                 contextFrameAdjustment: contextFrameAdjustment,
                 isLastChunk: isLastChunk,
@@ -325,8 +328,8 @@ public final class AsrManager {
                 encoderOutput: encoderOutput,
                 encoderSequenceLength: encoderSequenceLength,
                 actualAudioFrames: actualAudioFrames,
-                decoderModel: decoderModel!,
-                jointModel: jointModel!,
+                decoderModel: decoder_,
+                jointModel: joint,
                 decoderState: &decoderState,
                 contextFrameAdjustment: contextFrameAdjustment,
                 isLastChunk: isLastChunk,


### PR DESCRIPTION
Fixes #319

Force-unwraps of `asrModels!`, `decoderModel!`, and `jointModel!` in `tdtDecodeWithTimings` crash the app when models become nil during sustained rapid transcription calls (e.g., live preview loop at ~5 calls/sec) or when `cleanup()` races with in-flight transcription.

This PR replaces them with a single guard that throws `ASRError.notInitialized`, allowing callers to handle the failure gracefully instead of crashing.

### Minimal diff — no behavioral change for normal operation
The guard only triggers when models are unexpectedly nil. Normal transcription flow is unaffected.