### PR TITLE
docs: add architecture comments to PocketTTS pipeline

### DIFF
--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Flow.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Flow.swift
@@ -5,8 +5,10 @@ extension PocketTtsSynthesizer {
 
     /// Run the flow decoder using Euler integration (LSD steps).
     ///
-    /// Converts transformer output to a 32-dimensional audio latent
-    /// via `numSteps` iterative denoising steps.
+    /// Converts the 1024-d transformer hidden state into a 32-d audio latent code.
+    /// Flow matching works by starting from random Gaussian noise and iteratively
+    /// moving it toward a valid audio code over `numSteps` Euler steps. The
+    /// transformer output guides each step by predicting a velocity field.
     static func flowDecode(
         transformerOut: MLMultiArray,
         numSteps: Int,
@@ -17,7 +19,8 @@ extension PocketTtsSynthesizer {
         let latentDim = PocketTtsConstants.latentDim
         let dt: Float = 1.0 / Float(numSteps)
 
-        // Initialize latent with scaled random noise: randn * sqrt(temperature)
+        // Initialize latent with scaled random noise.
+        // sqrt(temperature) because variance scales quadratically with the multiplier.
         var latent = [Float](repeating: 0, count: latentDim)
         let scale = sqrtf(temperature)
         for i in 0..<latentDim {
@@ -52,6 +55,13 @@ extension PocketTtsSynthesizer {
     // MARK: - Private
 
     /// Run a single flow decoder step.
+    ///
+    /// - Parameters:
+    ///   - s: Start time of this Euler interval (e.g., 0.0, 0.125, 0.25, ...).
+    ///   - t: End time of this Euler interval (e.g., 0.125, 0.25, 0.375, ...).
+    ///
+    /// The model predicts a velocity vector given the current noisy latent and time
+    /// interval. The caller applies the Euler update: `latent += velocity * dt`.
     private static func runFlowDecoderStep(
         transformerOut: MLMultiArray,
         latent: [Float],

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
@@ -4,10 +4,19 @@ import Foundation
 extension PocketTtsSynthesizer {
 
     /// Mutable KV cache state passed through conditioning and generation steps.
+    ///
+    /// One cache per transformer layer stores the K (key) and V (value) projections
+    /// for every processed token. This avoids recomputing K/V for past tokens —
+    /// each new step only computes its own K/V, then reads all cached K/V via attention.
     struct KVCacheState {
-        /// 6 KV cache arrays, each [2, 1, 200, 16, 64].
+        /// 6 KV cache arrays, each shaped `[2, 1, kvCacheMaxLen, 16, 64]`:
+        ///  - `2`: K and V tensors (index 0 = keys, index 1 = values)
+        ///  - `1`: batch size
+        ///  - `kvCacheMaxLen` (512): pre-allocated position slots
+        ///  - `16`: attention heads
+        ///  - `64`: dims per head (16 × 64 = 1024 total)
         var caches: [MLMultiArray]
-        /// 6 position counters, each [1].
+        /// 6 position counters (one per layer) tracking the next write slot in the cache.
         var positions: [MLMultiArray]
     }
 
@@ -39,6 +48,11 @@ extension PocketTtsSynthesizer {
     }
 
     /// Run the conditioning step model for a single token, updating the KV cache in place.
+    ///
+    /// `cond_step` and `flowlm_step` share the same transformer weights. This function
+    /// runs the transformer in "prefill mode": it processes one conditioning token
+    /// (voice embedding or text embedding), computes K/V projections, and writes them
+    /// into the cache at the current position. No audio is produced.
     static func runCondStep(
         conditioning: MLMultiArray,
         state: inout KVCacheState,
@@ -74,7 +88,10 @@ extension PocketTtsSynthesizer {
 
     /// Prefill the KV cache with voice and text conditioning tokens.
     ///
-    /// Processes voice tokens first, then text tokens (critical ordering).
+    /// Processes voice tokens first, then text tokens. This ordering is critical —
+    /// the model was trained with voice conditioning before text, so reversing it
+    /// produces garbage. Each chunk gets a fresh cache because the 512-position
+    /// limit can't hold multiple chunks' worth of context.
     static func prefillKVCache(
         voiceData: PocketTtsVoiceData,
         textEmbeddings: [[Float]],
@@ -106,7 +123,9 @@ extension PocketTtsSynthesizer {
         return state
     }
 
-    /// Create a [1, 1, 1024] MLMultiArray from a float slice.
+    /// Create a `[1, 1, 1024]` MLMultiArray from a float slice.
+    ///
+    /// Shape: batch=1, sequence_length=1 (one token at a time), embedding_dim=1024.
     private static func createConditioningToken(
         from source: [Float], offset: Int, dim: Int
     ) throws -> MLMultiArray {
@@ -121,6 +140,12 @@ extension PocketTtsSynthesizer {
     }
 
     /// Run the generation step model, returning transformer output and EOS logit.
+    ///
+    /// Same transformer as `cond_step`, now in "generate mode". Takes the previous
+    /// audio latent (or NaN for BOS), attends to all cached K/V from conditioning
+    /// and prior generation steps, and produces a 1024-d hidden state (for flow_decoder)
+    /// plus an EOS logit indicating whether the model is done speaking.
+    /// Also writes this step's own K/V into the cache for future steps.
     static func runFlowLMStep(
         sequence: MLMultiArray,
         bosEmb: MLMultiArray,

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
@@ -3,10 +3,12 @@ import Foundation
 
 extension PocketTtsSynthesizer {
 
-    /// Mutable streaming state for the Mimi audio decoder.
+    /// Mutable streaming state for the Mimi neural audio codec decoder.
     ///
-    /// Contains 26 tensors that track convolutional history,
-    /// attention caches, and partial upsampling buffers.
+    /// Contains 26 tensors that track convolutional history, attention caches,
+    /// and partial upsampling buffers. Unlike the KV cache (which resets per
+    /// text chunk), Mimi state persists across all chunks to produce seamless
+    /// audio — the decoder needs prior frame context for smooth waveform continuity.
     struct MimiState {
         var tensors: [String: MLMultiArray]
     }
@@ -41,6 +43,8 @@ extension PocketTtsSynthesizer {
             let shape = shapeArray.map { NSNumber(value: $0) }
             let array = try MLMultiArray(shape: shape, dataType: .float32)
 
+            // Some tensors (e.g., res{0,1,2}_conv1_prev) have zero-length shapes
+            // and are empty pass-throughs — skip loading binary data for those.
             if byteCount > 0 && !shapeArray.contains(0) {
                 let binURL = stateDir.appendingPathComponent("\(name).bin")
                 let data = try Data(contentsOf: binURL)

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
@@ -15,6 +15,9 @@ extension PocketTtsSynthesizer {
     }
 
     /// CoreML output key names for the conditioning step model.
+    ///
+    /// These names are auto-generated during CoreML model tracing and must match
+    /// the compiled `.mlmodelc` exactly. They only change when models are re-converted.
     enum CondStepKeys {
         static let cacheKeys: [String] = [
             "new_cache_1_internal_tensor_assign_2",
@@ -30,6 +33,8 @@ extension PocketTtsSynthesizer {
     }
 
     /// CoreML output key names for the generation step model.
+    ///
+    /// Auto-generated during CoreML model tracing. Must match the compiled model.
     enum FlowLMStepKeys {
         /// CoreML assigned this output the name "input" during model tracing —
         /// it is the transformer hidden state output, not an input tensor.
@@ -55,8 +60,15 @@ extension PocketTtsSynthesizer {
 
     /// Mimi decoder streaming state key mappings (input name → output name).
     ///
-    /// 26 state tensors including 3 zero-length tensors (res{0,1,2}_conv1_prev)
-    /// whose input and output names are identical pass-throughs.
+    /// 26 state tensors that carry the decoder's streaming context across frames:
+    /// - Upsampling: `upsample_partial` — partial output buffer for upsampling layers
+    /// - Attention: `attn{0,1}_cache/offset/end_offset` — causal attention KV caches
+    /// - Convolutions: `conv*_prev/first` — causal conv padding buffers
+    /// - Residual blocks: `res{0,1,2}_conv{0,1}_prev/first` — residual conv state
+    /// - Transposed convs: `convtr{0,1,2}_partial` — transposed conv overlap buffers
+    ///
+    /// 3 zero-length tensors (`res{0,1,2}_conv1_prev`) are pass-throughs where
+    /// input and output names are identical.
     static let mimiStateMapping: [(input: String, output: String)] = [
         ("upsample_partial", "var_82"),
         ("attn0_cache", "var_262"),

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -8,7 +8,7 @@ import OSLog
 /// an 80ms audio frame (1920 samples at 24kHz).
 ///
 /// Long text is split into sentence-based chunks (≤50 tokens each)
-/// to stay within the KV cache limit (200 positions).
+/// to stay within the KV cache limit (512 positions).
 ///
 /// Pipeline: text → chunk → [tokenize → embed → prefill KV → generate → flow decode → mimi decode] → WAV
 public struct PocketTtsSynthesizer {
@@ -961,6 +961,9 @@ public struct PocketTtsSynthesizer {
     // MARK: - Helpers
 
     /// Estimate maximum generation frames based on text length.
+    ///
+    /// At 80ms per frame, 12.5 frames ≈ 1 second of audio per word.
+    /// The +2 adds margin for pauses and trailing silence.
     private static func estimateMaxFrames(text: String) -> Int {
         let wordCount = text.split(separator: " ").count
         let genLenSec = Double(wordCount) + 2.0
@@ -979,7 +982,10 @@ public struct PocketTtsSynthesizer {
         return array
     }
 
-    /// Create a NaN-filled sequence [1, 1, 32] (signals BOS to the model).
+    /// Create a NaN-filled sequence `[1, 1, 32]` to signal beginning-of-sequence.
+    ///
+    /// The first generation step has no previous audio latent. NaN values tell
+    /// the model to use the BOS embedding instead, triggering the start of speech.
     private static func createNaNSequence() throws -> MLMultiArray {
         let dim = PocketTtsConstants.latentDim
         let array = try MLMultiArray(
@@ -991,7 +997,10 @@ public struct PocketTtsSynthesizer {
         return array
     }
 
-    /// Create a sequence [1, 1, 32] from a latent vector.
+    /// Create a sequence `[1, 1, 32]` from a latent vector.
+    ///
+    /// Autoregressive feedback: each generated audio latent becomes the input
+    /// for the next flowlm_step, so the model conditions on its own output.
     private static func createSequenceFromLatent(_ latent: [Float]) throws -> MLMultiArray {
         let dim = PocketTtsConstants.latentDim
         let array = try MLMultiArray(

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
@@ -6,34 +6,46 @@ public enum PocketTtsConstants {
     // MARK: - Audio
 
     public static let audioSampleRate: Int = 24_000
+    /// Each generation step produces one frame of audio: 1920 samples = 80ms at 24kHz.
     public static let samplesPerFrame: Int = 1_920
 
     // MARK: - Model dimensions
 
+    /// Audio code dimensionality — output of flow_decoder, input to mimi_decoder.
     public static let latentDim: Int = 32
+    /// Transformer hidden state size — shared by flowlm_step output and flow_decoder input.
     public static let transformerDim: Int = 1024
+    /// SentencePiece vocabulary size for text tokenization.
     public static let vocabSize: Int = 4001
+    /// Embedding dimension for voice and text tokens (matches transformerDim).
     public static let embeddingDim: Int = 1024
 
     // MARK: - Generation parameters
 
+    /// Number of Euler integration steps in flow_decoder (noise → audio code).
     public static let numLsdSteps: Int = 8
+    /// Controls randomness in flow_decoder: scales initial noise by sqrt(temperature).
     public static let temperature: Float = 0.7
+    /// flowlm_step EOS logit threshold — above this means the model is done speaking.
     public static let eosThreshold: Float = -4.0
     public static let shortTextPadFrames: Int = 3
     public static let longTextExtraFrames: Int = 1
     public static let extraFramesAfterDetection: Int = 2
     public static let shortTextWordThreshold: Int = 5
+    /// Max text tokens per chunk — keeps total KV cache usage under kvCacheMaxLen.
     public static let maxTokensPerChunk: Int = 50
 
     // MARK: - KV cache
 
+    /// Number of transformer layers, each with its own KV cache.
     public static let kvCacheLayers: Int = 6
+    /// Max KV cache positions: voice (~125) + text (≤50) + generated frames.
     public static let kvCacheMaxLen: Int = 512
 
     // MARK: - Voice
 
     public static let defaultVoice: String = "alba"
+    /// Default voice prompt length in frames. Cloned voices may differ (up to 250).
     public static let voicePromptLength: Int = 125
 
     // MARK: - Repository


### PR DESCRIPTION
## Summary

- Adds clarifying comments across 6 PocketTTS pipeline files to document the architecture, data flow, and model I/O
- Fixes stale comment referencing "200 positions" when the actual KV cache max is 512
- No code changes, comments only

### Files modified

| File | Changes |
|------|---------|
| `PocketTtsConstants.swift` | Explain each constant's role (80ms frames, 32-d latent, EOS threshold, etc.) |
| `PocketTtsSynthesizer+KVCache.swift` | Document cache shape `[2,1,512,16,64]` dimensions, prefill vs generate mode, voice-first ordering |
| `PocketTtsSynthesizer+Types.swift` | Group Mimi state tensors by function, note auto-generated CoreML key names |
| `PocketTtsSynthesizer+Flow.swift` | Explain flow matching concept, Euler integration, s/t parameters, sqrt(temperature) |
| `PocketTtsSynthesizer+Mimi.swift` | Clarify streaming state persistence across chunks (unlike KV cache) |
| `PocketTtsSynthesizer.swift` | Fix stale "200 positions" → 512, document BOS/NaN signaling, autoregressive feedback |

## Test plan

- [x] `swift build` passes
- [x] `swift format lint` clean
- No behavioral changes — comments only
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
