### PR TITLE
Fix - Swift 6 strict concurrency error in TtsModels.swift — MLModel n…

### DIFF
--- a/Sources/FluidAudio/Shared/MLModel+Prediction.swift
+++ b/Sources/FluidAudio/Shared/MLModel+Prediction.swift
@@ -1,10 +1,5 @@
-import CoreML
+@preconcurrency import CoreML
 import Foundation
-
-// MLModel is thread-safe by design but lacks a formal Sendable conformance.
-// This retroactive conformance makes TaskGroup closures that capture MLModel
-// compile cleanly under Swift 6 strict concurrency.
-extension MLModel: @unchecked @retroactive Sendable {}
 
 extension MLModel {
     /// Compatibly call Core ML prediction using async API.

--- a/Sources/FluidAudioEspeak/TextToSpeech/TtsModels.swift
+++ b/Sources/FluidAudioEspeak/TextToSpeech/TtsModels.swift
@@ -1,4 +1,4 @@
-import CoreML
+@preconcurrency import CoreML
 import FluidAudio
 import Foundation
 import OSLog
@@ -40,37 +40,40 @@ public struct TtsModels: Sendable {
             return ModelNames.TTS.Variant.allCases
         }()
         let modelNames = targetVariants.map { $0.fileName }
-        let dict = try await DownloadUtils.loadModels(
+        var dict = try await DownloadUtils.loadModels(
             .kokoro,
             modelNames: modelNames,
             directory: modelsDirectory,
             // Only a small fraction of the model can run on ANE, and compile time takes a long time because of the complicated arch
             computeUnits: .cpuAndGPU
         )
-        var loaded: [ModelNames.TTS.Variant: MLModel] = [:]
+
         var warmUpDurations: [ModelNames.TTS.Variant: TimeInterval] = [:]
 
-        for variant in targetVariants {
-            let name = variant.fileName
-            guard let model = dict[name] else {
-                throw TTSError.modelNotFound(name)
-            }
-            loaded[variant] = model
-        }
+        let loaded = try await withThrowingTaskGroup(of: (ModelNames.TTS.Variant, MLModel, TimeInterval).self) { group in
+            for variant in targetVariants {
+                let name = variant.fileName
+                // By removing the model from `dict`, we disconnect its region.
+                // This allows the non-Sendable MLModel to be transferred into the task closure safely.
+                guard let model = dict.removeValue(forKey: name) else {
+                    throw TTSError.modelNotFound(name)
+                }
 
-        try await withThrowingTaskGroup(of: (ModelNames.TTS.Variant, TimeInterval).self) { group in
-            for (variant, model) in loaded {
                 group.addTask(priority: .userInitiated) {
                     let warmUpStart = Date()
                     await warmUpModel(model, variant: variant)
                     let warmUpDuration = Date().timeIntervalSince(warmUpStart)
-                    return (variant, warmUpDuration)
+                    // Transfer the model back out of the task
+                    return (variant, model, warmUpDuration)
                 }
             }
 
-            for try await (variant, duration) in group {
+            var finalLoaded: [ModelNames.TTS.Variant: MLModel] = [:]
+            for try await (variant, model, duration) in group {
                 warmUpDurations[variant] = duration
+                finalLoaded[variant] = model
             }
+            return finalLoaded
         }
 
         for variant in targetVariants {


### PR DESCRIPTION
[…ot Sendable

### Why is this change needed?
<!-- Explain the motivation for this change. What problem does it solve? -->

](https://github.com/FluidInference/FluidAudio/issues/331)

When building a project that uses FluidAudio with Swift 6 strict concurrency, the following error occurs:

Sources/FluidAudioEspeak/TextToSpeech/TtsModels.swift:63:23
Task-isolated value of type '() async -> (ModelNames.TTS.Variant, TimeInterval)' 
passed as a strongly transferred parameter; later accesses could race

The file currently uses @preconcurrency import CoreML, which suppressed this in Swift 5 compatibility mode.
However, in Swift 6 strict concurrency, MLModel must be explicitly Sendable for the closure to be passed across task boundaries.

The @preconcurrency import is no longer sufficient.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/332" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
