### PR TITLE
fix: skip CoreML compilation in AsrModels.download()

### DIFF
--- a/Sources/FluidAudio/ASR/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/AsrModels.swift
@@ -317,30 +317,22 @@ extension AsrModels {
             }
         }
 
-        struct DownloadSpec {
-            let fileName: String
-            let computeUnits: MLComputeUnits
-        }
-
-        let defaultUnits = defaultConfiguration().computeUnits
-
-        let specs: [DownloadSpec] = [
-            // Preprocessor ops map to CPU-only across all platforms.
-            DownloadSpec(fileName: Names.preprocessorFile, computeUnits: .cpuOnly),
-            DownloadSpec(fileName: Names.encoderFile, computeUnits: defaultUnits),
-            DownloadSpec(fileName: Names.decoderFile, computeUnits: defaultUnits),
-            DownloadSpec(fileName: Names.jointFile, computeUnits: defaultUnits),
-        ]
-
-        for spec in specs {
-            _ = try await DownloadUtils.loadModels(
-                version.repo,
-                modelNames: [spec.fileName],
-                directory: parentDir,
-                computeUnits: spec.computeUnits,
-                progressHandler: progressHandler
-            )
-        }
+        // Download files only — skip CoreML compilation.
+        //
+        // The previous implementation called loadModels() which runs
+        // MLModel(contentsOf:configuration:) on every model and then discards the
+        // loaded objects.  That compilation step triggers CoreML's MPS shader
+        // generation on the background, writing gigabytes to disk.  On first
+        // install the combined download + compilation I/O has been observed to
+        // exceed macOS's per-process disk-write budget, causing the system to kill
+        // the process (writesCaused ≈ 8.5 GB on a MacBookPro18,1 / macOS 15.6.1).
+        //
+        // Models are compiled once when load() is called.
+        try await DownloadUtils.downloadRepo(
+            version.repo,
+            to: parentDir,
+            progressHandler: progressHandler
+        )
 
         logger.info("Successfully downloaded ASR models")
         return targetDir


### PR DESCRIPTION
## Summary

- `AsrModels.download()` called `DownloadUtils.loadModels()` which runs `MLModel(contentsOf:configuration:)` on all 4 Parakeet models, then discards the loaded objects (`_ = try await ...`). That compilation triggers CoreML's internal MPS shader generation which writes gigabytes to disk.
- On first install the combined download + compilation I/O was observed at ~8.5 GB (`writesCaused`), causing macOS to kill the process with a disk-write exception.
- Switch `download()` to use `downloadRepo()` which fetches files without loading them into CoreML. Compilation is deferred to `load()` / `downloadAndLoad()` where the `MLModel` objects are actually used.

## Context

Crash report from a client (MacBookPro18,1, macOS 15.6.1):

```
writesCaused: 8590 MB

Triggering thread:
    ParakeetTranscriptionService.download(modelId:)
      AsrModels.download(to:force:version:)
        DownloadUtils.loadModelsOnce(_:modelNames:...)
          MLModel.__allocating_init(contentsOf:configuration:)

Background thread (734 samples):
    CoreML -> Espresso -> MetalPerformanceShadersGraph -> libsystem_kernel
```

## What this does NOT fix

The compilation during `load()` still writes to disk and could still be large. If the crash persists, the load-time compilation itself needs investigation — e.g. why CoreML generates MPS shaders when `computeUnits` is `.cpuAndNeuralEngine`, and whether compiling models one at a time or with `.cpuOnly` for the first load would reduce writes.

## Test plan

- [x] `swift build` succeeds
- [x] `swift test --filter AsrModelsTests` passes (18/18)
- [x] `swift test --filter CITests` passes (13/13)
- [ ] Verify first-time download on clean cache completes without disk-write kill
- [ ] Verify `downloadAndLoad()` still works end-to-end (downloads + compiles + returns models)
- [ ] Measure disk writes during `download()` vs `load()` separately to confirm reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/357" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
