### PR TITLE
Add CLAUDE.md rule: never upload to HuggingFace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,12 @@ FluidAudio is a Swift framework for local, low-latency audio processing on Apple
 - Always use the actual models required by the code
 - If model authentication is required, inform the user rather than creating dummy versions
 
+### NEVER UPLOAD TO HUGGINGFACE
+
+- Do not upload models, datasets, or any files to HuggingFace
+- Do not create HuggingFace repos
+- Prepare files locally and let the user handle all HF uploads themselves
+
 ### MODEL OPERATIONS - CONSULT BEFORE IMPLEMENTING
 
 - When asked to merge, convert, or modify models:


### PR DESCRIPTION
## Summary

- Adds a rule to CLAUDE.md preventing Claude from uploading files to HuggingFace or creating HF repos
- Users handle all HF uploads themselves; Claude should only prepare files locally

## Test plan

- [ ] Verify CLAUDE.md renders correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/408" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
