### PR TITLE
docs: fix CLI name references to fluidaudiocli

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ FluidAudio is a Swift framework for local, low-latency audio processing on Apple
 2. **Testing Policy**: Add unit tests when writing new code.
 3. **Git Operations**: Never run `git push` unless explicitly requested.
    - **No Co-Author Tags**: Do not add `Co-Authored-By` lines for Claude, Copilot, or any AI assistant in commit messages.
+   - **No GitHub comments**: Never post comments, reviews, or reactions on issues or PRs via `gh`. Reading issues, PRs, and comments is fine. Creating PRs and editing PR titles/bodies is fine.
 4. **Code Formatting**: All code must pass swift-format checks before merge
 5. **Avoid Deprecated Code**: Do not add support for deprecated models or features unless explicitly requested
 6. **Performance**: Keep RTFx > 1.0x for real-time capability
@@ -86,32 +87,32 @@ swift package clean
 
 ```bash
 # Transcription
-swift run fluidaudio transcribe audio.wav
-swift run fluidaudio transcribe audio.wav --low-latency
-swift run fluidaudio qwen3-transcribe audio.wav
-swift run fluidaudio multi-stream audio1.wav audio2.wav
+swift run fluidaudiocli transcribe audio.wav
+swift run fluidaudiocli transcribe audio.wav --low-latency
+swift run fluidaudiocli qwen3-transcribe audio.wav
+swift run fluidaudiocli multi-stream audio1.wav audio2.wav
 
 # TTS
-swift run fluidaudio tts "Hello world" --output hello.wav
+swift run fluidaudiocli tts "Hello world" --output hello.wav
 
 # Diarization
-swift run fluidaudio process meeting.wav --output results.json --threshold 0.6
-swift run fluidaudio sortformer audio.wav
-swift run fluidaudio parakeet-eou --input audio.wav
+swift run fluidaudiocli process meeting.wav --output results.json --threshold 0.6
+swift run fluidaudiocli sortformer audio.wav
+swift run fluidaudiocli parakeet-eou --input audio.wav
 
 # Benchmarks
-swift run fluidaudio asr-benchmark --subset test-clean --max-files 100
-swift run fluidaudio diarization-benchmark --auto-download
-swift run fluidaudio vad-benchmark --num-files 40 --threshold 0.5
-swift run fluidaudio fleurs-benchmark --languages en_us,fr_fr --samples 10
-swift run fluidaudio sortformer-benchmark
-swift run fluidaudio qwen3-benchmark
-swift run fluidaudio ctc-earnings-benchmark
-swift run fluidaudio g2p-benchmark
+swift run fluidaudiocli asr-benchmark --subset test-clean --max-files 100
+swift run fluidaudiocli diarization-benchmark --auto-download
+swift run fluidaudiocli vad-benchmark --num-files 40 --threshold 0.5
+swift run fluidaudiocli fleurs-benchmark --languages en_us,fr_fr --samples 10
+swift run fluidaudiocli sortformer-benchmark
+swift run fluidaudiocli qwen3-benchmark
+swift run fluidaudiocli ctc-earnings-benchmark
+swift run fluidaudiocli g2p-benchmark
 
 # Dataset downloads
-swift run fluidaudio download --dataset ami-sdm
-swift run fluidaudio download --dataset librispeech-test-clean
+swift run fluidaudiocli download --dataset ami-sdm
+swift run fluidaudiocli download --dataset librispeech-test-clean
 ```
 
 ## Project Structure
@@ -148,7 +149,7 @@ FluidAudio/
 - **Actor-based concurrency**: Thread-safe processing, no `@unchecked Sendable`
 - **Stateless ASR**: Each chunk transcribed independently (~14.96s chunks, 2.0s overlap)
 - **Auto-recovery**: Corrupt CoreML model detection and re-download from HuggingFace
-- **Model management**: Models auto-download from HuggingFace on first use. Can be pre-fetched via `swift run fluidaudio download`.
+- **Model management**: Models auto-download from HuggingFace on first use. Can be pre-fetched via `swift run fluidaudiocli download`.
 - **Cross-platform**: macOS 14.0+, iOS 17.0+ (library), CLI macOS-only
 
 ## Platform Requirements

