### PR TITLE
docs(showcase): add Kesha Voice Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[MimicScribe](https://mimicscribe.app/)** | macOS menu bar app combining Parakeet TDT streaming ASR, PyanNote Community 1 speaker diarization, and cloud LLMs to provide AI-generated talking points during meetings, derived from the live transcript and user-provided instructions. Features meeting summarization, natural language search, an MCP server for agent integration, and a keyboard- and voice-forward UI. |
 | **[Action Phrase](https://actionphrase.com/)** | Voice-controlled live production app for iOS, iPadOS, and macOS. Control cameras, graphics, layouts, and production workflows with natural voice commands. Integrates with popular tools including OBS, vMix, ProPresenter, Bitfocus Companion, and more. Uses Parakeet TDT ASR and Sortformer diarization. |
 | **[Sayboard](https://github.com/stanlsv/sayboard)** | Privacy-first AI voice keyboard for iOS. Local models, no servers, no tracking, no subscriptions, no ads, no in-app purchases. Fully offline and open-source. |
+| **[Kesha Voice Kit](https://github.com/drakulavich/kesha-voice-kit)** | Open-source voice toolkit for Apple Silicon. CLI tool and [OpenClaw](https://github.com/openclaw/openclaw) skill that gives LLM agents local speech-to-text in 25 languages. Uses Parakeet TDT ASR via FluidAudio. |
 
 ## Installation
 


### PR DESCRIPTION
Adds [Kesha Voice Kit](https://github.com/drakulavich/kesha-voice-kit) to the Showcase table.

## Summary

Kesha Voice Kit is an open-source voice toolkit for Apple Silicon. It ships as:
- A CLI (`kesha <audio>`) for fast local speech-to-text — 25 languages, ~19× faster than Whisper on Apple Silicon.
- An [OpenClaw](https://github.com/openclaw/openclaw) skill so LLM agents can transcribe voice messages locally (Telegram / WhatsApp / Slack bots etc.) without sending audio to the cloud.

It uses FluidAudio under the hood for the CoreML Parakeet TDT backend on Apple Silicon.

Appended to the end of the Showcase table to preserve chronological order.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/529" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
