### PR TITLE
fix: clamp numMasksInChunk to prevent heap-buffer-overflow in EmbeddingExtractor

### DIFF
--- a/Sources/FluidAudio/Diarizer/Extraction/EmbeddingExtractor.swift
+++ b/Sources/FluidAudio/Diarizer/Extraction/EmbeddingExtractor.swift
@@ -58,8 +58,12 @@ public final class EmbeddingExtractor {
         )
 
         // Calculate number of masks that are actually used
-
-        let numMasksInChunk = (firstMask.count * audio.count + 80_000) / 160_000
+        // Clamp to firstMask.count to prevent heap-buffer-overflow in fillMaskBufferOptimized
+        // when audio.count > 160_000 (the formula can produce values > firstMask.count)
+        let numMasksInChunk = min(
+            (firstMask.count * audio.count + 80_000) / 160_000,
+            firstMask.count
+        )
 
         // Process all speakers but optimize for active ones
         for speakerIdx in 0..<masks.count {

--- a/Tests/FluidAudioTests/Diarizer/Extraction/EmbeddingExtractorOverflowTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Extraction/EmbeddingExtractorOverflowTests.swift
@@ -1,0 +1,69 @@
+import Accelerate
+import XCTest
+
+@testable import FluidAudio
+
+/// Regression test for heap-buffer-overflow in EmbeddingExtractor.fillMaskBufferOptimized().
+///
+/// Bug: numMasksInChunk = (firstMask.count * audio.count + 80_000) / 160_000
+/// can exceed firstMask.count when audio > 10s, causing vDSP_mmov to read past allocation.
+/// Fix: clamp to firstMask.count with min().
+/// Introduced in v0.8.0 (PR #191). Affects v0.8.0–v0.12.4.
+final class EmbeddingExtractorOverflowTests: XCTestCase {
+
+    // MARK: - numMasksInChunk Bounds
+
+    func testNumMasksInChunkClampsForLongAudio() {
+        let maskCount = 100
+        let audioCount = 320_000  // 20s at 16kHz
+
+        // Buggy: (100 * 320000 + 80000) / 160000 = 200 — 2x overread
+        let unclamped = (maskCount * audioCount + 80_000) / 160_000
+        XCTAssertEqual(unclamped, 200, "Unclamped formula exceeds maskCount — proves bug exists")
+
+        let clamped = min(unclamped, maskCount)
+        XCTAssertEqual(clamped, maskCount)
+    }
+
+    func testNumMasksInChunkSafeForShortAudio() {
+        let maskCount = 100
+        let audioCount = 80_000  // 5s at 16kHz
+
+        // (100 * 80000 + 80000) / 160000 = 50
+        let result = min(
+            (maskCount * audioCount + 80_000) / 160_000,
+            maskCount
+        )
+        XCTAssertEqual(result, 50, "Short audio should not trigger clamp")
+    }
+
+    // MARK: - vDSP_mmov Bounds
+
+    func testFillMaskDoesNotOverreadWithLongAudio() {
+        // Simulates fillMaskBufferOptimized with 20s audio.
+        // Without clamp, vDSP_mmov reads 200 elements from 100-element buffer.
+        // Under ASan: READ of size 800 from 400-byte allocation.
+        let maskCount = 100
+        let audioCount = 320_000
+
+        let numMasksInChunk = min(
+            (maskCount * audioCount + 80_000) / 160_000,
+            maskCount
+        )
+
+        let mask = [Float](repeating: 1.0, count: maskCount)
+        var destination = [Float](repeating: 0.0, count: maskCount * 3)
+
+        mask.withUnsafeBufferPointer { src in
+            destination.withUnsafeMutableBufferPointer { dst in
+                vDSP_mmov(
+                    src.baseAddress!, dst.baseAddress!,
+                    vDSP_Length(numMasksInChunk), 1, 1,
+                    vDSP_Length(numMasksInChunk)
+                )
+            }
+        }
+
+        XCTAssertEqual(numMasksInChunk, maskCount)
+    }
+}


### PR DESCRIPTION
When audio.count > 160,000 samples (>10s at 16kHz), the numMasksInChunk formula `(firstMask.count * audio.count + 80_000) / 160_000` produces a value larger than firstMask.count. This causes vDSP_mmov in fillMaskBufferOptimized() to read past the mask buffer allocation.

For example, with maskCount=100 and 20s audio (320k samples):
  buggy:  (100 * 320000 + 80000) / 160000 = 200 — 2x overread
  fixed:  min(200, 100) = 100

The fix clamps numMasksInChunk to firstMask.count with min().

Bug introduced in v0.8.0 (PR #191, 2025-11-26). Affects v0.8.0–v0.12.4. Detected via AddressSanitizer: READ of size 3456 from 2388-byte buffer.

Includes regression tests validating the formula and vDSP_mmov bounds.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