--- a/Documentation/ASR/CustomPronunciation.md
+++ b/Documentation/ASR/CustomPronunciation.md
@@ -142,7 +142,7 @@ return normalizedEntries[normalized]
 ### CLI
 
 ```bash
-swift run fluidaudio tts "The NASDAQ index rose today" --lexicon custom.txt --output output.wav
+swift run fluidaudiocli tts "The NASDAQ index rose today" --lexicon custom.txt --output output.wav
 ```
 
 ### Swift API

--- a/Documentation/ASR/GettingStarted.md
+++ b/Documentation/ASR/GettingStarted.md
@@ -75,36 +75,36 @@ Working offline? Follow the [Manual Model Loading guide](ManualModelLoading.md) 
 
 ```bash
 # Transcribe an audio file (batch)
-swift run fluidaudio transcribe audio.wav
+swift run fluidaudiocli transcribe audio.wav
 
 # English-only run (better recall)
-swift run fluidaudio transcribe audio.wav --model-version v2
+swift run fluidaudiocli transcribe audio.wav --model-version v2
 
 # Transcribe multiple files in parallel
-swift run fluidaudio multi-stream audio1.wav audio2.wav
+swift run fluidaudiocli multi-stream audio1.wav audio2.wav
 
 # Benchmark ASR on LibriSpeech
-swift run fluidaudio asr-benchmark --subset test-clean --max-files 50
+swift run fluidaudiocli asr-benchmark --subset test-clean --max-files 50
 
 # Run the English-only benchmark
-swift run fluidaudio asr-benchmark --subset test-clean --max-files 50 --model-version v2
+swift run fluidaudiocli asr-benchmark --subset test-clean --max-files 50 --model-version v2
 
 # Multilingual ASR (FLEURS) benchmark
-swift run fluidaudio fleurs-benchmark --languages en_us,fr_fr --samples 10
+swift run fluidaudiocli fleurs-benchmark --languages en_us,fr_fr --samples 10
 
 # Download LibriSpeech test sets
-swift run fluidaudio download --dataset librispeech-test-clean
-swift run fluidaudio download --dataset librispeech-test-other
+swift run fluidaudiocli download --dataset librispeech-test-clean
+swift run fluidaudiocli download --dataset librispeech-test-other
 ```
 
 ## Streaming CLI (Parakeet EOU)
 
 ```bash
 # Transcribe a file (--use-cache auto-downloads models)
-swift run fluidaudio parakeet-eou --input audio.wav --use-cache
+swift run fluidaudiocli parakeet-eou --input audio.wav --use-cache
 
 # Run benchmark on LibriSpeech test-clean
-swift run fluidaudio parakeet-eou --benchmark --chunk-size 160 --max-files 100 --use-cache
+swift run fluidaudiocli parakeet-eou --benchmark --chunk-size 160 --max-files 100 --use-cache
 ```
 
 **Options:** `--input <path>`, `--benchmark`, `--max-files <n>`, `--chunk-size <160|320|1600>`, `--eou-debounce <ms>`, `--use-cache`, `--models <path>`, `--output <path>`, `--verbose`

--- a/Documentation/Benchmarks.md
+++ b/Documentation/Benchmarks.md
@@ -584,7 +584,7 @@ Hardware: Apple M2, 2022, macOS 26.1
 ### AMI SDM Dataset (NVIDIA High-Latency Config - 30.4s chunks)
 
 ```bash
-swift run fluidaudio sortformer-benchmark --nvidia-high-latency --hf --auto-download
+swift run fluidaudiocli sortformer-benchmark --nvidia-high-latency --hf --auto-download
 ```
 
 ```text

--- a/Documentation/CLI.md
+++ b/Documentation/CLI.md
@@ -7,78 +7,78 @@ This guide collects commonly used `fluidaudio` CLI commands for ASR, diarization
 TTS is built into the CLI. Run it directly:
 
 ```bash
-swift run fluidaudio tts "Hello from FluidAudio" --output out.wav
+swift run fluidaudiocli tts "Hello from FluidAudio" --output out.wav
 
 # Multilingual G2P benchmark
-swift run fluidaudio g2p-benchmark
+swift run fluidaudiocli g2p-benchmark
 ```
 
 ## ASR
 
 ```bash
 # Transcribe an audio file (batch)
