### PR TITLE
docs: fix stale references, versions, and missing CLI commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,24 +86,32 @@ swift package clean
 
 ```bash
 # Transcription
-swift run fluidaudiocli transcribe audio.wav
-swift run fluidaudiocli transcribe audio.wav --low-latency
+swift run fluidaudio transcribe audio.wav
+swift run fluidaudio transcribe audio.wav --low-latency
+swift run fluidaudio qwen3-transcribe audio.wav
+swift run fluidaudio multi-stream audio1.wav audio2.wav
+
+# TTS
+swift run fluidaudio tts "Hello world" --output hello.wav
 
 # Diarization
-swift run fluidaudiocli process meeting.wav --output results.json --threshold 0.6
-
-# Multi-stream processing
-swift run fluidaudiocli multi-stream audio1.wav audio2.wav
+swift run fluidaudio process meeting.wav --output results.json --threshold 0.6
+swift run fluidaudio sortformer audio.wav
+swift run fluidaudio parakeet-eou --input audio.wav
 
 # Benchmarks
-swift run fluidaudiocli asr-benchmark --subset test-clean --max-files 100
-swift run fluidaudiocli diarization-benchmark --auto-download
-swift run fluidaudiocli vad-benchmark --num-files 40 --threshold 0.5
-swift run fluidaudiocli fleurs-benchmark --languages en_us,fr_fr --samples 10
+swift run fluidaudio asr-benchmark --subset test-clean --max-files 100
+swift run fluidaudio diarization-benchmark --auto-download
+swift run fluidaudio vad-benchmark --num-files 40 --threshold 0.5
+swift run fluidaudio fleurs-benchmark --languages en_us,fr_fr --samples 10
+swift run fluidaudio sortformer-benchmark
+swift run fluidaudio qwen3-benchmark
+swift run fluidaudio ctc-earnings-benchmark
+swift run fluidaudio g2p-benchmark
 
 # Dataset downloads
-swift run fluidaudiocli download --dataset ami-sdm
-swift run fluidaudiocli download --dataset librispeech-test-clean
+swift run fluidaudio download --dataset ami-sdm
+swift run fluidaudio download --dataset librispeech-test-clean
 ```
 
 ## Project Structure
@@ -111,12 +119,12 @@ swift run fluidaudiocli download --dataset librispeech-test-clean
 ```
 FluidAudio/
 ├── Sources/
-│   ├── FluidAudio/           # Main library
+│   ├── FluidAudio/           # Main library (single product)
 │   │   ├── ASR/             # Automatic Speech Recognition (Parakeet TDT, Qwen3)
 │   │   ├── Diarizer/        # Speaker diarization (segmentation, embedding, clustering)
+│   │   ├── TTS/             # Text-to-speech (Kokoro, PocketTTS)
 │   │   ├── VAD/             # Voice Activity Detection (Silero VAD)
 │   │   └── Shared/          # Common utilities (audio conversion, model downloading)
-│   ├── FluidAudioTTS/       # Text-to-speech (Kokoro TTS)
 │   └── FluidAudioCLI/       # Command-line interface (macOS only)
 ├── Tests/                   # Test suite
 ├── Scripts/                 # Python utilities (benchmarks, evaluation tools)
@@ -133,13 +141,14 @@ FluidAudio/
 - **StreamingAsrManager** (`ASR/Streaming/`): Real-time streaming ASR with sliding window processing and cancellation support.
 - **OfflineDiarizerManager** (`Diarizer/`): Speaker separation via segmentation, embedding extraction, and VBx clustering. 17.7% DER on AMI dataset.
 - **VadManager** (`VAD/`): Voice activity detection with CoreML models.
-- **KokoroSynthesizer** (`FluidAudioTTS/`): Text-to-speech synthesis.
+- **KokoroSynthesizer** (`TTS/Kokoro/`): Kokoro text-to-speech synthesis.
+- **PocketTtsSynthesizer** (`TTS/PocketTTS/`): PocketTTS streaming text-to-speech synthesis.
 
 ### Key Patterns
 - **Actor-based concurrency**: Thread-safe processing, no `@unchecked Sendable`
 - **Stateless ASR**: Each chunk transcribed independently (~14.96s chunks, 2.0s overlap)
 - **Auto-recovery**: Corrupt CoreML model detection and re-download from HuggingFace
-- **Model management**: Models auto-download from HuggingFace on first use. Can be pre-fetched via `swift run fluidaudiocli download`.
+- **Model management**: Models auto-download from HuggingFace on first use. Can be pre-fetched via `swift run fluidaudio download`.
 - **Cross-platform**: macOS 14.0+, iOS 17.0+ (library), CLI macOS-only
 
 ## Platform Requirements

--- a/Documentation/ASR/CustomPronunciation.md
+++ b/Documentation/ASR/CustomPronunciation.md
@@ -162,8 +162,8 @@ let lexicon = TtsCustomLexicon(entries: [
     "kokoro": ["k", "ə", "k", "ˈ", "ɔ", "ɹ", "O"]
 ])
 
-// Use with TtSManager
-let manager = TtSManager(customLexicon: lexicon)
+// Use with KokoroTtsManager
+let manager = KokoroTtsManager(customLexicon: lexicon)
 try await manager.initialize()
 let audio = try await manager.synthesize(text: "Welcome to Kokoro TTS")
 

--- a/Documentation/CLI.md
+++ b/Documentation/CLI.md
@@ -8,6 +8,9 @@ TTS is built into the CLI. Run it directly:
 
 ```bash
 swift run fluidaudio tts "Hello from FluidAudio" --output out.wav
