### PR TITLE
Remove AI co-author tags from commit messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,6 +302,7 @@ The project uses GitHub Actions with the following workflows:
 7. **Avoid Deprecated Code**: Do not add support for deprecated models or features unless explicitly requested. Keep the codebase clean by only supporting current versions.
 8. **Testing Policy**: ONLY add or run tests when explicitly requested by the user
 9. **Git Operations**: NEVER run `git push` unless explicitly requested by the user. Only commit when asked.
+   - **No Co-Author Tags**: Do NOT add `Co-Authored-By` lines for Claude, Copilot, or any AI assistant in commit messages.
 10. **Code Formatting**: All code must pass swift-format checks before merge
 
 ## Next Steps


### PR DESCRIPTION
## Summary
- Adds rule to CLAUDE.md: do not include `Co-Authored-By` lines for Claude, Copilot, or any AI assistant in commit messages

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/339" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
