### PR TITLE
feat(asr/cohere): ANE-friendly static-shape decoder (v2)

### DIFF
--- a/Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift
+++ b/Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift
@@ -340,21 +340,43 @@ public actor CoherePipeline {
         self.melExtractor = mel
     }
 
+    /// Cache-external decoder variant selector.
+    ///
+    /// Both decoders share the same input/output contract; the difference is
+    /// the `attention_mask` shape and how position is sourced. `CoherePipeline`
+    /// auto-detects the runtime contract from the loaded decoder's input
+    /// description, so this enum only controls which file is loaded.
+    public enum DecoderVariant: Sendable {
+        /// `cohere_decoder_cache_external_v2.mlmodelc` — fixed
+        /// `attention_mask` shape `[1, 1, 1, 108]`, ANE-friendly. Default.
+        case v2
+        /// `cohere_decoder_cache_external.mlmodelc` — dynamic
+        /// `attention_mask` (`RangeDim(1, 108)`), CPU/GPU only.
+        case v1
+
+        public var compiledFileName: String {
+            switch self {
+            case .v2: return ModelNames.CohereTranscribe.decoderCacheExternalV2CompiledFile
+            case .v1: return ModelNames.CohereTranscribe.decoderCacheExternalCompiledFile
+            }
+        }
+    }
+
     /// Load encoder, decoder and vocabulary from (potentially different) directories.
     ///
     /// This supports mixed-precision — e.g. INT8 encoder + FP16 decoder. Pass
     /// the same URL to both for a single-precision setup.
     ///
