### PR TITLE
feat: separate exclusiveSegments from embeddingExcludeOverlap

### DIFF
--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
@@ -160,10 +160,20 @@ public struct OfflineDiarizerConfig: Sendable {
     public struct PostProcessing: Sendable {
         public var minGapDurationSeconds: Double
 
-        public static let community = PostProcessing(minGapDurationSeconds: 0.1)
+        /// When true, output segments are made non-overlapping by trimming later segments
+        /// so that only one speaker is active at any given time.
+        /// This is independent of `Embedding.excludeOverlap` which controls overlap masking
+        /// during embedding extraction.
+        public var exclusiveSegments: Bool
 
-        public init(minGapDurationSeconds: Double) {
+        public static let community = PostProcessing(
+            minGapDurationSeconds: 0.1,
+            exclusiveSegments: true
+        )
+
+        public init(minGapDurationSeconds: Double, exclusiveSegments: Bool = true) {
             self.minGapDurationSeconds = minGapDurationSeconds
+            self.exclusiveSegments = exclusiveSegments
         }
     }
 
@@ -211,6 +221,7 @@ public struct OfflineDiarizerConfig: Sendable {
         embeddingExcludeOverlap: Bool = Embedding.community.excludeOverlap,
         minSegmentDuration: Double = Embedding.community.minSegmentDurationSeconds,
         minGapDuration: Double = PostProcessing.community.minGapDurationSeconds,
+        exclusiveSegments: Bool = PostProcessing.community.exclusiveSegments,
         speechOnsetThreshold: Float = Segmentation.community.speechOnsetThreshold,
         speechOffsetThreshold: Float = Segmentation.community.speechOffsetThreshold,
         segmentationMinDurationOn: Double = Segmentation.community.minDurationOn,
@@ -243,7 +254,10 @@ public struct OfflineDiarizerConfig: Sendable {
                 maxIterations: maxVBxIterations,
                 convergenceTolerance: convergenceTolerance
             ),
-            postProcessing: PostProcessing(minGapDurationSeconds: minGapDuration),
+            postProcessing: PostProcessing(
+                minGapDurationSeconds: minGapDuration,
+                exclusiveSegments: exclusiveSegments
+            ),
             export: Export(embeddingsPath: embeddingExportPath)
         )
     }
@@ -409,6 +423,11 @@ public struct OfflineDiarizerConfig: Sendable {
     public var minGapDuration: Double {
         get { postProcessing.minGapDurationSeconds }
         set { postProcessing.minGapDurationSeconds = newValue }
+    }
+
+    public var exclusiveSegments: Bool {
+        get { postProcessing.exclusiveSegments }
+        set { postProcessing.exclusiveSegments = newValue }
     }
 
     public var embeddingExportPath: String? {

--- a/Sources/FluidAudio/Diarizer/Offline/Utils/OfflineReconstruction.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Utils/OfflineReconstruction.swift
@@ -410,7 +410,7 @@ struct OfflineReconstruction {
             ($0.endTimeSeconds - $0.startTimeSeconds) >= minimumDuration
         }
 
-        if config.embeddingExcludeOverlap {
+        if config.exclusiveSegments {
             ordered = excludeOverlaps(in: ordered)
         }
 


### PR DESCRIPTION
## Summary
- Add new `exclusiveSegments` flag to `OfflineDiarizerConfig.PostProcessing` that independently controls whether final output segments are made non-overlapping
- `embeddingExcludeOverlap` now only controls overlap masking during embedding extraction
- `exclusiveSegments` now controls the `excludeOverlaps()` call in `sanitize()`
- Both default to `true`, preserving existing behavior — no breaking changes

### Before
`embeddingExcludeOverlap` controlled two independent things:
1. Overlap frame masking during embedding extraction (clustering quality)
2. Final segment overlap removal (output format)

Setting `embeddingExcludeOverlap=false` for better clustering also disabled segment exclusivity.

### After
```swift
let config = OfflineDiarizerConfig(
    embeddingExcludeOverlap: false,  // overlap-inclusive embeddings for clustering
    exclusiveSegments: true           // still get non-overlapping output segments
)
```

Closes #343

## Test plan
- [x] `swift build` passes
- [ ] Run diarization benchmark to verify no regression with default config
- [ ] Test with `embeddingExcludeOverlap: false, exclusiveSegments: true` to verify independent control