### PR TITLE
fix: make SpeakerEnrollmentTests CI-safe with do/catch

### DIFF
--- a/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
@@ -40,65 +40,80 @@ final class SpeakerEnrollmentTests: XCTestCase {
 
     // MARK: - extractSpeakerEmbedding: Integration (requires model download)
 
-    func testExtractEmbeddingProducesValidResult() async throws {
+    func testExtractEmbeddingProducesValidResult() async {
         XCTExpectFailure("Download might fail in CI environment", strict: false)
 
-        let manager = DiarizerManager()
-        let models = try await DiarizerModels.downloadIfNeeded()
-        manager.initialize(models: models)
+        do {
+            let manager = DiarizerManager()
+            let models = try await DiarizerModels.downloadIfNeeded()
+            manager.initialize(models: models)
 
-        // 3 seconds of sine wave audio (simulates single speaker)
-        let audio = (0..<48000).map { i in sin(Float(i) * 0.1) * 0.3 }
+            // 3 seconds of sine wave audio (simulates single speaker)
+            let audio = (0..<48000).map { i in sin(Float(i) * 0.1) * 0.3 }
 
-        let embedding = try manager.extractSpeakerEmbedding(from: audio)
+            let embedding = try manager.extractSpeakerEmbedding(from: audio)
 
-        // Should be a 256-dimensional embedding
-        XCTAssertEqual(embedding.count, 256, "Embedding should be 256-dimensional")
+            // Should be a 256-dimensional embedding
+            XCTAssertEqual(embedding.count, 256, "Embedding should be 256-dimensional")
 
-        // Should not be all zeros (valid speaker audio)
-        let magnitude = sqrt(embedding.reduce(0) { $0 + $1 * $1 })
-        XCTAssertGreaterThan(magnitude, 0.01, "Embedding should have non-trivial magnitude")
+            // Should not be all zeros (valid speaker audio)
+            let magnitude = sqrt(embedding.reduce(0) { $0 + $1 * $1 })
+            XCTAssertGreaterThan(magnitude, 0.01, "Embedding should have non-trivial magnitude")
 
-        // Should not contain NaN or Inf
-        XCTAssertFalse(embedding.contains(where: { $0.isNaN }), "Embedding should not contain NaN")
-        XCTAssertFalse(embedding.contains(where: { $0.isInfinite }), "Embedding should not contain Inf")
-    }
-
-    func testExtractEmbeddingSameAudioProducesSimilarEmbeddings() async throws {
-        XCTExpectFailure("Download might fail in CI environment", strict: false)
-
-        let manager = DiarizerManager()
-        let models = try await DiarizerModels.downloadIfNeeded()
-        manager.initialize(models: models)
-
-        // Same audio extracted twice should produce identical embeddings
-        let audio = (0..<48000).map { i in sin(Float(i) * 0.1) * 0.3 }
-
-        let embedding1 = try manager.extractSpeakerEmbedding(from: audio)
-        let embedding2 = try manager.extractSpeakerEmbedding(from: audio)
-
-        XCTAssertEqual(embedding1.count, embedding2.count)
-        for i in 0..<embedding1.count {
-            XCTAssertEqual(
-                embedding1[i], embedding2[i], accuracy: 1e-5, "Embeddings should be identical for same input")
+            // Should not contain NaN or Inf
+            XCTAssertFalse(embedding.contains(where: { $0.isNaN }), "Embedding should not contain NaN")
+            XCTAssertFalse(
+                embedding.contains(where: { $0.isInfinite }), "Embedding should not contain Inf")
+        } catch {
+            XCTFail("Download or model inference failed: \(error)")
         }
     }
 
-    func testExtractEmbeddingUsableWithKnownSpeakers() async throws {
+    func testExtractEmbeddingSameAudioProducesSimilarEmbeddings() async {
         XCTExpectFailure("Download might fail in CI environment", strict: false)
 
-        let manager = DiarizerManager()
-        let models = try await DiarizerModels.downloadIfNeeded()
-        manager.initialize(models: models)
+        do {
+            let manager = DiarizerManager()
+            let models = try await DiarizerModels.downloadIfNeeded()
+            manager.initialize(models: models)
 
-        let audio = (0..<48000).map { i in sin(Float(i) * 0.1) * 0.3 }
-        let embedding = try manager.extractSpeakerEmbedding(from: audio)
+            // Same audio extracted twice should produce identical embeddings
+            let audio = (0..<48000).map { i in sin(Float(i) * 0.1) * 0.3 }
 
-        // Verify the embedding can be used with initializeKnownSpeakers
-        let speaker = Speaker(id: "test", name: "Test", currentEmbedding: embedding, isPermanent: true)
-        manager.initializeKnownSpeakers([speaker])
+            let embedding1 = try manager.extractSpeakerEmbedding(from: audio)
+            let embedding2 = try manager.extractSpeakerEmbedding(from: audio)
 
-        XCTAssertEqual(manager.speakerManager.speakerCount, 1, "Known speaker should be registered")
+            XCTAssertEqual(embedding1.count, embedding2.count)
+            for i in 0..<embedding1.count {
+                XCTAssertEqual(
+                    embedding1[i], embedding2[i], accuracy: 1e-5,
+                    "Embeddings should be identical for same input")
+            }
+        } catch {
+            XCTFail("Download or model inference failed: \(error)")
+        }
+    }
+
+    func testExtractEmbeddingUsableWithKnownSpeakers() async {
+        XCTExpectFailure("Download might fail in CI environment", strict: false)
+
+        do {
+            let manager = DiarizerManager()
+            let models = try await DiarizerModels.downloadIfNeeded()
+            manager.initialize(models: models)
+
+            let audio = (0..<48000).map { i in sin(Float(i) * 0.1) * 0.3 }
+            let embedding = try manager.extractSpeakerEmbedding(from: audio)
+
+            // Verify the embedding can be used with initializeKnownSpeakers
+            let speaker = Speaker(
+                id: "test", name: "Test", currentEmbedding: embedding, isPermanent: true)
+            manager.initializeKnownSpeakers([speaker])
+
+            XCTAssertEqual(manager.speakerManager.speakerCount, 1, "Known speaker should be registered")
+        } catch {
+            XCTFail("Download or model inference failed: \(error)")
+        }
     }
 
     // MARK: - primeWithAudio: Error Cases
@@ -134,81 +149,96 @@ final class SpeakerEnrollmentTests: XCTestCase {
 
     // MARK: - primeWithAudio: State Verification (requires model download)
 
-    func testPrimeResetsTimelineButKeepsState() async throws {
+    func testPrimeResetsTimelineButKeepsState() async {
         XCTExpectFailure("Download might fail in CI environment", strict: false)
 
-        let config = SortformerConfig.default
-        let diarizer = SortformerDiarizer(config: config)
+        do {
+            let config = SortformerConfig.default
+            let diarizer = SortformerDiarizer(config: config)
 
-        let models = try await SortformerModels.loadFromHuggingFace(config: config)
-        diarizer.initialize(models: models)
+            let models = try await SortformerModels.loadFromHuggingFace(config: config)
+            diarizer.initialize(models: models)
 
-        // Prime with 5 seconds of audio
-        let enrollmentAudio = (0..<80000).map { i in sin(Float(i) * 0.05) * 0.3 }
-        try diarizer.primeWithAudio(enrollmentAudio)
+            // Prime with 5 seconds of audio
+            let enrollmentAudio = (0..<80000).map { i in sin(Float(i) * 0.05) * 0.3 }
+            try diarizer.primeWithAudio(enrollmentAudio)
 
-        // Timeline should be reset (frame count = 0)
-        XCTAssertEqual(diarizer.numFramesProcessed, 0, "Frame counter should be 0 after priming")
-        XCTAssertEqual(diarizer.timeline.numFrames, 0, "Timeline should have 0 frames after priming")
+            // Timeline should be reset (frame count = 0)
+            XCTAssertEqual(diarizer.numFramesProcessed, 0, "Frame counter should be 0 after priming")
+            XCTAssertEqual(
+                diarizer.timeline.numFrames, 0, "Timeline should have 0 frames after priming")
 
-        // Streaming state should be preserved (spkcache or fifo may be populated)
-        let state = diarizer.state
-        let hasState = state.spkcacheLength > 0 || state.fifoLength > 0
-        XCTAssertTrue(hasState, "Streaming state (spkcache/fifo) should be populated after priming")
+            // Streaming state should be preserved (spkcache or fifo may be populated)
+            let state = diarizer.state
+            let hasState = state.spkcacheLength > 0 || state.fifoLength > 0
+            XCTAssertTrue(
+                hasState, "Streaming state (spkcache/fifo) should be populated after priming")
+        } catch {
+            XCTFail("Download or model inference failed: \(error)")
+        }
     }
 
-    func testPrimeFollowedByStreamingProcessing() async throws {
+    func testPrimeFollowedByStreamingProcessing() async {
         XCTExpectFailure("Download might fail in CI environment", strict: false)
 
-        let config = SortformerConfig.default
-        let diarizer = SortformerDiarizer(config: config)
+        do {
+            let config = SortformerConfig.default
+            let diarizer = SortformerDiarizer(config: config)
 
-        let models = try await SortformerModels.loadFromHuggingFace(config: config)
-        diarizer.initialize(models: models)
+            let models = try await SortformerModels.loadFromHuggingFace(config: config)
+            diarizer.initialize(models: models)
 
-        // Prime with enrollment audio
-        let enrollmentAudio = (0..<80000).map { i in sin(Float(i) * 0.05) * 0.3 }
-        try diarizer.primeWithAudio(enrollmentAudio)
+            // Prime with enrollment audio
+            let enrollmentAudio = (0..<80000).map { i in sin(Float(i) * 0.05) * 0.3 }
+            try diarizer.primeWithAudio(enrollmentAudio)
 
-        // Stream new audio after priming — should not crash
-        let liveAudio = (0..<48000).map { i in sin(Float(i) * 0.08) * 0.2 }
-        diarizer.addAudio(liveAudio)
+            // Stream new audio after priming — should not crash
+            let liveAudio = (0..<48000).map { i in sin(Float(i) * 0.08) * 0.2 }
+            diarizer.addAudio(liveAudio)
 
-        // Process should work without errors
-        let result = try diarizer.process()
-        // Result may or may not contain data depending on buffer thresholds — that's fine
-        _ = result
+            // Process should work without errors
+            let result = try diarizer.process()
+            // Result may or may not contain data depending on buffer thresholds — that's fine
+            _ = result
+        } catch {
+            XCTFail("Download or model inference failed: \(error)")
+        }
     }
 
-    func testMultiplePrimeCalls() async throws {
+    func testMultiplePrimeCalls() async {
         XCTExpectFailure("Download might fail in CI environment", strict: false)
 
-        let config = SortformerConfig.default
-        let diarizer = SortformerDiarizer(config: config)
+        do {
+            let config = SortformerConfig.default
+            let diarizer = SortformerDiarizer(config: config)
 
-        let models = try await SortformerModels.loadFromHuggingFace(config: config)
-        diarizer.initialize(models: models)
+            let models = try await SortformerModels.loadFromHuggingFace(config: config)
+            diarizer.initialize(models: models)
 
-        // Prime with speaker A
-        let speakerA = (0..<80000).map { i in sin(Float(i) * 0.05) * 0.3 }
-        try diarizer.primeWithAudio(speakerA)
+            // Prime with speaker A
+            let speakerA = (0..<80000).map { i in sin(Float(i) * 0.05) * 0.3 }
+            try diarizer.primeWithAudio(speakerA)
 
-        let stateAfterA = diarizer.state
-        let spkcacheAfterA = stateAfterA.spkcacheLength
+            let stateAfterA = diarizer.state
+            let spkcacheAfterA = stateAfterA.spkcacheLength
 
-        // Prime with speaker B
-        let speakerB = (0..<80000).map { i in cos(Float(i) * 0.07) * 0.4 }
-        try diarizer.primeWithAudio(speakerB)
+            // Prime with speaker B
+            let speakerB = (0..<80000).map { i in cos(Float(i) * 0.07) * 0.4 }
+            try diarizer.primeWithAudio(speakerB)
 
-        // State should accumulate (more data in cache)
-        let stateAfterB = diarizer.state
-        XCTAssertGreaterThanOrEqual(
-            stateAfterB.spkcacheLength + stateAfterB.fifoLength,
-            spkcacheAfterA,
-            "State should accumulate across prime calls"
-        )
+            // State should accumulate (more data in cache)
+            let stateAfterB = diarizer.state
+            XCTAssertGreaterThanOrEqual(
+                stateAfterB.spkcacheLength + stateAfterB.fifoLength,
+                spkcacheAfterA,
+                "State should accumulate across prime calls"
+            )
 
-        // Timeline should still be reset
-        XCTAssertEqual(diarizer.numFramesProcessed, 0, "Frame counter should be 0 after priming")
+            // Timeline should still be reset
+            XCTAssertEqual(
+                diarizer.numFramesProcessed, 0, "Frame counter should be 0 after priming")
+        } catch {
+            XCTFail("Download or model inference failed: \(error)")
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Fixes CI test failures in `SpeakerEnrollmentTests` caused by HTTP 401 when downloading from the gated sortformer HuggingFace repo
- `XCTExpectFailure` does not catch Swift `throw` errors that propagate out of `async throws` test methods — it only intercepts `XCTAssert*` failures
- Wraps all 6 integration test bodies in `do/catch` so download errors become `XCTFail` calls, which `XCTExpectFailure(strict: false)` properly handles
- Changes test signatures from `async throws` to `async` (the `throws` is now handled internally)

## Root Cause

The sortformer model repo (`FluidInference/diar-streaming-sortformer-coreml`) is gated and requires `HF_TOKEN` for access. In CI without the token, `SortformerModels.loadFromHuggingFace()` throws an HTTP 401 error. This error escaped the test method before `XCTExpectFailure` could catch it, causing 3 test failures:

- `testMultiplePrimeCalls`
- `testPrimeResetsTimelineButKeepsState`
- `testPrimeFollowedByStreamingProcessing`

## Test plan

- [x] `swift build` passes
- [x] `swift format lint` clean
- [ ] CI tests pass (the 6 integration tests should now show as "expected failure" instead of hard failure)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/379" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
