### PR TITLE
Convert AsrManager to actor for Swift 6 concurrency safety

### DIFF
--- a/Sources/FluidAudio/ASR/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/AsrManager.swift
@@ -8,7 +8,7 @@ public enum AudioSource: Sendable {
     case system
 }
 
-public final class AsrManager {
+public actor AsrManager {
 
     internal let logger = AppLogger(category: "ASR")
     internal let config: ASRConfig
@@ -228,17 +228,26 @@ public final class AsrManager {
         ])
     }
 
-    internal func initializeDecoderState(decoderState: inout TdtDecoderState) async throws {
+    internal func initializeDecoderState(for source: AudioSource) async throws {
         guard let decoderModel = decoderModel else {
             throw ASRError.notInitialized
         }
 
+        // Get the appropriate decoder state
+        var state: TdtDecoderState
+        switch source {
+        case .microphone:
+            state = microphoneDecoderState
+        case .system:
+            state = systemDecoderState
+        }
+
         // Reset the existing decoder state to clear all cached values including predictorOutput
-        decoderState.reset()
+        state.reset()
 
         let initDecoderInput = try prepareDecoderInput(
-            hiddenState: decoderState.hiddenState,
-            cellState: decoderState.cellState
+            hiddenState: state.hiddenState,
+            cellState: state.cellState
         )
 
         let initDecoderOutput = try await decoderModel.compatPrediction(
@@ -246,8 +255,15 @@ public final class AsrManager {
             options: predictionOptions
         )
 
-        decoderState.update(from: initDecoderOutput)
+        state.update(from: initDecoderOutput)
 
+        // Store back
+        switch source {
+        case .microphone:
+            microphoneDecoderState = state
+        case .system:
+            systemDecoderState = state
+        }
     }
 
     private func loadModel(
@@ -474,15 +490,7 @@ public final class AsrManager {
             _ = await progressEmitter.ensureSession()
         }
         do {
-            let result: ASRResult
-            switch source {
-            case .microphone:
-                result = try await transcribeWithState(
-                    audioSamples, decoderState: &microphoneDecoderState)
-            case .system:
-                result = try await transcribeWithState(
-                    audioSamples, decoderState: &systemDecoderState)
-            }
+            let result = try await transcribeWithState(audioSamples, source: source)
 
             // Stateless architecture: reset decoder state after each transcription to ensure
             // independent processing for batch operations without state carryover
@@ -509,12 +517,7 @@ public final class AsrManager {
     /// Reset the decoder state for a specific audio source
     /// This should be called when starting a new transcription session or switching between different audio files
     public func resetDecoderState(for source: AudioSource) async throws {
-        switch source {
-        case .microphone:
-            try await initializeDecoderState(decoderState: &microphoneDecoderState)
-        case .system:
-            try await initializeDecoderState(decoderState: &systemDecoderState)
-        }
+        try await initializeDecoderState(for: source)
     }
 
     internal func normalizedTimingToken(_ token: String) -> String {
@@ -566,7 +569,7 @@ public final class AsrManager {
         return (text, adjustedTimings)
     }
 
-    internal func extractFeatureValue(
+    nonisolated internal func extractFeatureValue(
         from provider: MLFeatureProvider, key: String, errorMessage: String
     ) throws -> MLMultiArray {
         guard let value = provider.featureValue(for: key)?.multiArrayValue else {
@@ -575,7 +578,7 @@ public final class AsrManager {
         return value
     }
 
-    internal func extractFeatureValues(
+    nonisolated internal func extractFeatureValues(
         from provider: MLFeatureProvider, keys: [(key: String, errorSuffix: String)]
     ) throws -> [String: MLMultiArray] {
         var results: [String: MLMultiArray] = [:]

--- a/Sources/FluidAudio/ASR/AsrTranscription.swift
+++ b/Sources/FluidAudio/ASR/AsrTranscription.swift
@@ -5,12 +5,21 @@ import OSLog
 extension AsrManager {
 
     internal func transcribeWithState(
-        _ audioSamples: [Float], decoderState: inout TdtDecoderState
+        _ audioSamples: [Float], source: AudioSource
     ) async throws -> ASRResult {
         guard isAvailable else { throw ASRError.notInitialized }
         guard audioSamples.count >= 16_000 else { throw ASRError.invalidAudioData }
 
         let startTime = Date()
+
+        // Get the appropriate decoder state
+        var decoderState: TdtDecoderState
+        switch source {
+        case .microphone:
+            decoderState = microphoneDecoderState
+        case .system:
+            decoderState = systemDecoderState
+        }
 
         // Route to appropriate processing method based on audio length
         if audioSamples.count <= ASRConstants.maxModelSamples {
@@ -50,6 +59,14 @@ extension AsrManager {
                 result = await applyVocabularyRescoring(result: result, audioSamples: audioSamples)
             }
 
+            // Store decoder state back
+            switch source {
+            case .microphone:
+                microphoneDecoderState = decoderState
+            case .system:
+                systemDecoderState = decoderState
+            }
+
             return result
         }
 
@@ -67,6 +84,14 @@ extension AsrManager {
         // Auto-apply vocabulary rescoring when configured
         if vocabBoostingEnabled {
             result = await applyVocabularyRescoring(result: result, audioSamples: audioSamples)
+        }
+
+        // Store decoder state back (ChunkProcessor uses the stored state directly)
+        switch source {
+        case .microphone:
+            microphoneDecoderState = decoderState
+        case .system:
+            systemDecoderState = decoderState
         }
 
         return result
@@ -283,7 +308,7 @@ extension AsrManager {
         )
     }
 
-    internal func padAudioIfNeeded(_ audioSamples: [Float], targetLength: Int) -> [Float] {
+    nonisolated internal func padAudioIfNeeded(_ audioSamples: [Float], targetLength: Int) -> [Float] {
         guard audioSamples.count < targetLength else { return audioSamples }
         return audioSamples + Array(repeating: 0, count: targetLength - audioSamples.count)
     }
@@ -487,7 +512,7 @@ extension AsrManager {
     }
 
     /// Calculate start frame offset for a sliding window segment (deprecated - now handled by timeJump)
-    internal func calculateStartFrameOffset(segmentIndex: Int, leftContextSeconds: Double) -> Int {
+    nonisolated internal func calculateStartFrameOffset(segmentIndex: Int, leftContextSeconds: Double) -> Int {
         // This method is deprecated as frame tracking is now handled by the decoder's timeJump mechanism
         // Kept for test compatibility
         return 0

--- a/Sources/FluidAudio/ASR/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/ChunkProcessor.swift
@@ -127,7 +127,7 @@ struct ChunkProcessor {
         }
 
         guard var mergedTokens = chunkOutputs.first else {
-            return manager.processTranscriptionResult(
+            return await manager.processTranscriptionResult(
                 tokenIds: [],
                 timestamps: [],
                 confidences: [],
@@ -152,7 +152,7 @@ struct ChunkProcessor {
         let allConfidences = mergedTokens.map { $0.confidence }
         let allDurations = mergedTokens.map { $0.duration }
 
-        return manager.processTranscriptionResult(
+        return await manager.processTranscriptionResult(
             tokenIds: allTokens,
             timestamps: allTimestamps,
             confidences: allConfidences,

--- a/Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Streaming/StreamingAsrManager.swift
@@ -17,9 +17,7 @@ public actor StreamingAsrManager {
     private var updateContinuation: AsyncStream<StreamingTranscriptionUpdate>.Continuation?
 
     // ASR components
-    // AsrManager contains CoreML models which are not Sendable.
-    // We manage the safety ourselves by only accessing it from within the actor.
-    nonisolated(unsafe) private var asrManager: AsrManager?
+    private var asrManager: AsrManager?
     private var recognizerTask: Task<Void, Error>?
     private var audioSource: AudioSource = .microphone
 
@@ -223,7 +221,7 @@ public actor StreamingAsrManager {
             if !volatileTranscript.isEmpty { parts.append(volatileTranscript) }
             finalText = parts.joined(separator: " ")
         } else if let asrManager = asrManager, !accumulatedTokens.isEmpty {
-            let finalResult = asrManager.processTranscriptionResult(
+            let finalResult = await asrManager.processTranscriptionResult(
                 tokenIds: accumulatedTokens,
                 timestamps: [],
                 confidences: [],  // No per-token confidences needed for final text
@@ -398,7 +396,7 @@ public actor StreamingAsrManager {
 
             // Convert only the current chunk tokens to text for clean incremental updates
             // The final result will use all accumulated tokens for proper deduplication
-            let interim = asrManager.processTranscriptionResult(
+            let interim = await asrManager.processTranscriptionResult(
                 tokenIds: tokens,  // Only current chunk tokens for progress updates
                 timestamps: adjustedTimestamps,
                 confidences: confidences,
@@ -420,7 +418,7 @@ public actor StreamingAsrManager {
             var displayResult = interim
             if shouldConfirm && vocabBoostingEnabled {
                 let chunkLocalTimings =
-                    asrManager.processTranscriptionResult(
+                    await asrManager.processTranscriptionResult(
                         tokenIds: tokens,
                         timestamps: timestamps,  // Original chunk-local timestamps (not adjusted)
                         confidences: confidences,

--- a/Sources/FluidAudioCLI/Commands/ASR/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/TranscribeCommand.swift
@@ -461,7 +461,7 @@ enum TranscribeCommand {
             }
 
             // Cleanup
-            asrManager.cleanup()
+            await asrManager.cleanup()
 
         } catch {
             logger.error("Batch transcription failed: \(error)")

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -395,7 +395,7 @@ public struct TTS {
                     logger.info(String(format: "WER: %.1f%%", werValue! * 100))
 
                     // Clean up ASR resources
-                    asr.cleanup()
+                    await asr.cleanup()
                 } catch {
                     logger.warning("ASR evaluation failed: \(error.localizedDescription)")
                 }
@@ -598,7 +598,7 @@ public struct TTS {
                     logger.info("Hypothesis: \(transcription.text)")
                     logger.info(String(format: "WER: %.1f%%", werValue! * 100))
 
-                    asr.cleanup()
+                    await asr.cleanup()
                 } catch {
                     logger.warning("ASR evaluation failed: \(error.localizedDescription)")
                 }

--- a/Tests/FluidAudioTests/ASR/AsrTranscriptionTests.swift
+++ b/Tests/FluidAudioTests/ASR/AsrTranscriptionTests.swift
@@ -11,9 +11,10 @@ final class AsrTranscriptionTests: XCTestCase {
     override func setUp() {
         super.setUp()
         manager = AsrManager()
+    }
 
-        // Set up mock vocabulary for testing
-        #if DEBUG
+    #if DEBUG
+    func setupMockVocabulary() async {
         let mockVocabulary = [
             1: "hello",
             2: "▁world",
@@ -27,9 +28,9 @@ final class AsrTranscriptionTests: XCTestCase {
             200: "▁token",
             300: "!",
         ]
-        manager.setVocabularyForTesting(mockVocabulary)
-        #endif
+        await manager.setVocabularyForTesting(mockVocabulary)
     }
+    #endif
 
     override func tearDown() {
         manager = nil
@@ -79,12 +80,13 @@ final class AsrTranscriptionTests: XCTestCase {
 
     // MARK: - Process Transcription Result Tests
 
-    func testProcessTranscriptionResult() {
+    func testProcessTranscriptionResult() async {
+        await setupMockVocabulary()
         let tokenIds = [1, 2, 3, 4, 5]
         let audioSamples = Array(repeating: Float(0), count: 16_000)  // 1 second
         let processingTime = 0.5
 
-        let result = manager.processTranscriptionResult(
+        let result = await manager.processTranscriptionResult(
             tokenIds: tokenIds,
             confidences: [0.63, 0.63, 0.63, 0.63, 0.63],  // Mean 0.63 (pure model confidence)
             encoderSequenceLength: 100,
@@ -99,7 +101,8 @@ final class AsrTranscriptionTests: XCTestCase {
         XCTAssertTrue(result.tokenTimings?.isEmpty == true)  // No timestamps provided, should be empty array
     }
 
-    func testProcessTranscriptionResultWithTimings() {
+    func testProcessTranscriptionResultWithTimings() async {
+        await setupMockVocabulary()
         let tokenIds = [10, 20, 30]
         let audioSamples = Array(repeating: Float(0), count: 48_000)  // 3 seconds
         let timings = [
@@ -108,7 +111,7 @@ final class AsrTranscriptionTests: XCTestCase {
             TokenTiming(token: "test", tokenId: 30, startTime: 2.0, endTime: 3.0, confidence: 0.95),
         ]
 
-        let result = manager.processTranscriptionResult(
+        let result = await manager.processTranscriptionResult(
             tokenIds: tokenIds,
             encoderSequenceLength: 150,
             audioSamples: audioSamples,
@@ -121,13 +124,14 @@ final class AsrTranscriptionTests: XCTestCase {
         // Note: Actual timing count may differ due to convertTokensWithExistingTimings filtering
     }
 
-    func testProcessTranscriptionResultWithTimestamps() {
+    func testProcessTranscriptionResultWithTimestamps() async {
+        await setupMockVocabulary()
         let tokenIds = [100, 200, 300]
         let timestamps = [10, 20, 30]  // Frame indices
         let audioSamples = Array(repeating: Float(0), count: 32_000)  // 2 seconds
         let processingTime = 0.8
 
-        let result = manager.processTranscriptionResult(
+        let result = await manager.processTranscriptionResult(
             tokenIds: tokenIds,
             timestamps: timestamps,
             confidences: [0.51, 0.51, 0.51],  // Mean 0.51 (pure model confidence)


### PR DESCRIPTION
Fixes #415

## Summary

Converts `AsrManager` from a class to an actor to fix Swift 6 strict concurrency checking errors reported in issue #415. This eliminates data race warnings when compiling with Xcode 16.4 RC's stricter concurrency enforcement.

## Problem

With Swift 6 strict concurrency checking enabled, the compiler correctly flags the following pattern as unsafe:

```swift
if let asrManager = asrManager {
    try await asrManager.resetDecoderState(for: audioSource)
}
```

The `nonisolated(unsafe)` workaround was hiding real data race risks.

## Solution

Convert `AsrManager` to an actor, which:
- Makes it automatically `Sendable` 
- Provides compiler-enforced data race safety
- Eliminates the need for unsafe workarounds
- Ensures all external access is properly isolated with `await`

## Changes

### Core Conversion
- **AsrManager.swift**: Changed `public final class AsrManager` → `public actor AsrManager`
- Refactored `initializeDecoderState(decoderState: inout TdtDecoderState)` to `initializeDecoderState(for: AudioSource)` to handle actor isolation
- Modified `transcribeWithState` to take `source: AudioSource` instead of `inout` decoder state

### Removed Unsafe Workarounds
- **StreamingAsrManager.swift**: Removed `nonisolated(unsafe)` from `asrManager` property

### Updated Call Sites
- Added `await` to all actor method calls in:
  - `StreamingAsrManager.swift` (3 locations)
  - `ChunkProcessor.swift` (3 locations)
  - `TranscribeCommand.swift` (1 location)
  - `TTSCommand.swift` (2 locations)

### Marked Pure Functions as Nonisolated
- `extractFeatureValue`, `extractFeatureValues` - ML feature extraction utilities
- `padAudioIfNeeded` - Audio padding helper
- `calculateStartFrameOffset` - Deprecated test compatibility helper

### Test Updates
- **AsrTranscriptionTests.swift**: Made test functions async and created `setupMockVocabulary()` helper

## Testing

✅ All CI tests pass (13 tests, 0 failures)

```
Test Suite 'CITests' passed
Executed 13 tests, with 0 failures in 1.030 seconds
```

## Impact

- **Breaking Change**: Yes - external calls to `AsrManager` methods now require `await`
- **Performance**: No impact - actor isolation has minimal overhead
- **Safety**: Significantly improved - compiler-enforced data race safety
- **Compatibility**: Requires Swift 6 for full benefits

## Migration Guide

For users of FluidAudio:

```swift
// Before
let manager = AsrManager()
try await manager.initialize(models: models)
let result = try await manager.transcribe(audioBuffer)
manager.cleanup()

// After
let manager = AsrManager()
try await manager.initialize(models: models)
let result = try await manager.transcribe(audioBuffer)
await manager.cleanup()  // Add await
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