-swift run fluidaudio transcribe audio.wav
+swift run fluidaudiocli transcribe audio.wav
 
 # English-only run with higher accuracy
-swift run fluidaudio transcribe audio.wav --model-version v2
+swift run fluidaudiocli transcribe audio.wav --model-version v2
 
 # Transcribe with Qwen3 ASR
-swift run fluidaudio qwen3-transcribe audio.wav
+swift run fluidaudiocli qwen3-transcribe audio.wav
 
 # Streaming ASR with Parakeet EOU
-swift run fluidaudio parakeet-eou --input audio.wav
+swift run fluidaudiocli parakeet-eou --input audio.wav
 
 # Transcribe multiple files in parallel
-swift run fluidaudio multi-stream audio1.wav audio2.wav
+swift run fluidaudiocli multi-stream audio1.wav audio2.wav
 
 # Benchmark ASR on LibriSpeech
-swift run fluidaudio asr-benchmark --subset test-clean --max-files 50
+swift run fluidaudiocli asr-benchmark --subset test-clean --max-files 50
 
 # English benchmark preset (LibriSpeech)
-swift run fluidaudio asr-benchmark --subset test-clean --max-files 50 --model-version v2
+swift run fluidaudiocli asr-benchmark --subset test-clean --max-files 50 --model-version v2
 
 # Multilingual ASR (FLEURS) benchmark
-swift run fluidaudio fleurs-benchmark --languages en_us,fr_fr --samples 10
+swift run fluidaudiocli fleurs-benchmark --languages en_us,fr_fr --samples 10
 
 # Qwen3 ASR benchmark
-swift run fluidaudio qwen3-benchmark
+swift run fluidaudiocli qwen3-benchmark
 
 # CTC keyword spotting benchmark on Earnings22
-swift run fluidaudio ctc-earnings-benchmark
+swift run fluidaudiocli ctc-earnings-benchmark
 ```
 
 ## Diarization
 
 ```bash
 # Run AMI benchmark (auto-download dataset)
-swift run fluidaudio diarization-benchmark --auto-download
+swift run fluidaudiocli diarization-benchmark --auto-download
 
 # Tune threshold and save results
-swift run fluidaudio diarization-benchmark --threshold 0.7 --output results.json
+swift run fluidaudiocli diarization-benchmark --threshold 0.7 --output results.json
 
 # Quick test on a single AMI file
-swift run fluidaudio diarization-benchmark --single-file ES2004a --threshold 0.8
+swift run fluidaudiocli diarization-benchmark --single-file ES2004a --threshold 0.8
 
 # Real-time-ish streaming benchmark (~3s chunks with 2s overlap)
-swift run fluidaudio diarization-benchmark --single-file ES2004a \
+swift run fluidaudiocli diarization-benchmark --single-file ES2004a \
   --chunk-seconds 3 --overlap-seconds 2
 
 # Balanced throughput/quality (~10s chunks with 5s overlap)
-swift run fluidaudio diarization-benchmark --dataset ami-sdm \
+swift run fluidaudiocli diarization-benchmark --dataset ami-sdm \
   --chunk-seconds 10 --overlap-seconds 5
 
 # Run the full VBx offline pipeline
-swift run fluidaudio diarization-benchmark --mode offline --dataset ami-sdm --threshold 0.6
+swift run fluidaudiocli diarization-benchmark --mode offline --dataset ami-sdm --threshold 0.6
 
 # Process a single file with streaming vs. offline inference
-swift run fluidaudio process meeting.wav --mode streaming --threshold 0.7
-swift run fluidaudio process meeting.wav --mode offline --threshold 0.6 --debug
+swift run fluidaudiocli process meeting.wav --mode streaming --threshold 0.7
+swift run fluidaudiocli process meeting.wav --mode offline --threshold 0.6 --debug
 
 # Sortformer streaming diarization
-swift run fluidaudio sortformer audio.wav
+swift run fluidaudiocli sortformer audio.wav
 
 # Sortformer benchmark on AMI dataset
