### PR TITLE
fix: respect CustomVocabularyContext.minSimilarity in rescoring

### DIFF
--- a/Sources/FluidAudio/ASR/AsrTranscription.swift
+++ b/Sources/FluidAudio/ASR/AsrTranscription.swift
@@ -530,6 +530,9 @@ extension AsrManager {
             }
 
             let vocabConfig = vocabSizeConfig ?? ContextBiasingConstants.rescorerConfig(forVocabSize: 0)
+            // Use the higher of the size-based default and the caller-specified threshold
+            // so that CustomVocabularyContext.minSimilarity is respected when stricter.
+            let effectiveMinSimilarity = max(vocabConfig.minSimilarity, vocab.minSimilarity)
 
             let rescoreOutput = rescorer.ctcTokenRescore(
                 transcript: result.text,
@@ -538,7 +541,7 @@ extension AsrManager {
                 frameDuration: spotResult.frameDuration,
                 cbw: vocabConfig.cbw,
                 marginSeconds: 0.5,
-                minSimilarity: vocabConfig.minSimilarity
+                minSimilarity: effectiveMinSimilarity
             )
 
             guard rescoreOutput.wasModified else {

--- a/Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift
@@ -531,9 +531,10 @@ public actor StreamingAsrManager {
                 return nil
             }
 
-            // Determine rescoring parameters based on vocabulary size
+            // Determine rescoring parameters based on vocabulary size,
+            // but respect the caller-specified threshold when stricter.
             let vocabConfig = vocabSizeConfig ?? ContextBiasingConstants.rescorerConfig(forVocabSize: 0)
-            let minSimilarity = vocabConfig.minSimilarity
+            let minSimilarity = max(vocabConfig.minSimilarity, vocab.minSimilarity)
             let cbw = vocabConfig.cbw
 
             // Apply constrained CTC rescoring

--- a/Tests/FluidAudioTests/ASR/CustomVocabulary/ContextBiasingConstantsTests.swift
+++ b/Tests/FluidAudioTests/ASR/CustomVocabulary/ContextBiasingConstantsTests.swift
@@ -80,4 +80,31 @@ final class ContextBiasingConstantsTests: XCTestCase {
         let large = ContextBiasingConstants.rescorerConfig(forVocabSize: 15)
         XCTAssertGreaterThan(large.minSimilarity, small.minSimilarity)
     }
+
+    // MARK: - Effective minSimilarity (context override)
+
+    func testEffectiveMinSimilarityRespectsCallerThreshold() {
+        // When a caller sets a stricter minSimilarity on CustomVocabularyContext,
+        // the effective threshold should be the max of the size-based config
+        // and the caller-specified value. This matches the logic in
+        // AsrTranscription.applyVocabularyRescoring() and
+        // StreamingAsrManager.applyVocabularyRescoring().
+        let smallVocabConfig = ContextBiasingConstants.rescorerConfig(forVocabSize: 5)
+        XCTAssertEqual(smallVocabConfig.minSimilarity, 0.50, accuracy: 0.01)
+
+        let callerThreshold: Float = 0.60
+        let effective = max(smallVocabConfig.minSimilarity, callerThreshold)
+        XCTAssertEqual(effective, 0.60, accuracy: 0.01, "Caller's stricter threshold should win")
+    }
+
+    func testEffectiveMinSimilarityUsesVocabConfigWhenStricter() {
+        // When the size-based config is stricter than the caller's threshold,
+        // the size-based config should win.
+        let largeVocabConfig = ContextBiasingConstants.rescorerConfig(forVocabSize: 15)
+        XCTAssertEqual(largeVocabConfig.minSimilarity, 0.60, accuracy: 0.01)
+
+        let callerThreshold: Float = 0.52
+        let effective = max(largeVocabConfig.minSimilarity, callerThreshold)
+        XCTAssertEqual(effective, 0.60, accuracy: 0.01, "Size-based stricter threshold should win")
+    }
 }


### PR DESCRIPTION
## Summary

The vocabulary rescorer ignores `CustomVocabularyContext.minSimilarity` passed by callers. Both `AsrTranscription.applyVocabularyRescoring()` and `StreamingAsrManager.applyVocabularyRescoring()` use only the size-based `vocabConfig.minSimilarity` from `rescorerConfig(forVocabSize:)`, which returns 0.50 for small vocabularies (≤10 terms).

This causes false replacements even when the caller explicitly sets a stricter threshold (e.g., 0.60):
- "called" → "Balen" at sim=0.50
- "gonna" → "Ghanta" at sim=0.50

## Fix

Use `max(vocabConfig.minSimilarity, vocab.minSimilarity)` so the caller's threshold is respected when it is stricter than the size-based default.

**Files changed:**
- `Sources/FluidAudio/ASR/AsrTranscription.swift` — batch transcription path
- `Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift` — streaming path

## How to reproduce

1. Create a `CustomVocabularyContext` with `minSimilarity: 0.60` and ≤10 terms (e.g., "Balen", "Ghanta")
2. Speak "I called them" or "gonna work"
3. Observe `MinSimilarity: 0.5` in VocabularyRescorer debug logs despite passing 0.60
4. "called" gets replaced by "Balen" at sim=0.50 (should be rejected at 0.60 threshold)

## Test plan

- [x] `swift build` passes
- [x] Existing `ContextBiasingConstantsTests` still pass (size-based defaults unchanged)
- [x] Verify with small vocabulary (≤10 terms) that caller's `minSimilarity` is now logged and enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/349" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