+
+# Multilingual G2P benchmark
+swift run fluidaudio g2p-benchmark
 ```
 
 ## ASR
@@ -18,6 +21,12 @@ swift run fluidaudio transcribe audio.wav
 
 # English-only run with higher accuracy
 swift run fluidaudio transcribe audio.wav --model-version v2
+
+# Transcribe with Qwen3 ASR
+swift run fluidaudio qwen3-transcribe audio.wav
+
+# Streaming ASR with Parakeet EOU
+swift run fluidaudio parakeet-eou --input audio.wav
 
 # Transcribe multiple files in parallel
 swift run fluidaudio multi-stream audio1.wav audio2.wav
@@ -30,6 +39,12 @@ swift run fluidaudio asr-benchmark --subset test-clean --max-files 50 --model-ve
 
 # Multilingual ASR (FLEURS) benchmark
 swift run fluidaudio fleurs-benchmark --languages en_us,fr_fr --samples 10
+
+# Qwen3 ASR benchmark
+swift run fluidaudio qwen3-benchmark
+
+# CTC keyword spotting benchmark on Earnings22
+swift run fluidaudio ctc-earnings-benchmark
 ```
 
 ## Diarization
@@ -58,6 +73,12 @@ swift run fluidaudio diarization-benchmark --mode offline --dataset ami-sdm --th
 # Process a single file with streaming vs. offline inference
 swift run fluidaudio process meeting.wav --mode streaming --threshold 0.7
 swift run fluidaudio process meeting.wav --mode offline --threshold 0.6 --debug
+
+# Sortformer streaming diarization
+swift run fluidaudio sortformer audio.wav
+
+# Sortformer benchmark on AMI dataset
+swift run fluidaudio sortformer-benchmark
 ```
 
 - `--mode offline` switches the CLI to `OfflineDiarizerManager`, running the full VBx pipeline with PLDA refinement. Expect DER ≈ 18–20 % on AMI-SDM with threshold 0.6.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -24,7 +24,8 @@
 - [Segmentation](VAD/Segmentation.md)
 
 ## TTS
-- [Getting Started](TTS/README.md)
+- [Kokoro](TTS/Kokoro.md)
+- [PocketTTS](TTS/PocketTTS.md)
 - [SSML](TTS/SSML.md)
 
 ## Guides

--- a/Documentation/TTS/Kokoro.md
+++ b/Documentation/TTS/Kokoro.md
@@ -35,7 +35,7 @@ Swap in `manager.initialize(models:)` when you want to preload only the long-for
 ## Inspecting Chunk Metadata
 
 ```swift
