### PR TITLE
fix: correct license from MIT to Apache 2.0 in PocketTTS docs

### DIFF
--- a/Documentation/TTS/PocketTTS.md
+++ b/Documentation/TTS/PocketTTS.md
@@ -208,4 +208,4 @@ try await manager.synthesizeToFile(
 ## License
 
 - **PocketTTS models**: CC-BY-4.0, inherited from [kyutai/pocket-tts](https://huggingface.co/kyutai/pocket-tts)
-- **FluidAudio SDK**: MIT licensed (no GPL dependencies)
+- **FluidAudio SDK**: Apache 2.0 licensed (no GPL dependencies)


### PR DESCRIPTION
## Summary
- PocketTTS.md incorrectly stated FluidAudio SDK is MIT licensed
- The project license is Apache 2.0 per README and LICENSE file
- One-line fix: "MIT licensed" → "Apache 2.0 licensed"

## Test plan
- [ ] Verify no other docs reference MIT for the SDK license
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
