### PR TITLE
Fix: Lower ASR minimum audio guard from 1s to 300ms

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift
@@ -133,7 +133,7 @@ public enum ASRError: Error, LocalizedError {
         case .notInitialized:
             return "AsrManager not initialized. Call initialize() first."
         case .invalidAudioData:
-            return "Invalid audio data provided. Must be at least 1 second of 16kHz audio."
+            return "Invalid audio data provided. Must be at least 300ms of 16kHz audio."
         case .modelLoadFailed:
             return "Failed to load Parakeet CoreML models."
         case .processingFailed(let message):

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -6,7 +6,8 @@ extension AsrManager {
         _ audioSamples: [Float], decoderState: inout TdtDecoderState
     ) async throws -> ASRResult {
         guard isAvailable else { throw ASRError.notInitialized }
-        guard audioSamples.count >= config.sampleRate else { throw ASRError.invalidAudioData }
+        let minimumRequiredSamples = ASRConstants.minimumRequiredSamples(forSampleRate: config.sampleRate)
+        guard audioSamples.count >= minimumRequiredSamples else { throw ASRError.invalidAudioData }
 
         let startTime = Date()
 

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
@@ -332,7 +332,8 @@ public actor AsrManager {
         )
 
         let totalSamples = sampleSource.sampleCount
-        guard totalSamples >= config.sampleRate else {
+        let minimumRequiredSamples = ASRConstants.minimumRequiredSamples(forSampleRate: config.sampleRate)
+        guard totalSamples >= minimumRequiredSamples else {
             sampleSource.cleanup()
             throw ASRError.invalidAudioData
         }

--- a/Sources/FluidAudio/Shared/ASRConstants.swift
+++ b/Sources/FluidAudio/Shared/ASRConstants.swift
@@ -11,6 +11,9 @@ public enum ASRConstants {
     /// Maximum audio samples supported by CoreML encoder (sampleRate × maxDurationSeconds)
     public static let maxModelSamples: Int = 240_000
 
+    /// Minimum audio duration accepted by the ASR guard (seconds).
+    public static let minimumAudioDurationSeconds: Double = 0.3
+
     /// Mel-spectrogram hop size in samples (10ms at 16kHz)
     public static let melHopSize: Int = 160
 
@@ -50,5 +53,12 @@ public enum ASRConstants {
     /// - Returns: Number of encoder frames
     public static func calculateEncoderFrames(from samples: Int) -> Int {
         return Int(ceil(Double(samples) / Double(samplesPerEncoderFrame)))
+    }
+
+    /// Minimum number of samples required by the ASR guard for a given sample rate.
+    /// - Parameter sampleRate: Audio sample rate in Hz
+    /// - Returns: Sample count corresponding to `minimumAudioDurationSeconds`
+    public static func minimumRequiredSamples(forSampleRate sampleRate: Int) -> Int {
+        return Int(Double(sampleRate) * minimumAudioDurationSeconds)
     }
 }

--- a/Tests/FluidAudioTests/ASR/Parakeet/ASRConstantsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/ASRConstantsTests.swift
@@ -93,6 +93,18 @@ final class ASRConstantsTests: XCTestCase {
         XCTAssertEqual(actualFrameDurationMs, expectedFrameDurationMs, accuracy: 0.1, "Frame duration should be 80ms")
     }
 
+    func testMinimumAudioDurationSeconds() {
+        XCTAssertEqual(
+            ASRConstants.minimumAudioDurationSeconds, 0.3, accuracy: 1e-9,
+            "Minimum accepted audio duration should be 300ms")
+
+        // At 16 kHz, 300 ms = 4,800 samples. Exercises the helper the ASR guards
+        // actually call, so a regression in either the constant or the conversion is caught.
+        XCTAssertEqual(
+            ASRConstants.minimumRequiredSamples(forSampleRate: ASRConstants.sampleRate),
+            4_800)
+    }
+
     func testFrameCalculationConsistencyWithChunkProcessor() {
         // Test that frame calculations are consistent with stateless ChunkProcessor expectations
         let chunkSeconds = 14.96  // New stateless chunks: ~14.96s


### PR DESCRIPTION
Short single-word utterances (e.g. "yes", "no", "stop") are typically 500-700ms and were silently rejected by AsrManager with ASRError.invalidAudioData before transcription ran. Lower the guard to 300ms so these reach the model.

Adds ASRConstants.minimumAudioDurationSeconds and a companion minimumRequiredSamples(forSampleRate:) helper, mirroring the existing calculateEncoderFrames(from:) pattern so the arithmetic lives next to the other ASR audio math rather than being inlined at each guard.

  ## Summary
  - Lower the minimum audio length accepted by `AsrManager` from 1s (16,000 samples) to 300ms (4,800 samples) so short single-word utterances
  ("yes", "no", "stop") reach the Parakeet TDT model instead of being silently rejected with `ASRError.invalidAudioData`.
  - Add `ASRConstants.minimumAudioDurationSeconds` (= 0.3) and a companion `minimumRequiredSamples(forSampleRate:)` helper, mirroring the existing
   `calculateEncoderFrames(from:)` pattern so the arithmetic is defined once next to the other ASR audio math.
  - Update the in-memory guard in `AsrManager+Transcription.swift` and the disk-backed guard in `AsrManager.swift` to call the helper via a locally-named `minimumRequiredSamples`.
  - Refresh the `ASRError.invalidAudioData` message from "at least 1 second" to "at least 300ms" so it stays truthful.
  
 ## Files changed
  - `Sources/FluidAudio/Shared/ASRConstants.swift` — add `minimumAudioDurationSeconds` constant and `minimumRequiredSamples(forSampleRate:)`
  helper.
  - `Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift` — in-memory guard now uses the helper.
  - `Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift` — disk-backed guard (`transcribeDiskBacked`) now uses the helper.
  - `Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift` — update `ASRError.invalidAudioData` message to reflect the new threshold.
  - `Tests/FluidAudioTests/ASR/Parakeet/ASRConstantsTests.swift` — add `testMinimumAudioDurationSeconds` covering both the constant and the
  helper.

## Why is this change needed?
<img width="849" height="630" alt="image" src="https://github.com/user-attachments/assets/a4adba61-4f37-4bd6-b341-554362cb2e32" />

https://github.com/altic-dev/FluidVoice/issues/276

https://github.com/altic-dev/FluidAudio/blob/f3dba78a23cb706d01c889bd54f7efd26871e82e/Sources/FluidAudio/ASR/Parakeet/AsrTranscription.swift#L11


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/531" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
