### PR TITLE
feat: add Audite to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[Enconvo](https://enconvo.com)** | AI Agent Launcher for macOS with voice input, live captions, and text-to-speech. Uses Parakeet ASR for local speech recognition. |
 | **[Meeting Transcriber](https://github.com/pasrom/meeting-transcriber)** | macOS menu bar app that auto-detects, records, and transcribes meetings (Teams, Zoom, Webex) with dual-track speaker diarization. Uses speaker diarization. |
 | **[Hitoku Draft](https://hitoku.me/draft)** | A local, private, voice writing assistant on your macOS menu bar. Uses Parakeet ASR. |
+| **[Audite](https://github.com/zachatrocity/audite)** | macOS menu-bar app that records meetings and transcribes them locally into Markdown notes for Obsidian. Uses Parakeet ASR via FluidAudio on the Apple Neural Engine. |
 
 ## Installation
 


### PR DESCRIPTION
## Add Audite to Showcase

[Audite](https://github.com/zachatrocity/audite) is a macOS menu-bar app that records meetings and transcribes them locally into Markdown notes for Obsidian.

- Uses FluidAudio's Parakeet TDT v3 for fully local, on-device transcription via the Apple Neural Engine
- Menu-bar native — lives in the status bar, stays out of the way
- Obsidian integration — saves transcripts as `.md` files with YAML frontmatter directly into your vault
- Calendar integration — shows upcoming Apple Calendar events to use as recording titles
- No audio leaves the machine

Added to the bottom of the showcase table in chronological order.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