-swift run fluidaudio sortformer-benchmark
+swift run fluidaudiocli sortformer-benchmark
 ```
 
 - `--mode offline` switches the CLI to `OfflineDiarizerManager`, running the full VBx pipeline with PLDA refinement. Expect DER ≈ 18–20 % on AMI-SDM with threshold 0.6.
@@ -89,27 +89,27 @@ swift run fluidaudio sortformer-benchmark
 
 ```bash
 # Offline segmentation with seconds output (default mode)
-swift run fluidaudio vad-analyze path/to/audio.wav
+swift run fluidaudiocli vad-analyze path/to/audio.wav
 
 # Streaming only with 128 ms chunks and a custom threshold (timestamps emitted in seconds)
-swift run fluidaudio vad-analyze path/to/audio.wav --streaming --threshold 0.65 --min-silence-ms 400
+swift run fluidaudiocli vad-analyze path/to/audio.wav --streaming --threshold 0.65 --min-silence-ms 400
 
 # Run VAD benchmark (mini50 dataset by default)
-swift run fluidaudio vad-benchmark --num-files 50 --threshold 0.3
+swift run fluidaudiocli vad-benchmark --num-files 50 --threshold 0.3
 
 # Save benchmark results and enable debug output
-swift run fluidaudio vad-benchmark --all-files --output vad_results.json --debug
+swift run fluidaudiocli vad-benchmark --all-files --output vad_results.json --debug
 ```
 
-`swift run fluidaudio vad-analyze --help` lists every tuning option (padding,
+`swift run fluidaudiocli vad-analyze --help` lists every tuning option (padding,
 negative threshold overrides, max-duration splitting, etc.).
 
 ## Datasets
 
 ```bash
 # Download test sets
-swift run fluidaudio download --dataset librispeech-test-clean
-swift run fluidaudio download --dataset librispeech-test-other
-swift run fluidaudio download --dataset ami-sdm
-swift run fluidaudio download --dataset vad
+swift run fluidaudiocli download --dataset librispeech-test-clean
+swift run fluidaudiocli download --dataset librispeech-test-other
+swift run fluidaudiocli download --dataset ami-sdm
+swift run fluidaudiocli download --dataset vad
 ```

--- a/Documentation/Diarization/GettingStarted.md
+++ b/Documentation/Diarization/GettingStarted.md
@@ -206,8 +206,8 @@ The offline controller mirrors the reference pipeline:
 The CLI exposes the same controller via `fluidaudio process` and the diarization benchmark tooling:
 
 ```bash
-swift run fluidaudio process meeting.wav --mode offline --threshold 0.6 --debug --chunk-seconds 10.0 --overlap-seconds 0.0
-swift run fluidaudio diarization-benchmark --mode offline --dataset ami-sdm --threshold 0.6 --auto-download
+swift run fluidaudiocli process meeting.wav --mode offline --threshold 0.6 --debug --chunk-seconds 10.0 --overlap-seconds 0.0
+swift run fluidaudiocli diarization-benchmark --mode offline --dataset ami-sdm --threshold 0.6 --auto-download
 ```
 
 Add `--rttm path/to/meeting.rttm` when you have ground-truth annotations to emit DER/JER directly on the console, or `--export-embeddings embeddings.json` to inspect cluster assignments. The GitHub Actions workflow [`offline-pipeline.yml`](../.github/workflows/offline-pipeline.yml) executes the single-file AMI benchmark on every PR, keeping downloads, PLDA transforms, and VBx clustering guard-railed.
@@ -531,7 +531,7 @@ Evaluate performance on your audio:
 
 ```bash
 # Command-line benchmark
-swift run fluidaudio diarization-benchmark --single-file ES2004a
+swift run fluidaudiocli diarization-benchmark --single-file ES2004a
 
 # Results:
 # DER: 17.7% (Miss: 10.3%, FA: 1.6%, Speaker Error: 5.8%)

--- a/Documentation/TTS/Kokoro.md
+++ b/Documentation/TTS/Kokoro.md
@@ -9,7 +9,7 @@ Kokoro is a high-quality, English-only TTS backend. It generates the entire audi
 ### CLI
 
 ```bash
-swift run fluidaudio tts "Welcome to FluidAudio text to speech" \
+swift run fluidaudiocli tts "Welcome to FluidAudio text to speech" \
   --output ~/Desktop/demo.wav \
   --voice af_heart
 ```
