### PR TITLE
fix: populate tokenDurations in TDT decoder for accurate word endTime

### DIFF
--- a/Sources/FluidAudio/ASR/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/ChunkProcessor.swift
@@ -7,7 +7,7 @@ struct ChunkProcessor {
     let totalSamples: Int
 
     private let logger = AppLogger(category: "ChunkProcessor")
-    private typealias TokenWindow = (token: Int, timestamp: Int, confidence: Float)
+    private typealias TokenWindow = (token: Int, timestamp: Int, confidence: Float, duration: Int)
     private struct IndexedToken {
         let index: Int
         let token: TokenWindow
@@ -86,7 +86,7 @@ struct ChunkProcessor {
             let chunkLengthWithContext = chunkEnd - contextStart
             let chunkSamplesArray = try readSamples(offset: contextStart, count: chunkLengthWithContext)
 
-            let (windowTokens, windowTimestamps, windowConfidences) = try await transcribeChunk(
+            let (windowTokens, windowTimestamps, windowConfidences, windowDurations) = try await transcribeChunk(
                 samples: chunkSamplesArray,
                 contextSamples: contextSamples,
                 chunkStart: chunkStart,
@@ -100,8 +100,15 @@ struct ChunkProcessor {
                 throw ASRError.processingFailed("Token, timestamp, and confidence arrays are misaligned")
             }
 
-            let windowData: [TokenWindow] = zip(zip(windowTokens, windowTimestamps), windowConfidences).map {
-                (token: $0.0.0, timestamp: $0.0.1, confidence: $0.1)
+            // Default to 0 per token if durations array is misaligned (shouldn't happen in practice)
+            let durations =
+                windowDurations.count == windowTokens.count
+                ? windowDurations : Array(repeating: 0, count: windowTokens.count)
+
+            let windowData: [TokenWindow] = zip(
+                zip(zip(windowTokens, windowTimestamps), windowConfidences), durations
+            ).map {
+                (token: $0.0.0.0, timestamp: $0.0.0.1, confidence: $0.0.1, duration: $0.1)
             }
             chunkOutputs.append(windowData)
 
@@ -143,11 +150,13 @@ struct ChunkProcessor {
         let allTokens = mergedTokens.map { $0.token }
         let allTimestamps = mergedTokens.map { $0.timestamp }
         let allConfidences = mergedTokens.map { $0.confidence }
+        let allDurations = mergedTokens.map { $0.duration }
 
         return manager.processTranscriptionResult(
             tokenIds: allTokens,
             timestamps: allTimestamps,
             confidences: allConfidences,
+            tokenDurations: allDurations,
             encoderSequenceLength: 0,  // Not relevant for chunk processing
             audioSamples: [],
             processingTime: Date().timeIntervalSince(startTime)
@@ -169,8 +178,8 @@ struct ChunkProcessor {
         isLastChunk: Bool,
         using manager: AsrManager,
         decoderState: inout TdtDecoderState
-    ) async throws -> (tokens: [Int], timestamps: [Int], confidences: [Float]) {
-        guard !samples.isEmpty else { return ([], [], []) }
+    ) async throws -> (tokens: [Int], timestamps: [Int], confidences: [Float], durations: [Int]) {
+        guard !samples.isEmpty else { return ([], [], [], []) }
 
         let paddedChunk = manager.padAudioIfNeeded(samples, targetLength: maxModelSamples)
 
@@ -195,10 +204,10 @@ struct ChunkProcessor {
         )
 
         if hypothesis.isEmpty || encoderSequenceLength == 0 {
-            return ([], [], [])
+            return ([], [], [], [])
         }
 
-        return (hypothesis.ySequence, hypothesis.timestamps, hypothesis.tokenConfidences)
+        return (hypothesis.ySequence, hypothesis.timestamps, hypothesis.tokenConfidences, hypothesis.tokenDurations)
     }
 
     private func mergeChunks(

--- a/Sources/FluidAudio/ASR/TDT/TdtDecoderV3.swift
+++ b/Sources/FluidAudio/ASR/TDT/TdtDecoderV3.swift
@@ -376,6 +376,7 @@ internal struct TdtDecoderV3 {
                 hypothesis.score += score
                 hypothesis.timestamps.append(timeIndicesCurrentLabels + globalFrameOffset)
                 hypothesis.tokenConfidences.append(score)
+                hypothesis.tokenDurations.append(duration)
                 hypothesis.lastToken = label  // Remember for next iteration
 
                 // CRITICAL: Update decoder LSTM with the new token
@@ -497,6 +498,7 @@ internal struct TdtDecoderV3 {
                         min(finalProcessingTimeIndices, effectiveSequenceLength - 1) + globalFrameOffset
                     hypothesis.timestamps.append(finalTimestamp)
                     hypothesis.tokenConfidences.append(score)
+                    hypothesis.tokenDurations.append(duration)
                     hypothesis.lastToken = token
 
                     // Update decoder state
@@ -811,9 +813,7 @@ internal struct TdtDecoderV3 {
         hypothesis.decState = decoderState
         hypothesis.lastToken = token
 
-        if config.tdtConfig.includeTokenDuration {
-            hypothesis.tokenDurations.append(duration)
-        }
+        hypothesis.tokenDurations.append(duration)
     }
 
     // MARK: - Private Helper Methods


### PR DESCRIPTION
## Summary

- Append token durations at both emission sites in `TdtDecoderV3` (main decode loop and last-chunk finalization) so `hypothesis.tokenDurations` is actually populated
- Propagate durations through `ChunkProcessor`'s `TokenWindow` pipeline so multi-chunk transcription also produces accurate word-level timing
- The duration-based `endTime` calculation in `createTokenTimings()` already existed but was never reached because `tokenDurations` was always empty

## Test plan

- [x] `swift build` compiles cleanly
- [x] All 148 existing tests pass (CITests, ChunkMergeTests, ChunkProcessorEdgeCaseTests, TdtDecoder* tests)
- [x] `swift format lint` passes
- [ ] Manual verification: `swift run fluidaudiocli transcribe <audio> --output-json result.json` — confirm `wordTimings` show proper gaps between words

Closes #381
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
