### PR TITLE
docs: add date metadata to showcase entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ GitHub Actions workflows:
 
 When adding apps to the README.md showcase:
 - Add date metadata as HTML comment after the app link: `<!-- YYYY-MM-DD -->`
-- Use the commit date (when the PR is merged) for new entries
+- Use the commit date (when the PR is merged) in EST/EDT timezone for new entries
 - Do not change existing entry order or descriptions
 
 Example:

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[NanoVoice](https://apps.apple.com/kz/app/nanovoice/id6760539688)** <!-- 2026-03-24 --> | Free iOS voice keyboard for fast, private dictation in any app. Uses Parakeet ASR. |
 | **[MiniWhisper](https://github.com/andyhtran/MiniWhisper)** <!-- 2026-03-24 --> | Open-source macOS menu bar for quick local voice-to-text with minimal setup. Pick a shortcut, start talking. Uses Parakeet ASR. |
 | **[Talat](https://talat.app)** <!-- 2026-03-25 --> | Privacy-focused AI meeting notes app. Records and transcribes meetings locally on your Mac with speaker identification and LLM-powered summaries. Featured in [TechCrunch](https://techcrunch.com/2026/03/24/talats-ai-meeting-notes-stay-on-your-machine-not-in-the-cloud/). Uses Parakeet ASR. |
-| **[Volocal](https://github.com/fikrikarim/volocal)** <!-- 2026-03-26 --> | Fully local voice AI on iOS. Uses streaming Parakeet EOU ASR and streaming PocketTTS. |
+| **[Volocal](https://github.com/fikrikarim/volocal)** <!-- 2026-03-25 --> | Fully local voice AI on iOS. Uses streaming Parakeet EOU ASR and streaming PocketTTS. |
 | **[VivaDicta](https://github.com/n0an/VivaDicta)** <!-- 2026-03-25 --> | Open-source iOS voice-to-text app with system-wide AI voice keyboard — dictate and AI-process text in any app. 15+ AI providers, 40+ AI presets. Uses Parakeet ASR. |
 
 ## Installation


### PR DESCRIPTION
## Summary
- Adds HTML comment timestamps to each showcase app entry (e.g., `<!-- 2026-03-24 -->`)
- Dates are hidden from UI but provide explicit metadata for chronological tracking
- Updates CLAUDE.md with showcase management guidelines for coding agents

## Motivation
Maintains chronological ordering with explicit date tracking rather than relying solely on git history. This makes it easier for:
- Contributors to maintain proper ordering when submitting PRs
- Coding agents to follow the format when adding new apps
- Maintainers to validate ordering at a glance

## Changes
- **README.md**: Added date metadata to all 34 showcase entries based on git blame history (includes newly added Talat and Volocal)
- **CLAUDE.md**: Added concise "Showcase Section Management" guidelines

## Format
```markdown
| **[App Name](https://url.com)** <!-- YYYY-MM-DD --> | Description |
```

Dates are extracted from git commit history when each app was originally added to the showcase.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
