### PR TITLE
feat: upgrade sortformer models to v2.1

### DIFF
--- a/Sources/FluidAudio/Diarizer/Sortformer/SortformerModelInference.swift
+++ b/Sources/FluidAudio/Diarizer/Sortformer/SortformerModelInference.swift
@@ -240,9 +240,11 @@ extension SortformerModels {
         // Extract outputs (names must match CoreML Sortformer model)
         // Note: Output names use _out suffix to avoid macOS 26+ BNNS compiler error
         // where input and output tensors cannot share the same name
-        guard let predictions = output.featureValue(for: "speaker_preds")?.shapedArrayValue(of: Float32.self)?.scalars,
-            let chunkEmbeddingsLength = output.featureValue(for: "chunk_pre_encoder_lengths_out")?.shapedArrayValue(
-                of: Int32.self)?.scalars.first
+        guard
+            let predictions = output.featureValue(for: "speaker_preds_out")?
+                .shapedArrayValue(of: Float32.self)?.scalars,
+            let chunkEmbeddingsLength = output.featureValue(for: "chunk_pre_encoder_lengths_out")?
+                .shapedArrayValue(of: Int32.self)?.scalars.first
         else {
             throw SortformerError.inferenceFailed("Missing model outputs")
         }

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -233,11 +233,11 @@ public enum ModelNames {
             public var name: String {
                 switch self {
                 case .default:
-                    return "SortformerV2"
+                    return "Sortformer_v2.1"
                 case .nvidiaLowLatency:
-                    return "SortformerNvidiaLowV2"
+                    return "SortformerNvidiaLow_v2.1"
                 case .nvidiaHighLatency:
-                    return "SortformerNvidiaHighV2"
+                    return "SortformerNvidiaHigh_v2.1"
                 }
             }
 


### PR DESCRIPTION
## Summary

- Upgrades sortformer model bundles from V2 to v2.1 on HuggingFace
- NVIDIA reports v2.1 is more robust in meeting scenarios
- Updates output key `speaker_preds` → `speaker_preds_out` to match v2.1 model output names

## Changes

| File | Change |
|------|--------|
| `ModelNames.swift` | `SortformerV2` → `Sortformer_v2.1`, `SortformerNvidiaLowV2` → `SortformerNvidiaLow_v2.1`, `SortformerNvidiaHighV2` → `SortformerNvidiaHigh_v2.1` |
| `SortformerModelInference.swift` | `speaker_preds` → `speaker_preds_out` (v2.1 renamed this output for consistency with other `_out` suffixed outputs) |

## Breaking change

Users with cached V2 models will need to re-download. The old `SortformerV2.mlmodelc` bundles are incompatible with the new output key.

## Test plan

- [x] `swift build` passes
- [x] `swift format lint` clean
- [ ] Sortformer benchmark CI passes with v2.1 models
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/386" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
