### PR TITLE
fix(diarizer): convert SpeakerManager to actor, Speaker to struct (#528)

### DIFF
--- a/Sources/FluidAudio/Diarizer/Clustering/SpeakerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Clustering/SpeakerManager.swift
@@ -4,7 +4,13 @@ import OSLog
 
 /// In-memory speaker database for streaming diarization
 /// Tracks speakers across chunks and maintains consistent IDs
-public class SpeakerManager {
+///
+/// This is an `actor` to provide thread-safe access under Swift 6 strict
+/// concurrency. Previous implementations used a `DispatchQueue` which could
+/// trigger `unsafeForcedSync` warnings (and occasional libmalloc heap
+/// corruption via concurrent `[Float]` COW mutations) when called from
+/// async contexts such as VAD / diarization buffer callbacks.
+public actor SpeakerManager {
     internal let logger = AppLogger(category: "SpeakerManager")
 
     // Constants
@@ -13,7 +19,6 @@ public class SpeakerManager {
     // Speaker database: ID -> Speaker
     internal var speakerDatabase: [String: Speaker] = [:]
     private var nextSpeakerId = 1
-    internal let queue = DispatchQueue(label: "speaker.manager.queue", attributes: .concurrent)
 
     // Track the highest speaker ID to ensure uniqueness
     private var highestSpeakerId = 0
@@ -35,6 +40,13 @@ public class SpeakerManager {
         self.minEmbeddingUpdateDuration = minEmbeddingUpdateDuration
     }
 
+    // MARK: - Threshold setters (actor-isolated)
+
+    public func setSpeakerThreshold(_ value: Float) { self.speakerThreshold = value }
+    public func setEmbeddingThreshold(_ value: Float) { self.embeddingThreshold = value }
+    public func setMinSpeechDuration(_ value: Float) { self.minSpeechDuration = value }
+    public func setMinEmbeddingUpdateDuration(_ value: Float) { self.minEmbeddingUpdateDuration = value }
+
     /// Add known speakers to the database
     /// - Parameters:
     ///   - speakers: Array of `Speaker`s to add
@@ -47,64 +59,62 @@ public class SpeakerManager {
             self.reset(keepIfPermanent: preserveIfPermanent)
         }
 
-        queue.sync(flags: .barrier) {
-            var maxNumericId = 0
+        var maxNumericId = 0
 
-            for speaker in speakers {
-                guard speaker.currentEmbedding.count == Self.embeddingSize else {
-                    logger.warning(
-                        "Skipping speaker \(speaker.id) - invalid embedding size: \(speaker.currentEmbedding.count)")
-                    continue
-                }
-
-                // Check if the speaker ID is already initialized
-                if let oldSpeaker = self.speakerDatabase[speaker.id] {
-                    // Handle duplicate speaker
-                    switch mode {
-                    case .reset, .overwrite:
-                        if !(oldSpeaker.isPermanent && preserveIfPermanent) {
-                            logger.warning("Speaker \(speaker.id) is already initialized. Overwriting old speaker.")
-                            speakerDatabase[speaker.id] = speaker
-                        } else {
-                            logger.warning(
-                                "Failed to overwrite Speaker \(speaker.id) because it is permanent. Skipping")
-                            continue
-                        }
-                    case .merge:
-                        if !(oldSpeaker.isPermanent && preserveIfPermanent) {
-                            logger.warning("Speaker \(speaker.id) is already initialized. Merging with old speaker.")
-                            oldSpeaker.mergeWith(speaker, keepName: speaker.name)
-                        } else {
-                            logger.warning(
-                                "Failed to merge Speaker \(speaker.id) into Speaker \(oldSpeaker.id) because the existing speaker is permanent. Skipping"
-                            )
-                            continue
-                        }
-                    case .skip:
-                        logger.warning("Speaker \(speaker.id) is already initialized. Skipping new speaker.")
-                        continue
-                    }
-                } else {
-                    speakerDatabase[speaker.id] = speaker
-                }
-
-                // Try to extract numeric ID if it's a pure number
-                if let numericId = Int(speaker.id) {
-                    maxNumericId = max(maxNumericId, numericId)
-                }
-
-                logger.info(
-                    "Initialized known speaker: \(speaker.id) with \(speaker.rawEmbeddings.count) raw embeddings"
-                )
+        for speaker in speakers {
+            guard speaker.currentEmbedding.count == Self.embeddingSize else {
+                logger.warning(
+                    "Skipping speaker \(speaker.id) - invalid embedding size: \(speaker.currentEmbedding.count)")
+                continue
             }
 
-            self.highestSpeakerId = maxNumericId
-            self.nextSpeakerId = maxNumericId + 1
+            // Check if the speaker ID is already initialized
+            if let oldSpeaker = self.speakerDatabase[speaker.id] {
+                // Handle duplicate speaker
+                switch mode {
+                case .reset, .overwrite:
+                    if !(oldSpeaker.isPermanent && preserveIfPermanent) {
+                        logger.warning("Speaker \(speaker.id) is already initialized. Overwriting old speaker.")
+                        speakerDatabase[speaker.id] = speaker
+                    } else {
+                        logger.warning(
+                            "Failed to overwrite Speaker \(speaker.id) because it is permanent. Skipping")
+                        continue
+                    }
+                case .merge:
+                    if !(oldSpeaker.isPermanent && preserveIfPermanent) {
+                        logger.warning("Speaker \(speaker.id) is already initialized. Merging with old speaker.")
+                        speakerDatabase[speaker.id]?.mergeWith(speaker, keepName: speaker.name)
+                    } else {
+                        logger.warning(
+                            "Failed to merge Speaker \(speaker.id) into Speaker \(oldSpeaker.id) because the existing speaker is permanent. Skipping"
+                        )
+                        continue
+                    }
+                case .skip:
+                    logger.warning("Speaker \(speaker.id) is already initialized. Skipping new speaker.")
+                    continue
+                }
+            } else {
+                speakerDatabase[speaker.id] = speaker
+            }
+
+            // Try to extract numeric ID if it's a pure number
+            if let numericId = Int(speaker.id) {
+                maxNumericId = max(maxNumericId, numericId)
+            }
 
             logger.info(
-                "Initialized with \(self.speakerDatabase.count) known speakers, next ID will be: \(self.nextSpeakerId)"
+                "Initialized known speaker: \(speaker.id) with \(speaker.rawEmbeddings.count) raw embeddings"
             )
         }
+
+        self.highestSpeakerId = maxNumericId
+        self.nextSpeakerId = maxNumericId + 1
+
+        logger.info(
+            "Initialized with \(self.speakerDatabase.count) known speakers, next ID will be: \(self.nextSpeakerId)"
+        )
     }
 
     /// Match the embedding to the closest existing speaker if sufficiently similar or create a new one if not.
@@ -130,42 +140,33 @@ public class SpeakerManager {
         let normalizedEmbedding = VDSPOperations.l2Normalize(embedding)
         let speakerThreshold = speakerThreshold ?? self.speakerThreshold
 
-        return queue.sync(flags: .barrier) {
-            let (closestSpeaker, distance) = findClosestSpeaker(to: normalizedEmbedding)
+        let (closestSpeaker, distance) = findClosestSpeaker(to: normalizedEmbedding)
 
-            if let speakerId = closestSpeaker, distance < speakerThreshold {
-                updateExistingSpeaker(
-                    speakerId: speakerId,
-                    embedding: normalizedEmbedding,
-                    duration: speechDuration,
-                    distance: distance
-                )
+        if let speakerId = closestSpeaker, distance < speakerThreshold {
+            updateExistingSpeaker(
+                speakerId: speakerId,
+                embedding: normalizedEmbedding,
+                duration: speechDuration,
+                distance: distance
+            )
 
-                if let speaker = speakerDatabase[speakerId] {
-                    return speaker
-                }
-                return nil
-            }
-
-            // Step 3: Create new speaker if duration is sufficient
-            if speechDuration >= minSpeechDuration {
-                let newSpeakerId = createNewSpeaker(
-                    embedding: normalizedEmbedding,
-                    duration: speechDuration,
-                    distanceToClosest: distance
-                )
-
-                // Return the Speaker object
-                if let speaker = speakerDatabase[newSpeakerId] {
-                    return speaker
-                }
-                return nil
-            }
-
-            // Step 4: Audio segment too short
-            logger.debug("Audio segment too short (\(speechDuration)s) to create new speaker")
-            return nil
+            return speakerDatabase[speakerId]
         }
+
+        // Step 3: Create new speaker if duration is sufficient
+        if speechDuration >= minSpeechDuration {
+            let newSpeakerId = createNewSpeaker(
+                embedding: normalizedEmbedding,
+                duration: speechDuration,
+                distanceToClosest: distance
+            )
+
+            return speakerDatabase[newSpeakerId]
+        }
+
+        // Step 4: Audio segment too short
+        logger.debug("Audio segment too short (\(speechDuration)s) to create new speaker")
+        return nil
     }
 
     /// Find the closest existing speaker to an embedding, up to a maximum cosine distance of `speakerThreshold`.
@@ -174,14 +175,12 @@ public class SpeakerManager {
     ///    - speakerThreshold: Maximum cosine distance to an existing speaker to create a new one (uses the default threshold for this `SpeakerManager` object if none is provided)
     ///  - Returns: ID of the match (if found) and the distance to that match.
     public func findSpeaker(with embedding: [Float], speakerThreshold: Float? = nil) -> (id: String?, distance: Float) {
-        queue.sync {
-            let (closestSpeakerId, minDistance) = findClosestSpeaker(to: embedding)
-            let speakerThreshold = speakerThreshold ?? self.speakerThreshold
-            if let closestSpeakerId, minDistance <= speakerThreshold {
-                return (closestSpeakerId, minDistance)
-            }
-            return (nil, .infinity)
+        let (closestSpeakerId, minDistance) = findClosestSpeaker(to: embedding)
+        let speakerThreshold = speakerThreshold ?? self.speakerThreshold
+        if let closestSpeakerId, minDistance <= speakerThreshold {
+            return (closestSpeakerId, minDistance)
         }
+        return (nil, .infinity)
     }
 
     /// Find the closest existing speaker to an embedding, up to a maximum cosine distance of `speakerThreshold`.
@@ -192,55 +191,47 @@ public class SpeakerManager {
     public func findMatchingSpeakers(
         with embedding: [Float], speakerThreshold: Float? = nil
     ) -> [(id: String, distance: Float)] {
-        queue.sync {
-            var matches: [(id: String, distance: Float)] = []
-            let speakerThreshold = speakerThreshold ?? self.speakerThreshold
+        var matches: [(id: String, distance: Float)] = []
+        let speakerThreshold = speakerThreshold ?? self.speakerThreshold
 
-            for (speakerId, speaker) in speakerDatabase {
-                let distance = cosineDistance(embedding, speaker.currentEmbedding)
-                if distance <= speakerThreshold {
-                    matches.append((speakerId, distance))
-                }
+        for (speakerId, speaker) in speakerDatabase {
+            let distance = cosineDistance(embedding, speaker.currentEmbedding)
+            if distance <= speakerThreshold {
+                matches.append((speakerId, distance))
             }
-            matches.sort { $0.distance < $1.distance }
-            return matches
         }
+        matches.sort { $0.distance < $1.distance }
+        return matches
     }
 
     /// Find all speakers that meet a certain predicate
     /// - Parameter predicate: Condition the speakers must meet to be returned
     /// - Returns: A list of all Speaker IDs corresponding to Speakers that meet the predicate
-    public func findSpeakers(where predicate: (Speaker) -> Bool) -> [String] {
-        queue.sync {
-            return speakerDatabase.filter { predicate($0.value) }.map(\.key)
-        }
+    public func findSpeakers(where predicate: @Sendable (Speaker) -> Bool) -> [String] {
+        return speakerDatabase.filter { predicate($0.value) }.map(\.key)
     }
 
     /// Mark a speaker as permanent
     /// - Parameter speakerId: ID of the speaker to mark as permanent
     public func makeSpeakerPermanent(_ speakerId: String) {
-        queue.sync(flags: .barrier) {
-            guard let speaker = speakerDatabase[speakerId] else {
-                logger.warning("Failed to mark speaker \(speakerId) as permanent (speaker not found).")
-                return
-            }
-            logger.info("Marking speaker \(speakerId) as permanent.")
-            speaker.isPermanent = true
+        guard speakerDatabase[speakerId] != nil else {
+            logger.warning("Failed to mark speaker \(speakerId) as permanent (speaker not found).")
+            return
         }
+        logger.info("Marking speaker \(speakerId) as permanent.")
+        speakerDatabase[speakerId]?.isPermanent = true
     }
 
     /// Remove a speaker's permanent marker
     /// - Parameter speakerId: ID of the speaker from which to remove the permanent marker
     public func revokePermanence(from speakerId: String) {
-        queue.sync(flags: .barrier) {
-            guard let speaker = speakerDatabase[speakerId] else {
-                logger.warning("Failed to revoke permanence from speaker \(speakerId) (speaker not found).")
-                return
-            }
-
-            logger.info("Revoking permanence from speaker \(speakerId).")
-            speaker.isPermanent = false
+        guard speakerDatabase[speakerId] != nil else {
+            logger.warning("Failed to revoke permanence from speaker \(speakerId) (speaker not found).")
+            return
         }
+
+        logger.info("Revoking permanence from speaker \(speakerId).")
+        speakerDatabase[speakerId]?.isPermanent = false
     }
 
     /// Merge two speakers in the database.
@@ -257,25 +248,23 @@ public class SpeakerManager {
             return
         }
 
-        queue.sync(flags: .barrier) {
-            // ensure both speakers exist
-            guard let speakerToMerge = speakerDatabase[sourceId],
-                let destinationSpeaker = speakerDatabase[destinationId]
-            else {
-                return
-            }
-
-            // don't merge permanent speakers into another one
-            guard !(stopIfPermanent && speakerToMerge.isPermanent) else {
-                return
-            }
-
-            // merge source into destination
-            destinationSpeaker.mergeWith(speakerToMerge, keepName: mergedName)
-
-            // remove source speaker
-            speakerDatabase.removeValue(forKey: sourceId)
+        // ensure both speakers exist
+        guard let speakerToMerge = speakerDatabase[sourceId],
+            speakerDatabase[destinationId] != nil
+        else {
+            return
         }
+
+        // don't merge permanent speakers into another one
+        guard !(stopIfPermanent && speakerToMerge.isPermanent) else {
+            return
+        }
+
+        // merge source into destination
+        speakerDatabase[destinationId]?.mergeWith(speakerToMerge, keepName: mergedName)
+
+        // remove source speaker
+        speakerDatabase.removeValue(forKey: sourceId)
     }
 
     /// Find all pairs of speakers that can be merged
@@ -286,50 +275,49 @@ public class SpeakerManager {
     public func findMergeablePairs(
         speakerThreshold: Float? = nil, excludeIfBothPermanent: Bool = true
     ) -> [(speakerToMerge: String, destination: String)] {
-        queue.sync {
-            let speakerThreshold = speakerThreshold ?? self.speakerThreshold
-            var pairs: [(speakerToMerge: String, destination: String)] = []
-            let ids = Array(speakerDatabase.keys)
+        let speakerThreshold = speakerThreshold ?? self.speakerThreshold
+        var pairs: [(speakerToMerge: String, destination: String)] = []
+        let ids = Array(speakerDatabase.keys)
+        let count = speakerDatabase.count
 
-            for i in (0..<speakerCount) {
-                // get speaker 1
-                guard let speaker1 = speakerDatabase[ids[i]] else {
-                    logger.error("ID \(ids[i]) not found in speakerDatabase")
+        for i in (0..<count) {
+            // get speaker 1
+            guard let speaker1 = speakerDatabase[ids[i]] else {
+                logger.error("ID \(ids[i]) not found in speakerDatabase")
+                continue
+            }
+
+            for j in (i + 1)..<count {
+                // get speaker 2
+                guard let speaker2 = speakerDatabase[ids[j]] else {
+                    logger.error("ID \(ids[j]) not found in speakerDatabase")
                     continue
                 }
 
-                for j in (i + 1)..<speakerCount {
-                    // get speaker 2
-                    guard let speaker2 = speakerDatabase[ids[j]] else {
-                        logger.error("ID \(ids[j]) not found in speakerDatabase")
-                        continue
-                    }
+                // skip double permanent pairs
+                if excludeIfBothPermanent && speaker1.isPermanent && speaker2.isPermanent {
+                    logger.info(
+                        "findMergeablePairs: Skipping \(speaker1.id) and \(speaker2.id) as both are permanent")
+                    continue
+                }
 
-                    // skip double permanent pairs
-                    if excludeIfBothPermanent && speaker1.isPermanent && speaker2.isPermanent {
-                        logger.info(
-                            "findMergeablePairs: Skipping \(speaker1.id) and \(speaker2.id) as both are permanent")
-                        continue
-                    }
+                // determine if they are similar enough
+                let distance = cosineDistance(speaker1.currentEmbedding, speaker2.currentEmbedding)
 
-                    // determine if they are similar enough
-                    let distance = cosineDistance(speaker1.currentEmbedding, speaker2.currentEmbedding)
+                guard distance < speakerThreshold else {
+                    continue
+                }
 
-                    guard distance < speakerThreshold else {
-                        continue
-                    }
-
-                    // prioritize putting speaker1 as the destination for consistency
-                    if !speaker2.isPermanent {
-                        pairs.append((speakerToMerge: speaker2.id, destination: speaker1.id))
-                    } else {
-                        pairs.append((speakerToMerge: speaker1.id, destination: speaker2.id))
-                    }
+                // prioritize putting speaker1 as the destination for consistency
+                if !speaker2.isPermanent {
+                    pairs.append((speakerToMerge: speaker2.id, destination: speaker1.id))
+                } else {
+                    pairs.append((speakerToMerge: speaker1.id, destination: speaker2.id))
                 }
             }
-
-            return pairs
         }
+
+        return pairs
     }
 
     /// Remove a speaker from the database
@@ -337,19 +325,17 @@ public class SpeakerManager {
     ///   - speakerID: ID of the speaker being removed
     ///   - keepIfPermanent: Whether to stop the removal if the speaker is marked as permanent
     public func removeSpeaker(_ speakerID: String, keepIfPermanent: Bool = true) {
-        queue.sync(flags: .barrier) {
-            // determine if we should skip the removal due to permanence
-            if keepIfPermanent, let speaker = self.speakerDatabase[speakerID], speaker.isPermanent {
-                logger.warning("Failed to remove speaker: \(speakerID) (Speaker is permanent)")
-                return
-            }
+        // determine if we should skip the removal due to permanence
+        if keepIfPermanent, let speaker = self.speakerDatabase[speakerID], speaker.isPermanent {
+            logger.warning("Failed to remove speaker: \(speakerID) (Speaker is permanent)")
+            return
+        }
 
-            // attempt to remove the speaker
-            if let _ = speakerDatabase.removeValue(forKey: speakerID) {
-                logger.info("Removing speaker: \(speakerID)")
-            } else {
-                logger.warning("Failed to remove speaker: \(speakerID) (Speaker not found)")
-            }
+        // attempt to remove the speaker
+        if let _ = speakerDatabase.removeValue(forKey: speakerID) {
+            logger.info("Removing speaker: \(speakerID)")
+        } else {
+            logger.warning("Failed to remove speaker: \(speakerID) (Speaker not found)")
         }
     }
 
@@ -358,19 +344,17 @@ public class SpeakerManager {
     ///   - date: Speakers who have not been active after this date will be removed.
     ///   - keepIfPermanent: Whether to stop the removal if the speaker is marked as permanent
     public func removeSpeakersInactive(since date: Date, keepIfPermanent: Bool = true) {
-        queue.sync(flags: .barrier) {
-            if keepIfPermanent {
-                // don't remove permanent speakers
-                for (speakerId, speaker) in speakerDatabase where speaker.updatedAt < date && !speaker.isPermanent {
-                    speakerDatabase.removeValue(forKey: speakerId)
-                    logger.info("Removing speaker \(speakerId) due to inactivity")
-                }
-            } else {
-                // remove all inactive speakers
-                for (speakerId, speaker) in speakerDatabase where speaker.updatedAt < date {
-                    speakerDatabase.removeValue(forKey: speakerId)
-                    logger.info("Removing speaker \(speakerId) due to inactivity")
-                }
+        if keepIfPermanent {
+            // don't remove permanent speakers
+            for (speakerId, speaker) in speakerDatabase where speaker.updatedAt < date && !speaker.isPermanent {
+                speakerDatabase.removeValue(forKey: speakerId)
+                logger.info("Removing speaker \(speakerId) due to inactivity")
+            }
+        } else {
+            // remove all inactive speakers
+            for (speakerId, speaker) in speakerDatabase where speaker.updatedAt < date {
+                speakerDatabase.removeValue(forKey: speakerId)
+                logger.info("Removing speaker \(speakerId) due to inactivity")
             }
         }
     }
@@ -388,19 +372,17 @@ public class SpeakerManager {
     /// - Parameters:
     ///   - predicate: The predicate to determine whether the speaker should be removed
     ///   - keepIfPermanent: Whether to stop the removal if the speaker is marked as permanent
-    public func removeSpeakers(where predicate: (Speaker) -> Bool, keepIfPermanent: Bool = true) {
-        queue.sync(flags: .barrier) {
-            if keepIfPermanent {
-                // don't remove permanent speakers
-                for (speakerId, speaker) in speakerDatabase where predicate(speaker) && !speaker.isPermanent {
-                    speakerDatabase.removeValue(forKey: speakerId)
-                    logger.info("Removing speaker \(speakerId) based on predicate")
-                }
-            } else {
-                for (speakerId, speaker) in speakerDatabase where predicate(speaker) {
-                    speakerDatabase.removeValue(forKey: speakerId)
-                    logger.info("Removing speaker \(speakerId) based on predicate")
-                }
+    public func removeSpeakers(where predicate: @Sendable (Speaker) -> Bool, keepIfPermanent: Bool = true) {
+        if keepIfPermanent {
+            // don't remove permanent speakers
+            for (speakerId, speaker) in speakerDatabase where predicate(speaker) && !speaker.isPermanent {
+                speakerDatabase.removeValue(forKey: speakerId)
+                logger.info("Removing speaker \(speakerId) based on predicate")
+            }
+        } else {
+            for (speakerId, speaker) in speakerDatabase where predicate(speaker) {
+                speakerDatabase.removeValue(forKey: speakerId)
+                logger.info("Removing speaker \(speakerId) based on predicate")
             }
         }
     }
@@ -408,7 +390,7 @@ public class SpeakerManager {
     /// Remove non-permanent speakers that meet a certain predicate
     /// - Parameters:
     ///   - predicate: Predicate to determine whether the speaker should be removed
-    public func removeSpeakers(where predicate: (Speaker) -> Bool) {
+    public func removeSpeakers(where predicate: @Sendable (Speaker) -> Bool) {
         removeSpeakers(where: predicate, keepIfPermanent: true)
     }
 
@@ -416,9 +398,7 @@ public class SpeakerManager {
     /// - Parameter speakerId: ID to check
     /// - Returns: `true` if a speaker is found, `false` if not
     public func hasSpeaker(_ speakerId: String) -> Bool {
-        queue.sync {
-            return speakerDatabase.keys.contains(speakerId)
-        }
+        return speakerDatabase.keys.contains(speakerId)
     }
 
     private func findDistanceToClosestSpeaker(to embedding: [Float]) -> Float {
@@ -448,7 +428,7 @@ public class SpeakerManager {
         duration: Float,
         distance: Float
     ) {
-        guard let speaker = speakerDatabase[speakerId] else {
+        guard speakerDatabase[speakerId] != nil else {
             logger.error("Speaker \(speakerId) not found in database")
             return
         }
@@ -458,7 +438,7 @@ public class SpeakerManager {
             var sumSquares: Float = 0
             vDSP_svesq(embedding, 1, &sumSquares, vDSP_Length(embedding.count))
             if sumSquares > 0.01 {
-                speaker.updateMainEmbedding(
+                speakerDatabase[speakerId]?.updateMainEmbedding(
                     duration: duration,
                     embedding: embedding,
                     segmentId: UUID(),
@@ -467,11 +447,9 @@ public class SpeakerManager {
             }
         } else {
             // Just update duration if not updating embedding
-            speaker.duration += duration
-            speaker.updatedAt = Date()
+            speakerDatabase[speakerId]?.duration += duration
+            speakerDatabase[speakerId]?.updatedAt = Date()
         }
-
-        speakerDatabase[speakerId] = speaker
     }
 
     private func createNewSpeaker(
@@ -488,7 +466,7 @@ public class SpeakerManager {
         highestSpeakerId = max(highestSpeakerId, nextSpeakerId - 1)
 
         // Create new Speaker object
-        let newSpeaker = Speaker(
+        var newSpeaker = Speaker(
             id: newSpeakerId,
             name: newSpeakerName,
             currentEmbedding: normalizedEmbedding,
@@ -508,44 +486,41 @@ public class SpeakerManager {
 
     /// Internal cosine distance calculation that delegates to SpeakerUtilities
     /// Kept for backward compatibility with tests
-    internal func cosineDistance(_ a: [Float], _ b: [Float]) -> Float {
+    internal nonisolated func cosineDistance(_ a: [Float], _ b: [Float]) -> Float {
         return SpeakerUtilities.cosineDistance(a, b)
     }
 
     public var speakerCount: Int {
-        queue.sync { speakerDatabase.count }
+        speakerDatabase.count
     }
 
     public var speakerIds: [String] {
-        queue.sync { Array(speakerDatabase.keys).sorted() }
+        Array(speakerDatabase.keys).sorted()
     }
 
     public var permanentSpeakerIds: [String] {
-        queue.sync { Array(speakerDatabase.filter(\.value.isPermanent).keys).sorted() }
+        Array(speakerDatabase.filter(\.value.isPermanent).keys).sorted()
     }
 
     /// Get all speakers (for testing/debugging).
     public func getAllSpeakers() -> [String: Speaker] {
-        queue.sync {
-            return speakerDatabase
-        }
+        return speakerDatabase
     }
 
     /// Get list of all speakers.
     public func getSpeakerList() -> [Speaker] {
-        queue.sync {
-            return [Speaker](speakerDatabase.values)
-        }
+        return [Speaker](speakerDatabase.values)
     }
 
     public func getSpeaker(for speakerId: String) -> Speaker? {
-        queue.sync { speakerDatabase[speakerId] }
+        speakerDatabase[speakerId]
     }
 
     /// - Parameter speaker: The Speaker object to upsert
     public func upsertSpeaker(_ speaker: Speaker) {
         upsertSpeaker(
             id: speaker.id,
+            name: speaker.name,
             currentEmbedding: speaker.currentEmbedding,
             duration: speaker.duration,
             rawEmbeddings: speaker.rawEmbeddings,
@@ -569,6 +544,7 @@ public class SpeakerManager {
     ///   - isPermanent: Whether the speaker should be protected from merges and removals by default
     public func upsertSpeaker(
         id: String,
+        name: String? = nil,
         currentEmbedding: [Float],
         duration: Float,
         rawEmbeddings: [RawEmbedding] = [],
@@ -577,79 +553,77 @@ public class SpeakerManager {
         updatedAt: Date? = nil,
         isPermanent: Bool = false
     ) {
-        queue.sync(flags: .barrier) {
-            let now = Date()
+        let now = Date()
 
-            if let existingSpeaker = speakerDatabase[id] {
-                // Update existing speaker
-                existingSpeaker.currentEmbedding = currentEmbedding
-                existingSpeaker.duration = duration
-                existingSpeaker.rawEmbeddings = rawEmbeddings
-                existingSpeaker.updateCount = updateCount
-                existingSpeaker.updatedAt = updatedAt ?? now
-                existingSpeaker.isPermanent = existingSpeaker.isPermanent || isPermanent
-                // Keep original createdAt and name
-
-                speakerDatabase[id] = existingSpeaker
-                logger.info("Updated existing speaker: \(id)")
-            } else {
-                // Insert new speaker
-                let newSpeaker = Speaker(
-                    id: id,
-                    name: id,  // Default name is the ID
-                    currentEmbedding: currentEmbedding,
-                    duration: duration,
-                    createdAt: createdAt ?? now,
-                    updatedAt: updatedAt ?? now,
-                    isPermanent: isPermanent
-                )
-
-                newSpeaker.rawEmbeddings = rawEmbeddings
-                newSpeaker.updateCount = updateCount
-
-                speakerDatabase[id] = newSpeaker
-
-                // Update tracking for numeric IDs
-                if let numericId = Int(id) {
-                    highestSpeakerId = max(highestSpeakerId, numericId)
-                    nextSpeakerId = max(nextSpeakerId, numericId + 1)
-                }
-
-                logger.info("Inserted new speaker: \(id)")
+        if speakerDatabase[id] != nil {
+            // Update existing speaker
+            speakerDatabase[id]?.currentEmbedding = currentEmbedding
+            speakerDatabase[id]?.duration = duration
+            speakerDatabase[id]?.rawEmbeddings = rawEmbeddings
+            speakerDatabase[id]?.updateCount = updateCount
+            speakerDatabase[id]?.updatedAt = updatedAt ?? now
+            if let name = name {
+                speakerDatabase[id]?.name = name
             }
+            if isPermanent {
+                speakerDatabase[id]?.isPermanent = true
+            }
+            // Keep original createdAt
+
+            logger.info("Updated existing speaker: \(id)")
+        } else {
+            // Insert new speaker
+            var newSpeaker = Speaker(
+                id: id,
+                name: name ?? id,  // Default name is the ID
+                currentEmbedding: currentEmbedding,
+                duration: duration,
+                createdAt: createdAt ?? now,
+                updatedAt: updatedAt ?? now,
+                isPermanent: isPermanent
+            )
+
+            newSpeaker.rawEmbeddings = rawEmbeddings
+            newSpeaker.updateCount = updateCount
+
+            speakerDatabase[id] = newSpeaker
+
+            // Update tracking for numeric IDs
+            if let numericId = Int(id) {
+                highestSpeakerId = max(highestSpeakerId, numericId)
+                nextSpeakerId = max(nextSpeakerId, numericId + 1)
+            }
+
+            logger.info("Inserted new speaker: \(id)")
         }
     }
 
     /// Reset the speaker database
     /// - Parameter keepIfPermanent: Whether to keep permanent speakers
     public func reset(keepIfPermanent: Bool = false) {
-        queue.sync(flags: .barrier) {
-            if !keepIfPermanent {
-                speakerDatabase.removeAll()
-                nextSpeakerId = 1
-                highestSpeakerId = 0
-            } else {
-                speakerDatabase = speakerDatabase.filter(\.value.isPermanent)
-                // Recalculate nextSpeakerId and highestSpeakerId based on remaining permanent speakers
-                var maxNumericId = 0
-                for id in speakerDatabase.keys {
-                    if let numericId = Int(id) {
-                        maxNumericId = max(maxNumericId, numericId)
-                    }
+        if !keepIfPermanent {
+            speakerDatabase.removeAll()
+            nextSpeakerId = 1
+            highestSpeakerId = 0
+        } else {
+            speakerDatabase = speakerDatabase.filter(\.value.isPermanent)
+            // Recalculate nextSpeakerId and highestSpeakerId based on remaining permanent speakers
+            var maxNumericId = 0
+            for id in speakerDatabase.keys {
+                if let numericId = Int(id) {
+                    maxNumericId = max(maxNumericId, numericId)
                 }
-                highestSpeakerId = maxNumericId
-                nextSpeakerId = maxNumericId + 1
             }
-            logger.info("Speaker database reset")
+            highestSpeakerId = maxNumericId
+            nextSpeakerId = maxNumericId + 1
         }
+        logger.info("Speaker database reset")
     }
 
     /// Mark all speakers as not permanent
     public func resetPermanentFlags() {
-        queue.sync(flags: .barrier) {
-            speakerDatabase.forEach {
-                $0.value.isPermanent = false
-            }
+        for id in Array(speakerDatabase.keys) {
+            speakerDatabase[id]?.isPermanent = false
         }
     }
 }

--- a/Sources/FluidAudio/Diarizer/Clustering/SpeakerOperations.swift
+++ b/Sources/FluidAudio/Diarizer/Clustering/SpeakerOperations.swift
@@ -518,38 +518,36 @@ extension SpeakerManager {
         from fromSpeakerId: String,
         to toSpeakerId: String
     ) -> Bool {
-        return queue.sync(flags: .barrier) {
-            // Get speaker info from database
-            guard let fromSpeakerInfo = speakerDatabase[fromSpeakerId],
-                let toSpeakerInfo = speakerDatabase[toSpeakerId]
-            else {
-                logger.warning("One or both speakers not found: from=\(fromSpeakerId), to=\(toSpeakerId)")
-                return false
-            }
-
-            // Find and remove the embedding from source speaker
-            guard let index = fromSpeakerInfo.rawEmbeddings.firstIndex(where: { $0.segmentId == segmentId })
-            else {
-                logger.warning("Segment \(segmentId) not found in speaker \(fromSpeakerId)")
-                return false
-            }
-
-            let embedding = fromSpeakerInfo.rawEmbeddings.remove(at: index)
-
-            // Add to destination speaker
-            toSpeakerInfo.rawEmbeddings.append(embedding)
-
-            // Update both speakers in database
-            speakerDatabase[fromSpeakerId] = fromSpeakerInfo
-            speakerDatabase[toSpeakerId] = toSpeakerInfo
-
-            // Recalculate embeddings for both speakers
-            // Note: This would need to be implemented using the SpeakerInfo structure
-            // For now, just log the successful reassignment
-
-            logger.info("✅ Reassigned segment \(segmentId) from \(fromSpeakerId) to \(toSpeakerId)")
-            return true
+        // Get speaker info from database
+        guard var fromSpeakerInfo = speakerDatabase[fromSpeakerId],
+            var toSpeakerInfo = speakerDatabase[toSpeakerId]
+        else {
+            logger.warning("One or both speakers not found: from=\(fromSpeakerId), to=\(toSpeakerId)")
+            return false
         }
+
+        // Find and remove the embedding from source speaker
+        guard let index = fromSpeakerInfo.rawEmbeddings.firstIndex(where: { $0.segmentId == segmentId })
+        else {
+            logger.warning("Segment \(segmentId) not found in speaker \(fromSpeakerId)")
+            return false
+        }
+
+        let embedding = fromSpeakerInfo.rawEmbeddings.remove(at: index)
+
+        // Add to destination speaker
+        toSpeakerInfo.rawEmbeddings.append(embedding)
+
+        // Update both speakers in database
+        speakerDatabase[fromSpeakerId] = fromSpeakerInfo
+        speakerDatabase[toSpeakerId] = toSpeakerInfo
+
+        // Recalculate embeddings for both speakers
+        // Note: This would need to be implemented using the SpeakerInfo structure
+        // For now, just log the successful reassignment
+
+        logger.info("Reassigned segment \(segmentId) from \(fromSpeakerId) to \(toSpeakerId)")
+        return true
     }
 
     // MARK: - Speaker Query Operations
@@ -561,9 +559,7 @@ extension SpeakerManager {
     ///
     /// - Returns: Array of speaker IDs/names currently in the database
     public func getCurrentSpeakerNames() -> [String] {
-        return queue.sync {
-            return Array(speakerDatabase.keys).sorted()
-        }
+        return Array(speakerDatabase.keys).sorted()
     }
 
     /// Get global speaker statistics from the in-memory database.
@@ -578,23 +574,21 @@ extension SpeakerManager {
         averageConfidence: Float,
         speakersWithHistory: Int
     ) {
-        return queue.sync { () -> (Int, Float, Float, Int) in
-            let speakers = Array(speakerDatabase.values)
+        let speakers = Array(speakerDatabase.values)
 
-            guard !speakers.isEmpty else {
-                return (0, 0, 0, 0)
-            }
-
-            let totalDuration = speakers.reduce(0) { $0 + $1.duration }
-            let totalUpdates = speakers.reduce(0) { $0 + $1.updateCount }
-            let averageConfidence = Float(totalUpdates) / Float(speakers.count) / 10.0  // Normalize
-            let speakersWithHistory = speakers.filter { !$0.rawEmbeddings.isEmpty }.count
-
-            logger.info(
-                "Global stats - Speakers: \(speakers.count), Duration: \(String(format: "%.1f", totalDuration))s, Avg confidence: \(String(format: "%.2f", averageConfidence)), With history: \(speakersWithHistory)"
-            )
-
-            return (speakers.count, totalDuration, min(1.0, averageConfidence), speakersWithHistory)
+        guard !speakers.isEmpty else {
+            return (0, 0, 0, 0)
         }
+
+        let totalDuration = speakers.reduce(0) { $0 + $1.duration }
+        let totalUpdates = speakers.reduce(0) { $0 + $1.updateCount }
+        let averageConfidence = Float(totalUpdates) / Float(speakers.count) / 10.0  // Normalize
+        let speakersWithHistory = speakers.filter { !$0.rawEmbeddings.isEmpty }.count
+
+        logger.info(
+            "Global stats - Speakers: \(speakers.count), Duration: \(String(format: "%.1f", totalDuration))s, Avg confidence: \(String(format: "%.2f", averageConfidence)), With history: \(speakersWithHistory)"
+        )
+
+        return (speakers.count, totalDuration, min(1.0, averageConfidence), speakersWithHistory)
     }
 }

--- a/Sources/FluidAudio/Diarizer/Clustering/SpeakerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/Clustering/SpeakerTypes.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Speaker profile representation for tracking speakers across audio
 /// This represents a speaker's identity, not a specific segment
-public final class Speaker: Identifiable, Codable, Equatable, Hashable {
+public struct Speaker: Identifiable, Codable, Equatable, Hashable, Sendable {
     /// Speaker ID
     public let id: String
     /// Speaker name
@@ -65,7 +65,7 @@ public final class Speaker: Identifiable, Codable, Equatable, Hashable {
     ///   - embedding: 256D speaker embedding vector
     ///   - segmentId: The ID of the segment
     ///   - alpha: EMA blending parameter
-    public func updateMainEmbedding(
+    public mutating func updateMainEmbedding(
         duration: Float,
         embedding: [Float],
         segmentId: UUID,
@@ -101,7 +101,7 @@ public final class Speaker: Identifiable, Codable, Equatable, Hashable {
     }
 
     /// Add a raw embedding with FIFO queue management
-    public func addRawEmbedding(_ embedding: RawEmbedding) {
+    public mutating func addRawEmbedding(_ embedding: RawEmbedding) {
         // Validate embedding quality
         var sumSquares: Float = 0
         vDSP_svesq(embedding.embedding, 1, &sumSquares, vDSP_Length(embedding.embedding.count))
@@ -118,7 +118,7 @@ public final class Speaker: Identifiable, Codable, Equatable, Hashable {
 
     /// Remove a raw embedding by segment ID
     @discardableResult
-    public func removeRawEmbedding(segmentId: UUID) -> RawEmbedding? {
+    public mutating func removeRawEmbedding(segmentId: UUID) -> RawEmbedding? {
         guard let index = rawEmbeddings.firstIndex(where: { $0.segmentId == segmentId }) else {
             return nil
         }
@@ -129,7 +129,7 @@ public final class Speaker: Identifiable, Codable, Equatable, Hashable {
     }
 
     /// Recalculate main embedding as average of all raw embeddings
-    public func recalculateMainEmbedding() {
+    public mutating func recalculateMainEmbedding() {
         guard !rawEmbeddings.isEmpty,
             let firstEmbedding = rawEmbeddings.first,
             !firstEmbedding.embedding.isEmpty
@@ -165,7 +165,7 @@ public final class Speaker: Identifiable, Codable, Equatable, Hashable {
     /// - Parameters:
     ///   - other: Other Speaker to merge
     ///   - keepName: The resulting name after the merge
-    public func mergeWith(_ other: Speaker, keepName: String? = nil) {
+    public mutating func mergeWith(_ other: Speaker, keepName: String? = nil) {
         // Merge raw embeddings
         var allEmbeddings = rawEmbeddings + other.rawEmbeddings
 

--- a/Sources/FluidAudio/Diarizer/Clustering/SpeakerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/Clustering/SpeakerTypes.swift
@@ -270,7 +270,7 @@ public struct SendableSpeaker: Sendable, Identifiable, Hashable {
 }
 
 /// Configuration for handling initializing known speakers
-public enum SpeakerInitializationMode {
+public enum SpeakerInitializationMode: Sendable {
     /// Reset the speaker database and add the new speakers
     case reset
     /// Merge new speakers whose IDs match with existing ones

--- a/Sources/FluidAudio/Diarizer/Core/DiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Core/DiarizerManager.swift
@@ -71,8 +71,8 @@ public final class DiarizerManager {
     /// Accepts Speaker structs and adds them to the in-memory database.
     ///
     /// - Parameter speakers: Array of Speaker structs with embeddings and metadata
-    public func initializeKnownSpeakers(_ speakers: [Speaker]) {
-        speakerManager.initializeKnownSpeakers(speakers)
+    public func initializeKnownSpeakers(_ speakers: [Speaker]) async {
+        await speakerManager.initializeKnownSpeakers(speakers)
     }
 
     /// Extract a 256-dimensional speaker embedding from audio samples.
@@ -152,7 +152,7 @@ public final class DiarizerManager {
     /// ```
     public func performCompleteDiarization<C>(
         _ samples: C, sampleRate: Int = 16000, atTime startTime: TimeInterval = 0
-    ) throws -> DiarizationResult
+    ) async throws -> DiarizationResult
     where C: RandomAccessCollection, C.Element == Float, C.Index == Int {
         guard let models else {
             throw DiarizerError.notInitialized
@@ -183,7 +183,7 @@ public final class DiarizerManager {
             let chunk = samples[chunkStart..<chunkEnd]
             let chunkOffset = Double(chunkStartOffset) / Double(sampleRate) + startTime
 
-            let (chunkSegments, chunkTimings) = try processChunkWithSpeakerTracking(
+            let (chunkSegments, chunkTimings) = try await processChunkWithSpeakerTracking(
                 chunk,
                 chunkOffset: chunkOffset,
                 models: models,
@@ -213,7 +213,8 @@ public final class DiarizerManager {
             )
 
             // Build speakerDatabase from speakerManager for debug output
-            let speakerDB = speakerManager.getAllSpeakers().reduce(into: [String: [Float]]()) { result, item in
+            let speakerDB = await speakerManager.getAllSpeakers().reduce(into: [String: [Float]]()) {
+                result, item in
                 result[item.key] = item.value.currentEmbedding
             }
 
@@ -250,7 +251,7 @@ public final class DiarizerManager {
         sampleRate: Int = 16000,
         chunkSize: Int,
         chunkBuffer: inout [Float]
-    ) throws -> ([TimedSpeakerSegment], ChunkTimings)
+    ) async throws -> ([TimedSpeakerSegment], ChunkTimings)
     where C: RandomAccessCollection, C.Element == Float, C.Index == Int {
         let segmentationStartTime = Date()
 
@@ -349,7 +350,7 @@ public final class DiarizerManager {
 
                     let quality = calculateEmbeddingQuality(embedding) * (activity / Float(numFrames))
 
-                    if let speaker = speakerManager.assignSpeaker(
+                    if let speaker = await speakerManager.assignSpeaker(
                         embedding,
                         speechDuration: duration,
                         confidence: quality

--- a/Sources/FluidAudioCLI/Commands/DiarizationBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/DiarizationBenchmark.swift
@@ -438,8 +438,8 @@ enum StreamDiarizationBenchmark {
             diarizerManager.initialize(models: models)
 
             // Configure streaming manager
-            diarizerManager.speakerManager.speakerThreshold = assignmentThreshold
-            diarizerManager.speakerManager.embeddingThreshold = updateThreshold
+            await diarizerManager.speakerManager.setSpeakerThreshold(assignmentThreshold)
+            await diarizerManager.speakerManager.setEmbeddingThreshold(updateThreshold)
 
             // Process in chunks
             let samplesPerChunk = Int(chunkSeconds * 16000)
@@ -472,9 +472,8 @@ enum StreamDiarizationBenchmark {
 
                 // Process chunk and track timing
                 let inferenceStart = Date()
-                let chunkResult = try autoreleasepool {
-                    try diarizerManager.performCompleteDiarization(paddedChunk, atTime: chunkStartTime)
-                }
+                let chunkResult = try await diarizerManager.performCompleteDiarization(
+                    paddedChunk, atTime: chunkStartTime)
                 let inferenceTime = Date().timeIntervalSince(inferenceStart)
 
                 // Track chunk processing latency
@@ -516,11 +515,12 @@ enum StreamDiarizationBenchmark {
                     let processedDuration = Double(position) / 16000.0
                     let rtfx = processedDuration / elapsed
 
+                    let currentSpeakerCount = await diarizerManager.speakerManager.speakerCount
                     logger.info(
                         String(
                             format: "    [Chunk %3d] %.1f%% | RTFx: %.1fx | Speakers: %d | Latency: %.3fs",
                             chunkIndex, progress, rtfx,
-                            diarizerManager.speakerManager.speakerCount,
+                            currentSpeakerCount,
                             chunkLatency))
                 }
 
@@ -565,6 +565,8 @@ enum StreamDiarizationBenchmark {
             // Calculate total inference time
             let totalInferenceTime = totalSegmentationTime + totalEmbeddingTime + totalClusteringTime
 
+            let finalSpeakerCount = await diarizerManager.speakerManager.speakerCount
+
             return BenchmarkResult(
                 meetingName: meetingName,
                 der: metrics.der,
@@ -575,7 +577,7 @@ enum StreamDiarizationBenchmark {
                 rtfx: Float(finalRTFx),
                 processingTime: totalElapsed,
                 chunksProcessed: chunkIndex,
-                detectedSpeakers: diarizerManager.speakerManager.speakerCount,
+                detectedSpeakers: finalSpeakerCount,
                 groundTruthSpeakers: AMIParser.getGroundTruthSpeakerCount(for: meetingName),
                 speakerFragmentation: fragmentation,
                 latency90th: latency90th,

--- a/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
@@ -112,7 +112,7 @@ enum ProcessCommand {
                 logger.info("Loaded audio: \(audioSamples.count) samples")
 
                 let startTime = Date()
-                let result = try manager.performCompleteDiarization(
+                let result = try await manager.performCompleteDiarization(
                     audioSamples, sampleRate: 16000)
                 let processingTime = Date().timeIntervalSince(startTime)
 

--- a/Tests/FluidAudioTests/CI/BasicInitializationTests.swift
+++ b/Tests/FluidAudioTests/CI/BasicInitializationTests.swift
@@ -49,14 +49,14 @@ final class CoreMLDiarizerTests: XCTestCase {
         XCTAssertFalse(manager.isAvailable, "Manager should not be available before initialization")
     }
 
-    func testNotInitializedErrors() {
+    func testNotInitializedErrors() async {
         let testSamples = Array(repeating: Float(0.5), count: 16000)
         let config = DiarizerConfig()
         let manager = DiarizerManager(config: config)
 
         // Test diarization fails when not initialized
         do {
-            _ = try manager.performCompleteDiarization(testSamples, sampleRate: 16000)
+            _ = try await manager.performCompleteDiarization(testSamples, sampleRate: 16000)
             XCTFail("Should have thrown notInitialized error")
         } catch DiarizerError.notInitialized {
             // Expected error
@@ -400,7 +400,7 @@ final class CoreMLBackendIntegrationTests: XCTestCase {
             // Test that we can perform basic operations
             let testSamples = Array(repeating: Float(0.5), count: 16000)
 
-            let _ = try diarizer.performCompleteDiarization(testSamples, sampleRate: 16000)
+            let _ = try await diarizer.performCompleteDiarization(testSamples, sampleRate: 16000)
 
             diarizer.cleanup()
         } catch {

--- a/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
@@ -115,9 +115,10 @@ final class SpeakerEnrollmentTests: XCTestCase {
 
         // Verify the embedding can be used with initializeKnownSpeakers
         let speaker = Speaker(id: "test", name: "Test", currentEmbedding: embedding, isPermanent: true)
-        manager.initializeKnownSpeakers([speaker])
+        await manager.initializeKnownSpeakers([speaker])
 
-        XCTAssertEqual(manager.speakerManager.speakerCount, 1, "Known speaker should be registered")
+        let speakerCount = await manager.speakerManager.speakerCount
+        XCTAssertEqual(speakerCount, 1, "Known speaker should be registered")
     }
 
     // MARK: - Sortformer enrollSpeaker: Error Cases

--- a/Tests/FluidAudioTests/Diarizer/SpeakerManagerTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerManagerTests.swift
@@ -21,59 +21,64 @@ final class SpeakerManagerTests: XCTestCase {
 
     // MARK: - Basic Operations
 
-    func testInitialization() {
+    func testInitialization() async {
         let manager = SpeakerManager()
-        XCTAssertEqual(manager.speakerCount, 0)
-        XCTAssertTrue(manager.speakerIds.isEmpty)
+        let speakerCount = await manager.speakerCount
+        let speakerIds = await manager.speakerIds
+        XCTAssertEqual(speakerCount, 0)
+        XCTAssertTrue(speakerIds.isEmpty)
     }
 
-    func testAssignNewSpeaker() {
+    func testAssignNewSpeaker() async {
         let manager = SpeakerManager()
         let embedding = createDistinctEmbedding(pattern: 1)
 
-        let speaker = manager.assignSpeaker(embedding, speechDuration: 2.0)
+        let speaker = await manager.assignSpeaker(embedding, speechDuration: 2.0)
 
         XCTAssertNotNil(speaker)
-        XCTAssertEqual(manager.speakerCount, 1)
+        let speakerCount = await manager.speakerCount
+        XCTAssertEqual(speakerCount, 1)
         // ID should be numeric (starting from 1)
         XCTAssertEqual(speaker?.id, "1")
     }
 
-    func testAssignExistingSpeaker() {
+    func testAssignExistingSpeaker() async {
         let manager = SpeakerManager(speakerThreshold: 0.3)  // Low threshold for testing
 
         // Add first speaker
         let embedding1 = createDistinctEmbedding(pattern: 1)
-        let speaker1 = manager.assignSpeaker(embedding1, speechDuration: 2.0)
+        let speaker1 = await manager.assignSpeaker(embedding1, speechDuration: 2.0)
 
         // Add nearly identical embedding - should match existing speaker
         var embedding2 = embedding1
         embedding2[0] += 0.001  // Tiny variation
-        let speaker2 = manager.assignSpeaker(embedding2, speechDuration: 2.0)
+        let speaker2 = await manager.assignSpeaker(embedding2, speechDuration: 2.0)
 
         XCTAssertEqual(speaker1?.id, speaker2?.id)
-        XCTAssertEqual(manager.speakerCount, 1)  // Should still be 1 speaker
+        let speakerCount = await manager.speakerCount
+        XCTAssertEqual(speakerCount, 1)  // Should still be 1 speaker
     }
 
-    func testMultipleSpeakers() {
+    func testMultipleSpeakers() async {
         let manager = SpeakerManager(speakerThreshold: 0.5)
 
         // Create distinct embeddings
         let embedding1 = createDistinctEmbedding(pattern: 1)
         let embedding2 = createDistinctEmbedding(pattern: 2)
 
-        let speaker1 = manager.assignSpeaker(embedding1, speechDuration: 2.0)
-        let speaker2 = manager.assignSpeaker(embedding2, speechDuration: 2.0)
+        let speaker1 = await manager.assignSpeaker(embedding1, speechDuration: 2.0)
+        let speaker2 = await manager.assignSpeaker(embedding2, speechDuration: 2.0)
 
         XCTAssertNotNil(speaker1)
         XCTAssertNotNil(speaker2)
         XCTAssertNotEqual(speaker1?.id, speaker2?.id)
-        XCTAssertEqual(manager.speakerCount, 2)
+        let speakerCount = await manager.speakerCount
+        XCTAssertEqual(speakerCount, 2)
     }
 
     // MARK: - Known Speaker Initialization
 
-    func testInitializeKnownSpeakers() {
+    func testInitializeKnownSpeakers() async {
         let manager = SpeakerManager()
 
         let knownSpeakers = [
@@ -95,14 +100,16 @@ final class SpeakerManagerTests: XCTestCase {
             ),
         ]
 
-        manager.initializeKnownSpeakers(knownSpeakers)
+        await manager.initializeKnownSpeakers(knownSpeakers)
 
-        XCTAssertEqual(manager.speakerCount, 2)
-        XCTAssertTrue(manager.speakerIds.contains("Alice"))
-        XCTAssertTrue(manager.speakerIds.contains("Bob"))
+        let speakerCount = await manager.speakerCount
+        let speakerIds = await manager.speakerIds
+        XCTAssertEqual(speakerCount, 2)
+        XCTAssertTrue(speakerIds.contains("Alice"))
+        XCTAssertTrue(speakerIds.contains("Bob"))
     }
 
-    func testRecognizeKnownSpeaker() {
+    func testRecognizeKnownSpeaker() async {
         let manager = SpeakerManager(speakerThreshold: 0.3)
 
         let aliceEmbedding = createDistinctEmbedding(pattern: 10)
@@ -114,16 +121,16 @@ final class SpeakerManagerTests: XCTestCase {
             createdAt: Date(),
             updatedAt: Date()
         )
-        manager.initializeKnownSpeakers([aliceSpeaker])
+        await manager.initializeKnownSpeakers([aliceSpeaker])
 
         // Test with exact same embedding
         let testEmbedding = aliceEmbedding
 
-        let assignedSpeaker = manager.assignSpeaker(testEmbedding, speechDuration: 2.0)
+        let assignedSpeaker = await manager.assignSpeaker(testEmbedding, speechDuration: 2.0)
         XCTAssertEqual(assignedSpeaker?.id, "Alice")
     }
 
-    func testInitializeKnownSpeakersPreservesPermanentByDefault() {
+    func testInitializeKnownSpeakersPreservesPermanentByDefault() async {
         let manager = SpeakerManager()
 
         let original = Speaker(
@@ -132,8 +139,8 @@ final class SpeakerManagerTests: XCTestCase {
             currentEmbedding: createDistinctEmbedding(pattern: 10),
             duration: 4.0
         )
-        manager.initializeKnownSpeakers([original])
-        manager.makeSpeakerPermanent("Alice")
+        await manager.initializeKnownSpeakers([original])
+        await manager.makeSpeakerPermanent("Alice")
 
         let replacement = Speaker(
             id: "Alice",
@@ -142,14 +149,14 @@ final class SpeakerManagerTests: XCTestCase {
             duration: 8.0
         )
 
-        manager.initializeKnownSpeakers([replacement], mode: .overwrite, preserveIfPermanent: true)
+        await manager.initializeKnownSpeakers([replacement], mode: .overwrite, preserveIfPermanent: true)
 
-        let stored = manager.getSpeaker(for: "Alice")
+        let stored = await manager.getSpeaker(for: "Alice")
         XCTAssertEqual(stored?.name, "Original")
         XCTAssertEqual(stored?.duration, 4.0)
     }
 
-    func testInitializeKnownSpeakersOverwriteCanReplacePermanentWhenAllowed() {
+    func testInitializeKnownSpeakersOverwriteCanReplacePermanentWhenAllowed() async {
         let manager = SpeakerManager()
 
         let original = Speaker(
@@ -159,7 +166,7 @@ final class SpeakerManagerTests: XCTestCase {
             duration: 4.0,
             isPermanent: true
         )
-        manager.initializeKnownSpeakers([original])
+        await manager.initializeKnownSpeakers([original])
 
         let replacement = Speaker(
             id: "Alice",
@@ -168,14 +175,14 @@ final class SpeakerManagerTests: XCTestCase {
             duration: 10.0
         )
 
-        manager.initializeKnownSpeakers([replacement], mode: .overwrite, preserveIfPermanent: false)
+        await manager.initializeKnownSpeakers([replacement], mode: .overwrite, preserveIfPermanent: false)
 
-        let stored = manager.getSpeaker(for: "Alice")
+        let stored = await manager.getSpeaker(for: "Alice")
         XCTAssertEqual(stored?.name, "Replacement")
         XCTAssertEqual(stored?.duration, 10.0)
     }
 
-    func testInitializeKnownSpeakersMergeCombinesDurations() {
+    func testInitializeKnownSpeakersMergeCombinesDurations() async {
         let manager = SpeakerManager()
 
         let base = Speaker(
@@ -191,44 +198,47 @@ final class SpeakerManagerTests: XCTestCase {
             duration: 3.0
         )
 
-        manager.initializeKnownSpeakers([base])
-        manager.initializeKnownSpeakers([incoming], mode: .merge)
+        await manager.initializeKnownSpeakers([base])
+        await manager.initializeKnownSpeakers([incoming], mode: .merge)
 
-        XCTAssertEqual(manager.getSpeaker(for: "Alice")?.duration, 5.0)
+        let stored = await manager.getSpeaker(for: "Alice")
+        XCTAssertEqual(stored?.duration, 5.0)
     }
 
-    func testInvalidEmbeddingSize() {
+    func testInvalidEmbeddingSize() async {
         let manager = SpeakerManager()
 
         // Test with wrong size
         let invalidEmbedding = [Float](repeating: 0.5, count: 128)
-        let speaker = manager.assignSpeaker(invalidEmbedding, speechDuration: 2.0)
+        let speaker = await manager.assignSpeaker(invalidEmbedding, speechDuration: 2.0)
 
         XCTAssertNil(speaker)
-        XCTAssertEqual(manager.speakerCount, 0)
+        let speakerCount = await manager.speakerCount
+        XCTAssertEqual(speakerCount, 0)
     }
 
-    func testEmptyEmbedding() {
+    func testEmptyEmbedding() async {
         let manager = SpeakerManager()
 
         let emptyEmbedding = [Float]()
-        let speaker = manager.assignSpeaker(emptyEmbedding, speechDuration: 2.0)
+        let speaker = await manager.assignSpeaker(emptyEmbedding, speechDuration: 2.0)
 
         XCTAssertNil(speaker)
-        XCTAssertEqual(manager.speakerCount, 0)
+        let speakerCount = await manager.speakerCount
+        XCTAssertEqual(speakerCount, 0)
     }
 
     // MARK: - Speaker Info Access
 
-    func testGetSpeakerInfo() {
+    func testGetSpeakerInfo() async {
         let manager = SpeakerManager()
         let embedding = createDistinctEmbedding(pattern: 1)
 
-        let speaker = manager.assignSpeaker(embedding, speechDuration: 3.5)
+        let speaker = await manager.assignSpeaker(embedding, speechDuration: 3.5)
         XCTAssertNotNil(speaker)
 
         if let id = speaker?.id {
-            let info = manager.getSpeaker(for: id)
+            let info = await manager.getSpeaker(for: id)
             XCTAssertNotNil(info)
             XCTAssertEqual(info?.id, id)
             let normalizedExpected = VDSPOperations.l2Normalize(embedding)
@@ -237,15 +247,15 @@ final class SpeakerManagerTests: XCTestCase {
         }
     }
 
-    func testPublicSpeakerInfoMembers() {
+    func testPublicSpeakerInfoMembers() async {
         // This test verifies that all SpeakerInfo members are public as requested in PR #63
         let manager = SpeakerManager()
         let embedding = createDistinctEmbedding(pattern: 1)
 
-        let speaker = manager.assignSpeaker(embedding, speechDuration: 5.0)
+        let speaker = await manager.assignSpeaker(embedding, speechDuration: 5.0)
         XCTAssertNotNil(speaker)
 
-        if let id = speaker?.id, let info = manager.getSpeaker(for: id) {
+        if let id = speaker?.id, let info = await manager.getSpeaker(for: id) {
             // Test that all public properties are accessible
             let publicId = info.id
             let publicEmbedding = info.currentEmbedding
@@ -263,17 +273,17 @@ final class SpeakerManagerTests: XCTestCase {
         }
     }
 
-    func testGetAllSpeakerInfo() {
+    func testGetAllSpeakerInfo() async {
         let manager = SpeakerManager()
 
         // Add multiple speakers
         let embedding1 = createDistinctEmbedding(pattern: 1)
         let embedding2 = createDistinctEmbedding(pattern: 2)
 
-        let speaker1 = manager.assignSpeaker(embedding1, speechDuration: 2.0)
-        let speaker2 = manager.assignSpeaker(embedding2, speechDuration: 3.0)
+        let speaker1 = await manager.assignSpeaker(embedding1, speechDuration: 2.0)
+        let speaker2 = await manager.assignSpeaker(embedding2, speechDuration: 3.0)
 
-        let allInfo = manager.getAllSpeakers()
+        let allInfo = await manager.getAllSpeakers()
 
         XCTAssertEqual(allInfo.count, 2)
         if let id1 = speaker1?.id {
@@ -286,13 +296,13 @@ final class SpeakerManagerTests: XCTestCase {
 
     // MARK: - Lookup Helpers
 
-    func testFindSpeakerAndMatchingSpeakers() {
+    func testFindSpeakerAndMatchingSpeakers() async {
         let manager = SpeakerManager(speakerThreshold: 0.8)
 
-        manager.upsertSpeaker(id: "A", currentEmbedding: normalizedEmbedding(pattern: 1), duration: 5.0)
-        manager.upsertSpeaker(id: "B", currentEmbedding: normalizedEmbedding(pattern: 2), duration: 5.0)
+        await manager.upsertSpeaker(id: "A", currentEmbedding: normalizedEmbedding(pattern: 1), duration: 5.0)
+        await manager.upsertSpeaker(id: "B", currentEmbedding: normalizedEmbedding(pattern: 2), duration: 5.0)
 
-        let (matchId, distance) = manager.findSpeaker(with: normalizedEmbedding(pattern: 1))
+        let (matchId, distance) = await manager.findSpeaker(with: normalizedEmbedding(pattern: 1))
         XCTAssertEqual(matchId, "A")
         XCTAssertEqual(distance, 0.0, accuracy: 0.0001)
 
@@ -300,8 +310,8 @@ final class SpeakerManagerTests: XCTestCase {
         var orthogonalEmbedding1 = [Float](repeating: 0, count: 256)
         orthogonalEmbedding0[0] = 1
         orthogonalEmbedding1[1] = 1
-        manager.upsertSpeaker(id: "C", currentEmbedding: orthogonalEmbedding0, duration: 5.0)
-        let (missingId, missingDistance) = manager.findSpeaker(
+        await manager.upsertSpeaker(id: "C", currentEmbedding: orthogonalEmbedding0, duration: 5.0)
+        let (missingId, missingDistance) = await manager.findSpeaker(
             with: orthogonalEmbedding1,
             speakerThreshold: 0.5
         )
@@ -309,7 +319,7 @@ final class SpeakerManagerTests: XCTestCase {
         XCTAssertEqual(missingDistance, .infinity)
 
         let combined = zip(normalizedEmbedding(pattern: 1), normalizedEmbedding(pattern: 2)).map { ($0 + $1) / 2 }
-        let matches = manager.findMatchingSpeakers(
+        let matches = await manager.findMatchingSpeakers(
             with: VDSPOperations.l2Normalize(combined),
             speakerThreshold: 2.0
         )
@@ -319,34 +329,34 @@ final class SpeakerManagerTests: XCTestCase {
         XCTAssertEqual(Set(matches.map(\.id)), Set(["A", "B", "C"]))
     }
 
-    func testFindSpeakersWhereFiltersByPredicate() {
+    func testFindSpeakersWhereFiltersByPredicate() async {
         let manager = SpeakerManager()
-        manager.upsertSpeaker(id: "short", currentEmbedding: normalizedEmbedding(pattern: 10), duration: 1.0)
-        manager.upsertSpeaker(id: "long", currentEmbedding: normalizedEmbedding(pattern: 20), duration: 8.0)
+        await manager.upsertSpeaker(id: "short", currentEmbedding: normalizedEmbedding(pattern: 10), duration: 1.0)
+        await manager.upsertSpeaker(id: "long", currentEmbedding: normalizedEmbedding(pattern: 20), duration: 8.0)
 
-        let filtered = manager.findSpeakers { $0.duration > 5.0 }
+        let filtered = await manager.findSpeakers { $0.duration > 5.0 }
         XCTAssertEqual(filtered.count, 1)
         XCTAssertEqual(filtered.first, "long")
     }
 
     // MARK: - Clear Operations
 
-    func testResetSpeakers() {
+    func testResetSpeakers() async {
         let manager = SpeakerManager()
 
         // Add speakers
-        _ = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
-        _ = manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 2.0)
+        _ = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
+        _ = await manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 2.0)
 
-        XCTAssertEqual(manager.speakerCount, 2)
+        let countBefore = await manager.speakerCount
+        XCTAssertEqual(countBefore, 2)
 
-        manager.reset()
+        await manager.reset()
 
-        // Wait a bit for async reset to complete
-        Thread.sleep(forTimeInterval: 0.1)
-
-        XCTAssertEqual(manager.speakerCount, 0)
-        XCTAssertTrue(manager.speakerIds.isEmpty)
+        let countAfter = await manager.speakerCount
+        let idsAfter = await manager.speakerIds
+        XCTAssertEqual(countAfter, 0)
+        XCTAssertTrue(idsAfter.isEmpty)
     }
 
     // MARK: - Distance Calculations
@@ -385,27 +395,26 @@ final class SpeakerManagerTests: XCTestCase {
 
     // MARK: - Statistics
 
-    func testGetStatistics() {
+    func testGetStatistics() async {
         let manager = SpeakerManager()
 
         // Add speakers with different durations
-        _ = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 10.0)
-        _ = manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 20.0)
+        _ = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 10.0)
+        _ = await manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 20.0)
 
         // getStatistics method was removed - test speaker count instead
-        XCTAssertEqual(manager.speakerCount, 2)
+        let speakerCount = await manager.speakerCount
+        XCTAssertEqual(speakerCount, 2)
 
         // Verify speakers were added with correct info
-        let allInfo = manager.getAllSpeakers()
+        let allInfo = await manager.getAllSpeakers()
         XCTAssertEqual(allInfo.count, 2)
     }
 
     // MARK: - Thread Safety
 
-    func testConcurrentAccess() {
+    func testConcurrentAccess() async {
         let manager = SpeakerManager(speakerThreshold: 0.5)  // Set threshold for distinct embeddings
-        let queue = DispatchQueue(label: "test", attributes: .concurrent)
-        let group = DispatchGroup()
         let iterations = 10  // Reduced iterations for more reliable test
 
         // Use a serial queue to ensure embeddings are distinct
@@ -426,53 +435,47 @@ final class SpeakerManagerTests: XCTestCase {
             return embedding
         }
 
-        // Concurrent writes with pre-created distinct embeddings
-        for i in 0..<iterations {
-            group.enter()
-            queue.async {
-                _ = manager.assignSpeaker(embeddings[i], speechDuration: 2.0)
-                group.leave()
+        // Concurrent writes and reads via structured concurrency
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<iterations {
+                let embedding = embeddings[i]
+                group.addTask {
+                    _ = await manager.assignSpeaker(embedding, speechDuration: 2.0)
+                }
+            }
+
+            for _ in 0..<iterations {
+                group.addTask {
+                    _ = await manager.speakerCount
+                    _ = await manager.speakerIds
+                }
             }
         }
 
-        // Concurrent reads
-        for _ in 0..<iterations {
-            group.enter()
-            queue.async {
-                _ = manager.speakerCount
-                _ = manager.speakerIds
-                group.leave()
-            }
-        }
-
-        let expectation = XCTestExpectation(description: "Concurrent operations complete")
-        group.notify(queue: .main) {
-            // Due to concurrent operations and clustering, we may not get exactly iterations speakers
-            // But we should have at least some distinct speakers
-            XCTAssertGreaterThan(manager.speakerCount, 0)
-            XCTAssertLessThanOrEqual(manager.speakerCount, iterations)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 5.0)
+        // Due to concurrent operations and clustering, we may not get exactly iterations speakers
+        // But we should have at least some distinct speakers
+        let finalCount = await manager.speakerCount
+        XCTAssertGreaterThan(finalCount, 0)
+        XCTAssertLessThanOrEqual(finalCount, iterations)
     }
 
     // MARK: - Upsert Tests
 
-    func testUpsertNewSpeaker() {
+    func testUpsertNewSpeaker() async {
         let manager = SpeakerManager()
         let embedding = createDistinctEmbedding(pattern: 1)
 
         // Upsert a new speaker
-        manager.upsertSpeaker(
+        await manager.upsertSpeaker(
             id: "TestSpeaker1",
             currentEmbedding: embedding,
             duration: 5.0
         )
 
-        XCTAssertEqual(manager.speakerCount, 1)
+        let speakerCount = await manager.speakerCount
+        XCTAssertEqual(speakerCount, 1)
 
-        let info = manager.getSpeaker(for: "TestSpeaker1")
+        let info = await manager.getSpeaker(for: "TestSpeaker1")
         XCTAssertNotNil(info)
         XCTAssertEqual(info?.id, "TestSpeaker1")
         let normalizedExpected = VDSPOperations.l2Normalize(embedding)
@@ -481,35 +484,36 @@ final class SpeakerManagerTests: XCTestCase {
         XCTAssertEqual(info?.updateCount, 1)
     }
 
-    func testUpsertExistingSpeaker() {
+    func testUpsertExistingSpeaker() async {
         let manager = SpeakerManager()
         let embedding1 = createDistinctEmbedding(pattern: 1)
         let embedding2 = createDistinctEmbedding(pattern: 2)
 
         // Insert initial speaker
-        manager.upsertSpeaker(
+        await manager.upsertSpeaker(
             id: "TestSpeaker1",
             currentEmbedding: embedding1,
             duration: 5.0
         )
 
-        let originalInfo = manager.getSpeaker(for: "TestSpeaker1")
+        let originalInfo = await manager.getSpeaker(for: "TestSpeaker1")
         let originalCreatedAt = originalInfo?.createdAt
 
         // Wait a bit to ensure different timestamp
-        Thread.sleep(forTimeInterval: 0.01)
+        try? await Task.sleep(nanoseconds: 10_000_000)
 
         // Update the same speaker
-        manager.upsertSpeaker(
+        await manager.upsertSpeaker(
             id: "TestSpeaker1",
             currentEmbedding: embedding2,
             duration: 10.0,
             updateCount: 5
         )
 
-        XCTAssertEqual(manager.speakerCount, 1)  // Should still be 1 speaker
+        let speakerCount = await manager.speakerCount
+        XCTAssertEqual(speakerCount, 1)  // Should still be 1 speaker
 
-        let updatedInfo = manager.getSpeaker(for: "TestSpeaker1")
+        let updatedInfo = await manager.getSpeaker(for: "TestSpeaker1")
         XCTAssertNotNil(updatedInfo)
         XCTAssertEqual(updatedInfo?.id, "TestSpeaker1")
         XCTAssertEqual(updatedInfo?.currentEmbedding, embedding2)
@@ -521,11 +525,11 @@ final class SpeakerManagerTests: XCTestCase {
         XCTAssertNotEqual(updatedInfo?.updatedAt, originalCreatedAt)
     }
 
-    func testUpsertWithSpeakerObject() {
+    func testUpsertWithSpeakerObject() async {
         let manager = SpeakerManager()
         let embedding = createDistinctEmbedding(pattern: 1)
 
-        let speaker = Speaker(
+        var speaker = Speaker(
             id: "Alice",
             name: "Alice",
             currentEmbedding: embedding,
@@ -536,11 +540,12 @@ final class SpeakerManagerTests: XCTestCase {
         let rawEmbedding = RawEmbedding(embedding: embedding)
         speaker.addRawEmbedding(rawEmbedding)
 
-        manager.upsertSpeaker(speaker)
+        await manager.upsertSpeaker(speaker)
 
-        XCTAssertEqual(manager.speakerCount, 1)
+        let speakerCount = await manager.speakerCount
+        XCTAssertEqual(speakerCount, 1)
 
-        let info = manager.getSpeaker(for: "Alice")
+        let info = await manager.getSpeaker(for: "Alice")
         XCTAssertNotNil(info)
         XCTAssertEqual(info?.id, "Alice")
         let normalizedExpected = VDSPOperations.l2Normalize(embedding)
@@ -551,44 +556,52 @@ final class SpeakerManagerTests: XCTestCase {
 
     // MARK: - Permanence & Merge Operations
 
-    func testMakeAndRevokePermanentSpeakers() throws {
+    func testMakeAndRevokePermanentSpeakers() async throws {
         let manager = SpeakerManager()
-        let speaker = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.5)
+        let speaker = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.5)
         let id = try XCTUnwrap(speaker?.id)
 
-        manager.makeSpeakerPermanent(id)
-        XCTAssertTrue(manager.permanentSpeakerIds.contains(id))
+        await manager.makeSpeakerPermanent(id)
+        let permanentIds = await manager.permanentSpeakerIds
+        XCTAssertTrue(permanentIds.contains(id))
 
-        manager.removeSpeaker(id)
-        XCTAssertTrue(manager.hasSpeaker(id))
+        await manager.removeSpeaker(id)
+        let stillHas = await manager.hasSpeaker(id)
+        XCTAssertTrue(stillHas)
 
-        manager.revokePermanence(from: id)
-        manager.removeSpeaker(id)
-        XCTAssertFalse(manager.hasSpeaker(id))
+        await manager.revokePermanence(from: id)
+        await manager.removeSpeaker(id)
+        let removedNow = await manager.hasSpeaker(id)
+        XCTAssertFalse(removedNow)
     }
 
-    func testMergeSpeakerRespectsPermanentFlag() throws {
+    func testMergeSpeakerRespectsPermanentFlag() async throws {
         let manager = SpeakerManager()
-        let speaker1 = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 3.0)
-        let speaker2 = manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 4.0)
+        let speaker1 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 3.0)
+        let speaker2 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 4.0)
 
         let id1 = try XCTUnwrap(speaker1?.id)
         let id2 = try XCTUnwrap(speaker2?.id)
 
-        manager.makeSpeakerPermanent(id1)
-        manager.mergeSpeaker(id1, into: id2)
-        XCTAssertTrue(manager.hasSpeaker(id1))
-        XCTAssertTrue(manager.hasSpeaker(id2))
+        await manager.makeSpeakerPermanent(id1)
+        await manager.mergeSpeaker(id1, into: id2)
+        let has1 = await manager.hasSpeaker(id1)
+        let has2 = await manager.hasSpeaker(id2)
+        XCTAssertTrue(has1)
+        XCTAssertTrue(has2)
 
-        manager.mergeSpeaker(id1, into: id2, mergedName: "Merged Speaker", stopIfPermanent: false)
-        XCTAssertFalse(manager.hasSpeaker(id1))
-        let merged = try XCTUnwrap(manager.getSpeaker(for: id2))
+        await manager.mergeSpeaker(id1, into: id2, mergedName: "Merged Speaker", stopIfPermanent: false)
+        let hasAfterMerge1 = await manager.hasSpeaker(id1)
+        XCTAssertFalse(hasAfterMerge1)
+        let mergedOpt = await manager.getSpeaker(for: id2)
+        let merged = try XCTUnwrap(mergedOpt)
         XCTAssertEqual(merged.name, "Merged Speaker")
-        XCTAssertEqual(manager.speakerCount, 1)
+        let finalCount = await manager.speakerCount
+        XCTAssertEqual(finalCount, 1)
         XCTAssertGreaterThan(merged.duration, 4.0)
     }
 
-    func testFindMergeablePairsRespectsPermanentExclusion() {
+    func testFindMergeablePairsRespectsPermanentExclusion() async {
         let manager = SpeakerManager(speakerThreshold: 0.3)
         let base = normalizedEmbedding(pattern: 1)
         var close = base
@@ -596,74 +609,81 @@ final class SpeakerManagerTests: XCTestCase {
         close = VDSPOperations.l2Normalize(close)
         let far = normalizedEmbedding(pattern: 80)
 
-        manager.upsertSpeaker(id: "A", currentEmbedding: base, duration: 5.0)
-        manager.upsertSpeaker(id: "B", currentEmbedding: close, duration: 5.0)
-        manager.upsertSpeaker(id: "C", currentEmbedding: far, duration: 5.0)
+        await manager.upsertSpeaker(id: "A", currentEmbedding: base, duration: 5.0)
+        await manager.upsertSpeaker(id: "B", currentEmbedding: close, duration: 5.0)
+        await manager.upsertSpeaker(id: "C", currentEmbedding: far, duration: 5.0)
 
-        let pairs = manager.findMergeablePairs(speakerThreshold: 0.2)
+        let pairs = await manager.findMergeablePairs(speakerThreshold: 0.2)
         XCTAssertEqual(pairs.count, 1)
         XCTAssertEqual(Set([pairs[0].speakerToMerge, pairs[0].destination]), Set(["A", "B"]))
 
-        manager.makeSpeakerPermanent("A")
-        manager.makeSpeakerPermanent("B")
+        await manager.makeSpeakerPermanent("A")
+        await manager.makeSpeakerPermanent("B")
 
-        let filtered = manager.findMergeablePairs(speakerThreshold: 0.2, excludeIfBothPermanent: true)
+        let filtered = await manager.findMergeablePairs(speakerThreshold: 0.2, excludeIfBothPermanent: true)
         XCTAssertTrue(filtered.isEmpty)
 
-        let unfiltered = manager.findMergeablePairs(speakerThreshold: 0.2, excludeIfBothPermanent: false)
+        let unfiltered = await manager.findMergeablePairs(speakerThreshold: 0.2, excludeIfBothPermanent: false)
         XCTAssertEqual(unfiltered.count, 1)
         XCTAssertEqual(Set([unfiltered[0].speakerToMerge, unfiltered[0].destination]), Set(["A", "B"]))
     }
 
     // MARK: - Removal & Reset
 
-    func testRemoveSpeakersInactiveAndPredicateVariants() {
+    func testRemoveSpeakersInactiveAndPredicateVariants() async {
         let manager = SpeakerManager()
         let now = Date()
-        manager.upsertSpeaker(
+        await manager.upsertSpeaker(
             id: "old",
             currentEmbedding: normalizedEmbedding(pattern: 3),
             duration: 2.0,
             updatedAt: now.addingTimeInterval(-120)
         )
-        manager.upsertSpeaker(
+        await manager.upsertSpeaker(
             id: "recent",
             currentEmbedding: normalizedEmbedding(pattern: 4),
             duration: 2.0,
             updatedAt: now
         )
 
-        manager.removeSpeakersInactive(since: now.addingTimeInterval(-60))
-        XCTAssertFalse(manager.hasSpeaker("old"))
-        XCTAssertTrue(manager.hasSpeaker("recent"))
+        await manager.removeSpeakersInactive(since: now.addingTimeInterval(-60))
+        let hasOld = await manager.hasSpeaker("old")
+        let hasRecent = await manager.hasSpeaker("recent")
+        XCTAssertFalse(hasOld)
+        XCTAssertTrue(hasRecent)
 
-        manager.makeSpeakerPermanent("recent")
-        manager.removeSpeakers { $0.duration <= 2.0 }
-        XCTAssertTrue(manager.hasSpeaker("recent"))
+        await manager.makeSpeakerPermanent("recent")
+        await manager.removeSpeakers { $0.duration <= 2.0 }
+        let hasRecentAfterKeep = await manager.hasSpeaker("recent")
+        XCTAssertTrue(hasRecentAfterKeep)
 
-        manager.removeSpeakers(where: { $0.duration <= 2.0 }, keepIfPermanent: false)
-        XCTAssertFalse(manager.hasSpeaker("recent"))
+        await manager.removeSpeakers(where: { $0.duration <= 2.0 }, keepIfPermanent: false)
+        let hasRecentAfterForce = await manager.hasSpeaker("recent")
+        XCTAssertFalse(hasRecentAfterForce)
     }
 
-    func testResetKeepsPermanentSpeakers() throws {
+    func testResetKeepsPermanentSpeakers() async throws {
         let manager = SpeakerManager()
-        let speaker1 = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
-        let speaker2 = manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 2.0)
+        let speaker1 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
+        let speaker2 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 2.0)
 
         let id1 = try XCTUnwrap(speaker1?.id)
         let id2 = try XCTUnwrap(speaker2?.id)
 
-        manager.makeSpeakerPermanent(id1)
-        manager.reset(keepIfPermanent: true)
+        await manager.makeSpeakerPermanent(id1)
+        await manager.reset(keepIfPermanent: true)
 
-        XCTAssertTrue(manager.hasSpeaker(id1))
-        XCTAssertFalse(manager.hasSpeaker(id2))
-        XCTAssertEqual(manager.speakerIds, [id1])
+        let has1 = await manager.hasSpeaker(id1)
+        let has2 = await manager.hasSpeaker(id2)
+        let ids = await manager.speakerIds
+        XCTAssertTrue(has1)
+        XCTAssertFalse(has2)
+        XCTAssertEqual(ids, [id1])
     }
 
     // MARK: - Embedding Update Tests
 
-    func testEmbeddingUpdateWithinAssignSpeaker() {
+    func testEmbeddingUpdateWithinAssignSpeaker() async {
         let manager = SpeakerManager(
             speakerThreshold: 0.3,
             embeddingThreshold: 0.2,
@@ -672,27 +692,27 @@ final class SpeakerManagerTests: XCTestCase {
 
         // Create initial speaker
         let emb1 = createDistinctEmbedding(pattern: 1)
-        let speaker1 = manager.assignSpeaker(emb1, speechDuration: 3.0)
+        let speaker1 = await manager.assignSpeaker(emb1, speechDuration: 3.0)
         XCTAssertNotNil(speaker1)
 
         // Get initial state
-        let initialInfo = manager.getSpeaker(for: speaker1!.id)
+        let initialInfo = await manager.getSpeaker(for: speaker1!.id)
         let initialUpdateCount = initialInfo?.updateCount ?? 0
 
         // Assign similar embedding with sufficient duration - should update
         var emb2 = emb1
         emb2[0] += 0.01  // Very similar
-        let speaker2 = manager.assignSpeaker(emb2, speechDuration: 3.0)
+        let speaker2 = await manager.assignSpeaker(emb2, speechDuration: 3.0)
 
         XCTAssertEqual(speaker2?.id, speaker1?.id)  // Same speaker
 
         // Check that embedding was updated
-        let updatedInfo = manager.getSpeaker(for: speaker1!.id)
+        let updatedInfo = await manager.getSpeaker(for: speaker1!.id)
         XCTAssertGreaterThan(updatedInfo?.updateCount ?? 0, initialUpdateCount)
         XCTAssertNotEqual(updatedInfo?.currentEmbedding, emb1)  // Embedding changed
     }
 
-    func testNoEmbeddingUpdateForShortDuration() {
+    func testNoEmbeddingUpdateForShortDuration() async {
         let manager = SpeakerManager(
             speakerThreshold: 0.3,
             embeddingThreshold: 0.2,
@@ -701,28 +721,28 @@ final class SpeakerManagerTests: XCTestCase {
 
         // Create initial speaker
         let emb1 = createDistinctEmbedding(pattern: 1)
-        let speaker1 = manager.assignSpeaker(emb1, speechDuration: 3.0)
+        let speaker1 = await manager.assignSpeaker(emb1, speechDuration: 3.0)
         XCTAssertNotNil(speaker1)
 
         // Get initial state
-        let initialInfo = manager.getSpeaker(for: speaker1!.id)
+        let initialInfo = await manager.getSpeaker(for: speaker1!.id)
         let initialUpdateCount = initialInfo?.updateCount ?? 0
 
         // Assign similar embedding with short duration - WILL update embedding now (duration check removed)
         var emb2 = emb1
         emb2[0] += 0.01
-        let speaker2 = manager.assignSpeaker(emb2, speechDuration: 0.5)
+        let speaker2 = await manager.assignSpeaker(emb2, speechDuration: 0.5)
 
         XCTAssertEqual(speaker2?.id, speaker1?.id)  // Same speaker
 
         // Check that embedding WAS updated (since duration check was removed)
-        let updatedInfo = manager.getSpeaker(for: speaker1!.id)
+        let updatedInfo = await manager.getSpeaker(for: speaker1!.id)
         XCTAssertGreaterThan(updatedInfo?.updateCount ?? 0, initialUpdateCount)  // Updated
         XCTAssertNotEqual(updatedInfo?.currentEmbedding, emb1)  // Embedding changed
         XCTAssertGreaterThan(updatedInfo?.duration ?? 0, 3.0)  // Duration still increased
     }
 
-    func testRawEmbeddingFIFOInManager() {
+    func testRawEmbeddingFIFOInManager() async {
         let manager = SpeakerManager(
             speakerThreshold: 0.3,
             embeddingThreshold: 0.2,
@@ -731,41 +751,43 @@ final class SpeakerManagerTests: XCTestCase {
 
         // Create initial speaker
         let emb1 = createDistinctEmbedding(pattern: 1)
-        let speaker = manager.assignSpeaker(emb1, speechDuration: 3.0)
+        let speaker = await manager.assignSpeaker(emb1, speechDuration: 3.0)
         XCTAssertNotNil(speaker)
 
         // Add many embeddings to trigger FIFO (max 50)
         for i in 0..<60 {
             var emb = emb1
             emb[0] += Float(i) * 0.001  // Slight variations
-            _ = manager.assignSpeaker(emb, speechDuration: 2.5)
+            _ = await manager.assignSpeaker(emb, speechDuration: 2.5)
         }
 
         // Check that raw embeddings are limited to 50
-        let info = manager.getSpeaker(for: speaker!.id)
+        let info = await manager.getSpeaker(for: speaker!.id)
         XCTAssertLessThanOrEqual(info?.rawEmbeddings.count ?? 0, 50)
     }
 
     // MARK: - Edge Cases
 
-    func testSpeakerThresholdBoundaries() {
+    func testSpeakerThresholdBoundaries() async {
         // Test with very low threshold (everything matches)
         let manager1 = SpeakerManager(speakerThreshold: 0.01)
-        _ = manager1.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
+        _ = await manager1.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
         var similarEmbedding = createDistinctEmbedding(pattern: 1)
         similarEmbedding[0] += 0.001  // Tiny variation
-        _ = manager1.assignSpeaker(similarEmbedding, speechDuration: 2.0)
-        XCTAssertEqual(manager1.speakerCount, 1)  // Should match to same speaker
+        _ = await manager1.assignSpeaker(similarEmbedding, speechDuration: 2.0)
+        let count1 = await manager1.speakerCount
+        XCTAssertEqual(count1, 1)  // Should match to same speaker
 
         // Test with high threshold (only exact matches)
         let manager2 = SpeakerManager(speakerThreshold: 0.001)  // Very small threshold
         let emb1 = createDistinctEmbedding(pattern: 1)
-        _ = manager2.assignSpeaker(emb1, speechDuration: 2.0)
-        _ = manager2.assignSpeaker(emb1, speechDuration: 2.0)  // Exact same embedding
-        XCTAssertEqual(manager2.speakerCount, 1)  // Should match to same speaker
+        _ = await manager2.assignSpeaker(emb1, speechDuration: 2.0)
+        _ = await manager2.assignSpeaker(emb1, speechDuration: 2.0)  // Exact same embedding
+        let count2 = await manager2.speakerCount
+        XCTAssertEqual(count2, 1)  // Should match to same speaker
     }
 
-    func testMinDurationFiltering() {
+    func testMinDurationFiltering() async {
         let manager = SpeakerManager(
             speakerThreshold: 0.5,
             embeddingThreshold: 0.3,
@@ -775,17 +797,19 @@ final class SpeakerManagerTests: XCTestCase {
         let embedding = createDistinctEmbedding(pattern: 1)
 
         // Test with duration below threshold - should not create new speaker
-        let speaker1 = manager.assignSpeaker(embedding, speechDuration: 0.5)
+        let speaker1 = await manager.assignSpeaker(embedding, speechDuration: 0.5)
         XCTAssertNil(speaker1)  // Should return nil for short duration
-        XCTAssertEqual(manager.speakerCount, 0)  // No speaker created
+        let count0 = await manager.speakerCount
+        XCTAssertEqual(count0, 0)  // No speaker created
 
         // Test with duration above threshold - should create speaker
-        let speaker2 = manager.assignSpeaker(embedding, speechDuration: 3.0)
+        let speaker2 = await manager.assignSpeaker(embedding, speechDuration: 3.0)
         XCTAssertNotNil(speaker2)
-        XCTAssertEqual(manager.speakerCount, 1)  // One speaker created
+        let count1 = await manager.speakerCount
+        XCTAssertEqual(count1, 1)  // One speaker created
 
         // Test again with short duration on existing speaker
-        let speaker3 = manager.assignSpeaker(embedding, speechDuration: 0.5)
+        let speaker3 = await manager.assignSpeaker(embedding, speechDuration: 0.5)
         XCTAssertEqual(speaker3?.id, speaker2?.id)  // Should match existing speaker even with short duration
     }
 }

--- a/Tests/FluidAudioTests/Diarizer/SpeakerOperationsTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerOperationsTests.swift
@@ -334,7 +334,7 @@ final class SpeakerOperationsTests: XCTestCase {
     // MARK: - Merge Speakers Tests
 
     func testMergeSpeakers() {
-        let speaker1 = Speaker(
+        var speaker1 = Speaker(
             id: "speaker1",
             name: "Alice",
             currentEmbedding: createDistinctEmbedding(pattern: 1),
@@ -343,7 +343,7 @@ final class SpeakerOperationsTests: XCTestCase {
         speaker1.updateCount = 5
         speaker1.addRawEmbedding(RawEmbedding(embedding: createDistinctEmbedding(pattern: 3)))
 
-        let speaker2 = Speaker(
+        var speaker2 = Speaker(
             id: "speaker2",
             name: "Bob",
             currentEmbedding: createDistinctEmbedding(pattern: 2),
@@ -365,8 +365,8 @@ final class SpeakerOperationsTests: XCTestCase {
     }
 
     func testMergeSpeakersWithMaxCapacity() {
-        let speaker1 = Speaker(id: "speaker1", name: "Alice", currentEmbedding: createDistinctEmbedding(pattern: 1))
-        let speaker2 = Speaker(id: "speaker2", name: "Bob", currentEmbedding: createDistinctEmbedding(pattern: 2))
+        var speaker1 = Speaker(id: "speaker1", name: "Alice", currentEmbedding: createDistinctEmbedding(pattern: 1))
+        var speaker2 = Speaker(id: "speaker2", name: "Bob", currentEmbedding: createDistinctEmbedding(pattern: 2))
 
         // Add many raw embeddings
         for i in 0..<30 {
@@ -433,58 +433,59 @@ final class SpeakerOperationsTests: XCTestCase {
 
     // MARK: - SpeakerManager Extension Tests
 
-    func testReassignSegment() {
+    func testReassignSegment() async {
         let manager = SpeakerManager()
 
         // Create initial speakers
         let emb1 = createDistinctEmbedding(pattern: 1)
         let emb2 = createDistinctEmbedding(pattern: 2)
 
-        let speaker1 = manager.assignSpeaker(emb1, speechDuration: 5.0)
-        let speaker2 = manager.assignSpeaker(emb2, speechDuration: 5.0)
+        let speaker1 = await manager.assignSpeaker(emb1, speechDuration: 5.0)
+        let speaker2 = await manager.assignSpeaker(emb2, speechDuration: 5.0)
 
         XCTAssertNotNil(speaker1)
         XCTAssertNotNil(speaker2)
 
         // Test that both speakers were created
-        XCTAssertEqual(manager.speakerCount, 2)
+        let speakerCount = await manager.speakerCount
+        XCTAssertEqual(speakerCount, 2)
 
         // Test reassigning an embedding that's closer to speaker2
-        let reassignedSpeaker = manager.assignSpeaker(emb2, speechDuration: 3.0)
+        let reassignedSpeaker = await manager.assignSpeaker(emb2, speechDuration: 3.0)
         XCTAssertEqual(reassignedSpeaker?.id, speaker2?.id)
     }
 
-    func testGetCurrentSpeakerNames() {
+    func testGetCurrentSpeakerNames() async {
         let manager = SpeakerManager()
 
         // Add speakers with names
         let alice = Speaker(id: "alice", name: "Alice", currentEmbedding: createDistinctEmbedding(pattern: 1))
         let bob = Speaker(id: "bob", name: "Bob", currentEmbedding: createDistinctEmbedding(pattern: 2))
 
-        manager.initializeKnownSpeakers([alice, bob])
+        await manager.initializeKnownSpeakers([alice, bob])
 
         // getCurrentSpeakerNames actually returns speaker IDs, not names
-        let speakerIds = manager.getCurrentSpeakerNames()
+        let speakerIds = await manager.getCurrentSpeakerNames()
 
         XCTAssertEqual(speakerIds.count, 2)
         XCTAssertTrue(speakerIds.contains("alice"))
         XCTAssertTrue(speakerIds.contains("bob"))
     }
 
-    func testGetGlobalSpeakerStats() {
+    func testGetGlobalSpeakerStats() async {
         let manager = SpeakerManager(speakerThreshold: 0.5)  // Use higher threshold to ensure distinct speakers
 
         // Add speakers with very different embeddings to ensure they're distinct
-        let speaker1 = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 10.0)
-        let speaker2 = manager.assignSpeaker(createDistinctEmbedding(pattern: 100), speechDuration: 20.0)
-        let speaker3 = manager.assignSpeaker(createDistinctEmbedding(pattern: 200), speechDuration: 30.0)
+        let speaker1 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 10.0)
+        let speaker2 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 100), speechDuration: 20.0)
+        let speaker3 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 200), speechDuration: 30.0)
 
         // Debug: check if all speakers were created
         XCTAssertNotNil(speaker1)
         XCTAssertNotNil(speaker2)
         XCTAssertNotNil(speaker3)
 
-        let stats = manager.getGlobalSpeakerStats()
+        let stats = await manager.getGlobalSpeakerStats()
 
         // If not all 3 speakers were created, adjust expectations
         XCTAssertGreaterThanOrEqual(stats.totalSpeakers, 2)

--- a/Tests/FluidAudioTests/Diarizer/SpeakerTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerTests.swift
@@ -49,24 +49,28 @@ final class SpeakerTests: XCTestCase {
 
     // MARK: - Speaker Enrollment Workflow
 
-    func testSpeakerEnrollmentWithName() {
+    func testSpeakerEnrollmentWithName() async {
         // Simulate the "My name is Alice" enrollment scenario
         let manager = SpeakerManager()
         let aliceEmbedding = createDistinctEmbedding(pattern: 10)
 
         // Step 1: User speaks and we get their embedding
-        let speaker = manager.assignSpeaker(aliceEmbedding, speechDuration: 3.0)
+        let speaker = await manager.assignSpeaker(aliceEmbedding, speechDuration: 3.0)
         XCTAssertNotNil(speaker)
 
         // Step 2: Transcription detects "My name is Alice"
-        // Step 3: Update the speaker's name from default to actual name
-        speaker?.name = "Alice"
+        // Step 3: Update the speaker's name from default to actual name (persist via upsert since struct)
+        if var updated = speaker {
+            updated.name = "Alice"
+            await manager.upsertSpeaker(updated)
+        }
 
-        XCTAssertEqual(speaker?.name, "Alice")
-        XCTAssertNotEqual(speaker?.name, speaker?.id)  // Name should be different from ID
+        let stored = await manager.getSpeaker(for: speaker!.id)
+        XCTAssertEqual(stored?.name, "Alice")
+        XCTAssertNotEqual(stored?.name, stored?.id)  // Name should be different from ID
 
         // Step 4: Future audio from same speaker should be identified as "Alice"
-        let futureSpeaker = manager.assignSpeaker(aliceEmbedding, speechDuration: 2.0)
+        let futureSpeaker = await manager.assignSpeaker(aliceEmbedding, speechDuration: 2.0)
         XCTAssertEqual(futureSpeaker?.id, speaker?.id)
         XCTAssertEqual(futureSpeaker?.name, "Alice")
     }
@@ -75,7 +79,7 @@ final class SpeakerTests: XCTestCase {
 
     func testUpdateMainEmbedding() {
         let embedding1 = createDistinctEmbedding(pattern: 1)
-        let speaker = Speaker(id: "test", currentEmbedding: embedding1)
+        var speaker = Speaker(id: "test", currentEmbedding: embedding1)
 
         let embedding2 = createDistinctEmbedding(pattern: 2)
         speaker.updateMainEmbedding(
@@ -97,7 +101,7 @@ final class SpeakerTests: XCTestCase {
 
     func testUpdateMainEmbeddingWithAlpha() {
         let embedding1 = [Float](repeating: 1.0, count: 256)
-        let speaker = Speaker(id: "test", currentEmbedding: embedding1)
+        var speaker = Speaker(id: "test", currentEmbedding: embedding1)
 
         // Use a valid embedding with non-zero magnitude
         let embedding2 = [Float](repeating: 0.5, count: 256)
@@ -122,7 +126,7 @@ final class SpeakerTests: XCTestCase {
 
     func testUpdateMainEmbeddingLowMagnitude() {
         let embedding1 = createDistinctEmbedding(pattern: 1)
-        let speaker = Speaker(id: "test", currentEmbedding: embedding1)
+        var speaker = Speaker(id: "test", currentEmbedding: embedding1)
 
         // Create an embedding with magnitude below 0.1 threshold
         let lowMagnitudeEmbedding = [Float](repeating: 0.001, count: 256)  // Very low magnitude
@@ -148,7 +152,7 @@ final class SpeakerTests: XCTestCase {
     // MARK: - Raw Embedding Management Tests
 
     func testAddRawEmbedding() {
-        let speaker = Speaker(id: "test", currentEmbedding: createDistinctEmbedding(pattern: 1))
+        var speaker = Speaker(id: "test", currentEmbedding: createDistinctEmbedding(pattern: 1))
 
         let rawEmb1 = RawEmbedding(embedding: createDistinctEmbedding(pattern: 2))
         let rawEmb2 = RawEmbedding(embedding: createDistinctEmbedding(pattern: 3))
@@ -160,7 +164,7 @@ final class SpeakerTests: XCTestCase {
     }
 
     func testRawEmbeddingFIFO() {
-        let speaker = Speaker(id: "test", currentEmbedding: createDistinctEmbedding(pattern: 1))
+        var speaker = Speaker(id: "test", currentEmbedding: createDistinctEmbedding(pattern: 1))
 
         // Add 60 raw embeddings (more than the 50 limit)
         for i in 0..<60 {
@@ -180,7 +184,7 @@ final class SpeakerTests: XCTestCase {
     }
 
     func testRemoveRawEmbedding() {
-        let speaker = Speaker(id: "test", currentEmbedding: createDistinctEmbedding(pattern: 1))
+        var speaker = Speaker(id: "test", currentEmbedding: createDistinctEmbedding(pattern: 1))
 
         let rawEmb1 = RawEmbedding(embedding: createDistinctEmbedding(pattern: 2))
         let rawEmb2 = RawEmbedding(embedding: createDistinctEmbedding(pattern: 3))
@@ -204,7 +208,7 @@ final class SpeakerTests: XCTestCase {
     // MARK: - Recalculate Main Embedding Tests
 
     func testRecalculateMainEmbedding() {
-        let speaker = Speaker(id: "test", currentEmbedding: [Float](repeating: 0, count: 256))
+        var speaker = Speaker(id: "test", currentEmbedding: [Float](repeating: 0, count: 256))
 
         // Add some raw embeddings
         let emb1 = [Float](repeating: 1.0, count: 256)
@@ -226,7 +230,7 @@ final class SpeakerTests: XCTestCase {
 
     func testRecalculateMainEmbeddingEmpty() {
         let original = createDistinctEmbedding(pattern: 1)
-        let speaker = Speaker(id: "test", currentEmbedding: original)
+        var speaker = Speaker(id: "test", currentEmbedding: original)
 
         // No raw embeddings
         speaker.recalculateMainEmbedding()
@@ -241,7 +245,7 @@ final class SpeakerTests: XCTestCase {
     // MARK: - Speaker Merging Tests
 
     func testMergeSpeakers() {
-        let speaker1 = Speaker(
+        var speaker1 = Speaker(
             id: "speaker1",
             name: "Alice",
             currentEmbedding: createDistinctEmbedding(pattern: 1),
@@ -249,7 +253,7 @@ final class SpeakerTests: XCTestCase {
         )
         speaker1.updateCount = 5
 
-        let speaker2 = Speaker(
+        var speaker2 = Speaker(
             id: "speaker2",
             name: "Bob",
             currentEmbedding: createDistinctEmbedding(pattern: 2),
@@ -272,7 +276,7 @@ final class SpeakerTests: XCTestCase {
     }
 
     func testMergeSpeakersWithCustomName() {
-        let speaker1 = Speaker(id: "speaker1", name: "Alice", currentEmbedding: createDistinctEmbedding(pattern: 1))
+        var speaker1 = Speaker(id: "speaker1", name: "Alice", currentEmbedding: createDistinctEmbedding(pattern: 1))
         let speaker2 = Speaker(id: "speaker2", name: "Bob", currentEmbedding: createDistinctEmbedding(pattern: 2))
 
         speaker1.mergeWith(speaker2, keepName: "Charlie")
@@ -283,7 +287,7 @@ final class SpeakerTests: XCTestCase {
     // MARK: - SendableSpeaker Tests
 
     func testToSendable() {
-        let speaker = Speaker(
+        var speaker = Speaker(
             id: "test1",
             name: "Alice",
             currentEmbedding: createDistinctEmbedding(pattern: 1),
@@ -327,7 +331,7 @@ final class SpeakerTests: XCTestCase {
     // MARK: - Codable Tests
 
     func testSpeakerCodable() throws {
-        let speaker = Speaker(
+        var speaker = Speaker(
             id: "test1",
             name: "Alice",
             currentEmbedding: createDistinctEmbedding(pattern: 1),

--- a/Tests/FluidAudioTests/Shared/ArraySliceTests.swift
+++ b/Tests/FluidAudioTests/Shared/ArraySliceTests.swift
@@ -119,13 +119,13 @@ final class ArraySliceTests: XCTestCase {
 
         // Test with full array
         let arrayStart = Date()
-        _ = try diarizer.performCompleteDiarization(fullAudio, sampleRate: 16000)
+        _ = try await diarizer.performCompleteDiarization(fullAudio, sampleRate: 16000)
         let arrayTime = Date().timeIntervalSince(arrayStart)
 
         // Test with ArraySlice (no copy needed)
         let slice = fullAudio[80000..<400000]  // 20 seconds from middle
         let sliceStart = Date()
-        _ = try diarizer.performCompleteDiarization(slice, sampleRate: 16000)
+        _ = try await diarizer.performCompleteDiarization(slice, sampleRate: 16000)
         let sliceTime = Date().timeIntervalSince(sliceStart)
 
         print("Array processing time: \(arrayTime)s")

--- a/Tests/FluidAudioTests/Shared/RandomAccessCollectionTests.swift
+++ b/Tests/FluidAudioTests/Shared/RandomAccessCollectionTests.swift
@@ -348,7 +348,7 @@ final class RandomAccessCollectionTests: XCTestCase {
             .lazy.map { $0 * 0.5 }  // Reduce amplitude lazily
 
         // This should work without issues
-        let result = try diarizer.performCompleteDiarization(
+        let result = try await diarizer.performCompleteDiarization(
             complexCollection,
             sampleRate: 16000
         )


### PR DESCRIPTION
## Summary

Fixes [#528](https://github.com/FluidInference/FluidAudio/issues/528): heap corruption (`BUG IN CLIENT OF LIBMALLOC: memory corruption of free block`) and `Potential Structural Swift Concurrency Issue: unsafeForcedSync called from Swift Concurrent context` warnings in the diarizer on iOS 26.4 when `DiarizerModels.download()` + `SpeakerManager.extractSpeakerEmbedding` are called from an async context under Swift 6 strict concurrency.

**Root cause**
- `SpeakerManager` used `DispatchQueue.sync(flags: .barrier)` &rarr; `unsafeForcedSync` warning when called from a Swift concurrent context.
- `Speaker` was a reference type with mutable `[Float]` embeddings &rarr; concurrent COW mutations on the embedding buffers corrupted the heap.

**Fix** &mdash; apply the same actor-conversion pattern used for `AsrManager` in #419:
- `Speaker`: `final class` &rarr; `struct` (Sendable value type)
- `SpeakerManager`: class + `DispatchQueue` &rarr; `actor`
- `SpeakerOperations` extension: dropped `queue.sync`
- `DiarizerManager`: async-ified methods
- `SpeakerManager.upsertSpeaker(_:)` + `upsertSpeaker(id:...)`: thread the speaker's `name` through persistence (previously implicit via class-reference mutation; now required with struct value semantics).
- CLI (`ProcessCommand`, `DiarizationBenchmark`) and all speaker/diarizer tests updated to `await` the actor-isolated API.
- `testConcurrentAccess` rewritten from `DispatchQueue.async`/`DispatchGroup` to `withTaskGroup` for structured concurrency.

## Test plan

- [x] `swift build` &mdash; clean on macOS
- [x] `swift test` &mdash; 1435 tests, 0 failures (24 skipped)
- [x] swift-format &mdash; no new warnings in touched files (pre-existing warnings only, unrelated to this change)
- [ ] CI: build + tests + swift-format checks
- [ ] Verify on reporter's iOS 26.4 repro from #528
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
