### PR TITLE
Fix parakeet-ctc-ja download error: Prevent AsrModels from loading CTC-only models

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -180,6 +180,24 @@ extension AsrModels {
         version: AsrModelVersion = .v3,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> AsrModels {
+        // Validate that CTC-only models use their dedicated managers
+        if version.isCtcOnly {
+            switch version {
+            case .ctcJa:
+                throw AsrModelsError.loadingFailed(
+                    "CTC-only model .ctcJa must be loaded via CtcJaManager, not AsrModels"
+                )
+            case .ctcZhCn:
+                throw AsrModelsError.loadingFailed(
+                    "CTC-only model .ctcZhCn must be loaded via CtcZhCnManager, not AsrModels"
+                )
+            default:
+                throw AsrModelsError.loadingFailed(
+                    "CTC-only models must be loaded via their dedicated manager classes"
+                )
+            }
+        }
+
         logger.info("Loading ASR models from: \(directory.path)")
 
         let config = configuration ?? defaultConfiguration()
@@ -402,6 +420,24 @@ extension AsrModels {
         version: AsrModelVersion = .v3,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> URL {
+        // Validate that CTC-only models use their dedicated managers
+        if version.isCtcOnly {
+            switch version {
+            case .ctcJa:
+                throw AsrModelsError.downloadFailed(
+                    "CTC-only model .ctcJa must be downloaded via CtcJaModels, not AsrModels"
+                )
+            case .ctcZhCn:
+                throw AsrModelsError.downloadFailed(
+                    "CTC-only model .ctcZhCn must be downloaded via CtcZhCnModels, not AsrModels"
+                )
+            default:
+                throw AsrModelsError.downloadFailed(
+                    "CTC-only models must be downloaded via their dedicated model classes"
+                )
+            }
+        }
+
         let targetDir = directory ?? defaultCacheDirectory(for: version)
         logger.info("Downloading ASR models to: \(targetDir.path)")
         let parentDir = targetDir.deletingLastPathComponent()

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
@@ -377,4 +377,94 @@ final class AsrModelsTests: XCTestCase {
             XCTAssertGreaterThan(version.decoderLayers, 0)
         }
     }
+
+    // MARK: - CTC-Only Model Validation Tests
+
+    func testCtcJaModelRejectsAsrModelsLoad() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AsrModelsTests-CtcJa-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        do {
+            _ = try await AsrModels.load(from: tempDir, version: .ctcJa)
+            XCTFail("AsrModels.load should reject .ctcJa version")
+        } catch let error as AsrModelsError {
+            // Verify it's the correct error
+            if case .loadingFailed(let message) = error {
+                XCTAssertTrue(
+                    message.contains("CtcJaManager"),
+                    "Error should direct user to CtcJaManager"
+                )
+            } else {
+                XCTFail("Wrong error type: \(error)")
+            }
+        }
+    }
+
+    func testCtcZhCnModelRejectsAsrModelsLoad() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AsrModelsTests-CtcZhCn-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        do {
+            _ = try await AsrModels.load(from: tempDir, version: .ctcZhCn)
+            XCTFail("AsrModels.load should reject .ctcZhCn version")
+        } catch let error as AsrModelsError {
+            // Verify it's the correct error
+            if case .loadingFailed(let message) = error {
+                XCTAssertTrue(
+                    message.contains("CtcZhCnManager"),
+                    "Error should direct user to CtcZhCnManager"
+                )
+            } else {
+                XCTFail("Wrong error type: \(error)")
+            }
+        }
+    }
+
+    func testCtcJaModelRejectsAsrModelsDownload() async throws {
+        do {
+            _ = try await AsrModels.download(version: .ctcJa)
+            XCTFail("AsrModels.download should reject .ctcJa version")
+        } catch let error as AsrModelsError {
+            // Verify it's the correct error
+            if case .downloadFailed(let message) = error {
+                XCTAssertTrue(
+                    message.contains("CtcJaModels"),
+                    "Error should direct user to CtcJaModels"
+                )
+            } else {
+                XCTFail("Wrong error type: \(error)")
+            }
+        }
+    }
+
+    func testCtcZhCnModelRejectsAsrModelsDownload() async throws {
+        do {
+            _ = try await AsrModels.download(version: .ctcZhCn)
+            XCTFail("AsrModels.download should reject .ctcZhCn version")
+        } catch let error as AsrModelsError {
+            // Verify it's the correct error
+            if case .downloadFailed(let message) = error {
+                XCTAssertTrue(
+                    message.contains("CtcZhCnModels"),
+                    "Error should direct user to CtcZhCnModels"
+                )
+            } else {
+                XCTFail("Wrong error type: \(error)")
+            }
+        }
+    }
+
+    func testCtcOnlyModelsAreMarkedCorrectly() {
+        // Verify CTC-only models are identified correctly
+        XCTAssertTrue(AsrModelVersion.ctcJa.isCtcOnly)
+        XCTAssertTrue(AsrModelVersion.ctcZhCn.isCtcOnly)
+
+        // Verify TDT models are not marked as CTC-only
+        XCTAssertFalse(AsrModelVersion.v2.isCtcOnly)
+        XCTAssertFalse(AsrModelVersion.v3.isCtcOnly)
+        XCTAssertFalse(AsrModelVersion.tdtCtc110m.isCtcOnly)
+        XCTAssertFalse(AsrModelVersion.tdtJa.isCtcOnly)
+    }
 }


### PR DESCRIPTION
## Problem

Issue #514 reported that downloading `parakeet-ctc-ja` models would succeed, but then fail during loading with:
```
[WARN] First load failed: Model file not found: Decoder.mlmodelc
```

### Root Cause

`AsrModels` (designed for TDT models) was incorrectly accepting `.ctcJa` and `.ctcZhCn` model versions, which use different decoder file names:
- **TDT models** use `Decoder.mlmodelc`
- **Japanese CTC models** use `CtcDecoder.mlmodelc`
- **Chinese CTC models** use `Decoder.mlmodelc` (but with different structure)

When users tried to load `.ctcJa` models via `AsrModels`:
1. Download succeeded (correct files downloaded: `CtcDecoder.mlmodelc`)
2. Loading failed (looking for wrong file: `Decoder.mlmodelc`)

## Solution

Added validation in `AsrModels.load()` and `AsrModels.download()` to reject CTC-only model versions with clear error messages that direct users to the correct manager classes:
- For `.ctcJa` → Use `CtcJaManager`
- For `.ctcZhCn` → Use `CtcZhCnManager`

## Changes

### Modified Files
- `Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift`
  - Added validation at the start of `load()` method
  - Added validation at the start of `download()` method
  - Throws descriptive `AsrModelsError` with guidance to correct manager

- `Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift`
  - Added 5 new tests for CTC-only model validation
  - Tests verify both `.ctcJa` and `.ctcZhCn` are properly rejected
  - Tests verify error messages contain correct manager class names

## Testing

All 32 tests in `AsrModelsTests` pass, including the new validation tests:
- ✅ `testCtcJaModelRejectsAsrModelsLoad()`
- ✅ `testCtcJaModelRejectsAsrModelsDownload()`
- ✅ `testCtcZhCnModelRejectsAsrModelsLoad()`
- ✅ `testCtcZhCnModelRejectsAsrModelsDownload()`
- ✅ `testCtcOnlyModelsAreMarkedCorrectly()`

## Example Error Message

Before (confusing):
```
Model file not found: Decoder.mlmodelc
```

After (clear guidance):
```
CTC-only model .ctcJa must be loaded via CtcJaManager, not AsrModels
```

Closes #514
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