@@ -126,5 +126,5 @@ import FluidAudio
 ### CLI
 
 ```bash
-swift run fluidaudio tts "Welcome to FluidAudio" --output ~/Desktop/demo.wav
+swift run fluidaudiocli tts "Welcome to FluidAudio" --output ~/Desktop/demo.wav
 ```

--- a/Documentation/VAD/GettingStarted.md
+++ b/Documentation/VAD/GettingStarted.md
@@ -213,7 +213,7 @@ Start with the general-purpose `process` command, which runs the diarization
 pipeline (and therefore VAD) end-to-end on a single file:
 
 ```bash
-swift run fluidaudio process path/to/audio.wav
+swift run fluidaudiocli process path/to/audio.wav
 ```
 
 Once you need to experiment with the VAD-specific heuristics directly, use the
@@ -221,21 +221,21 @@ CLI commands below:
 
 ```bash
 # Inspect offline segments (default mode is offline only)
-swift run fluidaudio vad-analyze path/to/audio.wav
+swift run fluidaudiocli vad-analyze path/to/audio.wav
 
 # Streaming only, 128 ms chunks, tighter silence rules (timestamps are emitted in seconds)
-swift run fluidaudio vad-analyze path/to/audio.wav --streaming --min-silence-ms 300
+swift run fluidaudiocli vad-analyze path/to/audio.wav --streaming --min-silence-ms 300
 
 # Run both offline + streaming in one pass
-swift run fluidaudio vad-analyze path/to/audio.wav --mode both
+swift run fluidaudiocli vad-analyze path/to/audio.wav --mode both
 
 # Classic benchmark tooling remains available
-swift run fluidaudio vad-benchmark --num-files 50 --threshold 0.3
+swift run fluidaudiocli vad-benchmark --num-files 50 --threshold 0.3
 ```
 
-`swift run fluidaudio vad-analyze --help` prints the full list of tuning
+`swift run fluidaudiocli vad-analyze --help` prints the full list of tuning
 options, including negative-threshold overrides and max-duration splitting.
 Offline runs emit an RTFx summary calculated from per-chunk inference time. Use
 `--mode both` if you also want to see streaming start/end events in the same run.
 
-Datasets for benchmarking can be fetched with `swift run fluidaudio download --dataset vad`.
+Datasets for benchmarking can be fetched with `swift run fluidaudiocli download --dataset vad`.

--- a/README.md
+++ b/README.md
@@ -162,11 +162,11 @@ let diarizer = DiarizerManager()
 ```bash
 # Use custom registry
 export REGISTRY_URL=https://your-mirror.example.com
-swift run fluidaudio transcribe audio.wav
+swift run fluidaudiocli transcribe audio.wav
 
 # Or use the MODEL_REGISTRY_URL alias
 export MODEL_REGISTRY_URL=https://models.internal.corp
-swift run fluidaudio diarization-benchmark --auto-download
+swift run fluidaudiocli diarization-benchmark --auto-download
 ```
 
 **Xcode Scheme Configuration:**
@@ -189,7 +189,7 @@ export https_proxy=http://proxy.company.com:8080
 # or for authenticated proxies:
 export https_proxy=http://user:password@proxy.company.com:8080
 
-swift run fluidaudio transcribe audio.wav
+swift run fluidaudiocli transcribe audio.wav
 ```
 
 **Xcode Scheme Configuration for Proxy:**
@@ -279,10 +279,10 @@ Task {
 
 ```bash
 # Transcribe an audio file (batch)
-swift run fluidaudio transcribe audio.wav
+swift run fluidaudiocli transcribe audio.wav
 
 # English-only run with higher recall
-swift run fluidaudio transcribe audio.wav --model-version v2
+swift run fluidaudiocli transcribe audio.wav --model-version v2
 ```
 
 ## Speaker Diarization
@@ -319,11 +319,11 @@ for segment in result.segments {
 
 ```bash
 # Process a meeting with full VBx clustering
