### PR TITLE
docs: add Kokoro English voice quality report

### DIFF
--- a/Documentation/TTS/voice-quality.md
+++ b/Documentation/TTS/voice-quality.md
@@ -1,5 +1,14 @@
 # Kokoro English Voice Quality Report
 
+Quality assessment for all 28 English Kokoro TTS voices (11 AF, 9 AM, 4 BF, 4 BM). Includes upstream Kokoro grades, training data, pitch analysis, character traits, and our own quality ratings. Voice descriptions sourced from VoiceRankings, grades from Kokoro VOICES.md.
+
+## Key Findings
+
+- Only af_heart (A) and af_bella (A-) are top-graded, but both have sibilance issues
+- Male voices have fewer sibilance problems but several have subtle background noise
+- British English voices are the strongest group overall, with bf_emma rated "quite good"
+- Kokoro's own grades don't always match perceived quality (e.g. am_adam graded F+ but sounds usable)
+
 ## Methodology
 
 **Test Sentence:** "The quick brown fox jumps over the lazy dog near the riverbank, while the morning sun casts golden light across the meadow."


### PR DESCRIPTION
## Summary
- Adds quality assessment for all 28 English Kokoro TTS voices (11 AF, 9 AM, 4 BF, 4 BM)
- Includes upstream Kokoro grades, training data, pitch analysis, character traits, and our own quality ratings
- Voice descriptions sourced from [VoiceRankings](https://voicerankings.com), grades from [Kokoro VOICES.md](https://huggingface.co/hexgrad/Kokoro-82M/blob/main/VOICES.md)

## Key findings
- Only **af_heart** (A) and **af_bella** (A-) are top-graded, but both have sibilance issues
- Male voices have fewer sibilance problems but several have subtle background noise
- British English voices are the strongest group overall, with **bf_emma** rated "quite good"
- Kokoro's own grades don't always match perceived quality (e.g. am_adam graded F+ but sounds usable)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/373" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
