### PR TITLE
fix: use SDK guard instead of compiler version for MLMultiArrayDataType.int8

### DIFF
--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer+Memory.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer+Memory.swift
@@ -95,7 +95,7 @@ extension KokoroSynthesizer {
             case .float16:
                 let pointer = array.dataPointer.bindMemory(to: UInt16.self, capacity: elementCount)
                 pointer.initialize(repeating: 0, count: elementCount)
-            #if swift(>=6.2)
+            #if canImport(FoundationModels)
             case .int8:
                 array.dataPointer.initializeMemory(as: Int8.self, repeating: 0, count: elementCount)
             @unknown default:


### PR DESCRIPTION
## Summary
- Replaces `#if swift(>=6.2)` with `#if canImport(FoundationModels)` in `KokoroSynthesizer+Memory.swift` to correctly gate `MLMultiArrayDataType.int8` on macOS 26 SDK availability rather than compiler version
- `swift(>=6.2)` checks compiler version, but `.int8` is an SDK-gated API — Swift 6.2 ships with both macOS 15 and macOS 26 SDKs, so the compiler check is insufficient
- `canImport(FoundationModels)` is a macOS 26-only framework, making it a correct compile-time proxy for SDK version

Closes #363

## Test plan
- [x] Builds on macOS 26 SDK (verified locally)
- [ ] Verify build passes on `macos-15` CI runner (GitHub Actions)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