-let manager = TtSManager()
+let manager = KokoroTtsManager()
 try await manager.initialize()
 
 let detailed = try await manager.synthesizeDetailed(
@@ -106,7 +106,7 @@ Kokoro TTS is included in the `FluidAudio` product — no separate product neede
 **Package.swift:**
 ```swift
 dependencies: [
-    .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.2"),
+    .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.4"),
 ],
 targets: [
     .target(

--- a/Documentation/TTS/SSML.md
+++ b/Documentation/TTS/SSML.md
@@ -192,14 +192,14 @@ Read as a fraction.
 <!-- Output: "three and one half" -->
 ```
 
-## Usage with TtSManager
+## Usage with KokoroTtsManager
 
 SSML tags are processed automatically when you call `synthesize()`:
 
 ```swift
-import FluidAudioTTS
+import FluidAudio
 
-let ttsManager = TtSManager()
+let ttsManager = KokoroTtsManager()
 try await ttsManager.initialize()
 
 // SSML is processed automatically

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Add FluidAudio to your project using Swift Package Manager:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.2"),
+    .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.4"),
 ],
 ```
 
@@ -106,7 +106,7 @@ dependencies: [
 .product(name: "FluidAudio", package: "FluidAudio")
 ```
 
-**CocoaPods:** We recommend using [cocoapods-spm](https://github.com/trinhngocthuyen/cocoapods-spm) for better SPM integration, but if needed, you can also use our podspec: `pod 'FluidAudio', '~> 0.12.2'`
+**CocoaPods:** We recommend using [cocoapods-spm](https://github.com/trinhngocthuyen/cocoapods-spm) for better SPM integration, but if needed, you can also use our podspec: `pod 'FluidAudio', '~> 0.12.4'`
 
 ### Other Frameworks
 
@@ -577,7 +577,7 @@ Kokoro-82M: <https://huggingface.co/hexgrad/Kokoro-82M>
 
 If you use FluidAudio in your work, please cite:
 
-FluidInference Team. (2025). FluidAudio: Local Speaker Diarization, ASR, and VAD for Apple Platforms (Version 0.12.2) [Computer software]. GitHub. <https://github.com/FluidInference/FluidAudio>
+FluidInference Team. (2025). FluidAudio: Local Speaker Diarization, ASR, and VAD for Apple Platforms (Version 0.12.4) [Computer software]. GitHub. <https://github.com/FluidInference/FluidAudio>
 
 ```bibtex
 @software{FluidInferenceTeam_FluidAudio_2025,
@@ -585,7 +585,7 @@ FluidInference Team. (2025). FluidAudio: Local Speaker Diarization, ASR, and VAD
   title = {{FluidAudio: Local Speaker Diarization, ASR, and VAD for Apple Platforms}},
   year = {2025},
   month = {3},
-  version = {0.12.2},
+  version = {0.12.4},
   url = {https://github.com/FluidInference/FluidAudio},
   note = {Computer software}
 }


### PR DESCRIPTION
## Summary

- Fix broken `TTS/README.md` link in Documentation index (file doesn't exist) — replaced with links to `Kokoro.md` and `PocketTTS.md`
- Replace `TtSManager` (nonexistent class) with `KokoroTtsManager` in Kokoro.md, SSML.md, CustomPronunciation.md
- Fix `import FluidAudioTTS` to `import FluidAudio` in SSML.md (FluidAudioTTS is not a separate product)
- Update version `0.12.2` → `0.12.4` in README.md (SPM, CocoaPods, citation) and Kokoro.md
- Fix CLI invocation from `swift run fluidaudiocli` to `swift run fluidaudio` in CLAUDE.md
- Fix project structure: `FluidAudioTTS/` → `TTS/` under `FluidAudio/` in CLAUDE.md
- Add missing CLI commands to CLI.md and CLAUDE.md: `qwen3-transcribe`, `qwen3-benchmark`, `parakeet-eou`, `sortformer`, `sortformer-benchmark`, `ctc-earnings-benchmark`, `g2p-benchmark`

## Test plan

- [ ] Verify all doc links resolve correctly
- [ ] Confirm version numbers match latest release (v0.12.4)
- [ ] Check CLI command names match `FluidAudioCLI.swift` switch cases
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
