### PR TITLE
fix: computeFlat mel frame count off-by-one for center-padded audio

### DIFF
--- a/Sources/FluidAudio/Shared/AudioMelSpectrogram.swift
+++ b/Sources/FluidAudio/Shared/AudioMelSpectrogram.swift
@@ -190,7 +190,10 @@ public final class AudioMelSpectrogram {
         C.Element == Float, C.Index == Int
     {
         let audioCount = audio.count
-        let numFrames = audioCount / hopLength
+        // Center padding adds nFFT/2 on each side, producing one extra
+        // frame from the leading pad. Without +1, 10080 samples at hop=160
+        // yields 63 frames instead of the EOU model's expected 64.
+        let numFrames = 1 + audioCount / hopLength
 
         guard numFrames > 0, let firstSample = audio.first else {
             return (mel: [Float](repeating: padValue, count: nMels), melLength: 0, numFrames: 1)


### PR DESCRIPTION
Center padding adds nFFT/2 (256 samples) on each side before windowing. The leading pad produces one additional STFT frame that the original formula (audioCount / hopLength) misses. This causes the EOU streaming model to receive 63 mel frames instead of the expected 64, triggering a CoreML shape mismatch error on every inference.

Fix: 1 + audioCount / hopLength (matches the center-padded frame count). Only affects computeFlat — computeFlatTransposed is used by Sortformer which handles the frame count differently via melLength * melStride.

### Why is this change needed?
<!-- Explain the motivation for this change. What problem does it solve? -->


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
