### PR TITLE
Fix TdtJaModels to use correct HuggingFace repo (parakeet-ctc-0.6b-ja-coreml)

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/TdtJaModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/TdtJaModels.swift
@@ -2,9 +2,10 @@
 import Foundation
 
 /// Configuration for Japanese TDT models
+/// NOTE: Uses parakeetCtcJa repo where TDT v2 models (Decoderv2, Jointerv2) are uploaded alongside CTC models
 public enum TdtJaConfig: ParakeetLanguageModelConfig {
     public static let blankId: Int = 3072
-    public static let repository: Repo = .parakeetTdtJa
+    public static let repository: Repo = .parakeetCtcJa
     public static let languageLabel: String = "TDT ja (Japanese)"
     public static let loggerCategory: String = "TdtJaModels"
 


### PR DESCRIPTION
## Problem

`TdtJaModels` was pointing to `Repo.parakeetTdtJa` which maps to a **non-existent** HuggingFace repository.

```swift
// TdtJaModels.swift - BEFORE
public static let repository: Repo = .parakeetTdtJa  // ❌ Maps to non-existent repo
```

This would cause TDT Japanese model downloads to fail with 404.

## Root Cause

The TDT v2 Japanese models (`Decoderv2.mlmodelc`, `Jointerv2.mlmodelc`) are actually uploaded to the **same repository as the CTC models**, not a separate TDT repo.

### Verified Repository Structure

**✅ parakeet-ctc-0.6b-ja-coreml** (EXISTS):
- `CtcDecoder.mlmodelc` - for CTC decoding
- `Decoderv2.mlmodelc` - for TDT decoding
- `Jointerv2.mlmodelc` - for TDT joint network
- `Preprocessor.mlmodelc`
- `Encoder.mlmodelc`

**❌ parakeet-tdt-0.6b-ja-coreml** (DOESN'T EXIST):
- Returns 404

## Solution

Changed `TdtJaModels` to use `Repo.parakeetCtcJa` (the actual repository that contains the TDT v2 models).

## Changes

- **TdtJaModels.swift**: 
  - Changed `repository` from `.parakeetTdtJa` to `.parakeetCtcJa`
  - Added comment explaining TDT v2 models are in the CTC repo

## Testing

- Build succeeds
- TDT Japanese models will now download from the correct repository

## Related

- Closes the repo inconsistency issue raised by @Josscii in #516
- Complements #516 which prevents `AsrModels` from loading CTC-only models
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
