### PR TITLE
docs: Fix speaker diarization model references from 3.1 to community-1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ GitHub Actions workflows:
 
 ## Model Sources
 
-- **Diarization**: [pyannote/speaker-diarization-3.1](https://huggingface.co/pyannote/speaker-diarization-3.1)
+- **Diarization**: [FluidInference/speaker-diarization-coreml](https://huggingface.co/FluidInference/speaker-diarization-coreml) (based on pyannote/speaker-diarization-community-1)
 - **VAD CoreML**: [FluidInference/silero-vad-coreml](https://huggingface.co/FluidInference/silero-vad-coreml)
 - **ASR Models**: [FluidInference/parakeet-tdt-0.6b-v3-coreml](https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml)
 - **Test Data**: [alexwengg/musan_mini*](https://huggingface.co/datasets/alexwengg) variants

--- a/Documentation/Benchmarks.md
+++ b/Documentation/Benchmarks.md
@@ -460,7 +460,7 @@ swift run -c release fluidaudiocli nemotron-benchmark --chunk 560
 
 ## Speaker Diarization
 
-The offline version uses the community-1 model, the online version uses the legacy speaker-diarization-3.1 model.
+Both offline and online versions use the community-1 model (via FluidInference/speaker-diarization-coreml).
 
 ### Offline diarization pipeline
 

--- a/Sources/FluidAudio/Diarizer/Segmentation/SegmentationProcessor.swift
+++ b/Sources/FluidAudio/Diarizer/Segmentation/SegmentationProcessor.swift
@@ -224,7 +224,7 @@ public struct SegmentationProcessor {
     func createSlidingWindowFeature(
         binarizedSegments: [[[Float]]], chunkOffset: Double = 0.0
     ) -> SlidingWindowFeature {
-        // These values come from the pyannote/speaker-diarization-3.1 model configuration
+        // These values come from the pyannote/speaker-diarization-community-1 model configuration
         let slidingWindow = SlidingWindow(
             start: chunkOffset,
             duration: 0.0619375,  // 991 samples at 16kHz (model's sliding window duration)


### PR DESCRIPTION
### Why is this change needed?
Clarifies that FluidAudio's speaker diarization is based on pyannote/speaker-diarization-community-1, not 3.1. Fixes confusion from issue #508.

### What changed?
- Updated code comment in `SegmentationProcessor.swift`
- Fixed `CLAUDE.md` model source reference
- Clarified `Documentation/Benchmarks.md` that both online/offline use community-1

### Context
The actual CoreML model at [FluidInference/speaker-diarization-coreml](https://huggingface.co/FluidInference/speaker-diarization-coreml) has always been based on community-1, but some documentation incorrectly referenced 3.1.

Related: #508
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
