### PR TITLE
docs(showcase): add talat + FluidAudio demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Want to convert your own model? Check [möbius](https://github.com/FluidInferenc
 | **[PocketTTS](https://x.com/sach1n/status/2017627657006158296)** | Streaming text-to-speech using PocketTTS on iOS |
 | **[Parakeet EOU Ultra-Low Latency](https://x.com/y_earu/status/2038654262608064967)** | Real-time Parakeet EOU transcription on iOS demonstrating ultra-low latency speech-to-text |
 | **[Action Phrase Live Production Control](https://www.youtube.com/watch?v=ykcvdTHHmrk)** | Voice-controlled live production workflow using FluidAudio's ASR and speaker diarization to trigger cameras, graphics, and layouts with natural voice commands |
+| **[talat - VAD, ASR, Speaker ID](https://www.youtube.com/watch?v=OjP4Adrv9_E)** | A video demo showcasing FluidAudio's VAD, two different ASR models, and speaker diarization during a talat.app meeting recording |
 
 ## Showcase
 


### PR DESCRIPTION
Adds a <60s video of talat which shows off FluidAudio's VAD, ASR (parakeet EOU + parakeet v2) and speaker diarization during a meeting recording

### Why is this change needed?

You've already very kindly featured talat in a couple of places, but I thought this quick walk through explainer might showcase in a more visual and visceral way just how awesome FluidAudio is at powering talat and all the other use cases it enables.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/532" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
