### PR TITLE
fix: add Task cancellation support to ASR transcription

### DIFF
--- a/Sources/FluidAudio/ASR/AsrTranscription.swift
+++ b/Sources/FluidAudio/ASR/AsrTranscription.swift
@@ -92,6 +92,7 @@ extension AsrManager {
                 throw ASRError.notInitialized
             }
 
+            try Task.checkCancellation()
             let preprocessorOutput = try await preprocessorModel.compatPrediction(
                 from: preprocessorInput,
                 options: predictionOptions
@@ -103,6 +104,7 @@ extension AsrManager {
                 originalInput: preprocessorInput
             )
 
+            try Task.checkCancellation()
             let encoderOutputProvider = try await encoderModel.compatPrediction(
                 from: encoderInput,
                 options: predictionOptions

--- a/Sources/FluidAudio/ASR/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/ChunkProcessor.swift
@@ -68,6 +68,7 @@ struct ChunkProcessor {
         var chunkDecoderState = TdtDecoderState.make()
 
         while chunkStart < totalSamples {
+            try Task.checkCancellation()
             let candidateEnd = chunkStart + chunkSamples
             let isLastChunk = candidateEnd >= totalSamples
             let chunkEnd = isLastChunk ? totalSamples : candidateEnd

--- a/Sources/FluidAudio/ASR/TDT/TdtDecoderV3.swift
+++ b/Sources/FluidAudio/ASR/TDT/TdtDecoderV3.swift
@@ -225,6 +225,7 @@ internal struct TdtDecoderV3 {
         // ===== MAIN DECODING LOOP =====
         // Process each encoder frame until we've consumed all audio
         while activeMask {
+            try Task.checkCancellation()
             // Use last emitted token for decoder context, or blank if starting
             var label = hypothesis.lastToken ?? config.tdtConfig.blankId
             let stateToUse = hypothesis.decState ?? decoderState
@@ -324,6 +325,7 @@ internal struct TdtDecoderV3 {
             // - Maintains linguistic continuity across gaps in speech
             // - Speeds up processing by 2-3x for audio with silence
             while advanceMask {
+                try Task.checkCancellation()
                 timeIndicesCurrentLabels = timeIndices
 
                 // INTENTIONAL: Reusing prepared decoder step from outside loop
@@ -428,6 +430,7 @@ internal struct TdtDecoderV3 {
 
             // Continue until we get consecutive blanks or hit max steps
             while additionalSteps < maxSymbolsPerStep && consecutiveBlanks < maxConsecutiveBlanks {
+                try Task.checkCancellation()
                 let stateToUse = hypothesis.decState ?? decoderState
 
                 // Get decoder output for final processing


### PR DESCRIPTION
## Summary
- Add `try Task.checkCancellation()` checkpoints throughout the ASR transcription pipeline
- Cancellation is checked: between chunks in `ChunkProcessor`, at each iteration of the TDT decoder loops (main, inner blank, last-chunk finalization), and before expensive CoreML model predictions (preprocessor, encoder)
- Follows the existing cancellation pattern used in the Diarizer (`OfflineSegmentationProcessor`, `OfflineEmbeddingExtractor`)

Closes #335

## Test plan
- [x] `swift build` passes
- [ ] `swift test --filter CITests` passes
- [ ] Verify cancelling a parent Task during transcription stops processing promptly