### PR TITLE
Make parakeetTdtCtc110m folderName consistent with other Parakeet models

### DIFF
--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -135,8 +135,6 @@ public enum Repo: String, CaseIterable {
             return "pocket-tts"
         case .multilingualG2p:
             return "charsiu-g2p-byt5"
-        case .parakeetTdtCtc110m:
-            return "parakeet-tdt-ctc-110m"
         default:
             return name
         }


### PR DESCRIPTION
## Summary
- Removes special case for `parakeetTdtCtc110m` in the `folderName` property
- Makes it consistent with other Parakeet models by using the default case (returns `name` directly)
- Changes folder name from `"parakeet-tdt-ctc-110m"` to `"parakeet-tdt-ctc-110m-coreml"` to match the pattern used by `.parakeet`, `.parakeetV2`, etc.

## Context
This addresses the inconsistency raised in #442. Previously, `parakeetTdtCtc110m` had a special case that removed the `-coreml` suffix from the folder name, while all other Parakeet models use their full name (including the `-coreml` suffix) as the folder name.

Fixes #442

## Test plan
- [x] Build completes successfully
- [x] Change aligns with existing pattern used by other Parakeet models
- [ ] Verify model downloads still work correctly with new folder structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