-swift run fluidaudio process ~/FluidAudioDatasets/ami_official/sdm/ES2004a.Mix-Headset.wav \
+swift run fluidaudiocli process ~/FluidAudioDatasets/ami_official/sdm/ES2004a.Mix-Headset.wav \
   --mode offline --threshold 0.6 --output es2004a_offline.json
 
 # Run the AMI single-file benchmark with automatic downloads
-swift run fluidaudio diarization-benchmark --mode offline --auto-download \
+swift run fluidaudiocli diarization-benchmark --mode offline --auto-download \
   --single-file ES2004a --threshold 0.6 --output offline_results.json
 ```
 
@@ -362,7 +362,7 @@ Task {
 For diarization streaming see [Documentation/Diarization/GettingStarted.md](Documentation/Diarization/GettingStarted.md)
 
 ```bash
-swift run fluidaudio diarization-benchmark --single-file ES2004a \
+swift run fluidaudiocli diarization-benchmark --single-file ES2004a \
   --chunk-seconds 3 --overlap-seconds 2
 ```
 
@@ -370,7 +370,7 @@ swift run fluidaudio diarization-benchmark --single-file ES2004a \
 
 ```bash
 # Process an individual file and save JSON
-swift run fluidaudio process meeting.wav --output results.json --threshold 0.6
+swift run fluidaudiocli process meeting.wav --output results.json --threshold 0.6
 ```
 
 ## Voice Activity Detection (VAD)
@@ -461,23 +461,23 @@ Start with the general-purpose `process` command, which runs the diarization
 pipeline (and therefore VAD) end-to-end on a single file:
 
 ```bash
-swift run fluidaudio process path/to/audio.wav
+swift run fluidaudiocli process path/to/audio.wav
 ```
 
 Once you need to experiment with VAD-specific knobs directly, reach for:
 
 ```bash
 # Inspect offline segments (default mode)
-swift run fluidaudio vad-analyze path/to/audio.wav
+swift run fluidaudiocli vad-analyze path/to/audio.wav
 
 # Streaming simulation only (timestamps printed in seconds by default)
-swift run fluidaudio vad-analyze path/to/audio.wav --streaming
+swift run fluidaudiocli vad-analyze path/to/audio.wav --streaming
 
 # Benchmark accuracy/precision trade-offs
-swift run fluidaudio vad-benchmark --num-files 50 --threshold 0.3
+swift run fluidaudiocli vad-benchmark --num-files 50 --threshold 0.3
 ```
 
-`swift run fluidaudio vad-analyze --help` lists every tuning option, including
+`swift run fluidaudiocli vad-analyze --help` lists every tuning option, including
 negative-threshold overrides, max-speech splitting, padding, and chunk size.
 Offline mode also reports RTFx using the model's per-chunk processing time.
 
@@ -513,10 +513,10 @@ Task {
 
 ```bash
 # Synthesize with default voice
-swift run fluidaudio tts "Hello from FluidAudio." --output out.wav --backend pocket
+swift run fluidaudiocli tts "Hello from FluidAudio." --output out.wav --backend pocket
 
 # Clone a voice from an audio sample
-swift run fluidaudio tts "Hello world." --output out.wav --backend pocket --clone-voice speaker.wav
+swift run fluidaudiocli tts "Hello world." --output out.wav --backend pocket --clone-voice speaker.wav
 ```
 
 ### Kokoro
@@ -535,7 +535,7 @@ Task {
 ```
 
 ```bash
-swift run fluidaudio tts "Hello from FluidAudio." --auto-download --output out.wav
+swift run fluidaudiocli tts "Hello from FluidAudio." --auto-download --output out.wav
 ```
 
 Dictionary and model assets are cached under `~/.cache/fluidaudio/Models/kokoro`.

