### PR TITLE
fix: add @unchecked Sendable conformance to AsrManager for Swift 6

### DIFF
--- a/Sources/FluidAudio/ASR/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/AsrManager.swift
@@ -8,7 +8,7 @@ public enum AudioSource: Sendable {
     case system
 }
 
-public final class AsrManager {
+public final class AsrManager: @unchecked Sendable {
 
     internal let logger = AppLogger(category: "ASR")
     internal let config: ASRConfig


### PR DESCRIPTION
## Summary
- Marks `AsrManager` as `@unchecked Sendable` to resolve Swift 6 strict concurrency errors
- Fixes `Sending 'asrManager' risks causing data races` errors at lines 258, 379, and 621 of `StreamingAsrManager.swift`

## Rationale
- `AsrManager` is already used across async boundaries throughout the codebase
- Safety is manually managed within `StreamingAsrManager` (an actor)
- Consistent with how `CtcKeywordSpotter` and `VocabularyRescorer` are already handled

Closes #322

## Test plan
- [x] Verify the change compiles with Swift 6 strict concurrency (`SWIFT_STRICT_CONCURRENCY=complete`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)