### PR TITLE
fix: resolve iOS build and CI benchmark failures

### DIFF
--- a/.github/workflows/offline-pipeline.yml
+++ b/.github/workflows/offline-pipeline.yml
@@ -35,7 +35,7 @@ jobs:
           # Record start time
           BENCHMARK_START=$(date +%s)
 
-          swift run fluidaudiocli diarization-benchmark --mode offline --auto-download --single-file ES2004a --output offline_results.json
+          swift run -c release fluidaudiocli diarization-benchmark --mode offline --auto-download --single-file ES2004a --output offline_results.json
 
           # Check if results file was generated
           if [ -f offline_results.json ]; then

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
             name: "FluidAudio",
             targets: ["FluidAudio"]
         ),
-.executable(
+        .executable(
             name: "fluidaudiocli",
             targets: ["FluidAudioCLI"]
         ),
@@ -43,7 +43,7 @@ let package = Package(
             path: "Sources/MachTaskSelfWrapper",
             publicHeadersPath: "include"
         ),
-.executableTarget(
+        .executableTarget(
             name: "FluidAudioCLI",
             dependencies: [
                 "FluidAudio",

--- a/Sources/FluidAudio/TTS/TtsModels.swift
+++ b/Sources/FluidAudio/TTS/TtsModels.swift
@@ -57,19 +57,10 @@ public struct TtsModels: Sendable {
             loaded[variant] = model
         }
 
-        try await withThrowingTaskGroup(of: (ModelNames.TTS.Variant, TimeInterval).self) { group in
-            for (variant, model) in loaded {
-                group.addTask(priority: .userInitiated) {
-                    let warmUpStart = Date()
-                    await warmUpModel(model, variant: variant)
-                    let warmUpDuration = Date().timeIntervalSince(warmUpStart)
-                    return (variant, warmUpDuration)
-                }
-            }
-
-            for try await (variant, duration) in group {
-                warmUpDurations[variant] = duration
-            }
+        for (variant, model) in loaded {
+            let warmUpStart = Date()
+            await warmUpModel(model, variant: variant)
+            warmUpDurations[variant] = Date().timeIntervalSince(warmUpStart)
         }
 
         for variant in targetVariants {


### PR DESCRIPTION
## Summary
- **iOS build**: Fix Swift 6 task-isolation error in `TtsModels.swift:62` — replace concurrent `withThrowingTaskGroup` warm-up with sequential warm-up. Models compete for the same GPU/ANE, so concurrent warm-up provides no benefit and causes `task-isolated value passed as a strongly transferred parameter` errors in strict concurrency mode.
- **Benchmark segfault**: Run offline diarization benchmark with `-c release` instead of debug mode. The 7GB CI runner was OOMing on a 17-minute audio file in unoptimized debug builds.
- **Package.swift**: Fix indentation on `.executable` and `.executableTarget` entries.

## Test plan
- [ ] iOS build should pass (no more `TtsModels.swift` errors)
- [ ] Offline pipeline benchmark should complete without segfault
- [ ] macOS build + tests pass (verified locally)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/353" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
