### PR TITLE
fix: release build data race and currency number spelling

### DIFF
--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Preprocess/TtsTextPreprocessor.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Preprocess/TtsTextPreprocessor.swift
@@ -200,7 +200,7 @@ enum TtsTextPreprocessor {
 
     // MARK: - Currency Processing
 
-    /// Process currencies ($12.50 → 12 dollars and 50 cents)
+    /// Process currencies ($12.50 → twelve dollars and fifty cents)
     private static func processCurrencies(_ text: String) -> String {
         let currencyPattern = try! NSRegularExpression(
             pattern:
@@ -221,15 +221,19 @@ enum TtsTextPreprocessor {
 
             let value = String(matchText.dropFirst())
             let components = value.components(separatedBy: ".")
-            let dollars = components[0]
-            let cents = components.count > 1 ? components[1] : "0"
+            guard let dollarsInt = Int(components[0]) else { continue }
+            let centsInt = components.count > 1 ? (Int(components[1]) ?? 0) : 0
 
+            let dollarsWord = spellOutFormatter.string(from: NSNumber(value: dollarsInt)) ?? components[0]
             let replacement: String
-            if Int(cents) == 0 {
-                replacement = Int(dollars) == 1 ? "\(dollars) \(currency.bill)" : "\(dollars) \(currency.bill)s"
+            if centsInt == 0 {
+                replacement = dollarsInt == 1 ? "\(dollarsWord) \(currency.bill)" : "\(dollarsWord) \(currency.bill)s"
             } else {
-                let dollarPart = Int(dollars) == 1 ? "\(dollars) \(currency.bill)" : "\(dollars) \(currency.bill)s"
-                replacement = "\(dollarPart) and \(cents) \(currency.cent)s"
+                let centsWord = spellOutFormatter.string(from: NSNumber(value: centsInt)) ?? "\(centsInt)"
+                let dollarPart =
+                    dollarsInt == 1 ? "\(dollarsWord) \(currency.bill)" : "\(dollarsWord) \(currency.bill)s"
+                let centPart = centsInt == 1 ? "\(centsWord) \(currency.cent)" : "\(centsWord) \(currency.cent)s"
+                replacement = "\(dollarPart) and \(centPart)"
             }
 
             result.replaceSubrange(fullRange, with: replacement)

--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer+Memory.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer+Memory.swift
@@ -24,17 +24,18 @@ extension KokoroSynthesizer {
         private var storage: [MultiArrayKey: [MLMultiArray]] = [:]
 
         func rent(
-            shape: [NSNumber],
+            shape: [Int],
             dataType: MLMultiArrayDataType,
             zeroFill: Bool
         ) async throws -> MLMultiArray {
-            let key = MultiArrayKey(dataType: dataType, shape: shape)
+            let nsShape = shape.map { NSNumber(value: $0) }
+            let key = MultiArrayKey(dataType: dataType, shape: nsShape)
             let array: MLMultiArray
             if var cached = storage[key], let candidate = cached.popLast() {
                 storage[key] = cached
                 array = candidate
             } else {
-                array = try MLMultiArray(shape: shape, dataType: dataType)
+                array = try MLMultiArray(shape: nsShape, dataType: dataType)
             }
 
             if zeroFill {

--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer.swift
@@ -257,9 +257,8 @@ public struct KokoroSynthesizer {
 
         let kokoro = try await model(for: variant)
 
-        let refShape: [NSNumber] = [1, NSNumber(value: referenceVector.count)]
         let refStyle = try await multiArrayPool.rent(
-            shape: refShape,
+            shape: [1, referenceVector.count],
             dataType: .float32,
             zeroFill: false
         )
@@ -283,20 +282,18 @@ public struct KokoroSynthesizer {
             trimmedIds.append(contentsOf: Array(repeating: Int32(0), count: targetTokens - trimmedIds.count))
         }
 
-        let inputShape: [NSNumber] = [1, NSNumber(value: targetTokens)]
-        let phasesShape: [NSNumber] = [1, 9]
         let inputArray = try await multiArrayPool.rent(
-            shape: inputShape,
+            shape: [1, targetTokens],
             dataType: .int32,
             zeroFill: false
         )
         let attentionMask = try await multiArrayPool.rent(
-            shape: inputShape,
+            shape: [1, targetTokens],
             dataType: .int32,
             zeroFill: false
         )
         let phasesArray = try await multiArrayPool.rent(
-            shape: phasesShape,
+            shape: [1, 9],
             dataType: .float32,
             zeroFill: true
         )


### PR DESCRIPTION
## Summary
- Fix `swift build -c release` error: `sending value of non-Sendable type '[NSNumber]' risks causing data races` in `KokoroSynthesizer.swift:288`. Changed `MultiArrayPool.rent()` to accept `[Int]` instead of `[NSNumber]`, converting internally.
- Fix currency TTS: `$5.23` now preprocesses to `"five dollars and twenty-three cents"` instead of `"5 dollars and 23 cents"` with raw digits that could fail phonemization.

## Test plan
- [x] `swift build -c release` passes with zero errors
- [x] `swift build --build-tests` passes
- [x] TTS stem and SSML tests pass
- [x] TTS wav verified: `$5.23` → "five dollars and twenty-three cents", `$1.00` → "one dollar"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/352" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
