### PR TITLE
fix: use fixed seed for reproducible test failures

### DIFF
--- a/Tests/FluidAudioTests/Diarizer/Sortformer/SortformerTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Sortformer/SortformerTests.swift
@@ -12,7 +12,7 @@ final class SortformerTests: XCTestCase {
         // Create 5 seconds of deterministic random audio
         let sampleRate = 16000
         let audioCount = sampleRate * 5
-        srand48(Int(Date().timeIntervalSince1970 * 1e6))
+        srand48(42)
         let audio = (0..<audioCount).map { _ in Float(drand48() - 0.5) }
 
         // 1. Get chunks from Batch Feature Provider


### PR DESCRIPTION
## Summary
- Use a fixed seed (`42`) for `srand48` in `testFeatureProviderEquivalency` instead of seeding with current time. The comment says "deterministic random audio" but the time-based seed made failures non-reproducible.

## Test plan
- [ ] `swift test --filter SortformerTests` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/393" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