--- a/Sources/FluidAudioCLI/Commands/VadBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/VadBenchmark.swift
@@ -177,7 +177,7 @@ struct VadBenchmark {
 
         // No fallback to mock data - fail cleanly
         logger.error(
-            "Failed to load VAD dataset from all sources:\nLocal dataset not found\nHugging Face cache empty\nHugging Face download failed\nTry: swift run fluidaudio download --dataset vad"
+            "Failed to load VAD dataset from all sources:\nLocal dataset not found\nHugging Face cache empty\nHugging Face download failed\nTry: swift run fluidaudiocli download --dataset vad"
         )
         throw NSError(
             domain: "VadError", code: 404,
@@ -597,7 +597,7 @@ struct VadBenchmark {
 
         guard FileManager.default.fileExists(atPath: voicesDir.path) else {
             logger.warning(
-                "VOiCES subset not found. Run: swift run fluidaudio download --dataset voices-subset"
+                "VOiCES subset not found. Run: swift run fluidaudiocli download --dataset voices-subset"
             )
             return nil
         }
@@ -675,7 +675,7 @@ struct VadBenchmark {
 
         guard FileManager.default.fileExists(atPath: musanDir.path) else {
             logger.warning(
-                "Full MUSAN dataset not found. Run: swift run fluidaudio download --dataset musan-full"
+                "Full MUSAN dataset not found. Run: swift run fluidaudiocli download --dataset musan-full"
             )
             return nil
         }

--- a/Sources/FluidAudioCLI/README.md
+++ b/Sources/FluidAudioCLI/README.md
@@ -16,13 +16,13 @@ Process a single audio file to identify speakers and their segments.
 
 ```bash
 # Basic usage
-swift run fluidaudio process audio.wav
+swift run fluidaudiocli process audio.wav
 
 # With custom output and threshold
-swift run fluidaudio process audio.wav --output results.json --threshold 0.7
+swift run fluidaudiocli process audio.wav --output results.json --threshold 0.7
 
 # With debug mode
-swift run fluidaudio process audio.wav --debug
+swift run fluidaudiocli process audio.wav --debug
 ```
 
 **Options:**
@@ -35,16 +35,16 @@ Transcribe audio files using streaming ASR with real-time updates.
 
 ```bash
 # Basic transcription
-swift run fluidaudio transcribe audio.wav
+swift run fluidaudiocli transcribe audio.wav
 
 # With low-latency configuration
-swift run fluidaudio transcribe audio.wav --config low-latency
+swift run fluidaudiocli transcribe audio.wav --config low-latency
 
 # With debug output
-swift run fluidaudio transcribe audio.wav --debug
+swift run fluidaudiocli transcribe audio.wav --debug
 
 # Compare with direct ASR API
-swift run fluidaudio transcribe audio.wav --compare
+swift run fluidaudiocli transcribe audio.wav --compare
 ```
 
 **Options:**
@@ -63,13 +63,13 @@ Transcribe multiple audio files in parallel using shared ASR models.
 
 ```bash
 # Process two different files
-swift run fluidaudio multi-stream mic_audio.wav system_audio.wav
+swift run fluidaudiocli multi-stream mic_audio.wav system_audio.wav
 
 # Process same file on both streams
-swift run fluidaudio multi-stream audio.wav
+swift run fluidaudiocli multi-stream audio.wav
 
 # With debug output
-swift run fluidaudio multi-stream audio1.wav audio2.wav --debug
+swift run fluidaudiocli multi-stream audio1.wav audio2.wav --debug
 ```
 
 **Options:**
@@ -81,16 +81,16 @@ Run comprehensive benchmarks on evaluation datasets.
 
 ```bash
 # Run on AMI dataset with auto-download
-swift run fluidaudio diarization-benchmark --auto-download
+swift run fluidaudiocli diarization-benchmark --auto-download
 
 # Test single file
-swift run fluidaudio diarization-benchmark --single-file ES2004a --threshold 0.7
+swift run fluidaudiocli diarization-benchmark --single-file ES2004a --threshold 0.7
 
 # Run on specific dataset
-swift run fluidaudio diarization-benchmark --dataset ami-sdm --max-files 10
+swift run fluidaudiocli diarization-benchmark --dataset ami-sdm --max-files 10
 
 # Save results to file
-swift run fluidaudio diarization-benchmark --output benchmark_results.json
+swift run fluidaudiocli diarization-benchmark --output benchmark_results.json
 ```
 
 **Options:**
@@ -107,13 +107,13 @@ Benchmark VAD performance on test datasets.
 
 ```bash
 # Run VAD benchmark
-swift run fluidaudio vad-benchmark --num-files 40
+swift run fluidaudiocli vad-benchmark --num-files 40
 
 # With custom threshold 
-swift run fluidaudio vad-benchmark --threshold 0.8
+swift run fluidaudiocli vad-benchmark --threshold 0.8
 
 # Test on specific dataset
-swift run fluidaudio vad-benchmark --dataset voices-subset
+swift run fluidaudiocli vad-benchmark --dataset voices-subset
 ```
 
 **Options:**
@@ -127,13 +127,13 @@ Benchmark ASR performance on LibriSpeech or other datasets.
 
 ```bash
 # Run on LibriSpeech test-clean
-swift run fluidaudio asr-benchmark --subset test-clean --max-files 100
+swift run fluidaudiocli asr-benchmark --subset test-clean --max-files 100
 
 # Run on test-other subset
-swift run fluidaudio asr-benchmark --subset test-other --max-files 50
+swift run fluidaudiocli asr-benchmark --subset test-other --max-files 50
 
 # With verbose output
-swift run fluidaudio asr-benchmark --verbose
+swift run fluidaudiocli asr-benchmark --verbose
 ```
 
 **Options:**
@@ -145,8 +145,8 @@ swift run fluidaudio asr-benchmark --verbose
 Real-time streaming transcription with end-of-utterance detection.
 
 ```bash
-swift run fluidaudio parakeet-eou --input audio.wav --use-cache
-swift run fluidaudio parakeet-eou --benchmark --chunk-size 160 --max-files 100 --use-cache
+swift run fluidaudiocli parakeet-eou --input audio.wav --use-cache
+swift run fluidaudiocli parakeet-eou --benchmark --chunk-size 160 --max-files 100 --use-cache
 ```
 
 **Options:** `--input <path>`, `--benchmark`, `--max-files <n>`, `--chunk-size <160|320|1600>`, `--eou-debounce <ms>`, `--use-cache`, `--models <path>`, `--output <path>`, `--verbose`
@@ -154,8 +154,8 @@ swift run fluidaudio parakeet-eou --benchmark --chunk-size 160 --max-files 100 -
 ### 8. `download` - Download Datasets
 
 ```bash
-swift run fluidaudio download --dataset ami-sdm
-swift run fluidaudio download --list
+swift run fluidaudiocli download --dataset ami-sdm
+swift run fluidaudiocli download --list
 ```
 
 **Options:** `--dataset <name>`, `--list`
@@ -197,26 +197,26 @@ swift run fluidaudio download --list
 ### Complete Workflow Example
 ```bash
 # 1. Download dataset
-swift run fluidaudio download --dataset ami-sdm
+swift run fluidaudiocli download --dataset ami-sdm
 
 # 2. Run diarization benchmark
-swift run fluidaudio diarization-benchmark --dataset ami-sdm --output results.json
+swift run fluidaudiocli diarization-benchmark --dataset ami-sdm --output results.json
 
 # 3. Process individual file
-swift run fluidaudio process audio.wav --threshold 0.7
+swift run fluidaudiocli process audio.wav --threshold 0.7
 
 # 4. Transcribe audio
-swift run fluidaudio transcribe audio.wav --config low-latency
+swift run fluidaudiocli transcribe audio.wav --config low-latency
 
 # 5. Multi-stream transcription
-swift run fluidaudio multi-stream mic.wav system.wav
+swift run fluidaudiocli multi-stream mic.wav system.wav
 ```
 
 ### Quick Test
 ```bash
 # Test with included sample files
-swift run fluidaudio transcribe medical.wav
-swift run fluidaudio process IS1001a.Mix-Headset.wav --threshold 0.7
+swift run fluidaudiocli transcribe medical.wav
+swift run fluidaudiocli process IS1001a.Mix-Headset.wav --threshold 0.7
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary
- Replace all `swift run fluidaudio` references with `swift run fluidaudiocli` across docs and source to match the actual executable name in Package.swift
- Add GitHub comments policy to CLAUDE.md development guidelines

## Files changed
- **CLAUDE.md** — CLI commands updated + GitHub comments rule added
- **README.md** — All CLI examples updated
- **Documentation/** — CLI.md, GettingStarted guides, Kokoro.md, Benchmarks.md, CustomPronunciation.md
- **Sources/FluidAudioCLI/README.md** — CLI examples updated
- **Sources/FluidAudioCLI/Commands/VadBenchmark.swift** — Error messages updated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
