### PR TITLE
Fix missing source_noise input in Kokoro TTS models

### DIFF
--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer.swift
@@ -304,7 +304,22 @@ public struct KokoroSynthesizer {
             zeroFill: true
         )
 
+        // Source noise for newer Kokoro models
+        let maxSeconds = variant.maxDurationSeconds
+        let noiseLength = TtsConstants.audioSampleRate * maxSeconds
+        let sourceNoise = try await multiArrayPool.rent(
+            shape: [1, noiseLength, 9],
+            dataType: .float16,
+            zeroFill: false
+        )
+        let noisePointer = sourceNoise.dataPointer.bindMemory(to: UInt16.self, capacity: noiseLength * 9)
+        for i in 0..<(noiseLength * 9) {
+            let randomValue = Float.random(in: -1...1)
+            noisePointer[i] = Float16(randomValue).bitPattern
+        }
+
         func recycleModelArrays() async {
+            await multiArrayPool.recycle(sourceNoise, zeroFill: false)
             await multiArrayPool.recycle(phasesArray, zeroFill: true)
             await multiArrayPool.recycle(attentionMask, zeroFill: false)
             await multiArrayPool.recycle(inputArray, zeroFill: false)
@@ -338,6 +353,7 @@ public struct KokoroSynthesizer {
             "attention_mask": attentionMask,
             "ref_s": refStyle,
             "random_phases": phasesArray,
+            "source_noise": sourceNoise,
         ])
 
         let predictionStart = Date()

--- a/Sources/FluidAudio/TTS/TtsModels.swift
+++ b/Sources/FluidAudio/TTS/TtsModels.swift
@@ -152,11 +152,25 @@ public struct TtsModels: Sendable {
                 randomPhases[index] = NSNumber(value: Float(0))
             }
 
+            // Source noise for newer Kokoro models
+            let maxSeconds = variant.maxDurationSeconds
+            let noiseLength = TtsConstants.audioSampleRate * maxSeconds
+            let sourceNoise = try MLMultiArray(
+                shape: [1, NSNumber(value: noiseLength), 9],
+                dataType: .float16
+            )
+            let noisePointer = sourceNoise.dataPointer.bindMemory(to: UInt16.self, capacity: noiseLength * 9)
+            for i in 0..<(noiseLength * 9) {
+                let randomValue = Float.random(in: -1...1)
+                noisePointer[i] = Float16(randomValue).bitPattern
+            }
+
             let features = try MLDictionaryFeatureProvider(dictionary: [
                 "input_ids": inputIds,
                 "attention_mask": attentionMask,
                 "ref_s": refStyle,
                 "random_phases": randomPhases,
+                "source_noise": sourceNoise,
             ])
 
             let options: MLPredictionOptions = optimizedPredictionOptions()


### PR DESCRIPTION
## Summary

Fixes CI failure in `test-tts` workflow caused by missing `source_noise` input after PR #411 merged.

PR #411 (Kokoro ANE optimization) updated the Kokoro CoreML models to fp16, which introduced a new required input `source_noise` that the inference code wasn't providing.

## Changes

- Add `source_noise` tensor [1, sampleRate*duration, 9] with random Float16 values
- Update both synthesis pipeline and warm-up prediction  
- Size adapts to model variant: 5s (120k samples) or 15s (360k samples)
- Use multiarray pooling for memory efficiency

## Error Fixed

```
Feature source_noise is required but not specified.
```

## Test Plan

- [x] Cherry-picked from commit c8a5056 (originally on feature/qwen3-tts-coreml)
- [ ] CI `test-tts` workflow should pass
- [ ] Verify Kokoro TTS synthesis completes successfully

Fixes the CI failure blocking PR #409 and other PRs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/412" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
