### PR TITLE
fix: add type annotation to withUnsafeBytes for Swift 6.2 compatibility

### DIFF
--- a/Sources/FluidAudio/ASR/Qwen3/Qwen3AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Qwen3/Qwen3AsrModels.swift
@@ -305,7 +305,7 @@ public final class EmbeddingWeights: Sendable {
         var result = [Float](repeating: 0, count: hiddenSize)
 
         #if arch(arm64)
-        data.withUnsafeBytes { ptr in
+        data.withUnsafeBytes { (ptr: UnsafeRawBufferPointer) in
             let f16Ptr = ptr.baseAddress!.advanced(by: offset)
                 .assumingMemoryBound(to: Float16.self)
 


### PR DESCRIPTION
## Summary
- Add explicit `UnsafeRawBufferPointer` type annotation to the `Data.withUnsafeBytes` closure in `Qwen3AsrModels.EmbeddingWeights.embedding(for:)`
- Resolves "Type of expression is ambiguous without a type annotation" compile error on Swift 6.2.3 / Xcode 26.2

Closes #333

## Test plan
- [x] `swift build` passes
- [ ] Verify compilation on Swift 6.2.3 / Xcode 26.2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
