### PR TITLE
Add Muesli to showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[Meeting Transcriber](https://github.com/pasrom/meeting-transcriber)** | macOS menu bar app that auto-detects, records, and transcribes meetings (Teams, Zoom, Webex) with dual-track speaker diarization. Uses speaker diarization. |
 | **[Hitoku Draft](https://hitoku.me/draft)** | A local, private, voice writing assistant on your macOS menu bar. Uses Parakeet ASR. |
 | **[Audite](https://github.com/zachatrocity/audite)** | macOS menu-bar app that records meetings and transcribes them locally into Markdown notes for Obsidian. Uses Parakeet ASR via FluidAudio on the Apple Neural Engine. |
+| **[Muesli](https://github.com/pHequals7/muesli)** | Native macOS dictation and meeting transcription with ~0.13s latency. Captures microphone and system audio with automatic speaker diarization. Uses Parakeet TDT and Qwen3 ASR. |
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Adds [Muesli](https://github.com/pHequals7/muesli) to the showcase section.

## About Muesli

Muesli is a native macOS application for local-first dictation and meeting transcription with the following features:

- **Hold-to-talk dictation** with ~0.13 second latency
- **Meeting recording** with simultaneous microphone and system audio capture
- **Speaker diarization** for automatic speaker identification
- **VAD-driven transcription** to avoid mid-sentence interruptions
- **Multiple ASR models**: Parakeet TDT, Qwen3 ASR, and Whisper variants
- **32MB Swift app** with no Python dependencies

Uses FluidAudio's Parakeet TDT and Qwen3 ASR for speech recognition.

**License**: MIT (open source)
**Link**: https://github.com/pHequals7/muesli
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
