### PR TITLE
Fix AsrModelVersion.tdtJa repo mapping to use separate TDT repo

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -21,7 +21,7 @@ public enum AsrModelVersion: Sendable {
         case .tdtCtc110m: return .parakeetTdtCtc110m
         case .ctcZhCn: return .parakeetCtcZhCn
         case .ctcJa: return .parakeetCtcJa
-        case .tdtJa: return .parakeetCtcJa  // TDT v2 models uploaded to CTC repo
+        case .tdtJa: return .parakeetTdtJa
         }
     }
 

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
@@ -467,4 +467,17 @@ final class AsrModelsTests: XCTestCase {
         XCTAssertFalse(AsrModelVersion.tdtCtc110m.isCtcOnly)
         XCTAssertFalse(AsrModelVersion.tdtJa.isCtcOnly)
     }
+
+    func testJapaneseModelRepoMapping() {
+        // Verify CTC and TDT Japanese models use different repos (fixes issue #514)
+        XCTAssertEqual(AsrModelVersion.ctcJa.repo, .parakeetCtcJa)
+        XCTAssertEqual(AsrModelVersion.tdtJa.repo, .parakeetTdtJa)
+
+        // Verify the repos are actually different
+        XCTAssertNotEqual(Repo.parakeetCtcJa, Repo.parakeetTdtJa)
+
+        // Verify repo paths
+        XCTAssertEqual(Repo.parakeetCtcJa.rawValue, "FluidInference/parakeet-ctc-0.6b-ja-coreml")
+        XCTAssertEqual(Repo.parakeetTdtJa.rawValue, "FluidInference/parakeet-tdt-0.6b-ja-coreml")
+    }
 }


### PR DESCRIPTION
## Problem

Issue spotted by @Josscii in #516: \`AsrModelVersion.tdtJa\` was incorrectly mapped to \`Repo.parakeetCtcJa\` instead of \`Repo.parakeetTdtJa\`.

This means attempts to download TDT Japanese models via \`AsrModels\` (now blocked by #516) would have fetched files from the wrong HuggingFace repository.

## Root Cause

The comment in AsrModels.swift said "TDT v2 models uploaded to CTC repo", but this appears to be incorrect or outdated. The TDT Japanese models are actually in a separate repository.

## Evidence of Separate Repositories

1. **GitHub Actions workflow** caches both repos separately:
   ```yaml
   ~/Library/Application Support/FluidAudio/Models/parakeet-tdt-ja
   ~/Library/Application Support/FluidAudio/Models/parakeet-ctc-ja
   ```

2. **TdtJaModels class** (the proper manager) uses \`Repo.parakeetTdtJa\`:
   ```swift
   public static let repository: Repo = .parakeetTdtJa
   ```

3. **ModelNames.getRequiredModelNames()** returns different files for each repo:
   - \`.parakeetCtcJa\` → \`ModelNames.CTCJa.requiredModels\` (includes \`CtcDecoder.mlmodelc\`)
   - \`.parakeetTdtJa\` → \`ModelNames.TDTJa.requiredModels\` (includes \`Decoderv2.mlmodelc\` + \`Jointerv2.mlmodelc\`)

## Solution

Changed \`AsrModelVersion.tdtJa\` to return \`Repo.parakeetTdtJa\` instead of \`Repo.parakeetCtcJa\`.

## Changes

- **AsrModels.swift**: Fixed \`.tdtJa\` repo mapping
- **AsrModelsTests.swift**: Added \`testJapaneseModelRepoMapping()\` to verify:
  - \`.ctcJa\` uses \`.parakeetCtcJa\`
  - \`.tdtJa\` uses \`.parakeetTdtJa\`
  - The two repos are distinct

## Testing

All 33 tests in \`AsrModelsTests\` pass, including the new test.

## Related

Follow-up to #516 which prevents \`AsrModels\` from loading CTC-only models.

Fixes the repo inconsistency noted by @Josscii in https://github.com/FluidInference/FluidAudio/pull/516#issuecomment-4230687775
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