-    /// Decoder lookup in `decoderDir` prefers
-    /// `cohere_decoder_cache_external_v2.mlmodelc` (static-shape,
-    /// ANE-friendly) and falls back to the legacy
-    /// `cohere_decoder_cache_external.mlmodelc` (FP16, dynamic
-    /// `attention_mask`). The runtime automatically adapts the mask build
-    /// to whichever variant is loaded.
+    /// `decoderVariant` selects which cache-external decoder file to load
+    /// from `decoderDir`. The default (`.v2`) is the ANE-friendly
+    /// static-shape build; pass `.v1` for the legacy FP16 dynamic-shape
+    /// decoder. The runtime automatically adapts the `attention_mask`
+    /// build to whichever variant is loaded.
     public static func loadModels(
         encoderDir: URL,
         decoderDir: URL,
         vocabDir: URL,
+        decoderVariant: DecoderVariant = .v2,
         computeUnits: MLComputeUnits = .all
     ) async throws -> LoadedModels {
         let config = MLModelConfiguration()
@@ -362,22 +384,11 @@ public actor CoherePipeline {
 
         let encoderURL = encoderDir.appendingPathComponent(
             ModelNames.CohereTranscribe.encoderCompiledFile)
+        let decoderURL = decoderDir.appendingPathComponent(decoderVariant.compiledFileName)
 
-        let fm = FileManager.default
-        let v2URL = decoderDir.appendingPathComponent(
-            ModelNames.CohereTranscribe.decoderCacheExternalV2CompiledFile)
-        let v1URL = decoderDir.appendingPathComponent(
-            ModelNames.CohereTranscribe.decoderCacheExternalCompiledFile)
-        let decoderURL: URL
-        if fm.fileExists(atPath: v2URL.path) {
-            decoderURL = v2URL
-        } else if fm.fileExists(atPath: v1URL.path) {
-            decoderURL = v1URL
-        } else {
+        guard FileManager.default.fileExists(atPath: decoderURL.path) else {
             throw CohereAsrError.modelNotFound(
-                "No cohere decoder found in \(decoderDir.path). "
-                    + "Expected \(ModelNames.CohereTranscribe.decoderCacheExternalV2CompiledFile) "
-                    + "or \(ModelNames.CohereTranscribe.decoderCacheExternalCompiledFile).")
+                "Decoder not found at \(decoderURL.path) (variant: \(decoderVariant)).")
         }
 
         pipelineLogger.info("Loading encoder from \(encoderURL.path)")

--- a/Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift
+++ b/Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift
@@ -343,10 +343,14 @@ public actor CoherePipeline {
     /// Load encoder, decoder and vocabulary from (potentially different) directories.
     ///
     /// This supports mixed-precision — e.g. INT8 encoder + FP16 decoder. Pass
-    /// the same URL to both for a single-precision setup. Each directory must
-    /// contain `cohere_encoder.mlmodelc` and/or
-    /// `cohere_decoder_cache_external.mlmodelc`; the vocab is loaded from
-    /// `vocabDir`.
+    /// the same URL to both for a single-precision setup.
+    ///
+    /// Decoder lookup in `decoderDir` prefers
+    /// `cohere_decoder_cache_external_v2.mlmodelc` (static-shape,
+    /// ANE-friendly) and falls back to the legacy
+    /// `cohere_decoder_cache_external.mlmodelc` (FP16, dynamic
+    /// `attention_mask`). The runtime automatically adapts the mask build
+    /// to whichever variant is loaded.
     public static func loadModels(
         encoderDir: URL,
         decoderDir: URL,
@@ -356,8 +360,25 @@ public actor CoherePipeline {
         let config = MLModelConfiguration()
         config.computeUnits = computeUnits
 
-        let encoderURL = encoderDir.appendingPathComponent("cohere_encoder.mlmodelc")
-        let decoderURL = decoderDir.appendingPathComponent("cohere_decoder_cache_external.mlmodelc")
+        let encoderURL = encoderDir.appendingPathComponent(
+            ModelNames.CohereTranscribe.encoderCompiledFile)
+
+        let fm = FileManager.default
+        let v2URL = decoderDir.appendingPathComponent(
+            ModelNames.CohereTranscribe.decoderCacheExternalV2CompiledFile)
+        let v1URL = decoderDir.appendingPathComponent(
+            ModelNames.CohereTranscribe.decoderCacheExternalCompiledFile)
+        let decoderURL: URL
+        if fm.fileExists(atPath: v2URL.path) {
+            decoderURL = v2URL
+        } else if fm.fileExists(atPath: v1URL.path) {
+            decoderURL = v1URL
+        } else {
+            throw CohereAsrError.modelNotFound(
+                "No cohere decoder found in \(decoderDir.path). "
+                    + "Expected \(ModelNames.CohereTranscribe.decoderCacheExternalV2CompiledFile) "
+                    + "or \(ModelNames.CohereTranscribe.decoderCacheExternalCompiledFile).")
+        }
 
         pipelineLogger.info("Loading encoder from \(encoderURL.path)")
         let encoder = try await MLModel.load(contentsOf: encoderURL, configuration: config)
@@ -520,6 +541,19 @@ public actor CoherePipeline {
             return .float16
         }()
 
+        // Probe attention_mask shape: if the decoder was exported with a
+        // fixed [1,1,1,108] attention_mask (static / ANE-friendly variant),
+        // build a full-length additive causal mask every step. Otherwise
+        // fall back to the RangeDim dynamic [1,1,1,step+1] zero-filled mask.
+        let useStaticSelfMask: Bool = {
+            guard let desc = decoder.modelDescription.inputDescriptionsByName["attention_mask"],
+                let arrCon = desc.multiArrayConstraint
+            else { return false }
+            let shape = arrCon.shape
+            return shape.count == 4
+                && shape[3].intValue == CohereAsrConfig.maxSeqLen
+        }()
+
         var kCaches: [MLMultiArray] = []
         var vCaches: [MLMultiArray] = []
         kCaches.reserveCapacity(CohereAsrConfig.numDecoderLayers)
@@ -554,9 +588,8 @@ public actor CoherePipeline {
             let positionId = try MLMultiArray(shape: [1, 1], dataType: .int32)
             positionId[0] = NSNumber(value: step)
 
-            let selfMask = try MLMultiArray(
-                shape: [1, 1, 1, NSNumber(value: step + 1)], dataType: cacheDType)
-            Self.zeroFill(selfMask)
+            let selfMask = try Self.buildSelfAttentionMask(
+                step: step, useStatic: useStaticSelfMask, dtype: cacheDType)
 
             var inputs: [String: MLFeatureValue] = [
                 "input_id": MLFeatureValue(multiArray: inputId),
@@ -619,6 +652,49 @@ public actor CoherePipeline {
     }
 
     // MARK: Helpers
+
+    /// Build the self-attention additive mask for one decoding step.
+    ///
+    /// Dynamic path (RangeDim decoder): shape `[1, 1, 1, step+1]`, all zeros.
+    /// The model's attended K/V slice is exactly `step+1` long.
+    ///
+    /// Static path (fixed-shape decoder): shape `[1, 1, 1, maxSeqLen]`. The
+    /// decoder attends over the full cache; positions `[0..=step]` get `0`
+    /// (attend) and `[step+1..maxSeqLen-1]` get `-1e4` (masked — the cache
+    /// slots aren't written yet).
+    static func buildSelfAttentionMask(
+        step: Int, useStatic: Bool, dtype: MLMultiArrayDataType
+    ) throws -> MLMultiArray {
+        if !useStatic {
+            let mask = try MLMultiArray(
+                shape: [1, 1, 1, NSNumber(value: step + 1)], dataType: dtype)
+            zeroFill(mask)
+            return mask
+        }
+
+        let length = CohereAsrConfig.maxSeqLen
+        let mask = try MLMultiArray(
+            shape: [1, 1, 1, NSNumber(value: length)], dataType: dtype)
+        zeroFill(mask)
+        let firstBlocked = step + 1
+        guard firstBlocked < length else { return mask }
+
+        let invalidValue: Float = -1.0e4
+        switch dtype {
+        case .float32:
+            let ptr = mask.dataPointer.bindMemory(to: Float.self, capacity: length)
+            for i in firstBlocked..<length { ptr[i] = invalidValue }
+        case .float16:
+            let ptr = mask.dataPointer.bindMemory(to: UInt16.self, capacity: length)
+            let bits = float16Bits(invalidValue)
+            for i in firstBlocked..<length { ptr[i] = bits }
+        default:
+            for i in firstBlocked..<length {
+                mask[[0, 0, 0, NSNumber(value: i)] as [NSNumber]] = NSNumber(value: invalidValue)
+            }
+        }
+        return mask
+    }
 
     static func buildCrossAttentionMask(
         encoderSeqLen: Int, encoderValid: Int, dtype: MLMultiArrayDataType

--- a/Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift
+++ b/Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift
@@ -332,6 +332,10 @@ public actor CoherePipeline {
         public let encoder: MLModel
         public let decoder: MLModel
         public let vocabulary: [Int: String]
+        /// Which cache-external decoder variant was loaded. Drives the
+        /// `attention_mask` build at decode time without re-probing the
+        /// model's input shape.
+        public let decoderVariant: DecoderVariant
     }
 
     private let melExtractor: CohereMelSpectrogram
@@ -342,10 +346,8 @@ public actor CoherePipeline {
 
     /// Cache-external decoder variant selector.
     ///
-    /// Both decoders share the same input/output contract; the difference is
-    /// the `attention_mask` shape and how position is sourced. `CoherePipeline`
-    /// auto-detects the runtime contract from the loaded decoder's input
-    /// description, so this enum only controls which file is loaded.
+    /// Both decoders share the same input/output contract except for the
+    /// `attention_mask` shape and how position is sourced.
     public enum DecoderVariant: Sendable {
         /// `cohere_decoder_cache_external_v2.mlmodelc` — fixed
         /// `attention_mask` shape `[1, 1, 1, 108]`, ANE-friendly. Default.
@@ -358,6 +360,16 @@ public actor CoherePipeline {
             switch self {
             case .v2: return ModelNames.CohereTranscribe.decoderCacheExternalV2CompiledFile
             case .v1: return ModelNames.CohereTranscribe.decoderCacheExternalCompiledFile
+            }
+        }
+
+        /// Whether the variant expects a full-length `[1, 1, 1, maxSeqLen]`
+        /// additive causal `attention_mask`. The dynamic v1 decoder instead
+        /// takes a `[1, 1, 1, step+1]` zero-filled mask.
+        public var usesStaticSelfMask: Bool {
+            switch self {
+            case .v2: return true
+            case .v1: return false
             }
         }
     }
@@ -404,7 +416,11 @@ public actor CoherePipeline {
         }
 
         let vocab = try loadVocabulary(vocabDir: vocabDir)
-        return LoadedModels(encoder: encoder, decoder: decoder, vocabulary: vocab)
+        return LoadedModels(
+            encoder: encoder,
+            decoder: decoder,
+            vocabulary: vocab,
+            decoderVariant: decoderVariant)
     }
 
     private static func loadVocabulary(vocabDir: URL) throws -> [Int: String] {
@@ -466,7 +482,8 @@ public actor CoherePipeline {
             maxNewTokens: maxNewTokens,
             repetitionPenalty: repetitionPenalty,
             noRepeatNgram: noRepeatNgram,
-            decoder: models.decoder)
+            decoder: models.decoder,
+            useStaticSelfMask: models.decoderVariant.usesStaticSelfMask)
         let decoderSecs = CFAbsoluteTimeGetCurrent() - dec0
 
         // 4) Detokenize
@@ -531,7 +548,8 @@ public actor CoherePipeline {
         maxNewTokens: Int,
         repetitionPenalty: Float,
         noRepeatNgram: Int,
-        decoder: MLModel
+        decoder: MLModel,
+        useStaticSelfMask: Bool
     ) async throws -> [Int] {
         let cacheShape: [NSNumber] = [
             1,
@@ -550,19 +568,6 @@ public actor CoherePipeline {
                 return arrCon.dataType
             }
             return .float16
-        }()
-
-        // Probe attention_mask shape: if the decoder was exported with a
-        // fixed [1,1,1,108] attention_mask (static / ANE-friendly variant),
-        // build a full-length additive causal mask every step. Otherwise
-        // fall back to the RangeDim dynamic [1,1,1,step+1] zero-filled mask.
-        let useStaticSelfMask: Bool = {
-            guard let desc = decoder.modelDescription.inputDescriptionsByName["attention_mask"],
-                let arrCon = desc.multiArrayConstraint
-            else { return false }
-            let shape = arrCon.shape
-            return shape.count == 4
-                && shape[3].intValue == CohereAsrConfig.maxSeqLen
         }()
 
         var kCaches: [MLMultiArray] = []

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -584,16 +584,36 @@ public enum ModelNames {
     }
 
     /// Cohere Transcribe model names
-    /// Encoder-decoder ASR with 14-language support (35-second window architecture)
+    /// Encoder-decoder ASR with 14-language support (35-second window architecture).
+    ///
+    /// Two decoder variants are published:
+    ///   - `decoderCacheExternal` (v1) — FP16, dynamic `attention_mask`
+    ///     (`RangeDim(1, 108)`). CPU/GPU only — dynamic shapes block ANE.
+    ///   - `decoderCacheExternalV2` — FP32, fixed `attention_mask` shape
+    ///     `[1, 1, 1, 108]`. ANE-resident, ~1.6× faster decoder end-to-end
+    ///     on Apple Silicon. Drop-in replacement; `CoherePipeline`
+    ///     auto-detects the variant by inspecting the `attention_mask`
+    ///     input shape.
     public enum CohereTranscribe {
         public static let encoder = "cohere_encoder"
         public static let decoderCacheExternal = "cohere_decoder_cache_external"
+        public static let decoderCacheExternalV2 = "cohere_decoder_cache_external_v2"
         public static let vocab = "vocab.json"
 
         public static let encoderCompiledFile = encoder + ".mlmodelc"
         public static let decoderCacheExternalCompiledFile = decoderCacheExternal + ".mlmodelc"
+        public static let decoderCacheExternalV2CompiledFile = decoderCacheExternalV2 + ".mlmodelc"
 
+        /// Default required set — ships the ANE-friendly v2 decoder.
         public static let requiredModels: Set<String> = [
+            encoderCompiledFile,
+            decoderCacheExternalV2CompiledFile,
+            vocab,
+        ]
+
+        /// Legacy set using the FP16 dynamic decoder (pre-v2). Retained so
+        /// callers that want the older decoder can opt in explicitly.
+        public static let requiredModelsLegacy: Set<String> = [
             encoderCompiledFile,
             decoderCacheExternalCompiledFile,
             vocab,

--- a/Sources/FluidAudioCLI/Commands/ASR/Cohere/CohereTranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Cohere/CohereTranscribeCommand.swift
@@ -193,7 +193,8 @@ enum CohereTranscribeCommand {
 
             Expected files inside each dir:
                 cohere_encoder.mlmodelc
-                cohere_decoder_cache_external.mlmodelc
+                cohere_decoder_cache_external_v2.mlmodelc  (preferred — ANE-resident)
+                cohere_decoder_cache_external.mlmodelc     (fallback — FP16 dynamic)
                 vocab.json  (in --vocab-dir / --model-dir)
 
             Decode options:

--- a/Sources/FluidAudioCLI/Commands/ASR/Cohere/CohereTranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Cohere/CohereTranscribeCommand.swift
@@ -25,6 +25,7 @@ enum CohereTranscribeCommand {
         var repetitionPenalty: Float = 1.1
         var noRepeatNgram = 3
         var computeUnits: MLComputeUnits = .all
+        var decoderVariant: CoherePipeline.DecoderVariant = .v2
 
         var i = 1
         while i < arguments.count {
@@ -82,6 +83,17 @@ enum CohereTranscribeCommand {
                 computeUnits = .cpuOnly
             case "--cpu-gpu":
                 computeUnits = .cpuAndGPU
+            case "--decoder-variant":
+                if i + 1 < arguments.count {
+                    switch arguments[i + 1].lowercased() {
+                    case "v2": decoderVariant = .v2
+                    case "v1": decoderVariant = .v1
+                    default:
+                        logger.error("Unknown decoder variant '\(arguments[i + 1])' (expected v1 or v2)")
+                        exit(1)
+                    }
+                    i += 1
+                }
             default:
                 logger.warning("Ignoring unknown option: \(arg)")
             }
@@ -109,7 +121,8 @@ enum CohereTranscribeCommand {
             maxTokens: maxTokens,
             repetitionPenalty: repetitionPenalty,
             noRepeatNgram: noRepeatNgram,
-            computeUnits: computeUnits
+            computeUnits: computeUnits,
+            decoderVariant: decoderVariant
         )
     }
 
@@ -122,7 +135,8 @@ enum CohereTranscribeCommand {
         maxTokens: Int,
         repetitionPenalty: Float,
         noRepeatNgram: Int,
-        computeUnits: MLComputeUnits
+        computeUnits: MLComputeUnits,
+        decoderVariant: CoherePipeline.DecoderVariant
     ) async {
         guard #available(macOS 14, iOS 17, *) else {
             logger.error("Cohere mixed pipeline requires macOS 14 or later")
@@ -141,11 +155,14 @@ enum CohereTranscribeCommand {
             logger.info("Vocab dir:    \(vocabDir.path)")
             logger.info("Language:     \(language.englishName) (\(language.rawValue))")
 
+            logger.info("Decoder:      \(decoderVariant)")
+
             let loadStart = CFAbsoluteTimeGetCurrent()
             let models = try await CoherePipeline.loadModels(
                 encoderDir: encoderDir,
                 decoderDir: decoderDir,
                 vocabDir: vocabDir,
+                decoderVariant: decoderVariant,
                 computeUnits: computeUnits)
             let loadSecs = CFAbsoluteTimeGetCurrent() - loadStart
             logger.info("Models loaded in \(String(format: "%.2f", loadSecs))s")
@@ -193,8 +210,8 @@ enum CohereTranscribeCommand {
 
             Expected files inside each dir:
                 cohere_encoder.mlmodelc
-                cohere_decoder_cache_external_v2.mlmodelc  (preferred — ANE-resident)
-                cohere_decoder_cache_external.mlmodelc     (fallback — FP16 dynamic)
+                cohere_decoder_cache_external_v2.mlmodelc  (v2 — ANE-resident static shapes)
+                cohere_decoder_cache_external.mlmodelc     (v1 — FP16 dynamic RangeDim)
                 vocab.json  (in --vocab-dir / --model-dir)
 
             Decode options:
@@ -203,6 +220,7 @@ enum CohereTranscribeCommand {
                 --max-tokens <n>                Max decoded tokens (default: 108)
                 --repetition-penalty <f>        CTRL-style penalty, 1.0 disables (default: 1.1)
                 --no-repeat-ngram <n>           Forbid repeating n-grams, 0 disables (default: 3)
+                --decoder-variant <v1|v2>       Decoder to load (default: v2)
 
             Compute units:
                 --cpu-only                      Force CPU

--- a/Tests/FluidAudioTests/ASR/Cohere/CoherePipelineMaskTests.swift
+++ b/Tests/FluidAudioTests/ASR/Cohere/CoherePipelineMaskTests.swift
@@ -1,0 +1,148 @@
+import CoreML
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+@available(macOS 14, iOS 17, *)
+final class CoherePipelineMaskTests: XCTestCase {
+
+    // MARK: - DecoderVariant
+
+    func testDecoderVariantCompiledFileNames() {
+        XCTAssertEqual(
+            CoherePipeline.DecoderVariant.v2.compiledFileName,
+            ModelNames.CohereTranscribe.decoderCacheExternalV2CompiledFile)
+        XCTAssertEqual(
+            CoherePipeline.DecoderVariant.v1.compiledFileName,
+            ModelNames.CohereTranscribe.decoderCacheExternalCompiledFile)
+        XCTAssertEqual(
+            CoherePipeline.DecoderVariant.v2.compiledFileName,
+            "cohere_decoder_cache_external_v2.mlmodelc")
+        XCTAssertEqual(
+            CoherePipeline.DecoderVariant.v1.compiledFileName,
+            "cohere_decoder_cache_external.mlmodelc")
+    }
+
+    func testDecoderVariantUsesStaticSelfMask() {
+        XCTAssertTrue(CoherePipeline.DecoderVariant.v2.usesStaticSelfMask)
+        XCTAssertFalse(CoherePipeline.DecoderVariant.v1.usesStaticSelfMask)
+    }
+
+    // MARK: - buildSelfAttentionMask: dynamic (v1) path
+
+    func testDynamicMaskShapeAndZeroFillFloat32() throws {
+        let step = 4
+        let mask = try CoherePipeline.buildSelfAttentionMask(
+            step: step, useStatic: false, dtype: .float32)
+
+        XCTAssertEqual(mask.shape, [1, 1, 1, NSNumber(value: step + 1)])
+        XCTAssertEqual(mask.dataType, .float32)
+
+        let ptr = mask.dataPointer.bindMemory(to: Float.self, capacity: step + 1)
+        for i in 0...step {
+            XCTAssertEqual(ptr[i], 0.0, "Dynamic mask must be zero-filled at \(i)")
+        }
+    }
+
+    func testDynamicMaskShapeAndZeroFillFloat16() throws {
+        let step = 7
+        let mask = try CoherePipeline.buildSelfAttentionMask(
+            step: step, useStatic: false, dtype: .float16)
+
+        XCTAssertEqual(mask.shape, [1, 1, 1, NSNumber(value: step + 1)])
+        XCTAssertEqual(mask.dataType, .float16)
+
+        let ptr = mask.dataPointer.bindMemory(to: UInt16.self, capacity: step + 1)
+        for i in 0...step {
+            XCTAssertEqual(ptr[i], 0, "Dynamic FP16 mask must be zero-filled at \(i)")
+        }
+    }
+
+    func testDynamicMaskAtStepZero() throws {
+        let mask = try CoherePipeline.buildSelfAttentionMask(
+            step: 0, useStatic: false, dtype: .float32)
+        XCTAssertEqual(mask.shape, [1, 1, 1, 1])
+        let ptr = mask.dataPointer.bindMemory(to: Float.self, capacity: 1)
+        XCTAssertEqual(ptr[0], 0.0)
+    }
+
+    // MARK: - buildSelfAttentionMask: static (v2) path
+
+    func testStaticMaskShapeIsAlwaysMaxSeqLen() throws {
+        let mask = try CoherePipeline.buildSelfAttentionMask(
+            step: 0, useStatic: true, dtype: .float32)
+        XCTAssertEqual(
+            mask.shape, [1, 1, 1, NSNumber(value: CohereAsrConfig.maxSeqLen)])
+    }
+
+    func testStaticMaskCausalSplitFloat32() throws {
+        let step = 10
+        let length = CohereAsrConfig.maxSeqLen
+        let mask = try CoherePipeline.buildSelfAttentionMask(
+            step: step, useStatic: true, dtype: .float32)
+
+        XCTAssertEqual(mask.shape, [1, 1, 1, NSNumber(value: length)])
+        XCTAssertEqual(mask.dataType, .float32)
+
+        let ptr = mask.dataPointer.bindMemory(to: Float.self, capacity: length)
+        for i in 0...step {
+            XCTAssertEqual(ptr[i], 0.0, "Position \(i) (≤ step) must attend (0.0)")
+        }
+        for i in (step + 1)..<length {
+            XCTAssertEqual(
+                ptr[i], -1.0e4, "Position \(i) (> step) must be masked (-1e4)")
+        }
+    }
+
+    func testStaticMaskCausalSplitFloat16() throws {
+        let step = 5
+        let length = CohereAsrConfig.maxSeqLen
+        let mask = try CoherePipeline.buildSelfAttentionMask(
+            step: step, useStatic: true, dtype: .float16)
+
+        XCTAssertEqual(mask.shape, [1, 1, 1, NSNumber(value: length)])
+        XCTAssertEqual(mask.dataType, .float16)
+
+        let ptr = mask.dataPointer.bindMemory(to: UInt16.self, capacity: length)
+        // FP16 zero is 0x0000; -1e4 is a nonzero sign-bit-set pattern. Assert
+        // shape (zero vs. uniform nonzero) rather than hardcoding bits.
+        for i in 0...step {
+            XCTAssertEqual(
+                ptr[i], 0, "Position \(i) (≤ step) must attend (FP16 zero)")
+        }
+        let blockedBits = ptr[step + 1]
+        XCTAssertNotEqual(blockedBits, 0, "Blocked positions must be nonzero")
+        XCTAssertNotEqual(
+            blockedBits & 0x8000, 0, "Blocked positions must be negative (sign bit set)")
+        for i in (step + 1)..<length {
+            XCTAssertEqual(
+                ptr[i], blockedBits,
+                "All blocked positions must hold identical FP16 bits; mismatch at \(i)")
+        }
+    }
+
+    func testStaticMaskAtFinalStepHasNoBlockedPositions() throws {
+        // step == maxSeqLen - 1 → every position attends, none masked.
+        let length = CohereAsrConfig.maxSeqLen
+        let mask = try CoherePipeline.buildSelfAttentionMask(
+            step: length - 1, useStatic: true, dtype: .float32)
+
+        let ptr = mask.dataPointer.bindMemory(to: Float.self, capacity: length)
+        for i in 0..<length {
+            XCTAssertEqual(ptr[i], 0.0, "Final step: every position attends, got \(ptr[i]) at \(i)")
+        }
+    }
+
+    func testStaticMaskAtStepZeroBlocksAllExceptFirst() throws {
+        let length = CohereAsrConfig.maxSeqLen
+        let mask = try CoherePipeline.buildSelfAttentionMask(
+            step: 0, useStatic: true, dtype: .float32)
+
+        let ptr = mask.dataPointer.bindMemory(to: Float.self, capacity: length)
+        XCTAssertEqual(ptr[0], 0.0, "step=0 attends position 0")
+        for i in 1..<length {
+            XCTAssertEqual(ptr[i], -1.0e4, "step=0 must mask position \(i)")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for a new Cohere decoder variant — `cohere_decoder_cache_external_v2` — with **fully static shapes** so CoreML can dispatch the decoder to the Apple Neural Engine.

- `ModelNames.CohereTranscribe`: adds v2 constants, flips default `requiredModels` to v2, keeps legacy set as `requiredModelsLegacy`.
- `CoherePipeline.loadModels`: prefers v2 in `decoderDir`, falls back to v1, clear error if neither present.
- Decode loop already auto-detects the variant from `attention_mask` shape (shipped in #487 area) — nothing to change runtime-side.
- CLI help lists both decoder filenames.

v2 artifacts are published at [`FluidInference/cohere-transcribe-03-2026-coreml/q8`](https://huggingface.co/FluidInference/cohere-transcribe-03-2026-coreml) (`cohere_decoder_cache_external_v2.{mlmodelc,mlpackage}`). The existing v1 decoder remains supported as a fallback.

## Why

The v1 (`RangeDim(1, 108)`) decoder has a dynamic `attention_mask` length, which blocks ANE dispatch — `computeUnits = .all` silently falls back to CPU/GPU. v2 fixes the mask at `[1, 1, 1, 108]` and sources the decode position from `position_id`, letting the full decoder land on ANE.

Measured with `fluidaudiocli cohere-transcribe` on the same audio (15 tokens, same q8 encoder, 3 warm runs each):

| Decoder | Config | Median decoder time |
|---|---|---:|
| **Static (v2)** | `.all` (ANE) | **2.58 s** |
| Dynamic (v1) | `.all` | 4.13 s |
| Static (v2) | `--cpu-gpu` | 10.02 s |
| Dynamic (v1) | `--cpu-gpu` | 4.32 s |

~1.6× faster decoder end-to-end. The v1 `.all` ≈ v1 `--cpu-gpu` rows confirm RangeDim blocks ANE. v2 attends over the full 108 slots every step, so on pure CPU/GPU it's slower — the win is entirely from ANE residency. Transcripts are byte-identical across configs.

## Test plan

- [x] Smoke test v2-preferred: directory containing only `cohere_decoder_cache_external_v2.mlmodelc` transcribes `english_original.wav` correctly.
- [x] Smoke test v1 fallback: directory containing only `cohere_decoder_cache_external.mlmodelc` transcribes correctly.
- [x] `swift build -c release --product fluidaudiocli` clean.
- [x] `swift format` clean on changed files.
- [ ] Reviewer: run `fluidaudiocli cohere-transcribe <audio> --model-dir <q8 dir with v2>` to reproduce the ANE speedup.

## Related

- v2 export script (mobius): `export-decoder-cache-external-static.py` (uncommitted, to land in a follow-up mobius PR).
- HF repo: `FluidInference/cohere-transcribe-03-2026-coreml` now ships both decoders under `q8/`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/537" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
