### PR TITLE
docs: add Qwen3-TTS and Qwen3-ForcedAligner to evaluated models

### DIFF
--- a/Documentation/Models.md
+++ b/Documentation/Models.md
@@ -53,6 +53,8 @@ Models we converted and tested but haven't shipped yet — either still in devel
 | Model | Status |
 |-------|--------|
 | **Nemotron Speech Streaming 0.6B** ([#254](https://github.com/FluidInference/FluidAudio/pull/254)) | Streaming model with 1.12s chunks. Not significantly faster or more accurate than existing Parakeet models: streaming (EOU) and batch (TDT) modes. |
+| **Qwen3-TTS** ([FluidAudio#290](https://github.com/FluidInference/FluidAudio/pull/290), [mobius#20](https://github.com/FluidInference/mobius/pull/20), [HF](https://huggingface.co/alexwengg/qwen3-tts-coreml)) | ~5.9GB CoreML is too large for on-device. Low upstream adoption (Qwen ASR CoreML model downloads). |
+| **Qwen3-ForcedAligner-0.6B** ([FluidAudio#315](https://github.com/FluidInference/FluidAudio/pull/315), [mobius#21](https://github.com/FluidInference/mobius/pull/21), [HF](https://huggingface.co/alexwengg/Qwen3-ForcedAligner-0.6B-Coreml)) | 5-model CoreML pipeline, large footprint. Low upstream adoption (Qwen ASR CoreML model downloads). |
 
 ## Model Sources
 


### PR DESCRIPTION
## Summary

- Add Qwen3-TTS and Qwen3-ForcedAligner-0.6B to the "Evaluated Models (Not Shipped)" section in Documentation/Models.md
- Links to FluidAudio PRs, mobius conversion PRs, and HuggingFace repos

## Test plan

- [ ] Verify markdown renders correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
