### PR TITLE
Fix Swift 6 strict concurrency errors in StreamingAsrManager

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,60 @@
+{
+  "originHash" : "6e4b24045df80bb42c92a785100c719d3a927334a96142dc3f89f0906668e87c",
+  "pins" : [
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
+        "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "f731f03bf746481d4fda07f817c3774390c4d5b9",
+        "version" : "2.3.2"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
+        "version" : "1.1.9"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift
@@ -254,9 +254,7 @@ public actor StreamingAsrManager {
         nextWindowCenterStart = 0
 
         // Reset decoder state for the current audio source
-        if let asrManager = asrManager {
-            try await asrManager.resetDecoderState(for: audioSource)
-        }
+        try await resetAsrDecoderState(for: audioSource)
 
         // Reset sliding window state
         segmentIndex = 0
@@ -278,6 +276,27 @@ public actor StreamingAsrManager {
     /// Clear the update continuation
     private func clearUpdateContinuation() {
         updateContinuation = nil
+    }
+
+    // MARK: - Nonisolated Wrappers for Swift 6 Concurrency
+
+    /// Nonisolated wrapper: avoids sending actor-isolated local binding across isolation boundary.
+    /// Safe because asrManager is nonisolated(unsafe) and all parameters are Sendable value types.
+    nonisolated private func resetAsrDecoderState(for source: AudioSource) async throws {
+        try await asrManager?.resetDecoderState(for: source)
+    }
+
+    /// Nonisolated wrapper: avoids sending actor-isolated local binding across isolation boundary.
+    nonisolated private func transcribeAsrStreamingChunk(
+        _ samples: [Float],
+        source: AudioSource,
+        previousTokens: [Int],
+        isLastChunk: Bool
+    ) async throws -> (tokens: [Int], timestamps: [Int], confidences: [Float], encoderSequenceLength: Int) {
+        guard let mgr = asrManager else { return ([], [], [], 0) }
+        return try await mgr.transcribeStreamingChunk(
+            samples, source: source, previousTokens: previousTokens, isLastChunk: isLastChunk
+        )
     }
 
     // MARK: - Private Methods
@@ -376,7 +395,8 @@ public actor StreamingAsrManager {
             // Start frame offset is now handled by decoder's timeJump mechanism
 
             // Call AsrManager directly with deduplication
-            let (tokens, timestamps, confidences, _) = try await asrManager.transcribeStreamingChunk(
+            // Use nonisolated wrapper to avoid sending actor-isolated local binding across isolation boundary
+            let (tokens, timestamps, confidences, _) = try await transcribeAsrStreamingChunk(
                 windowSamples,
                 source: audioSource,
                 previousTokens: accumulatedTokens,
@@ -616,23 +636,22 @@ public actor StreamingAsrManager {
 
     /// Reset decoder state for error recovery
     private func resetDecoderForRecovery() async {
-        if let asrManager = asrManager {
-            do {
-                try await asrManager.resetDecoderState(for: audioSource)
-                logger.info("Successfully reset decoder state during error recovery")
-            } catch {
-                logger.error("Failed to reset decoder state during recovery: \(error)")
+        do {
+            // Use nonisolated wrapper to avoid sending actor-isolated local binding across isolation boundary
+            try await resetAsrDecoderState(for: audioSource)
+            logger.info("Successfully reset decoder state during error recovery")
+        } catch {
+            logger.error("Failed to reset decoder state during recovery: \(error)")
 
-                // Last resort: try to reinitialize the ASR manager
-                do {
-                    let models = try await AsrModels.downloadAndLoad()
-                    let newAsrManager = AsrManager(config: config.asrConfig)
-                    try await newAsrManager.initialize(models: models)
-                    self.asrManager = newAsrManager
-                    logger.info("Successfully reinitialized ASR manager during error recovery")
-                } catch {
-                    logger.error("Failed to reinitialize ASR manager during recovery: \(error)")
-                }
+            // Last resort: try to reinitialize the ASR manager
+            do {
+                let models = try await AsrModels.downloadAndLoad()
+                let newAsrManager = AsrManager(config: config.asrConfig)
+                try await newAsrManager.initialize(models: models)
+                self.asrManager = newAsrManager
+                logger.info("Successfully reinitialized ASR manager during error recovery")
+            } catch {
+                logger.error("Failed to reinitialize ASR manager during recovery: \(error)")
             }
         }
     }


### PR DESCRIPTION
## Summary

Fix three `SendingRisksDataRace` errors in `StreamingAsrManager.swift` that block Swift 6 strict concurrency builds.

The errors occur when actor-isolated methods create a local binding (`if let asrManager = asrManager`) and then call nonisolated async methods on it. The local binding inherits actor isolation, so calling out to a nonisolated async method "sends" an actor-isolated reference across an isolation boundary.

## Fix

Add two `nonisolated` private wrapper methods that access the `nonisolated(unsafe)` property directly:

- `resetAsrDecoderState(for:)` - wraps `AsrManager.resetDecoderState(for:)`
- `transcribeAsrStreamingChunk(...)` - wraps `AsrManager.transcribeStreamingChunk(...)`

Since `asrManager` is `nonisolated(unsafe)`, it can be accessed from `nonisolated` methods without creating an actor-isolated binding. All parameters passed from actor-isolated callers (`AudioSource`, `[Float]`, `[Int]`, `Bool`) are Sendable value types.

## Call-site changes

| Location | Method | Change |
|----------|--------|--------|
| Line 257 | `reset()` | Use `resetAsrDecoderState` wrapper |
| Line 379 | `processWindow()` | Use `transcribeAsrStreamingChunk` wrapper |
| Line 641 | `resetDecoderForRecovery()` | Use `resetAsrDecoderState` wrapper |

## Safety

- No `@unchecked Sendable` (forbidden by CLAUDE.md)
- No new actor wrappers or restructuring
- Safety contract unchanged: `asrManager` is only accessed within the actor's lifecycle
- Wrapper methods are thin pass-throughs with all Sendable value type parameters

## Testing

- `swift build` passes with zero errors in the fork
- Downstream project (MedicalTranscriber) builds and all 337 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/338" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
