### PR TITLE
feat(tts/pocket): multi-language support (EN + 9 new packs)

### DIFF
--- a/Documentation/TTS/PocketTTS.md
+++ b/Documentation/TTS/PocketTTS.md
@@ -245,7 +245,7 @@ that matches your input text — there is no automatic language detection.
 
 | ID | Layers | HF Path |
 |----|--------|---------|
-| `english` | 6 | repo root (legacy layout) |
+| `english` | 6 | `v2/english/` |
 | `german` | 6 | `v2/german/` |
 | `german_24l` | 24 | `v2/german_24l/` |
 | `italian` | 6 | `v2/italian/` |

--- a/Documentation/TTS/PocketTTS.md
+++ b/Documentation/TTS/PocketTTS.md
@@ -145,6 +145,29 @@ fluidaudio tts "Hello world" --backend pocket --voice-file my_voice.bin
 - The `mimi_encoder.mlmodelc` model is downloaded automatically on first use
 - Supports any audio format that AVFoundation can read
 
+### Cloning Across Languages
+
+The Mimi encoder is language-agnostic — voice cloning produces a generic
+acoustic embedding that any language pack's `cond_step` model can consume.
+You can:
+
+- Clone a voice once and reuse the same `PocketTtsVoiceData` across managers
+  configured with different languages.
+- Clone a voice with a Spanish-only manager without pulling in the English
+  language pack — only the encoder subtree is downloaded.
+
+```swift
+// Clone with a Spanish manager
+let esManager = PocketTtsManager(language: .spanish)
+try await esManager.initialize()
+let voiceData = try await esManager.cloneVoice(from: speakerAudioURL)
+
+// Use the same cloned voice with a French manager
+let frManager = PocketTtsManager(language: .french24L)
+try await frManager.initialize()
+let frAudio = try await frManager.synthesize(text: "Bonjour", voiceData: voiceData)
+```
+
 ## Pipeline and Pronunciation Control
 
 ```
@@ -213,6 +236,57 @@ for try await frame in session.frames {
 | One-shot synthesis | `synthesize()` |
 | Streaming playback | `synthesizeStreaming()` |
 | Streaming text or custom chunking | `makeSession()` |
+
+## Languages
+
+PocketTTS ships with multiple language packs converted from
+[kyutai/pocket-tts](https://huggingface.co/kyutai/pocket-tts). Pick the one
+that matches your input text — there is no automatic language detection.
+
+| ID | Layers | HF Path |
+|----|--------|---------|
+| `english` | 6 | repo root (legacy layout) |
+| `german` | 6 | `v2/german/` |
+| `german_24l` | 24 | `v2/german_24l/` |
+| `italian` | 6 | `v2/italian/` |
+| `italian_24l` | 24 | `v2/italian_24l/` |
+| `portuguese` | 6 | `v2/portuguese/` |
+| `portuguese_24l` | 24 | `v2/portuguese_24l/` |
+| `spanish` | 6 | `v2/spanish/` |
+| `spanish_24l` | 24 | `v2/spanish_24l/` |
+| `french_24l` | 24 | `v2/french_24l/` |
+
+Notes:
+- French only ships a 24-layer pack upstream (no 6-layer variant).
+- 24-layer packs are higher quality but slower and larger.
+- The 21 voice names (alba, anna, eve, michael, …) are shared across
+  languages, but the underlying acoustic embeddings are per-language.
+- Mimi encoder weights (used for voice cloning) are language-agnostic and
+  always live at the repo root.
+
+### Swift API
+
+```swift
+let manager = PocketTtsManager(language: .spanish)
+try await manager.initialize()
+let audio = try await manager.synthesize(text: "Hola mundo")
+```
+
+`PocketTtsManager.language` is immutable per instance. To support multiple
+languages in one app, instantiate one manager per language.
+
+### CLI Usage
+
+```bash
+# Default (English)
+fluidaudio tts "Hello world" --backend pocket --output en.wav
+
+# Spanish (6L)
+fluidaudio tts "Hola mundo" --backend pocket --language spanish --output es.wav
+
+# French (24L only)
+fluidaudio tts "Bonjour" --backend pocket --language french_24l --output fr.wav
+```
 
 ## Usage
 

--- a/Documentation/TTS/PocketTTS.md
+++ b/Documentation/TTS/PocketTTS.md
@@ -245,7 +245,7 @@ that matches your input text — there is no automatic language detection.
 
 | ID | Layers | HF Path |
 |----|--------|---------|
-| `english` | 6 | `v2/english/` |
+| `english` | 6 | repo root (legacy layout) |
 | `german` | 6 | `v2/german/` |
 | `german_24l` | 24 | `v2/german_24l/` |
 | `italian` | 6 | `v2/italian/` |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Want to convert your own model? Check [möbius](https://github.com/FluidInferenc
 
 - **Automatic Speech Recognition (ASR)**: [Parakeet TDT v3](Documentation/Models.md#batch-transcription-near-real-time) (0.6b) and other TDT/CTC models for batch transcription supporting 25 European languages, Japanese, and Chinese; [Parakeet EOU](Documentation/Models.md#streaming-transcription-true-real-time) (120m) for streaming ASR with end-of-utterance detection (English only). See all [ASR models](Documentation/Models.md#asr-models).
 - **Inverse Text Normalization (ITN)**: Post-process ASR output to convert spoken-form to written-form ("two hundred" → "200"). See [text-processing-rs](https://github.com/FluidInference/text-processing-rs)
-- **Text-to-Speech (TTS)**: Kokoro (82m) for parallel synthesis with SSML and pronunciation control across 9 languages (EN, ES, FR, HI, IT, JA, PT, ZH); PocketTTS for streaming TTS with voice cloning support (English only)
+- **Text-to-Speech (TTS)**: Kokoro (82m) for parallel synthesis with SSML and pronunciation control across 9 languages (EN, ES, FR, HI, IT, JA, PT, ZH); PocketTTS for streaming TTS with voice cloning support (EN, DE, ES, FR, IT, PT — 6L and 24L variants)
 - **Speaker Diarization (Online + Offline)**: Speaker separation and identification across audio streams. Streaming pipeline for real-time processing and offline batch pipeline with advanced clustering.
 - **Speaker Embedding Extraction**: Generate speaker embeddings for voice comparison and clustering, you can use this for speaker identification
 - **Voice Activity Detection (VAD)**: Voice activity detection with Silero models
@@ -556,24 +556,35 @@ FluidAudio ships two TTS backends:
 ### PocketTTS
 
 Streaming-friendly TTS with voice cloning support from short audio samples.
+Available language packs: `english` (default), `german`, `german_24l`,
+`italian`, `italian_24l`, `portuguese`, `portuguese_24l`, `spanish`,
+`spanish_24l`, `french_24l` (24-layer only — no 6-layer French upstream).
 
 ```swift
 import FluidAudio
 
 Task {
-    let manager = try await PocketTtsManager()
-    let audioData = try await manager.synthesize("Hello from FluidAudio.")
+    let manager = PocketTtsManager(language: .spanish)
+    try await manager.initialize()
+    let audioData = try await manager.synthesize(text: "Hola, mundo.")
     try audioData.write(to: URL(fileURLWithPath: "out.wav"))
 }
 ```
 
 ```bash
-# Synthesize with default voice
+# English (default)
 swift run fluidaudiocli tts "Hello from FluidAudio." --output out.wav --backend pocket
 
-# Clone a voice from an audio sample
+# Other languages
+swift run fluidaudiocli tts "Hola mundo" --backend pocket --language spanish --output es.wav
+swift run fluidaudiocli tts "Bonjour" --backend pocket --language french_24l --output fr.wav
+
+# Clone a voice from an audio sample (works with any language pack)
 swift run fluidaudiocli tts "Hello world." --output out.wav --backend pocket --clone-voice speaker.wav
 ```
+
+See [Documentation/TTS/PocketTTS.md](Documentation/TTS/PocketTTS.md#languages)
+for the full language table.
 
 ### Kokoro
 

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -575,8 +575,10 @@ public class DownloadUtils {
     public static func downloadSubdirectory(
         _ repo: Repo,
         subdirectory: String,
-        to repoDirectory: URL
+        to repoDirectory: URL,
+        progressHandler: ProgressHandler? = nil
     ) async throws {
+        progressHandler?(DownloadProgress(fractionCompleted: 0.0, phase: .listing))
         var filesToDownload: [(path: String, size: Int)] = []
 
         func listFiles(at path: String) async throws {
@@ -611,12 +613,22 @@ public class DownloadUtils {
         }
 
         try await listFiles(at: subdirectory)
-        logger.info("Found \(filesToDownload.count) files in \(subdirectory)")
+        let totalFiles = filesToDownload.count
+        logger.info("Found \(totalFiles) files in \(subdirectory)")
+        progressHandler?(
+            DownloadProgress(
+                fractionCompleted: totalFiles == 0 ? 1.0 : 0.0,
+                phase: .downloading(completedFiles: 0, totalFiles: totalFiles)))
 
         for (index, file) in filesToDownload.enumerated() {
             let destPath = repoDirectory.appendingPathComponent(file.path)
 
             if FileManager.default.fileExists(atPath: destPath.path) {
+                progressHandler?(
+                    DownloadProgress(
+                        fractionCompleted: Double(index + 1) / Double(totalFiles),
+                        phase: .downloading(
+                            completedFiles: index + 1, totalFiles: totalFiles)))
                 continue
             }
 
@@ -658,8 +670,14 @@ public class DownloadUtils {
             }
             try FileManager.default.moveItem(at: tempURL, to: destPath)
 
-            if (index + 1) % 5 == 0 || index == filesToDownload.count - 1 {
-                logger.info("Downloaded \(index + 1)/\(filesToDownload.count) \(subdirectory) files")
+            progressHandler?(
+                DownloadProgress(
+                    fractionCompleted: Double(index + 1) / Double(totalFiles),
+                    phase: .downloading(
+                        completedFiles: index + 1, totalFiles: totalFiles)))
+
+            if (index + 1) % 5 == 0 || index == totalFiles - 1 {
+                logger.info("Downloaded \(index + 1)/\(totalFiles) \(subdirectory) files")
             }
         }
 

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -639,6 +639,14 @@ public class DownloadUtils {
 
             if file.size == 0 {
                 FileManager.default.createFile(atPath: destPath.path, contents: Data())
+                progressHandler?(
+                    DownloadProgress(
+                        fractionCompleted: Double(index + 1) / Double(totalFiles),
+                        phase: .downloading(
+                            completedFiles: index + 1, totalFiles: totalFiles)))
+                if (index + 1) % 5 == 0 || index == totalFiles - 1 {
+                    logger.info("Downloaded \(index + 1)/\(totalFiles) \(subdirectory) files")
+                }
                 continue
             }
 

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -1,6 +1,5 @@
 import CoreML
 import Foundation
-import OSLog
 
 /// HuggingFace model downloader using URLSession
 public class DownloadUtils {
@@ -73,8 +72,6 @@ public class DownloadUtils {
             }
         }
     }
-
-    /// Download configuration
 
     /// Phase of a model download operation.
     public enum DownloadPhase: Sendable {

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -587,11 +587,6 @@ public enum ModelNames {
         public static let mimiDecoderV2File = mimiDecoderV2 + ".mlmodelc"
         public static let mimiEncoderFile = mimiEncoder + ".mlmodelc"
 
-        /// Backward-compatible alias used by callers expecting the English
-        /// (legacy root) Mimi decoder filename.
-        public static let mimiDecoder = mimiDecoderLegacy
-        public static let mimiDecoderFile = mimiDecoderLegacyFile
-
         /// Directory containing binary constants, tokenizer, and voice data.
         public static let constantsBinDir = "constants_bin"
 
@@ -614,9 +609,6 @@ public enum ModelNames {
                 constantsBinDir,
             ]
         }
-
-        /// Backward-compatible English-only set (legacy root layout).
-        public static let requiredModels: Set<String> = requiredModels(for: .english)
 
         /// Models required for voice cloning (optional feature).
         public static let voiceCloningModels: Set<String> = [
@@ -809,7 +801,7 @@ public enum ModelNames {
             return ttsModels.union(ModelNames.G2P.requiredModels)
                 .union(ModelNames.MultilingualG2P.requiredModels)
         case .pocketTts:
-            return ModelNames.PocketTTS.requiredModels
+            return ModelNames.PocketTTS.requiredModels(for: .english)
         case .kokoroAne:
             return ModelNames.KokoroAne.requiredModels
         case .sortformer:

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -574,25 +574,49 @@ public enum ModelNames {
         public static let condStep = "cond_step"
         public static let flowlmStep = "flowlm_step"
         public static let flowDecoder = "flow_decoder"
-        public static let mimiDecoder = "mimi_decoder_v2"
+        /// Legacy English (root-of-repo) Mimi decoder file basename.
+        public static let mimiDecoderLegacy = "mimi_decoder_v2"
+        /// New per-language `v2/<lang>/` Mimi decoder file basename.
+        public static let mimiDecoderV2 = "mimi_decoder"
         public static let mimiEncoder = "mimi_encoder"
 
         public static let condStepFile = condStep + ".mlmodelc"
         public static let flowlmStepFile = flowlmStep + ".mlmodelc"
         public static let flowDecoderFile = flowDecoder + ".mlmodelc"
-        public static let mimiDecoderFile = mimiDecoder + ".mlmodelc"
+        public static let mimiDecoderLegacyFile = mimiDecoderLegacy + ".mlmodelc"
+        public static let mimiDecoderV2File = mimiDecoderV2 + ".mlmodelc"
         public static let mimiEncoderFile = mimiEncoder + ".mlmodelc"
+
+        /// Backward-compatible alias used by callers expecting the English
+        /// (legacy root) Mimi decoder filename.
+        public static let mimiDecoder = mimiDecoderLegacy
+        public static let mimiDecoderFile = mimiDecoderLegacyFile
 
         /// Directory containing binary constants, tokenizer, and voice data.
         public static let constantsBinDir = "constants_bin"
 
-        public static let requiredModels: Set<String> = [
-            condStepFile,
-            flowlmStepFile,
-            flowDecoderFile,
-            mimiDecoderFile,
-            constantsBinDir,
-        ]
+        /// Returns the Mimi decoder filename used inside this language's pack.
+        public static func mimiDecoderFile(for language: PocketTtsLanguage) -> String {
+            language == .english ? mimiDecoderLegacyFile : mimiDecoderV2File
+        }
+
+        /// Required models inside the language root for the given language.
+        ///
+        /// English (legacy root) and other languages use different Mimi
+        /// decoder filenames, but all four model directories plus the
+        /// `constants_bin/` directory must be present.
+        public static func requiredModels(for language: PocketTtsLanguage) -> Set<String> {
+            [
+                condStepFile,
+                flowlmStepFile,
+                flowDecoderFile,
+                mimiDecoderFile(for: language),
+                constantsBinDir,
+            ]
+        }
+
+        /// Backward-compatible English-only set (legacy root layout).
+        public static let requiredModels: Set<String> = requiredModels(for: .english)
 
         /// Models required for voice cloning (optional feature).
         public static let voiceCloningModels: Set<String> = [

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -574,41 +574,26 @@ public enum ModelNames {
         public static let condStep = "cond_step"
         public static let flowlmStep = "flowlm_step"
         public static let flowDecoder = "flow_decoder"
-        /// Legacy English (root-of-repo) Mimi decoder file basename.
-        public static let mimiDecoderLegacy = "mimi_decoder_v2"
-        /// New per-language `v2/<lang>/` Mimi decoder file basename.
-        public static let mimiDecoderV2 = "mimi_decoder"
+        public static let mimiDecoder = "mimi_decoder"
         public static let mimiEncoder = "mimi_encoder"
 
         public static let condStepFile = condStep + ".mlmodelc"
         public static let flowlmStepFile = flowlmStep + ".mlmodelc"
         public static let flowDecoderFile = flowDecoder + ".mlmodelc"
-        public static let mimiDecoderLegacyFile = mimiDecoderLegacy + ".mlmodelc"
-        public static let mimiDecoderV2File = mimiDecoderV2 + ".mlmodelc"
+        public static let mimiDecoderFile = mimiDecoder + ".mlmodelc"
         public static let mimiEncoderFile = mimiEncoder + ".mlmodelc"
 
         /// Directory containing binary constants, tokenizer, and voice data.
         public static let constantsBinDir = "constants_bin"
 
-        /// Returns the Mimi decoder filename used inside this language's pack.
-        public static func mimiDecoderFile(for language: PocketTtsLanguage) -> String {
-            language == .english ? mimiDecoderLegacyFile : mimiDecoderV2File
-        }
-
-        /// Required models inside the language root for the given language.
-        ///
-        /// English (legacy root) and other languages use different Mimi
-        /// decoder filenames, but all four model directories plus the
-        /// `constants_bin/` directory must be present.
-        public static func requiredModels(for language: PocketTtsLanguage) -> Set<String> {
-            [
-                condStepFile,
-                flowlmStepFile,
-                flowDecoderFile,
-                mimiDecoderFile(for: language),
-                constantsBinDir,
-            ]
-        }
+        /// Required files inside any language's `v2/<lang>/` pack.
+        public static let requiredModels: Set<String> = [
+            condStepFile,
+            flowlmStepFile,
+            flowDecoderFile,
+            mimiDecoderFile,
+            constantsBinDir,
+        ]
     }
 
     /// Multilingual G2P (CharsiuG2P ByT5) model names
@@ -796,7 +781,7 @@ public enum ModelNames {
             return ttsModels.union(ModelNames.G2P.requiredModels)
                 .union(ModelNames.MultilingualG2P.requiredModels)
         case .pocketTts:
-            return ModelNames.PocketTTS.requiredModels(for: .english)
+            return ModelNames.PocketTTS.requiredModels
         case .kokoroAne:
             return ModelNames.KokoroAne.requiredModels
         case .sortformer:

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -609,11 +609,6 @@ public enum ModelNames {
                 constantsBinDir,
             ]
         }
-
-        /// Models required for voice cloning (optional feature).
-        public static let voiceCloningModels: Set<String> = [
-            mimiEncoderFile
-        ]
     }
 
     /// Multilingual G2P (CharsiuG2P ByT5) model names

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -574,27 +574,41 @@ public enum ModelNames {
         public static let condStep = "cond_step"
         public static let flowlmStep = "flowlm_step"
         public static let flowDecoder = "flow_decoder"
-        public static let mimiDecoder = "mimi_decoder"
+        /// Legacy English (root-of-repo) Mimi decoder file basename.
+        public static let mimiDecoderLegacy = "mimi_decoder_v2"
+        /// New per-language `v2/<lang>/` Mimi decoder file basename.
+        public static let mimiDecoderV2 = "mimi_decoder"
         public static let mimiEncoder = "mimi_encoder"
 
         public static let condStepFile = condStep + ".mlmodelc"
         public static let flowlmStepFile = flowlmStep + ".mlmodelc"
         public static let flowDecoderFile = flowDecoder + ".mlmodelc"
-        public static let mimiDecoderFile = mimiDecoder + ".mlmodelc"
+        public static let mimiDecoderLegacyFile = mimiDecoderLegacy + ".mlmodelc"
+        public static let mimiDecoderV2File = mimiDecoderV2 + ".mlmodelc"
         public static let mimiEncoderFile = mimiEncoder + ".mlmodelc"
 
         /// Directory containing binary constants, tokenizer, and voice data.
         public static let constantsBinDir = "constants_bin"
 
-        /// Required models inside a `v2/<lang>/` language pack (uniform
-        /// across all languages).
-        public static let requiredModels: Set<String> = [
-            condStepFile,
-            flowlmStepFile,
-            flowDecoderFile,
-            mimiDecoderFile,
-            constantsBinDir,
-        ]
+        /// Returns the Mimi decoder filename used inside this language's pack.
+        public static func mimiDecoderFile(for language: PocketTtsLanguage) -> String {
+            language == .english ? mimiDecoderLegacyFile : mimiDecoderV2File
+        }
+
+        /// Required models inside the language root for the given language.
+        ///
+        /// English (legacy root) and other languages use different Mimi
+        /// decoder filenames, but all four model directories plus the
+        /// `constants_bin/` directory must be present.
+        public static func requiredModels(for language: PocketTtsLanguage) -> Set<String> {
+            [
+                condStepFile,
+                flowlmStepFile,
+                flowDecoderFile,
+                mimiDecoderFile(for: language),
+                constantsBinDir,
+            ]
+        }
 
         /// Models required for voice cloning (optional feature).
         public static let voiceCloningModels: Set<String> = [
@@ -787,7 +801,7 @@ public enum ModelNames {
             return ttsModels.union(ModelNames.G2P.requiredModels)
                 .union(ModelNames.MultilingualG2P.requiredModels)
         case .pocketTts:
-            return ModelNames.PocketTTS.requiredModels
+            return ModelNames.PocketTTS.requiredModels(for: .english)
         case .kokoroAne:
             return ModelNames.KokoroAne.requiredModels
         case .sortformer:

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -574,41 +574,27 @@ public enum ModelNames {
         public static let condStep = "cond_step"
         public static let flowlmStep = "flowlm_step"
         public static let flowDecoder = "flow_decoder"
-        /// Legacy English (root-of-repo) Mimi decoder file basename.
-        public static let mimiDecoderLegacy = "mimi_decoder_v2"
-        /// New per-language `v2/<lang>/` Mimi decoder file basename.
-        public static let mimiDecoderV2 = "mimi_decoder"
+        public static let mimiDecoder = "mimi_decoder"
         public static let mimiEncoder = "mimi_encoder"
 
         public static let condStepFile = condStep + ".mlmodelc"
         public static let flowlmStepFile = flowlmStep + ".mlmodelc"
         public static let flowDecoderFile = flowDecoder + ".mlmodelc"
-        public static let mimiDecoderLegacyFile = mimiDecoderLegacy + ".mlmodelc"
-        public static let mimiDecoderV2File = mimiDecoderV2 + ".mlmodelc"
+        public static let mimiDecoderFile = mimiDecoder + ".mlmodelc"
         public static let mimiEncoderFile = mimiEncoder + ".mlmodelc"
 
         /// Directory containing binary constants, tokenizer, and voice data.
         public static let constantsBinDir = "constants_bin"
 
-        /// Returns the Mimi decoder filename used inside this language's pack.
-        public static func mimiDecoderFile(for language: PocketTtsLanguage) -> String {
-            language == .english ? mimiDecoderLegacyFile : mimiDecoderV2File
-        }
-
-        /// Required models inside the language root for the given language.
-        ///
-        /// English (legacy root) and other languages use different Mimi
-        /// decoder filenames, but all four model directories plus the
-        /// `constants_bin/` directory must be present.
-        public static func requiredModels(for language: PocketTtsLanguage) -> Set<String> {
-            [
-                condStepFile,
-                flowlmStepFile,
-                flowDecoderFile,
-                mimiDecoderFile(for: language),
-                constantsBinDir,
-            ]
-        }
+        /// Required models inside a `v2/<lang>/` language pack (uniform
+        /// across all languages).
+        public static let requiredModels: Set<String> = [
+            condStepFile,
+            flowlmStepFile,
+            flowDecoderFile,
+            mimiDecoderFile,
+            constantsBinDir,
+        ]
 
         /// Models required for voice cloning (optional feature).
         public static let voiceCloningModels: Set<String> = [
@@ -801,7 +787,7 @@ public enum ModelNames {
             return ttsModels.union(ModelNames.G2P.requiredModels)
                 .union(ModelNames.MultilingualG2P.requiredModels)
         case .pocketTts:
-            return ModelNames.PocketTTS.requiredModels(for: .english)
+            return ModelNames.PocketTTS.requiredModels
         case .kokoroAne:
             return ModelNames.KokoroAne.requiredModels
         case .sortformer:

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
@@ -10,25 +10,27 @@ public struct PocketTtsConstantsBundle: Sendable {
 
 /// Pre-loaded voice conditioning data.
 ///
-/// Two formats are supported:
-///  - **Flat audio prompt** (legacy English `<voice>_audio_prompt.bin`):
-///    a `[1, promptLength, 1024]` Float32 tensor that the runtime feeds
-///    through `cond_step` token-by-token to populate the LM transformer
-///    KV cache.
-///  - **Pre-baked KV cache snapshot** (v2 packs `<voice>.safetensors`):
-///    per-layer K/V tensors already shaped to drop directly into the
-///    LM transformer's `cache{i}` slots. Skips `cond_step` voice prefill.
+/// Two sources populate this:
+///  - **Pre-baked KV cache snapshot** (on-disk `<voice>.safetensors` from a
+///    v2 language pack): per-layer K/V tensors already shaped to drop
+///    directly into the LM transformer's `cache{i}` slots. Skips
+///    `cond_step` voice prefill.
+///  - **Flat audio prompt** (runtime voice cloning via `mimi_encoder`):
+///    a `[1, promptLength, 1024]` Float32 tensor that the synthesizer
+///    feeds through `cond_step` token-by-token to populate the LM
+///    transformer KV cache.
 ///
-/// At most one of the two is populated. The synthesizer's `prefillKVCache`
+/// Exactly one of the two is populated. The synthesizer's `prefillKVCache`
 /// branches on `cacheSnapshot != nil` to choose the path.
 public struct PocketTtsVoiceData: Sendable {
     /// Flattened audio prompt: [1, promptLength, 1024]. Empty when
-    /// `cacheSnapshot` is non-nil.
+    /// `cacheSnapshot` is non-nil. Populated by runtime voice cloning.
     public let audioPrompt: [Float]
-    /// Number of voice conditioning tokens (typically 125). Zero when
-    /// `cacheSnapshot` is non-nil.
+    /// Number of voice conditioning tokens (typically 125 for prebakes,
+    /// up to 250 for cloned voices). Zero when `cacheSnapshot` is non-nil.
     public let promptLength: Int
-    /// Pre-baked LM transformer KV cache (v2 packs only).
+    /// Pre-baked LM transformer KV cache loaded from a v2 voice safetensors
+    /// file. `nil` for cloned voices.
     public let cacheSnapshot: PocketTtsVoiceCacheSnapshot?
 
     public init(
@@ -113,15 +115,10 @@ public enum PocketTtsConstantsLoader {
 
     /// Load voice conditioning data from the given directory.
     ///
-    /// Resolution order:
-    ///  1. `<voice>.safetensors` — v2 packs ship pre-baked LM KV cache snapshots
-    ///     (per-layer `[2,1,seqLen,16,64]` F32 + `[1]` I64 offset).
-    ///  2. `<voice>_audio_prompt.bin` — legacy English flat `[1,promptLen,1024]` F32.
-    ///
-    /// Both legacy English (root-level pack) and v2 language packs are supported
-    /// without code branching at the call site — the loader picks the right
-    /// format and the synthesizer's `prefillKVCache` dispatches on
-    /// `cacheSnapshot`.
+    /// Reads `<voice>.safetensors` from the language pack's `constants_bin/`
+    /// directory — every v2 language pack ships pre-baked LM KV cache
+    /// snapshots in this format (per-layer `[2,1,seqLen,16,64]` F32 plus
+    /// `[1]` I64 offset).
     public static func loadVoice(
         _ voice: String, from directory: URL
     ) throws -> PocketTtsVoiceData {
@@ -133,52 +130,20 @@ public enum PocketTtsConstantsLoader {
 
         let constantsDir = directory.appendingPathComponent(ModelNames.PocketTTS.constantsBinDir)
         let safetensorsURL = constantsDir.appendingPathComponent("\(sanitized).safetensors")
-        let binURL = constantsDir.appendingPathComponent("\(sanitized)_audio_prompt.bin")
 
-        if FileManager.default.fileExists(atPath: safetensorsURL.path) {
-            let snapshot = try loadVoiceSnapshot(from: safetensorsURL, voiceName: sanitized)
-            logger.info(
-                "Loaded PocketTTS voice '\(sanitized)' from safetensors (\(snapshot.layers.count) layers, seq=\(snapshot.cacheSeqLen))"
-            )
-            return PocketTtsVoiceData(
-                audioPrompt: [],
-                promptLength: 0,
-                cacheSnapshot: snapshot
-            )
+        guard FileManager.default.fileExists(atPath: safetensorsURL.path) else {
+            throw LoadError.fileNotFound("\(sanitized).safetensors")
         }
 
-        guard FileManager.default.fileExists(atPath: binURL.path) else {
-            throw LoadError.fileNotFound("\(sanitized) (no .safetensors or _audio_prompt.bin)")
-        }
-
-        let data = try Data(contentsOf: binURL)
-        let embDim = PocketTtsConstants.embeddingDim
-        let floatCount = data.count / MemoryLayout<Float>.size
-
-        guard floatCount > 0, floatCount % embDim == 0 else {
-            throw LoadError.invalidSize(
-                "\(sanitized)_audio_prompt",
-                expected: embDim,
-                actual: floatCount
-            )
-        }
-
-        let promptLength = floatCount / embDim
-        guard promptLength <= PocketTtsVoiceCloner.maxVoiceFrames else {
-            throw LoadError.invalidSize(
-                "\(sanitized)_audio_prompt",
-                expected: PocketTtsVoiceCloner.maxVoiceFrames,
-                actual: promptLength
-            )
-        }
-        let audioPrompt = data.withUnsafeBytes { rawBuffer in
-            let floatBuffer = rawBuffer.bindMemory(to: Float.self)
-            return Array(floatBuffer)
-        }
-
-        logger.info("Loaded PocketTTS voice '\(sanitized)' conditioning data")
-
-        return PocketTtsVoiceData(audioPrompt: audioPrompt, promptLength: promptLength)
+        let snapshot = try loadVoiceSnapshot(from: safetensorsURL, voiceName: sanitized)
+        logger.info(
+            "Loaded PocketTTS voice '\(sanitized)' from safetensors (\(snapshot.layers.count) layers, seq=\(snapshot.cacheSeqLen))"
+        )
+        return PocketTtsVoiceData(
+            audioPrompt: [],
+            promptLength: 0,
+            cacheSnapshot: snapshot
+        )
     }
 
     /// Parse a v2 voice safetensors file into a `PocketTtsVoiceCacheSnapshot`.

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
@@ -10,27 +10,25 @@ public struct PocketTtsConstantsBundle: Sendable {
 
 /// Pre-loaded voice conditioning data.
 ///
-/// Two sources populate this:
-///  - **Pre-baked KV cache snapshot** (on-disk `<voice>.safetensors` from a
-///    v2 language pack): per-layer K/V tensors already shaped to drop
-///    directly into the LM transformer's `cache{i}` slots. Skips
-///    `cond_step` voice prefill.
-///  - **Flat audio prompt** (runtime voice cloning via `mimi_encoder`):
-///    a `[1, promptLength, 1024]` Float32 tensor that the synthesizer
-///    feeds through `cond_step` token-by-token to populate the LM
-///    transformer KV cache.
+/// Two formats are supported:
+///  - **Flat audio prompt** (legacy English `<voice>_audio_prompt.bin`):
+///    a `[1, promptLength, 1024]` Float32 tensor that the runtime feeds
+///    through `cond_step` token-by-token to populate the LM transformer
+///    KV cache.
+///  - **Pre-baked KV cache snapshot** (v2 packs `<voice>.safetensors`):
+///    per-layer K/V tensors already shaped to drop directly into the
+///    LM transformer's `cache{i}` slots. Skips `cond_step` voice prefill.
 ///
-/// Exactly one of the two is populated. The synthesizer's `prefillKVCache`
+/// At most one of the two is populated. The synthesizer's `prefillKVCache`
 /// branches on `cacheSnapshot != nil` to choose the path.
 public struct PocketTtsVoiceData: Sendable {
     /// Flattened audio prompt: [1, promptLength, 1024]. Empty when
-    /// `cacheSnapshot` is non-nil. Populated by runtime voice cloning.
+    /// `cacheSnapshot` is non-nil.
     public let audioPrompt: [Float]
-    /// Number of voice conditioning tokens (typically 125 for prebakes,
-    /// up to 250 for cloned voices). Zero when `cacheSnapshot` is non-nil.
+    /// Number of voice conditioning tokens (typically 125). Zero when
+    /// `cacheSnapshot` is non-nil.
     public let promptLength: Int
-    /// Pre-baked LM transformer KV cache loaded from a v2 voice safetensors
-    /// file. `nil` for cloned voices.
+    /// Pre-baked LM transformer KV cache (v2 packs only).
     public let cacheSnapshot: PocketTtsVoiceCacheSnapshot?
 
     public init(
@@ -115,10 +113,15 @@ public enum PocketTtsConstantsLoader {
 
     /// Load voice conditioning data from the given directory.
     ///
-    /// Reads `<voice>.safetensors` from the language pack's `constants_bin/`
-    /// directory — every v2 language pack ships pre-baked LM KV cache
-    /// snapshots in this format (per-layer `[2,1,seqLen,16,64]` F32 plus
-    /// `[1]` I64 offset).
+    /// Resolution order:
+    ///  1. `<voice>.safetensors` — v2 packs ship pre-baked LM KV cache snapshots
+    ///     (per-layer `[2,1,seqLen,16,64]` F32 + `[1]` I64 offset).
+    ///  2. `<voice>_audio_prompt.bin` — legacy English flat `[1,promptLen,1024]` F32.
+    ///
+    /// Both legacy English (root-level pack) and v2 language packs are supported
+    /// without code branching at the call site — the loader picks the right
+    /// format and the synthesizer's `prefillKVCache` dispatches on
+    /// `cacheSnapshot`.
     public static func loadVoice(
         _ voice: String, from directory: URL
     ) throws -> PocketTtsVoiceData {
@@ -130,20 +133,52 @@ public enum PocketTtsConstantsLoader {
 
         let constantsDir = directory.appendingPathComponent(ModelNames.PocketTTS.constantsBinDir)
         let safetensorsURL = constantsDir.appendingPathComponent("\(sanitized).safetensors")
+        let binURL = constantsDir.appendingPathComponent("\(sanitized)_audio_prompt.bin")
 
-        guard FileManager.default.fileExists(atPath: safetensorsURL.path) else {
-            throw LoadError.fileNotFound("\(sanitized).safetensors")
+        if FileManager.default.fileExists(atPath: safetensorsURL.path) {
+            let snapshot = try loadVoiceSnapshot(from: safetensorsURL, voiceName: sanitized)
+            logger.info(
+                "Loaded PocketTTS voice '\(sanitized)' from safetensors (\(snapshot.layers.count) layers, seq=\(snapshot.cacheSeqLen))"
+            )
+            return PocketTtsVoiceData(
+                audioPrompt: [],
+                promptLength: 0,
+                cacheSnapshot: snapshot
+            )
         }
 
-        let snapshot = try loadVoiceSnapshot(from: safetensorsURL, voiceName: sanitized)
-        logger.info(
-            "Loaded PocketTTS voice '\(sanitized)' from safetensors (\(snapshot.layers.count) layers, seq=\(snapshot.cacheSeqLen))"
-        )
-        return PocketTtsVoiceData(
-            audioPrompt: [],
-            promptLength: 0,
-            cacheSnapshot: snapshot
-        )
+        guard FileManager.default.fileExists(atPath: binURL.path) else {
+            throw LoadError.fileNotFound("\(sanitized) (no .safetensors or _audio_prompt.bin)")
+        }
+
+        let data = try Data(contentsOf: binURL)
+        let embDim = PocketTtsConstants.embeddingDim
+        let floatCount = data.count / MemoryLayout<Float>.size
+
+        guard floatCount > 0, floatCount % embDim == 0 else {
+            throw LoadError.invalidSize(
+                "\(sanitized)_audio_prompt",
+                expected: embDim,
+                actual: floatCount
+            )
+        }
+
+        let promptLength = floatCount / embDim
+        guard promptLength <= PocketTtsVoiceCloner.maxVoiceFrames else {
+            throw LoadError.invalidSize(
+                "\(sanitized)_audio_prompt",
+                expected: PocketTtsVoiceCloner.maxVoiceFrames,
+                actual: promptLength
+            )
+        }
+        let audioPrompt = data.withUnsafeBytes { rawBuffer in
+            let floatBuffer = rawBuffer.bindMemory(to: Float.self)
+            return Array(floatBuffer)
+        }
+
+        logger.info("Loaded PocketTTS voice '\(sanitized)' conditioning data")
+
+        return PocketTtsVoiceData(audioPrompt: audioPrompt, promptLength: promptLength)
     }
 
     /// Parse a v2 voice safetensors file into a `PocketTtsVoiceCacheSnapshot`.

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
@@ -36,9 +36,13 @@ public enum PocketTtsConstantsLoader {
             expectedCount: PocketTtsConstants.latentDim,
             name: "bos_emb"
         )
-        let embedTable = try loadFloatArray(
+        // text_embed_table vocab size is language-dependent — English ships
+        // 4001 rows, other languages may differ. Validate only that the file
+        // is a clean multiple of embeddingDim; the synthesizer indexes into
+        // this table by token ID at runtime.
+        let embedTable = try loadFloatArrayMultipleOf(
             from: constantsDir.appendingPathComponent("text_embed_table.bin"),
-            expectedCount: PocketTtsConstants.vocabSize * PocketTtsConstants.embeddingDim,
+            rowSize: PocketTtsConstants.embeddingDim,
             name: "text_embed_table"
         )
 
@@ -130,6 +134,29 @@ public enum PocketTtsConstantsLoader {
 
         guard actualCount == expectedCount else {
             throw LoadError.invalidSize(name, expected: expectedCount, actual: actualCount)
+        }
+
+        return data.withUnsafeBytes { rawBuffer in
+            let floatBuffer = rawBuffer.bindMemory(to: Float.self)
+            return Array(floatBuffer)
+        }
+    }
+
+    /// Load a raw Float32 binary file whose length must be a non-zero multiple
+    /// of `rowSize`. Used for tensors whose leading dimension varies per
+    /// language (e.g. `text_embed_table` vocab size).
+    private static func loadFloatArrayMultipleOf(
+        from url: URL, rowSize: Int, name: String
+    ) throws -> [Float] {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw LoadError.fileNotFound(name)
+        }
+
+        let data = try Data(contentsOf: url)
+        let actualCount = data.count / MemoryLayout<Float>.size
+
+        guard actualCount > 0, actualCount % rowSize == 0 else {
+            throw LoadError.invalidSize(name, expected: rowSize, actual: actualCount)
         }
 
         return data.withUnsafeBytes { rawBuffer in

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
@@ -9,11 +9,55 @@ public struct PocketTtsConstantsBundle: Sendable {
 }
 
 /// Pre-loaded voice conditioning data.
+///
+/// Two formats are supported:
+///  - **Flat audio prompt** (legacy English `<voice>_audio_prompt.bin`):
+///    a `[1, promptLength, 1024]` Float32 tensor that the runtime feeds
+///    through `cond_step` token-by-token to populate the LM transformer
+///    KV cache.
+///  - **Pre-baked KV cache snapshot** (v2 packs `<voice>.safetensors`):
+///    per-layer K/V tensors already shaped to drop directly into the
+///    LM transformer's `cache{i}` slots. Skips `cond_step` voice prefill.
+///
+/// At most one of the two is populated. The synthesizer's `prefillKVCache`
+/// branches on `cacheSnapshot != nil` to choose the path.
 public struct PocketTtsVoiceData: Sendable {
-    /// Flattened audio prompt: [1, promptLength, 1024]
+    /// Flattened audio prompt: [1, promptLength, 1024]. Empty when
+    /// `cacheSnapshot` is non-nil.
     public let audioPrompt: [Float]
-    /// Number of voice conditioning tokens (typically 125).
+    /// Number of voice conditioning tokens (typically 125). Zero when
+    /// `cacheSnapshot` is non-nil.
     public let promptLength: Int
+    /// Pre-baked LM transformer KV cache (v2 packs only).
+    public let cacheSnapshot: PocketTtsVoiceCacheSnapshot?
+
+    public init(
+        audioPrompt: [Float],
+        promptLength: Int,
+        cacheSnapshot: PocketTtsVoiceCacheSnapshot? = nil
+    ) {
+        self.audioPrompt = audioPrompt
+        self.promptLength = promptLength
+        self.cacheSnapshot = cacheSnapshot
+    }
+}
+
+/// Pre-baked KV cache snapshot for v2 voice packs.
+///
+/// One `LayerCache` per LM transformer layer, in layer order. Each
+/// `cache` is a flat Float32 array shaped `[2, 1, seqLen, 16, 64]`
+/// (K and V interleaved at outer dim) matching the model's `cache{i}`
+/// input layout, and `offset` is the number of tokens already filled
+/// (= seqLen for a fully-prebaked snapshot).
+public struct PocketTtsVoiceCacheSnapshot: Sendable {
+    public struct LayerCache: Sendable {
+        public let cache: [Float]
+        public let offset: Int
+    }
+
+    public let layers: [LayerCache]
+    /// Sequence length per layer in the source snapshot (e.g. 126).
+    public let cacheSeqLen: Int
 }
 
 /// Loads PocketTTS constants from raw `.bin` Float32 files on disk.
@@ -69,10 +113,15 @@ public enum PocketTtsConstantsLoader {
 
     /// Load voice conditioning data from the given directory.
     ///
-    /// Supports variable-length voice prompts — the prompt length is derived
-    /// from the file size (`floatCount / embeddingDim`).
+    /// Resolution order:
+    ///  1. `<voice>.safetensors` — v2 packs ship pre-baked LM KV cache snapshots
+    ///     (per-layer `[2,1,seqLen,16,64]` F32 + `[1]` I64 offset).
+    ///  2. `<voice>_audio_prompt.bin` — legacy English flat `[1,promptLen,1024]` F32.
     ///
-    /// HuggingFace layout: `constants_bin/<voice>_audio_prompt.bin`
+    /// Both legacy English (root-level pack) and v2 language packs are supported
+    /// without code branching at the call site — the loader picks the right
+    /// format and the synthesizer's `prefillKVCache` dispatches on
+    /// `cacheSnapshot`.
     public static func loadVoice(
         _ voice: String, from directory: URL
     ) throws -> PocketTtsVoiceData {
@@ -83,13 +132,26 @@ public enum PocketTtsConstantsLoader {
         }
 
         let constantsDir = directory.appendingPathComponent(ModelNames.PocketTTS.constantsBinDir)
-        let voiceURL = constantsDir.appendingPathComponent("\(sanitized)_audio_prompt.bin")
+        let safetensorsURL = constantsDir.appendingPathComponent("\(sanitized).safetensors")
+        let binURL = constantsDir.appendingPathComponent("\(sanitized)_audio_prompt.bin")
 
-        guard FileManager.default.fileExists(atPath: voiceURL.path) else {
-            throw LoadError.fileNotFound("\(sanitized)_audio_prompt")
+        if FileManager.default.fileExists(atPath: safetensorsURL.path) {
+            let snapshot = try loadVoiceSnapshot(from: safetensorsURL, voiceName: sanitized)
+            logger.info(
+                "Loaded PocketTTS voice '\(sanitized)' from safetensors (\(snapshot.layers.count) layers, seq=\(snapshot.cacheSeqLen))"
+            )
+            return PocketTtsVoiceData(
+                audioPrompt: [],
+                promptLength: 0,
+                cacheSnapshot: snapshot
+            )
         }
 
-        let data = try Data(contentsOf: voiceURL)
+        guard FileManager.default.fileExists(atPath: binURL.path) else {
+            throw LoadError.fileNotFound("\(sanitized) (no .safetensors or _audio_prompt.bin)")
+        }
+
+        let data = try Data(contentsOf: binURL)
         let embDim = PocketTtsConstants.embeddingDim
         let floatCount = data.count / MemoryLayout<Float>.size
 
@@ -119,6 +181,130 @@ public enum PocketTtsConstantsLoader {
         return PocketTtsVoiceData(audioPrompt: audioPrompt, promptLength: promptLength)
     }
 
+    /// Parse a v2 voice safetensors file into a `PocketTtsVoiceCacheSnapshot`.
+    ///
+    /// Expected schema (kyutai pocket-tts v2):
+    ///  - `transformer.layers.{N}.self_attn/cache` F32 `[2, 1, seqLen, 16, 64]`
+    ///  - `transformer.layers.{N}.self_attn/offset` I64 `[1]`
+    ///
+    /// All layers share the same `seqLen`. Layer count is auto-detected (6
+    /// for non-24L packs, 24 for `*_24l` packs).
+    private static func loadVoiceSnapshot(
+        from url: URL, voiceName: String
+    ) throws -> PocketTtsVoiceCacheSnapshot {
+        let raw = try Data(contentsOf: url)
+        let parsed = try parseSafetensors(raw, fileLabel: voiceName)
+
+        // Collect cache + offset entries by layer index.
+        var caches: [Int: SafetensorsTensor] = [:]
+        var offsets: [Int: SafetensorsTensor] = [:]
+        let cachePrefix = "transformer.layers."
+        let cacheSuffix = ".self_attn/cache"
+        let offsetSuffix = ".self_attn/offset"
+
+        for (key, tensor) in parsed.tensors {
+            guard key.hasPrefix(cachePrefix) else { continue }
+            let stripped = String(key.dropFirst(cachePrefix.count))
+            if let dotRange = stripped.firstIndex(of: ".") {
+                let idxStr = String(stripped[..<dotRange])
+                let rest = stripped[dotRange...]
+                guard let layerIdx = Int(idxStr) else { continue }
+                if rest == Substring(cacheSuffix) {
+                    caches[layerIdx] = tensor
+                } else if rest == Substring(offsetSuffix) {
+                    offsets[layerIdx] = tensor
+                }
+            }
+        }
+
+        guard !caches.isEmpty else {
+            throw LoadError.invalidSize(
+                "\(voiceName).safetensors: no transformer.layers.*.self_attn/cache entries",
+                expected: 1,
+                actual: 0
+            )
+        }
+        guard caches.count == offsets.count else {
+            throw LoadError.invalidSize(
+                "\(voiceName).safetensors: cache/offset count mismatch",
+                expected: caches.count,
+                actual: offsets.count
+            )
+        }
+
+        let sortedLayers = caches.keys.sorted()
+        // Layer indices must be 0..N-1 contiguous.
+        for (i, k) in sortedLayers.enumerated() where i != k {
+            throw LoadError.invalidSize(
+                "\(voiceName).safetensors: layer indices not contiguous (gap at \(i))",
+                expected: i,
+                actual: k
+            )
+        }
+
+        // All layer caches must share shape [2, 1, seqLen, 16, 64].
+        let firstShape = caches[sortedLayers[0]]!.shape
+        guard firstShape.count == 5,
+            firstShape[0] == 2,
+            firstShape[1] == 1,
+            firstShape[3] == 16,
+            firstShape[4] == 64
+        else {
+            throw LoadError.invalidSize(
+                "\(voiceName).safetensors: unexpected cache shape \(firstShape)",
+                expected: 0,
+                actual: 0
+            )
+        }
+        let seqLen = firstShape[2]
+
+        var layers: [PocketTtsVoiceCacheSnapshot.LayerCache] = []
+        layers.reserveCapacity(sortedLayers.count)
+
+        for layerIdx in sortedLayers {
+            guard let cacheTensor = caches[layerIdx], let offsetTensor = offsets[layerIdx]
+            else { continue }
+            guard cacheTensor.shape == firstShape else {
+                throw LoadError.invalidSize(
+                    "\(voiceName).safetensors: cache shape mismatch at layer \(layerIdx)",
+                    expected: 0,
+                    actual: 0
+                )
+            }
+            guard cacheTensor.dtype == "F32" else {
+                throw LoadError.invalidSize(
+                    "\(voiceName).safetensors: layer \(layerIdx) cache dtype \(cacheTensor.dtype) (want F32)",
+                    expected: 0,
+                    actual: 0
+                )
+            }
+            let floatCount = cacheTensor.byteCount / MemoryLayout<Float>.size
+            let cacheFloats: [Float] = raw.withUnsafeBytes { rawBuf -> [Float] in
+                let base = rawBuf.baseAddress!.advanced(by: cacheTensor.byteOffset)
+                let typed = base.assumingMemoryBound(to: Float.self)
+                return Array(UnsafeBufferPointer(start: typed, count: floatCount))
+            }
+
+            // offset is I64 [1]
+            guard offsetTensor.dtype == "I64", offsetTensor.shape == [1] else {
+                throw LoadError.invalidSize(
+                    "\(voiceName).safetensors: layer \(layerIdx) offset shape/dtype unexpected",
+                    expected: 0,
+                    actual: 0
+                )
+            }
+            let offsetVal: Int = raw.withUnsafeBytes { rawBuf -> Int in
+                let base = rawBuf.baseAddress!.advanced(by: offsetTensor.byteOffset)
+                let typed = base.assumingMemoryBound(to: Int64.self)
+                return Int(typed.pointee)
+            }
+
+            layers.append(.init(cache: cacheFloats, offset: offsetVal))
+        }
+
+        return PocketTtsVoiceCacheSnapshot(layers: layers, cacheSeqLen: seqLen)
+    }
+
     // MARK: - Private
 
     /// Load a raw Float32 binary file into a [Float] array.
@@ -140,6 +326,129 @@ public enum PocketTtsConstantsLoader {
             let floatBuffer = rawBuffer.bindMemory(to: Float.self)
             return Array(floatBuffer)
         }
+    }
+
+    // MARK: - safetensors
+
+    /// One tensor entry from a safetensors file.
+    fileprivate struct SafetensorsTensor {
+        let dtype: String
+        let shape: [Int]
+        /// Absolute byte offset into the original file (already includes
+        /// the 8-byte size prefix and JSON header length).
+        let byteOffset: Int
+        let byteCount: Int
+    }
+
+    fileprivate struct SafetensorsParsed {
+        let tensors: [String: SafetensorsTensor]
+    }
+
+    /// Minimal safetensors reader: 8-byte LE u64 header length, then JSON
+    /// header, then raw tensor bytes. Only used for v2 voice prebakes — no
+    /// need to support arbitrary safetensors features.
+    fileprivate static func parseSafetensors(
+        _ data: Data, fileLabel: String
+    ) throws -> SafetensorsParsed {
+        guard data.count >= 8 else {
+            throw LoadError.invalidSize(
+                "\(fileLabel).safetensors: too small",
+                expected: 8,
+                actual: data.count
+            )
+        }
+        // Header length: little-endian u64 at byte 0.
+        let headerLen: UInt64 = data.withUnsafeBytes { rawBuf -> UInt64 in
+            let typed = rawBuf.baseAddress!.assumingMemoryBound(to: UInt64.self)
+            return UInt64(littleEndian: typed.pointee)
+        }
+        let headerStart = 8
+        let headerEnd = headerStart + Int(headerLen)
+        guard headerEnd <= data.count else {
+            throw LoadError.invalidSize(
+                "\(fileLabel).safetensors: header overflow",
+                expected: headerEnd,
+                actual: data.count
+            )
+        }
+        let headerBytes = data.subdata(in: headerStart..<headerEnd)
+        let json: Any
+        do {
+            json = try JSONSerialization.jsonObject(with: headerBytes, options: [])
+        } catch {
+            throw LoadError.invalidSize(
+                "\(fileLabel).safetensors: header JSON parse failed: \(error)",
+                expected: 0,
+                actual: 0
+            )
+        }
+        guard let dict = json as? [String: Any] else {
+            throw LoadError.invalidSize(
+                "\(fileLabel).safetensors: header is not a JSON object",
+                expected: 0,
+                actual: 0
+            )
+        }
+
+        let dataStart = headerEnd
+        var tensors: [String: SafetensorsTensor] = [:]
+        for (key, value) in dict {
+            if key == "__metadata__" { continue }
+            guard let entry = value as? [String: Any] else { continue }
+            guard let dtype = entry["dtype"] as? String,
+                let shapeArr = entry["shape"] as? [Any],
+                let offsets = entry["data_offsets"] as? [Any],
+                offsets.count == 2
+            else {
+                throw LoadError.invalidSize(
+                    "\(fileLabel).safetensors: malformed entry '\(key)'",
+                    expected: 0,
+                    actual: 0
+                )
+            }
+            let shape: [Int] = shapeArr.compactMap { ($0 as? NSNumber)?.intValue }
+            guard shape.count == shapeArr.count else {
+                throw LoadError.invalidSize(
+                    "\(fileLabel).safetensors: bad shape for '\(key)'",
+                    expected: 0,
+                    actual: 0
+                )
+            }
+            guard let startNum = offsets[0] as? NSNumber,
+                let endNum = offsets[1] as? NSNumber
+            else {
+                throw LoadError.invalidSize(
+                    "\(fileLabel).safetensors: bad offsets for '\(key)'",
+                    expected: 0,
+                    actual: 0
+                )
+            }
+            let start = startNum.intValue
+            let end = endNum.intValue
+            guard end >= start else {
+                throw LoadError.invalidSize(
+                    "\(fileLabel).safetensors: negative span for '\(key)'",
+                    expected: start,
+                    actual: end
+                )
+            }
+            let absStart = dataStart + start
+            let span = end - start
+            guard absStart + span <= data.count else {
+                throw LoadError.invalidSize(
+                    "\(fileLabel).safetensors: tensor '\(key)' overflows file",
+                    expected: data.count,
+                    actual: absStart + span
+                )
+            }
+            tensors[key] = SafetensorsTensor(
+                dtype: dtype,
+                shape: shape,
+                byteOffset: absStart,
+                byteCount: span
+            )
+        }
+        return SafetensorsParsed(tensors: tensors)
     }
 
     /// Load a raw Float32 binary file whose length must be a non-zero multiple

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
@@ -9,25 +9,23 @@ public struct PocketTtsConstantsBundle: Sendable {
 
 /// Pre-loaded voice conditioning data.
 ///
-/// Two formats are supported:
-///  - **Flat audio prompt** (legacy English `<voice>_audio_prompt.bin`):
-///    a `[1, promptLength, 1024]` Float32 tensor that the runtime feeds
-///    through `cond_step` token-by-token to populate the LM transformer
-///    KV cache.
-///  - **Pre-baked KV cache snapshot** (v2 packs `<voice>.safetensors`):
-///    per-layer K/V tensors already shaped to drop directly into the
-///    LM transformer's `cache{i}` slots. Skips `cond_step` voice prefill.
+/// Shipped voices (one `<voice>.safetensors` per language pack) carry a
+/// **pre-baked KV cache snapshot** — per-layer K/V tensors already shaped
+/// to drop directly into the LM transformer's `cache{i}` slots, skipping
+/// `cond_step` voice prefill.
 ///
-/// At most one of the two is populated. The synthesizer's `prefillKVCache`
-/// branches on `cacheSnapshot != nil` to choose the path.
+/// `audioPrompt` / `promptLength` are populated only by the voice cloner
+/// (`PocketTtsVoiceCloner`), which produces a flat `[1, promptLength, 1024]`
+/// Float32 prompt that gets fed through `cond_step` at runtime. For shipped
+/// voices these fields are empty / zero.
 public struct PocketTtsVoiceData: Sendable {
-    /// Flattened audio prompt: [1, promptLength, 1024]. Empty when
-    /// `cacheSnapshot` is non-nil.
+    /// Flattened audio prompt: [1, promptLength, 1024]. Set only by the
+    /// voice cloner; empty for shipped voices.
     public let audioPrompt: [Float]
-    /// Number of voice conditioning tokens (typically 125). Zero when
-    /// `cacheSnapshot` is non-nil.
+    /// Number of voice conditioning tokens (typically 125). Set only by
+    /// the voice cloner; zero for shipped voices.
     public let promptLength: Int
-    /// Pre-baked LM transformer KV cache (v2 packs only).
+    /// Pre-baked LM transformer KV cache (shipped voices).
     public let cacheSnapshot: PocketTtsVoiceCacheSnapshot?
 
     public init(
@@ -111,17 +109,12 @@ public enum PocketTtsConstantsLoader {
         )
     }
 
-    /// Load voice conditioning data from the given directory.
+    /// Load voice conditioning data from the given language root.
     ///
-    /// Resolution order:
-    ///  1. `<voice>.safetensors` — v2 packs ship pre-baked LM KV cache snapshots
-    ///     (per-layer `[2,1,seqLen,16,64]` F32 + `[1]` I64 offset).
-    ///  2. `<voice>_audio_prompt.bin` — legacy English flat `[1,promptLen,1024]` F32.
-    ///
-    /// Both legacy English (root-level pack) and v2 language packs are supported
-    /// without code branching at the call site — the loader picks the right
-    /// format and the synthesizer's `prefillKVCache` dispatches on
-    /// `cacheSnapshot`.
+    /// Reads `<voice>.safetensors` from `constants_bin/` — pre-baked LM KV
+    /// cache snapshot (per-layer `[2,1,seqLen,16,64]` F32 + `[1]` I64 offset).
+    /// The synthesizer's `prefillKVCache` consumes the snapshot directly,
+    /// skipping `cond_step` voice prefill.
     public static func loadVoice(
         _ voice: String, from directory: URL
     ) throws -> PocketTtsVoiceData {
@@ -133,52 +126,20 @@ public enum PocketTtsConstantsLoader {
 
         let constantsDir = directory.appendingPathComponent(ModelNames.PocketTTS.constantsBinDir)
         let safetensorsURL = constantsDir.appendingPathComponent("\(sanitized).safetensors")
-        let binURL = constantsDir.appendingPathComponent("\(sanitized)_audio_prompt.bin")
 
-        if FileManager.default.fileExists(atPath: safetensorsURL.path) {
-            let snapshot = try loadVoiceSnapshot(from: safetensorsURL, voiceName: sanitized)
-            logger.info(
-                "Loaded PocketTTS voice '\(sanitized)' from safetensors (\(snapshot.layers.count) layers, seq=\(snapshot.cacheSeqLen))"
-            )
-            return PocketTtsVoiceData(
-                audioPrompt: [],
-                promptLength: 0,
-                cacheSnapshot: snapshot
-            )
+        guard FileManager.default.fileExists(atPath: safetensorsURL.path) else {
+            throw LoadError.fileNotFound("\(sanitized).safetensors")
         }
 
-        guard FileManager.default.fileExists(atPath: binURL.path) else {
-            throw LoadError.fileNotFound("\(sanitized) (no .safetensors or _audio_prompt.bin)")
-        }
-
-        let data = try Data(contentsOf: binURL)
-        let embDim = PocketTtsConstants.embeddingDim
-        let floatCount = data.count / MemoryLayout<Float>.size
-
-        guard floatCount > 0, floatCount % embDim == 0 else {
-            throw LoadError.invalidSize(
-                "\(sanitized)_audio_prompt",
-                expected: embDim,
-                actual: floatCount
-            )
-        }
-
-        let promptLength = floatCount / embDim
-        guard promptLength <= PocketTtsVoiceCloner.maxVoiceFrames else {
-            throw LoadError.invalidSize(
-                "\(sanitized)_audio_prompt",
-                expected: PocketTtsVoiceCloner.maxVoiceFrames,
-                actual: promptLength
-            )
-        }
-        let audioPrompt = data.withUnsafeBytes { rawBuffer in
-            let floatBuffer = rawBuffer.bindMemory(to: Float.self)
-            return Array(floatBuffer)
-        }
-
-        logger.info("Loaded PocketTTS voice '\(sanitized)' conditioning data")
-
-        return PocketTtsVoiceData(audioPrompt: audioPrompt, promptLength: promptLength)
+        let snapshot = try loadVoiceSnapshot(from: safetensorsURL, voiceName: sanitized)
+        logger.info(
+            "Loaded PocketTTS voice '\(sanitized)' from safetensors (\(snapshot.layers.count) layers, seq=\(snapshot.cacheSeqLen))"
+        )
+        return PocketTtsVoiceData(
+            audioPrompt: [],
+            promptLength: 0,
+            cacheSnapshot: snapshot
+        )
     }
 
     /// Parse a v2 voice safetensors file into a `PocketTtsVoiceCacheSnapshot`.

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
@@ -363,7 +363,16 @@ public enum PocketTtsConstantsLoader {
             return UInt64(littleEndian: typed.pointee)
         }
         let headerStart = 8
-        let headerEnd = headerStart + Int(headerLen)
+        // Reject corrupt/malicious files whose header length doesn't fit in
+        // an Int before `Int(_:)` would trap.
+        guard let headerLenInt = Int(exactly: headerLen) else {
+            throw LoadError.invalidSize(
+                "\(fileLabel).safetensors: header length \(headerLen) exceeds Int.max",
+                expected: Int.max,
+                actual: data.count
+            )
+        }
+        let headerEnd = headerStart + headerLenInt
         guard headerEnd <= data.count else {
             throw LoadError.invalidSize(
                 "\(fileLabel).safetensors: header overflow",

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
@@ -372,14 +372,17 @@ public enum PocketTtsConstantsLoader {
                 actual: data.count
             )
         }
-        let headerEnd = headerStart + headerLenInt
-        guard headerEnd <= data.count else {
+        // Bounds-check BEFORE adding `headerStart` to avoid an arithmetic
+        // overflow trap when a corrupt/malicious file encodes a header
+        // length close to `Int.max`.
+        guard headerLenInt <= data.count - headerStart else {
             throw LoadError.invalidSize(
                 "\(fileLabel).safetensors: header overflow",
-                expected: headerEnd,
-                actual: data.count
+                expected: data.count,
+                actual: headerLenInt
             )
         }
+        let headerEnd = headerStart + headerLenInt
         let headerBytes = data.subdata(in: headerStart..<headerEnd)
         let json: Any
         do {

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OSLog
 
 /// Pre-loaded binary constants for PocketTTS inference.
 public struct PocketTtsConstantsBundle: Sendable {
@@ -68,6 +67,7 @@ public enum PocketTtsConstantsLoader {
     public enum LoadError: Error {
         case fileNotFound(String)
         case invalidSize(String, expected: Int, actual: Int)
+        case malformed(String)
         case tokenizerLoadFailed(String)
     }
 
@@ -193,7 +193,7 @@ public enum PocketTtsConstantsLoader {
         from url: URL, voiceName: String
     ) throws -> PocketTtsVoiceCacheSnapshot {
         let raw = try Data(contentsOf: url)
-        let parsed = try parseSafetensors(raw, fileLabel: voiceName)
+        let tensors = try parseSafetensors(raw, fileLabel: voiceName)
 
         // Collect cache + offset entries by layer index.
         var caches: [Int: SafetensorsTensor] = [:]
@@ -202,7 +202,7 @@ public enum PocketTtsConstantsLoader {
         let cacheSuffix = ".self_attn/cache"
         let offsetSuffix = ".self_attn/offset"
 
-        for (key, tensor) in parsed.tensors {
+        for (key, tensor) in tensors {
             guard key.hasPrefix(cachePrefix) else { continue }
             let stripped = String(key.dropFirst(cachePrefix.count))
             guard let dotRange = stripped.firstIndex(of: ".") else { continue }
@@ -223,12 +223,13 @@ public enum PocketTtsConstantsLoader {
                 actual: 0
             )
         }
-        guard caches.count == offsets.count else {
-            throw LoadError.invalidSize(
-                "\(voiceName).safetensors: cache/offset count mismatch",
-                expected: caches.count,
-                actual: offsets.count
-            )
+        // Cache and offset entries must have the same set of layer indices —
+        // a count match isn't sufficient (different keys would silently drop
+        // layers in the loop below).
+        guard Set(caches.keys) == Set(offsets.keys) else {
+            throw LoadError.malformed(
+                "\(voiceName).safetensors: cache/offset layer indices differ "
+                    + "(caches: \(caches.keys.sorted()), offsets: \(offsets.keys.sorted()))")
         }
 
         let sortedLayers = caches.keys.sorted()
@@ -249,11 +250,8 @@ public enum PocketTtsConstantsLoader {
             firstShape[3] == 16,
             firstShape[4] == 64
         else {
-            throw LoadError.invalidSize(
-                "\(voiceName).safetensors: unexpected cache shape \(firstShape)",
-                expected: 0,
-                actual: 0
-            )
+            throw LoadError.malformed(
+                "\(voiceName).safetensors: unexpected cache shape \(firstShape)")
         }
         let seqLen = firstShape[2]
 
@@ -261,21 +259,19 @@ public enum PocketTtsConstantsLoader {
         layers.reserveCapacity(sortedLayers.count)
 
         for layerIdx in sortedLayers {
-            guard let cacheTensor = caches[layerIdx], let offsetTensor = offsets[layerIdx]
-            else { continue }
+            // Both lookups are guaranteed by the `Set(caches.keys) == Set(offsets.keys)`
+            // check above, so the force-unwraps are safe.
+            let cacheTensor = caches[layerIdx]!
+            let offsetTensor = offsets[layerIdx]!
             guard cacheTensor.shape == firstShape else {
-                throw LoadError.invalidSize(
-                    "\(voiceName).safetensors: cache shape mismatch at layer \(layerIdx)",
-                    expected: 0,
-                    actual: 0
-                )
+                throw LoadError.malformed(
+                    "\(voiceName).safetensors: cache shape mismatch at layer \(layerIdx) "
+                        + "(\(cacheTensor.shape) vs \(firstShape))")
             }
             guard cacheTensor.dtype == "F32" else {
-                throw LoadError.invalidSize(
-                    "\(voiceName).safetensors: layer \(layerIdx) cache dtype \(cacheTensor.dtype) (want F32)",
-                    expected: 0,
-                    actual: 0
-                )
+                throw LoadError.malformed(
+                    "\(voiceName).safetensors: layer \(layerIdx) cache dtype "
+                        + "\(cacheTensor.dtype) (want F32)")
             }
             let floatCount = cacheTensor.byteCount / MemoryLayout<Float>.size
             let cacheFloats: [Float] = raw.withUnsafeBytes { rawBuf -> [Float] in
@@ -286,11 +282,9 @@ public enum PocketTtsConstantsLoader {
 
             // offset is I64 [1]
             guard offsetTensor.dtype == "I64", offsetTensor.shape == [1] else {
-                throw LoadError.invalidSize(
-                    "\(voiceName).safetensors: layer \(layerIdx) offset shape/dtype unexpected",
-                    expected: 0,
-                    actual: 0
-                )
+                throw LoadError.malformed(
+                    "\(voiceName).safetensors: layer \(layerIdx) offset "
+                        + "shape/dtype unexpected (\(offsetTensor.shape), \(offsetTensor.dtype))")
             }
             let offsetVal: Int = raw.withUnsafeBytes { rawBuf -> Int in
                 let base = rawBuf.baseAddress!.advanced(by: offsetTensor.byteOffset)
@@ -339,16 +333,12 @@ public enum PocketTtsConstantsLoader {
         let byteCount: Int
     }
 
-    fileprivate struct SafetensorsParsed {
-        let tensors: [String: SafetensorsTensor]
-    }
-
     /// Minimal safetensors reader: 8-byte LE u64 header length, then JSON
     /// header, then raw tensor bytes. Only used for v2 voice prebakes — no
     /// need to support arbitrary safetensors features.
     fileprivate static func parseSafetensors(
         _ data: Data, fileLabel: String
-    ) throws -> SafetensorsParsed {
+    ) throws -> [String: SafetensorsTensor] {
         guard data.count >= 8 else {
             throw LoadError.invalidSize(
                 "\(fileLabel).safetensors: too small",
@@ -387,18 +377,12 @@ public enum PocketTtsConstantsLoader {
         do {
             json = try JSONSerialization.jsonObject(with: headerBytes, options: [])
         } catch {
-            throw LoadError.invalidSize(
-                "\(fileLabel).safetensors: header JSON parse failed: \(error)",
-                expected: 0,
-                actual: 0
-            )
+            throw LoadError.malformed(
+                "\(fileLabel).safetensors: header JSON parse failed: \(error)")
         }
         guard let dict = json as? [String: Any] else {
-            throw LoadError.invalidSize(
-                "\(fileLabel).safetensors: header is not a JSON object",
-                expected: 0,
-                actual: 0
-            )
+            throw LoadError.malformed(
+                "\(fileLabel).safetensors: header is not a JSON object")
         }
 
         let dataStart = headerEnd
@@ -411,28 +395,19 @@ public enum PocketTtsConstantsLoader {
                 let offsets = entry["data_offsets"] as? [Any],
                 offsets.count == 2
             else {
-                throw LoadError.invalidSize(
-                    "\(fileLabel).safetensors: malformed entry '\(key)'",
-                    expected: 0,
-                    actual: 0
-                )
+                throw LoadError.malformed(
+                    "\(fileLabel).safetensors: malformed entry '\(key)'")
             }
             let shape: [Int] = shapeArr.compactMap { ($0 as? NSNumber)?.intValue }
             guard shape.count == shapeArr.count else {
-                throw LoadError.invalidSize(
-                    "\(fileLabel).safetensors: bad shape for '\(key)'",
-                    expected: 0,
-                    actual: 0
-                )
+                throw LoadError.malformed(
+                    "\(fileLabel).safetensors: bad shape for '\(key)'")
             }
             guard let startNum = offsets[0] as? NSNumber,
                 let endNum = offsets[1] as? NSNumber
             else {
-                throw LoadError.invalidSize(
-                    "\(fileLabel).safetensors: bad offsets for '\(key)'",
-                    expected: 0,
-                    actual: 0
-                )
+                throw LoadError.malformed(
+                    "\(fileLabel).safetensors: bad offsets for '\(key)'")
             }
             let start = startNum.intValue
             let end = endNum.intValue
@@ -459,7 +434,7 @@ public enum PocketTtsConstantsLoader {
                 byteCount: span
             )
         }
-        return SafetensorsParsed(tensors: tensors)
+        return tensors
     }
 
     /// Load a raw Float32 binary file whose length must be a non-zero multiple

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsConstantsLoader.swift
@@ -205,15 +205,14 @@ public enum PocketTtsConstantsLoader {
         for (key, tensor) in parsed.tensors {
             guard key.hasPrefix(cachePrefix) else { continue }
             let stripped = String(key.dropFirst(cachePrefix.count))
-            if let dotRange = stripped.firstIndex(of: ".") {
-                let idxStr = String(stripped[..<dotRange])
-                let rest = stripped[dotRange...]
-                guard let layerIdx = Int(idxStr) else { continue }
-                if rest == Substring(cacheSuffix) {
-                    caches[layerIdx] = tensor
-                } else if rest == Substring(offsetSuffix) {
-                    offsets[layerIdx] = tensor
-                }
+            guard let dotRange = stripped.firstIndex(of: ".") else { continue }
+            let idxStr = String(stripped[..<dotRange])
+            let rest = stripped[dotRange...]
+            guard let layerIdx = Int(idxStr) else { continue }
+            if rest == Substring(cacheSuffix) {
+                caches[layerIdx] = tensor
+            } else if rest == Substring(offsetSuffix) {
+                offsets[layerIdx] = tensor
             }
         }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -137,20 +137,31 @@ public enum PocketTtsResourceDownloader {
             throw PocketTTSError.processingFailed("Invalid voice name: \(voice)")
         }
         let constantsDir = languageRoot.appendingPathComponent(ModelNames.PocketTTS.constantsBinDir)
-        let voiceFile = "\(sanitized)_audio_prompt.bin"
-        let voiceURL = constantsDir.appendingPathComponent(voiceFile)
+        let safetensorsFile = "\(sanitized).safetensors"
+        let binFile = "\(sanitized)_audio_prompt.bin"
+        let safetensorsURL = constantsDir.appendingPathComponent(safetensorsFile)
+        let binURL = constantsDir.appendingPathComponent(binFile)
 
-        if !FileManager.default.fileExists(atPath: voiceURL.path) {
-            logger.info(
-                "Downloading voice '\(sanitized)' for \(language.rawValue) from HuggingFace...")
+        let safetensorsExists = FileManager.default.fileExists(atPath: safetensorsURL.path)
+        let binExists = FileManager.default.fileExists(atPath: binURL.path)
+
+        if !safetensorsExists && !binExists {
+            // For non-English (v2) packs, voices ship as `.safetensors`. For
+            // legacy English (root pack), they ship as flat `.bin`. Pick the
+            // expected format based on language and download just that file.
             let remotePrefix: String
             if let subdir = language.repoSubdirectory {
                 remotePrefix = "\(subdir)/"
             } else {
                 remotePrefix = ""
             }
-            let remotePath = "\(remotePrefix)constants_bin/\(voiceFile)"
+            let preferredFile = (language == .english) ? binFile : safetensorsFile
+            let preferredLocalURL = (language == .english) ? binURL : safetensorsURL
+            let remotePath = "\(remotePrefix)constants_bin/\(preferredFile)"
             let remoteURL = try ModelRegistry.resolveModel(Repo.pocketTts.remotePath, remotePath)
+            logger.info(
+                "Downloading voice '\(sanitized)' for \(language.rawValue) from HuggingFace (\(preferredFile))..."
+            )
             let data = try await AssetDownloader.fetchData(
                 from: remoteURL,
                 description: "\(sanitized) voice prompt (\(language.rawValue))",
@@ -160,7 +171,7 @@ public enum PocketTtsResourceDownloader {
             // language pack that hasn't materialized constants_bin/ yet.
             try FileManager.default.createDirectory(
                 at: constantsDir, withIntermediateDirectories: true)
-            try data.write(to: voiceURL, options: [.atomic])
+            try data.write(to: preferredLocalURL, options: [.atomic])
             logger.info("Downloaded voice '\(sanitized)' (\(data.count / 1024) KB)")
         }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -7,7 +7,7 @@ public enum PocketTtsResourceDownloader {
     private static let logger = AppLogger(category: "PocketTtsResourceDownloader")
 
     /// Ensure all PocketTTS models for the given language are downloaded and
-    /// return the **language root** directory (`<repoDir>/v2/<lang>/`).
+    /// return the **language root** directory.
     ///
     /// - Parameters:
     ///   - language: Which upstream language pack to fetch.
@@ -15,7 +15,9 @@ public enum PocketTtsResourceDownloader {
     ///     When `nil`, uses the default platform cache location.
     ///   - progressHandler: Optional callback for download progress updates.
     /// - Returns: The directory that contains the four `.mlmodelc` packages
-    ///   plus `constants_bin/` for the requested language.
+    ///   plus `constants_bin/` for the requested language. For English this
+    ///   is the legacy repo root; for other languages it's
+    ///   `<repoDir>/v2/<lang>/`.
     public static func ensureModels(
         language: PocketTtsLanguage = .english,
         directory: URL? = nil,
@@ -26,24 +28,36 @@ public enum PocketTtsResourceDownloader {
             PocketTtsConstants.defaultModelsSubdirectory)
 
         let repoDir = modelsDirectory.appendingPathComponent(Repo.pocketTts.folderName)
-        let subdir = language.repoSubdirectory
-        let languageRoot = repoDir.appendingPathComponent(subdir)
 
-        let allPresent = ModelNames.PocketTTS.requiredModels.allSatisfy { model in
+        let languageRoot: URL
+        if let subdir = language.repoSubdirectory {
+            languageRoot = repoDir.appendingPathComponent(subdir)
+        } else {
+            languageRoot = repoDir
+        }
+
+        let requiredModels = ModelNames.PocketTTS.requiredModels(for: language)
+        let allPresent = requiredModels.allSatisfy { model in
             FileManager.default.fileExists(
                 atPath: languageRoot.appendingPathComponent(model).path)
         }
 
         if !allPresent {
-            logger.info(
-                "Downloading PocketTTS \(language.rawValue) language pack from HuggingFace (\(subdir))..."
-            )
-            try await DownloadUtils.downloadSubdirectory(
-                .pocketTts,
-                subdirectory: subdir,
-                to: repoDir,
-                progressHandler: progressHandler
-            )
+            if let subdir = language.repoSubdirectory {
+                logger.info(
+                    "Downloading PocketTTS \(language.rawValue) language pack from HuggingFace (\(subdir))..."
+                )
+                try await DownloadUtils.downloadSubdirectory(
+                    .pocketTts,
+                    subdirectory: subdir,
+                    to: repoDir,
+                    progressHandler: progressHandler
+                )
+            } else {
+                logger.info("Downloading PocketTTS English models from HuggingFace...")
+                try await DownloadUtils.downloadRepo(
+                    .pocketTts, to: modelsDirectory, progressHandler: progressHandler)
+            }
         } else {
             logger.info(
                 "PocketTTS \(language.rawValue) models found in cache")
@@ -125,13 +139,29 @@ public enum PocketTtsResourceDownloader {
         }
         let constantsDir = languageRoot.appendingPathComponent(ModelNames.PocketTTS.constantsBinDir)
         let safetensorsFile = "\(sanitized).safetensors"
+        let binFile = "\(sanitized)_audio_prompt.bin"
         let safetensorsURL = constantsDir.appendingPathComponent(safetensorsFile)
+        let binURL = constantsDir.appendingPathComponent(binFile)
 
-        if !FileManager.default.fileExists(atPath: safetensorsURL.path) {
-            let remotePath = "\(language.repoSubdirectory)/constants_bin/\(safetensorsFile)"
+        let safetensorsExists = FileManager.default.fileExists(atPath: safetensorsURL.path)
+        let binExists = FileManager.default.fileExists(atPath: binURL.path)
+
+        if !safetensorsExists && !binExists {
+            // For non-English (v2) packs, voices ship as `.safetensors`. For
+            // legacy English (root pack), they ship as flat `.bin`. Pick the
+            // expected format based on language and download just that file.
+            let remotePrefix: String
+            if let subdir = language.repoSubdirectory {
+                remotePrefix = "\(subdir)/"
+            } else {
+                remotePrefix = ""
+            }
+            let preferredFile = (language == .english) ? binFile : safetensorsFile
+            let preferredLocalURL = (language == .english) ? binURL : safetensorsURL
+            let remotePath = "\(remotePrefix)constants_bin/\(preferredFile)"
             let remoteURL = try ModelRegistry.resolveModel(Repo.pocketTts.remotePath, remotePath)
             logger.info(
-                "Downloading voice '\(sanitized)' for \(language.rawValue) from HuggingFace (\(safetensorsFile))..."
+                "Downloading voice '\(sanitized)' for \(language.rawValue) from HuggingFace (\(preferredFile))..."
             )
             let data = try await AssetDownloader.fetchData(
                 from: remoteURL,
@@ -142,7 +172,7 @@ public enum PocketTtsResourceDownloader {
             // language pack that hasn't materialized constants_bin/ yet.
             try FileManager.default.createDirectory(
                 at: constantsDir, withIntermediateDirectories: true)
-            try data.write(to: safetensorsURL, options: [.atomic])
+            try data.write(to: preferredLocalURL, options: [.atomic])
             logger.info("Downloaded voice '\(sanitized)' (\(data.count / 1024) KB)")
         }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -7,7 +7,7 @@ public enum PocketTtsResourceDownloader {
     private static let logger = AppLogger(category: "PocketTtsResourceDownloader")
 
     /// Ensure all PocketTTS models for the given language are downloaded and
-    /// return the **language root** directory.
+    /// return the **language root** directory (`<repoDir>/v2/<lang>/`).
     ///
     /// - Parameters:
     ///   - language: Which upstream language pack to fetch.
@@ -15,9 +15,7 @@ public enum PocketTtsResourceDownloader {
     ///     When `nil`, uses the default platform cache location.
     ///   - progressHandler: Optional callback for download progress updates.
     /// - Returns: The directory that contains the four `.mlmodelc` packages
-    ///   plus `constants_bin/` for the requested language. For English this
-    ///   is the legacy repo root; for other languages it's
-    ///   `<repoDir>/v2/<lang>/`.
+    ///   plus `constants_bin/` for the requested language.
     public static func ensureModels(
         language: PocketTtsLanguage = .english,
         directory: URL? = nil,
@@ -28,36 +26,24 @@ public enum PocketTtsResourceDownloader {
             PocketTtsConstants.defaultModelsSubdirectory)
 
         let repoDir = modelsDirectory.appendingPathComponent(Repo.pocketTts.folderName)
+        let subdir = language.repoSubdirectory
+        let languageRoot = repoDir.appendingPathComponent(subdir)
 
-        let languageRoot: URL
-        if let subdir = language.repoSubdirectory {
-            languageRoot = repoDir.appendingPathComponent(subdir)
-        } else {
-            languageRoot = repoDir
-        }
-
-        let requiredModels = ModelNames.PocketTTS.requiredModels(for: language)
-        let allPresent = requiredModels.allSatisfy { model in
+        let allPresent = ModelNames.PocketTTS.requiredModels.allSatisfy { model in
             FileManager.default.fileExists(
                 atPath: languageRoot.appendingPathComponent(model).path)
         }
 
         if !allPresent {
-            if let subdir = language.repoSubdirectory {
-                logger.info(
-                    "Downloading PocketTTS \(language.rawValue) language pack from HuggingFace (\(subdir))..."
-                )
-                try await DownloadUtils.downloadSubdirectory(
-                    .pocketTts,
-                    subdirectory: subdir,
-                    to: repoDir,
-                    progressHandler: progressHandler
-                )
-            } else {
-                logger.info("Downloading PocketTTS English models from HuggingFace...")
-                try await DownloadUtils.downloadRepo(
-                    .pocketTts, to: modelsDirectory, progressHandler: progressHandler)
-            }
+            logger.info(
+                "Downloading PocketTTS \(language.rawValue) language pack from HuggingFace (\(subdir))..."
+            )
+            try await DownloadUtils.downloadSubdirectory(
+                .pocketTts,
+                subdirectory: subdir,
+                to: repoDir,
+                progressHandler: progressHandler
+            )
         } else {
             logger.info(
                 "PocketTTS \(language.rawValue) models found in cache")
@@ -139,29 +125,13 @@ public enum PocketTtsResourceDownloader {
         }
         let constantsDir = languageRoot.appendingPathComponent(ModelNames.PocketTTS.constantsBinDir)
         let safetensorsFile = "\(sanitized).safetensors"
-        let binFile = "\(sanitized)_audio_prompt.bin"
         let safetensorsURL = constantsDir.appendingPathComponent(safetensorsFile)
-        let binURL = constantsDir.appendingPathComponent(binFile)
 
-        let safetensorsExists = FileManager.default.fileExists(atPath: safetensorsURL.path)
-        let binExists = FileManager.default.fileExists(atPath: binURL.path)
-
-        if !safetensorsExists && !binExists {
-            // For non-English (v2) packs, voices ship as `.safetensors`. For
-            // legacy English (root pack), they ship as flat `.bin`. Pick the
-            // expected format based on language and download just that file.
-            let remotePrefix: String
-            if let subdir = language.repoSubdirectory {
-                remotePrefix = "\(subdir)/"
-            } else {
-                remotePrefix = ""
-            }
-            let preferredFile = (language == .english) ? binFile : safetensorsFile
-            let preferredLocalURL = (language == .english) ? binURL : safetensorsURL
-            let remotePath = "\(remotePrefix)constants_bin/\(preferredFile)"
+        if !FileManager.default.fileExists(atPath: safetensorsURL.path) {
+            let remotePath = "\(language.repoSubdirectory)/constants_bin/\(safetensorsFile)"
             let remoteURL = try ModelRegistry.resolveModel(Repo.pocketTts.remotePath, remotePath)
             logger.info(
-                "Downloading voice '\(sanitized)' for \(language.rawValue) from HuggingFace (\(preferredFile))..."
+                "Downloading voice '\(sanitized)' for \(language.rawValue) from HuggingFace (\(safetensorsFile))..."
             )
             let data = try await AssetDownloader.fetchData(
                 from: remoteURL,
@@ -172,7 +142,7 @@ public enum PocketTtsResourceDownloader {
             // language pack that hasn't materialized constants_bin/ yet.
             try FileManager.default.createDirectory(
                 at: constantsDir, withIntermediateDirectories: true)
-            try data.write(to: preferredLocalURL, options: [.atomic])
+            try data.write(to: safetensorsURL, options: [.atomic])
             logger.info("Downloaded voice '\(sanitized)' (\(data.count / 1024) KB)")
         }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -50,7 +50,8 @@ public enum PocketTtsResourceDownloader {
                 try await DownloadUtils.downloadSubdirectory(
                     .pocketTts,
                     subdirectory: subdir,
-                    to: repoDir
+                    to: repoDir,
+                    progressHandler: progressHandler
                 )
             } else {
                 logger.info("Downloading PocketTTS English models from HuggingFace...")

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -6,13 +6,20 @@ public enum PocketTtsResourceDownloader {
 
     private static let logger = AppLogger(category: "PocketTtsResourceDownloader")
 
-    /// Ensure all PocketTTS models are downloaded and return the cache directory.
+    /// Ensure all PocketTTS models for the given language are downloaded and
+    /// return the **language root** directory.
     ///
     /// - Parameters:
+    ///   - language: Which upstream language pack to fetch.
     ///   - directory: Optional override for the base cache directory.
     ///     When `nil`, uses the default platform cache location.
     ///   - progressHandler: Optional callback for download progress updates.
+    /// - Returns: The directory that contains the four `.mlmodelc` packages
+    ///   plus `constants_bin/` for the requested language. For English this
+    ///   is the legacy repo root; for other languages it's
+    ///   `<repoDir>/v2/<lang>/`.
     public static func ensureModels(
+        language: PocketTtsLanguage = .english,
         directory: URL? = nil,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> URL {
@@ -22,37 +29,68 @@ public enum PocketTtsResourceDownloader {
 
         let repoDir = modelsDirectory.appendingPathComponent(Repo.pocketTts.folderName)
 
-        // Check that all required directories exist (models + constants_bin)
-        let requiredModels = ModelNames.PocketTTS.requiredModels
+        let languageRoot: URL
+        if let subdir = language.repoSubdirectory {
+            languageRoot = repoDir.appendingPathComponent(subdir)
+        } else {
+            languageRoot = repoDir
+        }
+
+        let requiredModels = ModelNames.PocketTTS.requiredModels(for: language)
         let allPresent = requiredModels.allSatisfy { model in
             FileManager.default.fileExists(
-                atPath: repoDir.appendingPathComponent(model).path)
+                atPath: languageRoot.appendingPathComponent(model).path)
         }
 
         if !allPresent {
-            logger.info("Downloading PocketTTS models from HuggingFace...")
-            try await DownloadUtils.downloadRepo(.pocketTts, to: modelsDirectory, progressHandler: progressHandler)
+            if let subdir = language.repoSubdirectory {
+                logger.info(
+                    "Downloading PocketTTS \(language.rawValue) language pack from HuggingFace (\(subdir))..."
+                )
+                try await DownloadUtils.downloadSubdirectory(
+                    .pocketTts,
+                    subdirectory: subdir,
+                    to: repoDir
+                )
+            } else {
+                logger.info("Downloading PocketTTS English models from HuggingFace...")
+                try await DownloadUtils.downloadRepo(
+                    .pocketTts, to: modelsDirectory, progressHandler: progressHandler)
+            }
         } else {
-            logger.info("PocketTTS models found in cache")
+            logger.info(
+                "PocketTTS \(language.rawValue) models found in cache")
         }
 
-        return repoDir
+        return languageRoot
     }
 
     /// Ensure the Mimi encoder model is downloaded for voice cloning.
     ///
     /// This is an optional model that's only needed for voice cloning functionality.
     /// It's downloaded separately from the main models to reduce initial download size.
+    /// The encoder is shared across all language packs and lives at the legacy
+    /// repo root regardless of which language is currently loaded — so a Spanish
+    /// (or any non-English) user can clone a voice without pulling in the
+    /// English language pack.
     /// - Parameter directory: Optional override for the base cache directory.
     ///   When `nil`, uses the default platform cache location.
     public static func ensureMimiEncoder(directory: URL? = nil) async throws -> URL {
-        let repoDir = try await ensureModels(directory: directory)
+        let targetDir = try directory ?? cacheDirectory()
+        let modelsDirectory = targetDir.appendingPathComponent(
+            PocketTtsConstants.defaultModelsSubdirectory)
+        let repoDir = modelsDirectory.appendingPathComponent(Repo.pocketTts.folderName)
         let encoderPath = repoDir.appendingPathComponent(ModelNames.PocketTTS.mimiEncoderFile)
 
         if FileManager.default.fileExists(atPath: encoderPath.path) {
             logger.info("Mimi encoder found in cache")
             return encoderPath
         }
+
+        // Make sure the parent directory exists — the user may not have
+        // downloaded any language pack yet.
+        try FileManager.default.createDirectory(
+            at: repoDir, withIntermediateDirectories: true)
 
         logger.info("Downloading Mimi encoder for voice cloning...")
         try await downloadMimiEncoder(to: repoDir)
@@ -74,36 +112,59 @@ public enum PocketTtsResourceDownloader {
     }
 
     /// Ensure constants (binary blobs + tokenizer) are available.
-    public static func ensureConstants(repoDirectory: URL) throws -> PocketTtsConstantsBundle {
-        try PocketTtsConstantsLoader.load(from: repoDirectory)
+    ///
+    /// - Parameter languageRoot: The directory returned by `ensureModels(...)`,
+    ///   which contains the language-specific `constants_bin/`.
+    public static func ensureConstants(languageRoot: URL) throws -> PocketTtsConstantsBundle {
+        try PocketTtsConstantsLoader.load(from: languageRoot)
     }
 
-    /// Ensure voice conditioning data is available, downloading from HuggingFace if missing.
+    /// Ensure voice conditioning data for the given language is available,
+    /// downloading from HuggingFace if missing.
+    ///
+    /// - Parameters:
+    ///   - voice: Voice name (e.g. `"alba"`, `"michael"`).
+    ///   - language: Language pack the voice belongs to. Voice files are
+    ///     per-language (same names, different acoustic embeddings).
+    ///   - languageRoot: The directory returned by `ensureModels(language:)`.
     public static func ensureVoice(
-        _ voice: String, repoDirectory: URL
+        _ voice: String,
+        language: PocketTtsLanguage = .english,
+        languageRoot: URL
     ) async throws -> PocketTtsVoiceData {
         let sanitized = voice.filter { $0.isLetter || $0.isNumber || $0 == "_" }
         guard !sanitized.isEmpty else {
             throw PocketTTSError.processingFailed("Invalid voice name: \(voice)")
         }
-        let constantsDir = repoDirectory.appendingPathComponent(ModelNames.PocketTTS.constantsBinDir)
+        let constantsDir = languageRoot.appendingPathComponent(ModelNames.PocketTTS.constantsBinDir)
         let voiceFile = "\(sanitized)_audio_prompt.bin"
         let voiceURL = constantsDir.appendingPathComponent(voiceFile)
 
         if !FileManager.default.fileExists(atPath: voiceURL.path) {
-            logger.info("Downloading voice '\(sanitized)' from HuggingFace...")
-            let remotePath = "constants_bin/\(voiceFile)"
+            logger.info(
+                "Downloading voice '\(sanitized)' for \(language.rawValue) from HuggingFace...")
+            let remotePrefix: String
+            if let subdir = language.repoSubdirectory {
+                remotePrefix = "\(subdir)/"
+            } else {
+                remotePrefix = ""
+            }
+            let remotePath = "\(remotePrefix)constants_bin/\(voiceFile)"
             let remoteURL = try ModelRegistry.resolveModel(Repo.pocketTts.remotePath, remotePath)
             let data = try await AssetDownloader.fetchData(
                 from: remoteURL,
-                description: "\(sanitized) voice prompt",
+                description: "\(sanitized) voice prompt (\(language.rawValue))",
                 logger: logger
             )
+            // Make sure the parent directory exists in case this is a fresh
+            // language pack that hasn't materialized constants_bin/ yet.
+            try FileManager.default.createDirectory(
+                at: constantsDir, withIntermediateDirectories: true)
             try data.write(to: voiceURL, options: [.atomic])
             logger.info("Downloaded voice '\(sanitized)' (\(data.count / 1024) KB)")
         }
 
-        return try PocketTtsConstantsLoader.loadVoice(voice, from: repoDirectory)
+        return try PocketTtsConstantsLoader.loadVoice(voice, from: languageRoot)
     }
 
     // MARK: - Private

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -16,7 +16,7 @@ public enum PocketTtsResourceDownloader {
     /// - Returns: The directory that contains the four `.mlmodelc` packages
     ///   plus `constants_bin/` for the requested language.
     public static func ensureModels(
-        language: PocketTtsLanguage = .english,
+        language: PocketTtsLanguage,
         directory: URL? = nil,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> URL {
@@ -102,7 +102,7 @@ public enum PocketTtsResourceDownloader {
     ///   - languageRoot: The directory returned by `ensureModels(language:)`.
     public static func ensureVoice(
         _ voice: String,
-        language: PocketTtsLanguage = .english,
+        language: PocketTtsLanguage,
         languageRoot: URL
     ) async throws -> PocketTtsVoiceData {
         let sanitized = voice.filter { $0.isLetter || $0.isNumber || $0 == "_" }
@@ -124,10 +124,6 @@ public enum PocketTtsResourceDownloader {
                 description: "\(sanitized) voice prompt (\(language.rawValue))",
                 logger: logger
             )
-            // Make sure the parent directory exists in case this is a fresh
-            // language pack that hasn't materialized constants_bin/ yet.
-            try FileManager.default.createDirectory(
-                at: constantsDir, withIntermediateDirectories: true)
             try data.write(to: safetensorsURL, options: [.atomic])
             logger.info("Downloaded voice '\(sanitized)' (\(data.count / 1024) KB)")
         }

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OSLog
 
 /// Downloads PocketTTS models and constants from HuggingFace.
 public enum PocketTtsResourceDownloader {
@@ -95,30 +94,17 @@ public enum PocketTtsResourceDownloader {
             at: repoDir, withIntermediateDirectories: true)
 
         logger.info("Downloading Mimi encoder for voice cloning...")
-        try await downloadMimiEncoder(to: repoDir)
+        try await DownloadUtils.downloadSubdirectory(
+            .pocketTts,
+            subdirectory: ModelNames.PocketTTS.mimiEncoderFile,
+            to: repoDir
+        )
 
         guard FileManager.default.fileExists(atPath: encoderPath.path) else {
             throw PocketTTSError.downloadFailed("Failed to download Mimi encoder model")
         }
 
         return encoderPath
-    }
-
-    /// Download the Mimi encoder model files from HuggingFace.
-    private static func downloadMimiEncoder(to repoDir: URL) async throws {
-        try await DownloadUtils.downloadSubdirectory(
-            .pocketTts,
-            subdirectory: ModelNames.PocketTTS.mimiEncoderFile,
-            to: repoDir
-        )
-    }
-
-    /// Ensure constants (binary blobs + tokenizer) are available.
-    ///
-    /// - Parameter languageRoot: The directory returned by `ensureModels(...)`,
-    ///   which contains the language-specific `constants_bin/`.
-    public static func ensureConstants(languageRoot: URL) throws -> PocketTtsConstantsBundle {
-        try PocketTtsConstantsLoader.load(from: languageRoot)
     }
 
     /// Ensure voice conditioning data for the given language is available,
@@ -144,19 +130,15 @@ public enum PocketTtsResourceDownloader {
         let safetensorsURL = constantsDir.appendingPathComponent(safetensorsFile)
         let binURL = constantsDir.appendingPathComponent(binFile)
 
-        let safetensorsExists = FileManager.default.fileExists(atPath: safetensorsURL.path)
-        let binExists = FileManager.default.fileExists(atPath: binURL.path)
+        let alreadyDownloaded =
+            FileManager.default.fileExists(atPath: safetensorsURL.path)
+            || FileManager.default.fileExists(atPath: binURL.path)
 
-        if !safetensorsExists && !binExists {
+        if !alreadyDownloaded {
             // For non-English (v2) packs, voices ship as `.safetensors`. For
             // legacy English (root pack), they ship as flat `.bin`. Pick the
             // expected format based on language and download just that file.
-            let remotePrefix: String
-            if let subdir = language.repoSubdirectory {
-                remotePrefix = "\(subdir)/"
-            } else {
-                remotePrefix = ""
-            }
+            let remotePrefix = language.repoSubdirectory.map { "\($0)/" } ?? ""
             let preferredFile = (language == .english) ? binFile : safetensorsFile
             let preferredLocalURL = (language == .english) ? binURL : safetensorsURL
             let remotePath = "\(remotePrefix)constants_bin/\(preferredFile)"

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -42,25 +42,26 @@ public enum PocketTtsResourceDownloader {
                 atPath: languageRoot.appendingPathComponent(model).path)
         }
 
-        if !allPresent {
-            if let subdir = language.repoSubdirectory {
-                logger.info(
-                    "Downloading PocketTTS \(language.rawValue) language pack from HuggingFace (\(subdir))..."
-                )
-                try await DownloadUtils.downloadSubdirectory(
-                    .pocketTts,
-                    subdirectory: subdir,
-                    to: repoDir,
-                    progressHandler: progressHandler
-                )
-            } else {
-                logger.info("Downloading PocketTTS English models from HuggingFace...")
-                try await DownloadUtils.downloadRepo(
-                    .pocketTts, to: modelsDirectory, progressHandler: progressHandler)
-            }
-        } else {
+        guard !allPresent else {
             logger.info(
                 "PocketTTS \(language.rawValue) models found in cache")
+            return languageRoot
+        }
+
+        if let subdir = language.repoSubdirectory {
+            logger.info(
+                "Downloading PocketTTS \(language.rawValue) language pack from HuggingFace (\(subdir))..."
+            )
+            try await DownloadUtils.downloadSubdirectory(
+                .pocketTts,
+                subdirectory: subdir,
+                to: repoDir,
+                progressHandler: progressHandler
+            )
+        } else {
+            logger.info("Downloading PocketTTS English models from HuggingFace...")
+            try await DownloadUtils.downloadRepo(
+                .pocketTts, to: modelsDirectory, progressHandler: progressHandler)
         }
 
         return languageRoot

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -6,7 +6,7 @@ public enum PocketTtsResourceDownloader {
     private static let logger = AppLogger(category: "PocketTtsResourceDownloader")
 
     /// Ensure all PocketTTS models for the given language are downloaded and
-    /// return the **language root** directory.
+    /// return the **language root** directory (`<repoDir>/v2/<lang>/`).
     ///
     /// - Parameters:
     ///   - language: Which upstream language pack to fetch.
@@ -14,9 +14,7 @@ public enum PocketTtsResourceDownloader {
     ///     When `nil`, uses the default platform cache location.
     ///   - progressHandler: Optional callback for download progress updates.
     /// - Returns: The directory that contains the four `.mlmodelc` packages
-    ///   plus `constants_bin/` for the requested language. For English this
-    ///   is the legacy repo root; for other languages it's
-    ///   `<repoDir>/v2/<lang>/`.
+    ///   plus `constants_bin/` for the requested language.
     public static func ensureModels(
         language: PocketTtsLanguage = .english,
         directory: URL? = nil,
@@ -27,16 +25,10 @@ public enum PocketTtsResourceDownloader {
             PocketTtsConstants.defaultModelsSubdirectory)
 
         let repoDir = modelsDirectory.appendingPathComponent(Repo.pocketTts.folderName)
+        let subdir = language.repoSubdirectory
+        let languageRoot = repoDir.appendingPathComponent(subdir)
 
-        let languageRoot: URL
-        if let subdir = language.repoSubdirectory {
-            languageRoot = repoDir.appendingPathComponent(subdir)
-        } else {
-            languageRoot = repoDir
-        }
-
-        let requiredModels = ModelNames.PocketTTS.requiredModels(for: language)
-        let allPresent = requiredModels.allSatisfy { model in
+        let allPresent = ModelNames.PocketTTS.requiredModels.allSatisfy { model in
             FileManager.default.fileExists(
                 atPath: languageRoot.appendingPathComponent(model).path)
         }
@@ -47,33 +39,26 @@ public enum PocketTtsResourceDownloader {
             return languageRoot
         }
 
-        if let subdir = language.repoSubdirectory {
-            logger.info(
-                "Downloading PocketTTS \(language.rawValue) language pack from HuggingFace (\(subdir))..."
-            )
-            try await DownloadUtils.downloadSubdirectory(
-                .pocketTts,
-                subdirectory: subdir,
-                to: repoDir,
-                progressHandler: progressHandler
-            )
-        } else {
-            logger.info("Downloading PocketTTS English models from HuggingFace...")
-            try await DownloadUtils.downloadRepo(
-                .pocketTts, to: modelsDirectory, progressHandler: progressHandler)
-        }
+        logger.info(
+            "Downloading PocketTTS \(language.rawValue) language pack from HuggingFace (\(subdir))..."
+        )
+        try await DownloadUtils.downloadSubdirectory(
+            .pocketTts,
+            subdirectory: subdir,
+            to: repoDir,
+            progressHandler: progressHandler
+        )
 
         return languageRoot
     }
 
     /// Ensure the Mimi encoder model is downloaded for voice cloning.
     ///
-    /// This is an optional model that's only needed for voice cloning functionality.
-    /// It's downloaded separately from the main models to reduce initial download size.
-    /// The encoder is shared across all language packs and lives at the legacy
-    /// repo root regardless of which language is currently loaded — so a Spanish
-    /// (or any non-English) user can clone a voice without pulling in the
-    /// English language pack.
+    /// This is an optional model that's only needed for voice cloning
+    /// functionality. It's downloaded separately from the main models to
+    /// reduce initial download size. The encoder is shared across all
+    /// language packs and lives at the repo root, so users on any language
+    /// can clone a voice without pulling in another language pack.
     /// - Parameter directory: Optional override for the base cache directory.
     ///   When `nil`, uses the default platform cache location.
     public static func ensureMimiEncoder(directory: URL? = nil) async throws -> URL {
@@ -126,25 +111,13 @@ public enum PocketTtsResourceDownloader {
         }
         let constantsDir = languageRoot.appendingPathComponent(ModelNames.PocketTTS.constantsBinDir)
         let safetensorsFile = "\(sanitized).safetensors"
-        let binFile = "\(sanitized)_audio_prompt.bin"
         let safetensorsURL = constantsDir.appendingPathComponent(safetensorsFile)
-        let binURL = constantsDir.appendingPathComponent(binFile)
 
-        let alreadyDownloaded =
-            FileManager.default.fileExists(atPath: safetensorsURL.path)
-            || FileManager.default.fileExists(atPath: binURL.path)
-
-        if !alreadyDownloaded {
-            // For non-English (v2) packs, voices ship as `.safetensors`. For
-            // legacy English (root pack), they ship as flat `.bin`. Pick the
-            // expected format based on language and download just that file.
-            let remotePrefix = language.repoSubdirectory.map { "\($0)/" } ?? ""
-            let preferredFile = (language == .english) ? binFile : safetensorsFile
-            let preferredLocalURL = (language == .english) ? binURL : safetensorsURL
-            let remotePath = "\(remotePrefix)constants_bin/\(preferredFile)"
+        if !FileManager.default.fileExists(atPath: safetensorsURL.path) {
+            let remotePath = "\(language.repoSubdirectory)/constants_bin/\(safetensorsFile)"
             let remoteURL = try ModelRegistry.resolveModel(Repo.pocketTts.remotePath, remotePath)
             logger.info(
-                "Downloading voice '\(sanitized)' for \(language.rawValue) from HuggingFace (\(preferredFile))..."
+                "Downloading voice '\(sanitized)' for \(language.rawValue) from HuggingFace (\(safetensorsFile))..."
             )
             let data = try await AssetDownloader.fetchData(
                 from: remoteURL,
@@ -155,7 +128,7 @@ public enum PocketTtsResourceDownloader {
             // language pack that hasn't materialized constants_bin/ yet.
             try FileManager.default.createDirectory(
                 at: constantsDir, withIntermediateDirectories: true)
-            try data.write(to: preferredLocalURL, options: [.atomic])
+            try data.write(to: safetensorsURL, options: [.atomic])
             logger.info("Downloaded voice '\(sanitized)' (\(data.count / 1024) KB)")
         }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsLayerKeys.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsLayerKeys.swift
@@ -1,0 +1,187 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Discovered CoreML output names for one transformer model (cond_step or
+/// flowlm_step).
+///
+/// CoreML auto-generates output names during tracing (`new_cache_N_internal_tensor_assign_2`,
+/// `var_NNN`) and the exact numeric suffixes differ between 6L and 24L packs.
+/// Rather than hardcoding the names per pack, we scan the model's output
+/// description at load time and group outputs by tensor shape:
+///
+/// - `[2, 1, kvCacheMaxLen, 16, 64]` → KV cache (one per layer)
+/// - `[1]`                           → position scalar (one per layer)
+/// - `[1, 1, transformerDim]`        → transformer hidden state (flowlm_step only)
+/// - `[1, 1, 1]`                     → EOS logit                (flowlm_step only)
+///
+/// Within each group we order by the numeric suffix in the name. Cache names
+/// follow the closed form `new_cache_{2*i+1}_internal_tensor_assign_2` for
+/// layers 0..N-2 with the last layer being `new_cache_internal_tensor_assign_2`
+/// (no number — sorted last). Position names use `var_NNN` with irregular
+/// strides that nevertheless increase monotonically per layer.
+struct PocketTtsLayerKeys: Sendable {
+    /// One cache output name per transformer layer, ordered by layer index.
+    let cacheKeys: [String]
+    /// One position output name per transformer layer, ordered by layer index.
+    let positionKeys: [String]
+    /// Hidden-state output name (flowlm_step only). `nil` for cond_step.
+    let transformerOut: String?
+    /// EOS logit output name (flowlm_step only). `nil` for cond_step.
+    let eosLogit: String?
+
+    var layerCount: Int { cacheKeys.count }
+
+    enum DiscoveryError: Error, LocalizedError {
+        case shapeMismatch(modelName: String, expectedLayers: Int, actualCaches: Int)
+        case missingFlowLMOutputs(modelName: String, hasTransformer: Bool, hasEos: Bool)
+
+        var errorDescription: String? {
+            switch self {
+            case .shapeMismatch(let modelName, let expected, let actual):
+                return
+                    "PocketTTS layer-key discovery on \(modelName): expected \(expected) cache outputs, found \(actual)"
+            case .missingFlowLMOutputs(let modelName, let hasTransformer, let hasEos):
+                return
+                    "PocketTTS \(modelName) missing flowlm outputs (transformer=\(hasTransformer), eos=\(hasEos))"
+            }
+        }
+    }
+
+    /// Discover the output keys for a `cond_step` or `flowlm_step` CoreML model.
+    ///
+    /// - Parameters:
+    ///   - model: The compiled CoreML model.
+    ///   - kind: Which model this is — affects whether transformer/eos
+    ///     outputs are required.
+    ///   - expectedLayers: Optional sanity check for the layer count.
+    static func discover(
+        from model: MLModel,
+        kind: ModelKind,
+        expectedLayers: Int? = nil,
+        modelName: String
+    ) throws -> PocketTtsLayerKeys {
+        let outputs = model.modelDescription.outputDescriptionsByName
+
+        // Bucket outputs by shape.
+        var cacheCandidates: [String] = []
+        var positionCandidates: [String] = []
+        var transformerCandidate: String?
+        var eosCandidate: String?
+
+        let cacheShape = [
+            2, 1, PocketTtsConstants.kvCacheMaxLen, 16, 64,
+        ]
+        let transformerShape = [1, 1, PocketTtsConstants.transformerDim]
+        let eosShape = [1, 1, 1]
+        let positionShape = [1]
+
+        for (name, desc) in outputs {
+            guard let constraint = desc.multiArrayConstraint else { continue }
+            let shape = constraint.shape.map { $0.intValue }
+
+            if shape == cacheShape {
+                cacheCandidates.append(name)
+            } else if shape == positionShape {
+                positionCandidates.append(name)
+            } else if shape == transformerShape {
+                transformerCandidate = name
+            } else if shape == eosShape {
+                eosCandidate = name
+            }
+        }
+
+        // Sort caches by extracted numeric suffix; "new_cache_internal_..."
+        // (no number) sorts as "last" (largest layer index).
+        cacheCandidates.sort { lhs, rhs in
+            let li = cacheLayerIndex(from: lhs) ?? Int.max
+            let ri = cacheLayerIndex(from: rhs) ?? Int.max
+            if li != ri { return li < ri }
+            return lhs < rhs
+        }
+
+        // Sort positions by trailing numeric suffix.
+        positionCandidates.sort { lhs, rhs in
+            let li = trailingNumber(in: lhs) ?? Int.max
+            let ri = trailingNumber(in: rhs) ?? Int.max
+            if li != ri { return li < ri }
+            return lhs < rhs
+        }
+
+        if let expected = expectedLayers, cacheCandidates.count != expected {
+            throw DiscoveryError.shapeMismatch(
+                modelName: modelName,
+                expectedLayers: expected,
+                actualCaches: cacheCandidates.count
+            )
+        }
+
+        if positionCandidates.count != cacheCandidates.count {
+            throw DiscoveryError.shapeMismatch(
+                modelName: modelName,
+                expectedLayers: cacheCandidates.count,
+                actualCaches: positionCandidates.count
+            )
+        }
+
+        switch kind {
+        case .condStep:
+            return PocketTtsLayerKeys(
+                cacheKeys: cacheCandidates,
+                positionKeys: positionCandidates,
+                transformerOut: nil,
+                eosLogit: nil
+            )
+        case .flowlmStep:
+            guard let transformerOut = transformerCandidate, let eosLogit = eosCandidate else {
+                throw DiscoveryError.missingFlowLMOutputs(
+                    modelName: modelName,
+                    hasTransformer: transformerCandidate != nil,
+                    hasEos: eosCandidate != nil
+                )
+            }
+            return PocketTtsLayerKeys(
+                cacheKeys: cacheCandidates,
+                positionKeys: positionCandidates,
+                transformerOut: transformerOut,
+                eosLogit: eosLogit
+            )
+        }
+    }
+
+    enum ModelKind {
+        case condStep
+        case flowlmStep
+    }
+
+    // MARK: - Name parsing
+
+    /// Extract the layer index from a cache output name.
+    ///
+    /// Pattern:
+    ///  - `new_cache_<N>_internal_tensor_assign_2` → returns `(N - 1) / 2`
+    ///  - `new_cache_internal_tensor_assign_2`     → returns `nil` (sorts last)
+    private static func cacheLayerIndex(from name: String) -> Int? {
+        // Strip the "new_cache_" prefix, then take everything up to the next "_".
+        guard name.hasPrefix("new_cache_") else { return nil }
+        let after = name.dropFirst("new_cache_".count)
+        guard let underscore = after.firstIndex(of: "_") else { return nil }
+        let head = after[..<underscore]
+        guard let raw = Int(head) else { return nil }
+        // Cache numbering uses odd numbers (1, 3, 5, ...) so map to 0, 1, 2, ...
+        return (raw - 1) / 2
+    }
+
+    /// Extract the trailing run of digits from a name like `var_445`.
+    private static func trailingNumber(in name: String) -> Int? {
+        var digits = ""
+        for char in name.reversed() {
+            if char.isNumber {
+                digits.append(char)
+            } else {
+                break
+            }
+        }
+        guard !digits.isEmpty else { return nil }
+        return Int(String(digits.reversed()))
+    }
+}

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsLayerKeys.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsLayerKeys.swift
@@ -57,11 +57,11 @@ struct PocketTtsLayerKeys: Sendable {
     ///   - model: The compiled CoreML model.
     ///   - kind: Which model this is — affects whether transformer/eos
     ///     outputs are required.
-    ///   - expectedLayers: Optional sanity check for the layer count.
+    ///   - expectedLayers: Sanity check for the layer count (6 or 24).
     static func discover(
         from model: MLModel,
         kind: ModelKind,
-        expectedLayers: Int? = nil,
+        expectedLayers: Int,
         modelName: String
     ) throws -> PocketTtsLayerKeys {
         let outputs = model.modelDescription.outputDescriptionsByName
@@ -111,10 +111,10 @@ struct PocketTtsLayerKeys: Sendable {
             return lhs < rhs
         }
 
-        if let expected = expectedLayers, cacheCandidates.count != expected {
+        if cacheCandidates.count != expectedLayers {
             throw DiscoveryError.shapeMismatch(
                 modelName: modelName,
-                expectedLayers: expected,
+                expectedLayers: expectedLayers,
                 actualCaches: cacheCandidates.count
             )
         }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsLayerKeys.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsLayerKeys.swift
@@ -33,6 +33,7 @@ struct PocketTtsLayerKeys: Sendable {
 
     enum DiscoveryError: Error, LocalizedError {
         case shapeMismatch(modelName: String, expectedLayers: Int, actualCaches: Int)
+        case positionMismatch(modelName: String, cacheCount: Int, positionCount: Int)
         case missingFlowLMOutputs(modelName: String, hasTransformer: Bool, hasEos: Bool)
 
         var errorDescription: String? {
@@ -40,6 +41,9 @@ struct PocketTtsLayerKeys: Sendable {
             case .shapeMismatch(let modelName, let expected, let actual):
                 return
                     "PocketTTS layer-key discovery on \(modelName): expected \(expected) cache outputs, found \(actual)"
+            case .positionMismatch(let modelName, let cacheCount, let positionCount):
+                return
+                    "PocketTTS layer-key discovery on \(modelName): \(cacheCount) cache outputs but \(positionCount) position outputs"
             case .missingFlowLMOutputs(let modelName, let hasTransformer, let hasEos):
                 return
                     "PocketTTS \(modelName) missing flowlm outputs (transformer=\(hasTransformer), eos=\(hasEos))"
@@ -116,10 +120,10 @@ struct PocketTtsLayerKeys: Sendable {
         }
 
         if positionCandidates.count != cacheCandidates.count {
-            throw DiscoveryError.shapeMismatch(
+            throw DiscoveryError.positionMismatch(
                 modelName: modelName,
-                expectedLayers: cacheCandidates.count,
-                actualCaches: positionCandidates.count
+                cacheCount: cacheCandidates.count,
+                positionCount: positionCandidates.count
             )
         }
 
@@ -172,16 +176,10 @@ struct PocketTtsLayerKeys: Sendable {
     }
 
     /// Extract the trailing run of digits from a name like `var_445`.
-    private static func trailingNumber(in name: String) -> Int? {
-        var digits = ""
-        for char in name.reversed() {
-            if char.isNumber {
-                digits.append(char)
-            } else {
-                break
-            }
-        }
-        guard !digits.isEmpty else { return nil }
-        return Int(String(digits.reversed()))
+    /// Shared with `PocketTtsMimiKeys` for `var_NNN` output ordering.
+    static func trailingNumber(in name: String) -> Int? {
+        let suffix = name.reversed().prefix(while: \.isNumber)
+        guard !suffix.isEmpty else { return nil }
+        return Int(String(suffix.reversed()))
     }
 }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
@@ -1,0 +1,218 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Discovered CoreML input/output schema for the Mimi audio decoder.
+///
+/// The Mimi decoder ships in two upstream variants that differ in attention
+/// cache layout and (auto-generated) output names:
+///  - **Legacy English** — `attn{0,1}_cache` shape `[2, 1, 8, 256, 64]`
+///    (heads-first) plus `attn{0,1}_end_offset` inputs.
+///  - **v2 multi-language packs** — `attn{0,1}_cache` shape
+///    `[2, 1, 256, 8, 64]` (seq-first), no `_end_offset` inputs.
+///
+/// CoreML auto-generates non-passthrough output names (`var_NNN`) at
+/// conversion time so they differ between packs. To keep one Swift runtime
+/// path we discover both the streaming-state mapping and the audio output
+/// name from the loaded model.
+struct PocketTtsMimiKeys: Sendable {
+
+    /// Output name for the `[1, 1, 1920]` audio frame.
+    let audioOutput: String
+
+    /// Ordered streaming-state input → output mapping. Only contains state
+    /// inputs the loaded model actually accepts (so packs missing
+    /// `attn*_end_offset` simply omit those entries).
+    let stateMapping: [(input: String, output: String)]
+
+    /// Declared shape per state input (as integers). Used by
+    /// `loadMimiInitialState` to allocate tensors matching the model.
+    let stateShapes: [String: [Int]]
+
+    enum DiscoveryError: Error, LocalizedError {
+        case missingAudioOutput
+        case unmatchedStateInput(name: String, shape: [Int])
+        case ambiguousMatch(name: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingAudioOutput:
+                return "PocketTTS Mimi decoder is missing a [1, 1, 1920] audio output"
+            case .unmatchedStateInput(let name, let shape):
+                return "PocketTTS Mimi decoder: no output of shape \(shape) for state input '\(name)'"
+            case .ambiguousMatch(let name):
+                return "PocketTTS Mimi decoder: could not deterministically pair state input '\(name)'"
+            }
+        }
+    }
+
+    /// Canonical streaming-state input order. Used to disambiguate
+    /// shape-bucket pairing (e.g. `attn0_cache` before `attn1_cache`).
+    /// Inputs absent in a given pack (e.g. `attn{0,1}_end_offset` for v2)
+    /// are simply skipped.
+    private static let canonicalStateOrder: [String] = [
+        "upsample_partial",
+        "attn0_cache", "attn0_offset", "attn0_end_offset",
+        "attn1_cache", "attn1_offset", "attn1_end_offset",
+        "conv0_prev", "conv0_first",
+        "convtr0_partial",
+        "res0_conv0_prev", "res0_conv0_first",
+        "res0_conv1_prev", "res0_conv1_first",
+        "convtr1_partial",
+        "res1_conv0_prev", "res1_conv0_first",
+        "res1_conv1_prev", "res1_conv1_first",
+        "convtr2_partial",
+        "res2_conv0_prev", "res2_conv0_first",
+        "res2_conv1_prev", "res2_conv1_first",
+        "conv_final_prev", "conv_final_first",
+    ]
+
+    /// Discover the Mimi schema from a loaded `MLModel`.
+    static func discover(from model: MLModel) throws -> PocketTtsMimiKeys {
+        let inputs = model.modelDescription.inputDescriptionsByName
+        let outputs = model.modelDescription.outputDescriptionsByName
+
+        // 1. Audio output is the only `[1, 1, 1920]` tensor.
+        let audioShape = [1, 1, PocketTtsConstants.samplesPerFrame]
+        let audioOutput = outputs.first { _, desc in
+            guard let constraint = desc.multiArrayConstraint else { return false }
+            return constraint.shape.map { $0.intValue } == audioShape
+        }?.key
+
+        guard let audio = audioOutput else {
+            throw DiscoveryError.missingAudioOutput
+        }
+
+        // 2. Build state input set + shapes (everything except `latent`).
+        var stateShapes: [String: [Int]] = [:]
+        for (name, desc) in inputs where name != "latent" {
+            guard let constraint = desc.multiArrayConstraint else { continue }
+            stateShapes[name] = constraint.shape.map { $0.intValue }
+        }
+
+        // 3. Pair inputs to outputs.
+        //    - Pass-through: output name equals input name (e.g. `conv0_first`,
+        //      `res*_conv1_prev` zero-shape carry-throughs).
+        //    - Semantic-named: outputs containing `end_offset` are reserved
+        //      for inputs containing `end_offset` (legacy English mimi has
+        //      `new_end_offset` / `new_end_offset_1` outputs that share shape
+        //      `[1]` with `var_NNN` offset outputs).
+        //    - Otherwise: match by shape, then disambiguate within a shape
+        //      bucket by sorting outputs by trailing `var_NNN` and inputs
+        //      in canonical order.
+        var availableOutputs = outputs
+        availableOutputs.removeValue(forKey: audio)
+
+        // Remove pass-throughs first (cheap to identify).
+        var passThroughMap: [String: String] = [:]
+        for inputName in stateShapes.keys {
+            if availableOutputs[inputName] != nil {
+                passThroughMap[inputName] = inputName
+                availableOutputs.removeValue(forKey: inputName)
+            }
+        }
+
+        // Reserve `*end_offset*` outputs exclusively for `*end_offset*` inputs.
+        // Pair them in canonical order, sorted by trailing digits ascending so
+        // `attn0_end_offset → new_end_offset_1`, `attn1_end_offset → new_end_offset`.
+        let endOffsetInputs = canonicalStateOrder.filter {
+            $0.contains("end_offset") && stateShapes[$0] != nil && passThroughMap[$0] == nil
+        }
+        var endOffsetOutputs = availableOutputs.keys.filter { $0.contains("end_offset") }.sorted {
+            let li = trailingNumber(in: $0) ?? Int.max
+            let ri = trailingNumber(in: $1) ?? Int.max
+            if li != ri { return li < ri }
+            return $0 < $1
+        }
+        var endOffsetMap: [String: String] = [:]
+        for inputName in endOffsetInputs {
+            guard !endOffsetOutputs.isEmpty else {
+                throw DiscoveryError.unmatchedStateInput(
+                    name: inputName, shape: stateShapes[inputName] ?? [])
+            }
+            let chosen = endOffsetOutputs.removeFirst()
+            endOffsetMap[inputName] = chosen
+            availableOutputs.removeValue(forKey: chosen)
+        }
+
+        // Bucket remaining outputs by shape, sorted by var-number ascending.
+        var outputsByShape: [[Int]: [String]] = [:]
+        for (name, desc) in availableOutputs {
+            guard let constraint = desc.multiArrayConstraint else { continue }
+            let shape = constraint.shape.map { $0.intValue }
+            outputsByShape[shape, default: []].append(name)
+        }
+        for key in outputsByShape.keys {
+            outputsByShape[key]?.sort { lhs, rhs in
+                let li = trailingNumber(in: lhs) ?? Int.max
+                let ri = trailingNumber(in: rhs) ?? Int.max
+                if li != ri { return li < ri }
+                return lhs < rhs
+            }
+        }
+
+        // Walk canonical order, taking outputs from each shape bucket. Skip
+        // inputs already resolved via pass-through or end-offset reservation.
+        var nonPassThroughInputs: [String] = []
+        for name in canonicalStateOrder
+        where stateShapes[name] != nil
+            && passThroughMap[name] == nil
+            && endOffsetMap[name] == nil
+        {
+            nonPassThroughInputs.append(name)
+        }
+        // Any inputs not in canonical list (defensive) appended in name order.
+        for name in stateShapes.keys.sorted()
+        where !canonicalStateOrder.contains(name)
+            && passThroughMap[name] == nil
+            && endOffsetMap[name] == nil
+        {
+            nonPassThroughInputs.append(name)
+        }
+
+        var resolvedMapping: [String: String] = passThroughMap
+        for (k, v) in endOffsetMap { resolvedMapping[k] = v }
+        for inputName in nonPassThroughInputs {
+            guard let shape = stateShapes[inputName] else { continue }
+            guard var bucket = outputsByShape[shape], !bucket.isEmpty else {
+                throw DiscoveryError.unmatchedStateInput(name: inputName, shape: shape)
+            }
+            let chosen = bucket.removeFirst()
+            outputsByShape[shape] = bucket
+            resolvedMapping[inputName] = chosen
+        }
+
+        // Emit mapping in canonical order so iteration is deterministic.
+        var orderedMapping: [(input: String, output: String)] = []
+        for name in canonicalStateOrder {
+            if let out = resolvedMapping[name] {
+                orderedMapping.append((input: name, output: out))
+            }
+        }
+        // Append any non-canonical inputs at the end (defensive).
+        for name in stateShapes.keys.sorted() where !canonicalStateOrder.contains(name) {
+            if let out = resolvedMapping[name] {
+                orderedMapping.append((input: name, output: out))
+            }
+        }
+
+        return PocketTtsMimiKeys(
+            audioOutput: audio,
+            stateMapping: orderedMapping,
+            stateShapes: stateShapes
+        )
+    }
+
+    /// Extract the trailing run of digits from a name like `var_445`.
+    private static func trailingNumber(in name: String) -> Int? {
+        var digits = ""
+        for char in name.reversed() {
+            if char.isNumber {
+                digits.append(char)
+            } else {
+                break
+            }
+        }
+        guard !digits.isEmpty else { return nil }
+        return Int(String(digits.reversed()))
+    }
+}

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
@@ -93,9 +93,9 @@ struct PocketTtsMimiKeys: Sendable {
         //    - Pass-through: output name equals input name (e.g. `conv0_first`,
         //      `res*_conv1_prev` zero-shape carry-throughs).
         //    - Semantic-named: outputs containing `end_offset` are reserved
-        //      for inputs containing `end_offset` so they can't be confused
-        //      with similarly-shaped `var_NNN` offset outputs sharing
-        //      shape `[1]`.
+        //      for inputs containing `end_offset` (legacy English mimi has
+        //      `new_end_offset` / `new_end_offset_1` outputs that share shape
+        //      `[1]` with `var_NNN` offset outputs).
         //    - Otherwise: match by shape, then disambiguate within a shape
         //      bucket by sorting outputs by trailing `var_NNN` and inputs
         //      in canonical order.

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
@@ -93,9 +93,9 @@ struct PocketTtsMimiKeys: Sendable {
         //    - Pass-through: output name equals input name (e.g. `conv0_first`,
         //      `res*_conv1_prev` zero-shape carry-throughs).
         //    - Semantic-named: outputs containing `end_offset` are reserved
-        //      for inputs containing `end_offset` (legacy English mimi has
-        //      `new_end_offset` / `new_end_offset_1` outputs that share shape
-        //      `[1]` with `var_NNN` offset outputs).
+        //      for inputs containing `end_offset` so they can't be confused
+        //      with similarly-shaped `var_NNN` offset outputs sharing
+        //      shape `[1]`.
         //    - Otherwise: match by shape, then disambiguate within a shape
         //      bucket by sorting outputs by trailing `var_NNN` and inputs
         //      in canonical order.

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
@@ -31,7 +31,6 @@ struct PocketTtsMimiKeys: Sendable {
     enum DiscoveryError: Error, LocalizedError {
         case missingAudioOutput
         case unmatchedStateInput(name: String, shape: [Int])
-        case ambiguousMatch(name: String)
 
         var errorDescription: String? {
             switch self {
@@ -39,8 +38,6 @@ struct PocketTtsMimiKeys: Sendable {
                 return "PocketTTS Mimi decoder is missing a [1, 1, 1920] audio output"
             case .unmatchedStateInput(let name, let shape):
                 return "PocketTTS Mimi decoder: no output of shape \(shape) for state input '\(name)'"
-            case .ambiguousMatch(let name):
-                return "PocketTTS Mimi decoder: could not deterministically pair state input '\(name)'"
             }
         }
     }
@@ -118,8 +115,8 @@ struct PocketTtsMimiKeys: Sendable {
             $0.contains("end_offset") && stateShapes[$0] != nil && passThroughMap[$0] == nil
         }
         var endOffsetOutputs = availableOutputs.keys.filter { $0.contains("end_offset") }.sorted {
-            let li = trailingNumber(in: $0) ?? Int.max
-            let ri = trailingNumber(in: $1) ?? Int.max
+            let li = PocketTtsLayerKeys.trailingNumber(in: $0) ?? Int.max
+            let ri = PocketTtsLayerKeys.trailingNumber(in: $1) ?? Int.max
             if li != ri { return li < ri }
             return $0 < $1
         }
@@ -143,8 +140,8 @@ struct PocketTtsMimiKeys: Sendable {
         }
         for key in outputsByShape.keys {
             outputsByShape[key]?.sort { lhs, rhs in
-                let li = trailingNumber(in: lhs) ?? Int.max
-                let ri = trailingNumber(in: rhs) ?? Int.max
+                let li = PocketTtsLayerKeys.trailingNumber(in: lhs) ?? Int.max
+                let ri = PocketTtsLayerKeys.trailingNumber(in: rhs) ?? Int.max
                 if li != ri { return li < ri }
                 return lhs < rhs
             }
@@ -152,26 +149,17 @@ struct PocketTtsMimiKeys: Sendable {
 
         // Walk canonical order, taking outputs from each shape bucket. Skip
         // inputs already resolved via pass-through or end-offset reservation.
-        var nonPassThroughInputs: [String] = []
-        for name in canonicalStateOrder
-        where stateShapes[name] != nil
-            && passThroughMap[name] == nil
-            && endOffsetMap[name] == nil
-        {
-            nonPassThroughInputs.append(name)
-        }
-        // Any inputs not in canonical list (defensive) appended in name order.
-        for name in stateShapes.keys.sorted()
-        where !canonicalStateOrder.contains(name)
-            && passThroughMap[name] == nil
-            && endOffsetMap[name] == nil
-        {
-            nonPassThroughInputs.append(name)
-        }
-
+        // Inputs outside the canonical list aren't supported — the canonical
+        // list is exhaustive across the legacy English and v2 multi-language
+        // packs, and downstream shape matching would fail for any unknown
+        // schema anyway.
         var resolvedMapping: [String: String] = passThroughMap
         for (k, v) in endOffsetMap { resolvedMapping[k] = v }
-        for inputName in nonPassThroughInputs {
+        for inputName in canonicalStateOrder
+        where stateShapes[inputName] != nil
+            && passThroughMap[inputName] == nil
+            && endOffsetMap[inputName] == nil
+        {
             guard let shape = stateShapes[inputName] else { continue }
             guard var bucket = outputsByShape[shape], !bucket.isEmpty else {
                 throw DiscoveryError.unmatchedStateInput(name: inputName, shape: shape)
@@ -188,12 +176,6 @@ struct PocketTtsMimiKeys: Sendable {
                 orderedMapping.append((input: name, output: out))
             }
         }
-        // Append any non-canonical inputs at the end (defensive).
-        for name in stateShapes.keys.sorted() where !canonicalStateOrder.contains(name) {
-            if let out = resolvedMapping[name] {
-                orderedMapping.append((input: name, output: out))
-            }
-        }
 
         return PocketTtsMimiKeys(
             audioOutput: audio,
@@ -202,17 +184,4 @@ struct PocketTtsMimiKeys: Sendable {
         )
     }
 
-    /// Extract the trailing run of digits from a name like `var_445`.
-    private static func trailingNumber(in name: String) -> Int? {
-        var digits = ""
-        for char in name.reversed() {
-            if char.isNumber {
-                digits.append(char)
-            } else {
-                break
-            }
-        }
-        guard !digits.isEmpty else { return nil }
-        return Int(String(digits.reversed()))
-    }
 }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
@@ -3,25 +3,16 @@ import Foundation
 
 /// Discovered CoreML input/output schema for the Mimi audio decoder.
 ///
-/// The Mimi decoder ships in two upstream variants that differ in attention
-/// cache layout and (auto-generated) output names:
-///  - **Legacy English** — `attn{0,1}_cache` shape `[2, 1, 8, 256, 64]`
-///    (heads-first) plus `attn{0,1}_end_offset` inputs.
-///  - **v2 multi-language packs** — `attn{0,1}_cache` shape
-///    `[2, 1, 256, 8, 64]` (seq-first), no `_end_offset` inputs.
-///
-/// CoreML auto-generates non-passthrough output names (`var_NNN`) at
-/// conversion time so they differ between packs. To keep one Swift runtime
-/// path we discover both the streaming-state mapping and the audio output
-/// name from the loaded model.
+/// `attn{0,1}_cache` ships shape `[2, 1, 256, 8, 64]` (seq-first). CoreML
+/// auto-generates non-passthrough output names (`var_NNN`) at conversion
+/// time, so we discover both the streaming-state mapping and the audio
+/// output name from the loaded model.
 struct PocketTtsMimiKeys: Sendable {
 
     /// Output name for the `[1, 1, 1920]` audio frame.
     let audioOutput: String
 
-    /// Ordered streaming-state input → output mapping. Only contains state
-    /// inputs the loaded model actually accepts (so packs missing
-    /// `attn*_end_offset` simply omit those entries).
+    /// Ordered streaming-state input → output mapping.
     let stateMapping: [(input: String, output: String)]
 
     /// Declared shape per state input (as integers). Used by
@@ -44,12 +35,10 @@ struct PocketTtsMimiKeys: Sendable {
 
     /// Canonical streaming-state input order. Used to disambiguate
     /// shape-bucket pairing (e.g. `attn0_cache` before `attn1_cache`).
-    /// Inputs absent in a given pack (e.g. `attn{0,1}_end_offset` for v2)
-    /// are simply skipped.
     private static let canonicalStateOrder: [String] = [
         "upsample_partial",
-        "attn0_cache", "attn0_offset", "attn0_end_offset",
-        "attn1_cache", "attn1_offset", "attn1_end_offset",
+        "attn0_cache", "attn0_offset",
+        "attn1_cache", "attn1_offset",
         "conv0_prev", "conv0_first",
         "convtr0_partial",
         "res0_conv0_prev", "res0_conv0_first",
@@ -89,10 +78,6 @@ struct PocketTtsMimiKeys: Sendable {
         // 3. Pair inputs to outputs.
         //    - Pass-through: output name equals input name (e.g. `conv0_first`,
         //      `res*_conv1_prev` zero-shape carry-throughs).
-        //    - Semantic-named: outputs containing `end_offset` are reserved
-        //      for inputs containing `end_offset` (legacy English mimi has
-        //      `new_end_offset` / `new_end_offset_1` outputs that share shape
-        //      `[1]` with `var_NNN` offset outputs).
         //    - Otherwise: match by shape, then disambiguate within a shape
         //      bucket by sorting outputs by trailing `var_NNN` and inputs
         //      in canonical order.
@@ -106,29 +91,6 @@ struct PocketTtsMimiKeys: Sendable {
                 passThroughMap[inputName] = inputName
                 availableOutputs.removeValue(forKey: inputName)
             }
-        }
-
-        // Reserve `*end_offset*` outputs exclusively for `*end_offset*` inputs.
-        // Pair them in canonical order, sorted by trailing digits ascending so
-        // `attn0_end_offset → new_end_offset_1`, `attn1_end_offset → new_end_offset`.
-        let endOffsetInputs = canonicalStateOrder.filter {
-            $0.contains("end_offset") && stateShapes[$0] != nil && passThroughMap[$0] == nil
-        }
-        var endOffsetOutputs = availableOutputs.keys.filter { $0.contains("end_offset") }.sorted {
-            let li = PocketTtsLayerKeys.trailingNumber(in: $0) ?? Int.max
-            let ri = PocketTtsLayerKeys.trailingNumber(in: $1) ?? Int.max
-            if li != ri { return li < ri }
-            return $0 < $1
-        }
-        var endOffsetMap: [String: String] = [:]
-        for inputName in endOffsetInputs {
-            guard !endOffsetOutputs.isEmpty else {
-                throw DiscoveryError.unmatchedStateInput(
-                    name: inputName, shape: stateShapes[inputName] ?? [])
-            }
-            let chosen = endOffsetOutputs.removeFirst()
-            endOffsetMap[inputName] = chosen
-            availableOutputs.removeValue(forKey: chosen)
         }
 
         // Bucket remaining outputs by shape, sorted by var-number ascending.
@@ -148,18 +110,13 @@ struct PocketTtsMimiKeys: Sendable {
         }
 
         // Walk canonical order, taking outputs from each shape bucket. Skip
-        // inputs already resolved via pass-through or end-offset reservation.
-        // Inputs outside the canonical list aren't supported — the canonical
-        // list is exhaustive across the legacy English and v2 multi-language
-        // packs, and downstream shape matching would fail for any unknown
-        // schema anyway.
+        // inputs already resolved via pass-through. Inputs outside the
+        // canonical list aren't supported — the canonical list is exhaustive
+        // across the v2 packs, and downstream shape matching would fail for
+        // any unknown schema anyway.
         var resolvedMapping: [String: String] = passThroughMap
-        for (k, v) in endOffsetMap { resolvedMapping[k] = v }
         for inputName in canonicalStateOrder
-        where stateShapes[inputName] != nil
-            && passThroughMap[inputName] == nil
-            && endOffsetMap[inputName] == nil
-        {
+        where stateShapes[inputName] != nil && passThroughMap[inputName] == nil {
             guard let shape = stateShapes[inputName] else { continue }
             guard var bucket = outputsByShape[shape], !bucket.isEmpty else {
                 throw DiscoveryError.unmatchedStateInput(name: inputName, shape: shape)

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsMimiKeys.swift
@@ -81,21 +81,16 @@ struct PocketTtsMimiKeys: Sendable {
         //    - Otherwise: match by shape, then disambiguate within a shape
         //      bucket by sorting outputs by trailing `var_NNN` and inputs
         //      in canonical order.
-        var availableOutputs = outputs
-        availableOutputs.removeValue(forKey: audio)
-
-        // Remove pass-throughs first (cheap to identify).
+        //
+        //    Single pass over outputs: identify pass-throughs by name match
+        //    against `stateShapes`, bucket the rest by shape (excluding audio).
         var passThroughMap: [String: String] = [:]
-        for inputName in stateShapes.keys {
-            if availableOutputs[inputName] != nil {
-                passThroughMap[inputName] = inputName
-                availableOutputs.removeValue(forKey: inputName)
-            }
-        }
-
-        // Bucket remaining outputs by shape, sorted by var-number ascending.
         var outputsByShape: [[Int]: [String]] = [:]
-        for (name, desc) in availableOutputs {
+        for (name, desc) in outputs where name != audio {
+            if stateShapes[name] != nil {
+                passThroughMap[name] = name
+                continue
+            }
             guard let constraint = desc.multiArrayConstraint else { continue }
             let shape = constraint.shape.map { $0.intValue }
             outputsByShape[shape, default: []].append(name)
@@ -109,29 +104,24 @@ struct PocketTtsMimiKeys: Sendable {
             }
         }
 
-        // Walk canonical order, taking outputs from each shape bucket. Skip
-        // inputs already resolved via pass-through. Inputs outside the
-        // canonical list aren't supported — the canonical list is exhaustive
-        // across the v2 packs, and downstream shape matching would fail for
-        // any unknown schema anyway.
-        var resolvedMapping: [String: String] = passThroughMap
-        for inputName in canonicalStateOrder
-        where stateShapes[inputName] != nil && passThroughMap[inputName] == nil {
+        // Walk canonical order once: pass-throughs land directly, others draw
+        // from their shape bucket. Inputs outside the canonical list are
+        // silently ignored — the canonical list is exhaustive across the v2
+        // packs, and downstream shape matching would fail for any unknown
+        // schema anyway.
+        var orderedMapping: [(input: String, output: String)] = []
+        for inputName in canonicalStateOrder {
             guard let shape = stateShapes[inputName] else { continue }
+            if let passThrough = passThroughMap[inputName] {
+                orderedMapping.append((input: inputName, output: passThrough))
+                continue
+            }
             guard var bucket = outputsByShape[shape], !bucket.isEmpty else {
                 throw DiscoveryError.unmatchedStateInput(name: inputName, shape: shape)
             }
             let chosen = bucket.removeFirst()
             outputsByShape[shape] = bucket
-            resolvedMapping[inputName] = chosen
-        }
-
-        // Emit mapping in canonical order so iteration is deterministic.
-        var orderedMapping: [(input: String, output: String)] = []
-        for name in canonicalStateOrder {
-            if let out = resolvedMapping[name] {
-                orderedMapping.append((input: name, output: out))
-            }
+            orderedMapping.append((input: inputName, output: chosen))
         }
 
         return PocketTtsMimiKeys(

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -24,6 +24,7 @@ public actor PocketTtsModelStore {
     private var languageRootDirectory: URL?
     private var condLayerKeys: PocketTtsLayerKeys?
     private var flowlmLayerKeys: PocketTtsLayerKeys?
+    private var mimiDecoderKeysCache: PocketTtsMimiKeys?
     private let directory: URL?
     public let language: PocketTtsLanguage
 
@@ -97,6 +98,12 @@ public actor PocketTtsModelStore {
             modelName: "flowlm_step"
         )
 
+        // Discover Mimi decoder schema. Legacy English and v2 packs differ in
+        // attention cache layout, presence of `attn*_end_offset` inputs, and
+        // auto-generated `var_NNN` output names. Discovery makes both work
+        // through one runtime path.
+        mimiDecoderKeysCache = try PocketTtsMimiKeys.discover(from: loadedModels[3])
+
         let elapsed = Date().timeIntervalSince(loadStart)
         logger.info("All PocketTTS models loaded in \(String(format: "%.2f", elapsed))s")
 
@@ -158,6 +165,15 @@ public actor PocketTtsModelStore {
     func flowLMStepLayerKeys() throws -> PocketTtsLayerKeys {
         guard let keys = flowlmLayerKeys else {
             throw PocketTTSError.modelNotFound("PocketTTS flowlm_step layer keys not discovered")
+        }
+        return keys
+    }
+
+    /// Discovered I/O schema for the Mimi audio decoder model (state mapping,
+    /// audio output name, declared state shapes).
+    func mimiDecoderKeys() throws -> PocketTtsMimiKeys {
+        guard let keys = mimiDecoderKeysCache else {
+            throw PocketTTSError.modelNotFound("PocketTTS mimi_decoder keys not discovered")
         }
         return keys
     }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -7,6 +7,9 @@ import OSLog
 /// Manages loading and storing of the four CoreML models
 /// (cond_step, flowlm_step, flow_decoder, mimi_decoder),
 /// the binary constants bundle, and voice conditioning data.
+///
+/// A store is bound to a single `PocketTtsLanguage` for its lifetime; switch
+/// languages by creating a new store/manager.
 public actor PocketTtsModelStore {
 
     private let logger = AppLogger(subsystem: "com.fluidaudio.tts", category: "PocketTtsModelStore")
@@ -18,12 +21,19 @@ public actor PocketTtsModelStore {
     private var mimiEncoderModel: MLModel?
     private var constantsBundle: PocketTtsConstantsBundle?
     private var voiceCache: [String: PocketTtsVoiceData] = [:]
-    private var repoDirectory: URL?
+    private var languageRootDirectory: URL?
+    private var condLayerKeys: PocketTtsLayerKeys?
+    private var flowlmLayerKeys: PocketTtsLayerKeys?
     private let directory: URL?
+    public let language: PocketTtsLanguage
 
-    /// - Parameter directory: Optional override for the base cache directory.
-    ///   When `nil`, uses the default platform cache location.
-    public init(directory: URL? = nil) {
+    /// - Parameters:
+    ///   - language: Which upstream language pack to load. Defaults to
+    ///     `.english` for backward compatibility.
+    ///   - directory: Optional override for the base cache directory. When
+    ///     `nil`, uses the default platform cache location.
+    public init(language: PocketTtsLanguage = .english, directory: URL? = nil) {
+        self.language = language
         self.directory = directory
     }
 
@@ -31,10 +41,15 @@ public actor PocketTtsModelStore {
     public func loadIfNeeded() async throws {
         guard condStepModel == nil else { return }
 
-        let repoDir = try await PocketTtsResourceDownloader.ensureModels(directory: directory)
-        self.repoDirectory = repoDir
+        let languageRoot = try await PocketTtsResourceDownloader.ensureModels(
+            language: language,
+            directory: directory
+        )
+        self.languageRootDirectory = languageRoot
 
-        logger.info("Loading PocketTTS CoreML models...")
+        logger.info(
+            "Loading PocketTTS CoreML models (language=\(self.language.rawValue))..."
+        )
 
         // Use CPU+GPU for all models to avoid ANE float16 precision loss.
         // The ANE processes in native float16, which causes audible artifacts
@@ -46,16 +61,16 @@ public actor PocketTtsModelStore {
 
         let loadStart = Date()
 
-        let modelFiles = [
+        let modelFiles: [String] = [
             ModelNames.PocketTTS.condStepFile,
             ModelNames.PocketTTS.flowlmStepFile,
             ModelNames.PocketTTS.flowDecoderFile,
-            ModelNames.PocketTTS.mimiDecoderFile,
+            ModelNames.PocketTTS.mimiDecoderFile(for: language),
         ]
 
         var loadedModels: [MLModel] = []
         for file in modelFiles {
-            let modelURL = repoDir.appendingPathComponent(file)
+            let modelURL = languageRoot.appendingPathComponent(file)
             let model = try MLModel(contentsOf: modelURL, configuration: config)
             loadedModels.append(model)
             logger.info("Loaded \(file)")
@@ -66,12 +81,28 @@ public actor PocketTtsModelStore {
         flowDecoderModel = loadedModels[2]
         mimiDecoderModel = loadedModels[3]
 
+        // Discover per-model output names. Names differ between 6L and 24L
+        // packs because CoreML auto-generates them during tracing.
+        let expectedLayers = language.transformerLayers
+        condLayerKeys = try PocketTtsLayerKeys.discover(
+            from: loadedModels[0],
+            kind: .condStep,
+            expectedLayers: expectedLayers,
+            modelName: "cond_step"
+        )
+        flowlmLayerKeys = try PocketTtsLayerKeys.discover(
+            from: loadedModels[1],
+            kind: .flowlmStep,
+            expectedLayers: expectedLayers,
+            modelName: "flowlm_step"
+        )
+
         let elapsed = Date().timeIntervalSince(loadStart)
         logger.info("All PocketTTS models loaded in \(String(format: "%.2f", elapsed))s")
 
         // Load constants
         constantsBundle = try PocketTtsResourceDownloader.ensureConstants(
-            repoDirectory: repoDir)
+            languageRoot: languageRoot)
         logger.info("PocketTTS constants loaded")
     }
 
@@ -115,9 +146,27 @@ public actor PocketTtsModelStore {
         return bundle
     }
 
-    /// The repository directory containing models and constants.
+    /// Discovered output names for the cond_step transformer model.
+    func condStepLayerKeys() throws -> PocketTtsLayerKeys {
+        guard let keys = condLayerKeys else {
+            throw PocketTTSError.modelNotFound("PocketTTS cond_step layer keys not discovered")
+        }
+        return keys
+    }
+
+    /// Discovered output names for the flowlm_step transformer model.
+    func flowLMStepLayerKeys() throws -> PocketTtsLayerKeys {
+        guard let keys = flowlmLayerKeys else {
+            throw PocketTTSError.modelNotFound("PocketTTS flowlm_step layer keys not discovered")
+        }
+        return keys
+    }
+
+    /// The language root directory (legacy repo root for English, or
+    /// `<repoDir>/v2/<lang>` otherwise) — contains the four model files,
+    /// `constants_bin/`, and is the right base for `loadMimiInitialState`.
     public func repoDir() throws -> URL {
-        guard let dir = repoDirectory else {
+        guard let dir = languageRootDirectory else {
             throw PocketTTSError.modelNotFound("PocketTTS repository not loaded")
         }
         return dir
@@ -128,10 +177,14 @@ public actor PocketTtsModelStore {
         if let cached = voiceCache[voice] {
             return cached
         }
-        guard let repoDir = repoDirectory else {
+        guard let languageRoot = languageRootDirectory else {
             throw PocketTTSError.modelNotFound("PocketTTS repository not loaded")
         }
-        let data = try await PocketTtsResourceDownloader.ensureVoice(voice, repoDirectory: repoDir)
+        let data = try await PocketTtsResourceDownloader.ensureVoice(
+            voice,
+            language: language,
+            languageRoot: languageRoot
+        )
         voiceCache[voice] = data
         return data
     }
@@ -140,17 +193,14 @@ public actor PocketTtsModelStore {
 
     /// Load the Mimi encoder model for voice cloning (lazy, on-demand).
     ///
-    /// Downloads the model from HuggingFace if not already cached.
+    /// Downloads the model from HuggingFace if not already cached. The Mimi
+    /// encoder is shared across all language packs and lives at the legacy
+    /// repo root.
     public func loadMimiEncoderIfNeeded() async throws {
         guard mimiEncoderModel == nil else { return }
 
         // Ensure the mimi_encoder is downloaded (downloads if needed)
         let modelURL = try await PocketTtsResourceDownloader.ensureMimiEncoder(directory: directory)
-
-        // Update repoDirectory if not set
-        if repoDirectory == nil {
-            repoDirectory = modelURL.deletingLastPathComponent()
-        }
 
         let config = MLModelConfiguration()
         config.computeUnits = .cpuAndGPU
@@ -174,8 +224,18 @@ public actor PocketTtsModelStore {
 
     /// Check if the Mimi encoder model is available.
     public func isMimiEncoderAvailable() -> Bool {
-        guard let repoDir = repoDirectory else { return false }
-        let modelURL = repoDir.appendingPathComponent(ModelNames.PocketTTS.mimiEncoderFile)
+        // The Mimi encoder always lives at the repo root regardless of the
+        // currently selected language pack.
+        let repoRoot: URL
+        if let langRoot = languageRootDirectory {
+            repoRoot =
+                (language.repoSubdirectory == nil)
+                ? langRoot
+                : langRoot.deletingLastPathComponent().deletingLastPathComponent()
+        } else {
+            return false
+        }
+        let modelURL = repoRoot.appendingPathComponent(ModelNames.PocketTTS.mimiEncoderFile)
         return FileManager.default.fileExists(atPath: modelURL.path)
     }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -66,7 +66,7 @@ public actor PocketTtsModelStore {
             ModelNames.PocketTTS.condStepFile,
             ModelNames.PocketTTS.flowlmStepFile,
             ModelNames.PocketTTS.flowDecoderFile,
-            ModelNames.PocketTTS.mimiDecoderFile(for: language),
+            ModelNames.PocketTTS.mimiDecoderFile,
         ]
 
         var loadedModels: [MLModel] = []
@@ -98,10 +98,10 @@ public actor PocketTtsModelStore {
             modelName: "flowlm_step"
         )
 
-        // Discover Mimi decoder schema. Legacy English and v2 packs differ in
-        // attention cache layout, presence of `attn*_end_offset` inputs, and
-        // auto-generated `var_NNN` output names. Discovery makes both work
-        // through one runtime path.
+        // Discover Mimi decoder schema. Auto-generated `var_NNN` output
+        // names and per-layer attention cache shapes vary between 6L and
+        // 24L packs, so we read them from the model itself instead of
+        // hardcoding.
         mimiDecoderKeysCache = try PocketTtsMimiKeys.discover(from: loadedModels[3])
 
         let elapsed = Date().timeIntervalSince(loadStart)
@@ -178,9 +178,9 @@ public actor PocketTtsModelStore {
         return keys
     }
 
-    /// The language root directory (legacy repo root for English, or
-    /// `<repoDir>/v2/<lang>` otherwise) — contains the four model files,
-    /// `constants_bin/`, and is the right base for `loadMimiInitialState`.
+    /// The language root directory (`<repoDir>/v2/<lang>`) — contains the
+    /// four model files, `constants_bin/`, and is the right base for
+    /// `loadMimiInitialState`.
     public func repoDir() throws -> URL {
         guard let dir = languageRootDirectory else {
             throw PocketTTSError.modelNotFound("PocketTTS repository not loaded")
@@ -241,16 +241,11 @@ public actor PocketTtsModelStore {
     /// Check if the Mimi encoder model is available.
     public func isMimiEncoderAvailable() -> Bool {
         // The Mimi encoder always lives at the repo root regardless of the
-        // currently selected language pack.
-        let repoRoot: URL
-        if let langRoot = languageRootDirectory {
-            repoRoot =
-                (language.repoSubdirectory == nil)
-                ? langRoot
-                : langRoot.deletingLastPathComponent().deletingLastPathComponent()
-        } else {
-            return false
-        }
+        // currently selected language pack. The language root is at
+        // `<repoRoot>/v2/<lang>`, so two `deletingLastPathComponent()` calls
+        // walk back up to the repo root.
+        guard let langRoot = languageRootDirectory else { return false }
+        let repoRoot = langRoot.deletingLastPathComponent().deletingLastPathComponent()
         let modelURL = repoRoot.appendingPathComponent(ModelNames.PocketTTS.mimiEncoderFile)
         return FileManager.default.fileExists(atPath: modelURL.path)
     }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -66,7 +66,7 @@ public actor PocketTtsModelStore {
             ModelNames.PocketTTS.condStepFile,
             ModelNames.PocketTTS.flowlmStepFile,
             ModelNames.PocketTTS.flowDecoderFile,
-            ModelNames.PocketTTS.mimiDecoderFile,
+            ModelNames.PocketTTS.mimiDecoderFile(for: language),
         ]
 
         var loadedModels: [MLModel] = []
@@ -98,10 +98,10 @@ public actor PocketTtsModelStore {
             modelName: "flowlm_step"
         )
 
-        // Discover Mimi decoder schema. Auto-generated `var_NNN` output
-        // names and per-layer attention cache shapes vary between 6L and
-        // 24L packs, so we read them from the model itself instead of
-        // hardcoding.
+        // Discover Mimi decoder schema. Legacy English and v2 packs differ in
+        // attention cache layout, presence of `attn*_end_offset` inputs, and
+        // auto-generated `var_NNN` output names. Discovery makes both work
+        // through one runtime path.
         mimiDecoderKeysCache = try PocketTtsMimiKeys.discover(from: loadedModels[3])
 
         let elapsed = Date().timeIntervalSince(loadStart)
@@ -178,9 +178,9 @@ public actor PocketTtsModelStore {
         return keys
     }
 
-    /// The language root directory (`<repoDir>/v2/<lang>`) — contains the
-    /// four model files, `constants_bin/`, and is the right base for
-    /// `loadMimiInitialState`.
+    /// The language root directory (legacy repo root for English, or
+    /// `<repoDir>/v2/<lang>` otherwise) — contains the four model files,
+    /// `constants_bin/`, and is the right base for `loadMimiInitialState`.
     public func repoDir() throws -> URL {
         guard let dir = languageRootDirectory else {
             throw PocketTTSError.modelNotFound("PocketTTS repository not loaded")
@@ -241,11 +241,16 @@ public actor PocketTtsModelStore {
     /// Check if the Mimi encoder model is available.
     public func isMimiEncoderAvailable() -> Bool {
         // The Mimi encoder always lives at the repo root regardless of the
-        // currently selected language pack. The language root is at
-        // `<repoRoot>/v2/<lang>`, so two `deletingLastPathComponent()` calls
-        // walk back up to the repo root.
-        guard let langRoot = languageRootDirectory else { return false }
-        let repoRoot = langRoot.deletingLastPathComponent().deletingLastPathComponent()
+        // currently selected language pack.
+        let repoRoot: URL
+        if let langRoot = languageRootDirectory {
+            repoRoot =
+                (language.repoSubdirectory == nil)
+                ? langRoot
+                : langRoot.deletingLastPathComponent().deletingLastPathComponent()
+        } else {
+            return false
+        }
         let modelURL = repoRoot.appendingPathComponent(ModelNames.PocketTTS.mimiEncoderFile)
         return FileManager.default.fileExists(atPath: modelURL.path)
     }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -65,7 +65,7 @@ public actor PocketTtsModelStore {
             ModelNames.PocketTTS.condStepFile,
             ModelNames.PocketTTS.flowlmStepFile,
             ModelNames.PocketTTS.flowDecoderFile,
-            ModelNames.PocketTTS.mimiDecoderFile(for: language),
+            ModelNames.PocketTTS.mimiDecoderFile,
         ]
 
         var loadedModels: [MLModel] = []
@@ -238,17 +238,10 @@ public actor PocketTtsModelStore {
 
     /// Check if the Mimi encoder model is available.
     public func isMimiEncoderAvailable() -> Bool {
-        // The Mimi encoder always lives at the repo root regardless of the
-        // currently selected language pack.
-        let repoRoot: URL
-        if let langRoot = languageRootDirectory {
-            repoRoot =
-                (language.repoSubdirectory == nil)
-                ? langRoot
-                : langRoot.deletingLastPathComponent().deletingLastPathComponent()
-        } else {
-            return false
-        }
+        // The Mimi encoder lives at the repo root, two levels above any
+        // `v2/<lang>/` language root.
+        guard let langRoot = languageRootDirectory else { return false }
+        let repoRoot = langRoot.deletingLastPathComponent().deletingLastPathComponent()
         let modelURL = repoRoot.appendingPathComponent(ModelNames.PocketTTS.mimiEncoderFile)
         return FileManager.default.fileExists(atPath: modelURL.path)
     }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -29,7 +29,7 @@ public actor PocketTtsModelStore {
 
     /// - Parameters:
     ///   - language: Which upstream language pack to load. Defaults to
-    ///     `.english` for backward compatibility.
+    ///     `.english`.
     ///   - directory: Optional override for the base cache directory. When
     ///     `nil`, uses the default platform cache location.
     public init(language: PocketTtsLanguage = .english, directory: URL? = nil) {
@@ -97,10 +97,9 @@ public actor PocketTtsModelStore {
             modelName: "flowlm_step"
         )
 
-        // Discover Mimi decoder schema. Legacy English and v2 packs differ in
-        // attention cache layout, presence of `attn*_end_offset` inputs, and
-        // auto-generated `var_NNN` output names. Discovery makes both work
-        // through one runtime path.
+        // Discover Mimi decoder schema (per-state input→output mapping +
+        // audio output name). CoreML auto-generates `var_NNN` output names
+        // during conversion so the exact names vary across packs.
         mimiDecoderKeysCache = try PocketTtsMimiKeys.discover(from: loadedModels[3])
 
         let elapsed = Date().timeIntervalSince(loadStart)
@@ -176,9 +175,9 @@ public actor PocketTtsModelStore {
         return keys
     }
 
-    /// The language root directory (legacy repo root for English, or
-    /// `<repoDir>/v2/<lang>` otherwise) — contains the four model files,
-    /// `constants_bin/`, and is the right base for `loadMimiInitialState`.
+    /// The language root directory (`<repoDir>/v2/<lang>`) — contains the
+    /// four model files, `constants_bin/`, and is the right base for
+    /// `loadMimiInitialState`.
     public func repoDir() throws -> URL {
         guard let dir = languageRootDirectory else {
             throw PocketTTSError.modelNotFound("PocketTTS repository not loaded")
@@ -208,8 +207,8 @@ public actor PocketTtsModelStore {
     /// Load the Mimi encoder model for voice cloning (lazy, on-demand).
     ///
     /// Downloads the model from HuggingFace if not already cached. The Mimi
-    /// encoder is shared across all language packs and lives at the legacy
-    /// repo root.
+    /// encoder is language-agnostic and lives at the repo root, shared
+    /// across all language packs.
     public func loadMimiEncoderIfNeeded() async throws {
         guard mimiEncoderModel == nil else { return }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -1,6 +1,5 @@
 @preconcurrency import CoreML
 import Foundation
-import OSLog
 
 /// Actor-based store for PocketTTS CoreML models and constants.
 ///

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -108,8 +108,7 @@ public actor PocketTtsModelStore {
         logger.info("All PocketTTS models loaded in \(String(format: "%.2f", elapsed))s")
 
         // Load constants
-        constantsBundle = try PocketTtsResourceDownloader.ensureConstants(
-            languageRoot: languageRoot)
+        constantsBundle = try PocketTtsConstantsLoader.load(from: languageRoot)
         logger.info("PocketTTS constants loaded")
     }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
@@ -58,6 +58,8 @@ public actor PocketTtsSession {
     private let stepModel: MLModel
     private let flowModel: MLModel
     private let mimiModel: MLModel
+    private let condLayerKeys: PocketTtsLayerKeys
+    private let flowlmLayerKeys: PocketTtsLayerKeys
 
     // Persistent state
     private let voiceKVSnapshot: PocketTtsSynthesizer.KVCacheState
@@ -80,6 +82,8 @@ public actor PocketTtsSession {
         stepModel: MLModel,
         flowModel: MLModel,
         mimiModel: MLModel,
+        condLayerKeys: PocketTtsLayerKeys,
+        flowlmLayerKeys: PocketTtsLayerKeys,
         bosEmb: MLMultiArray,
         temperature: Float,
         seed: UInt64
@@ -91,6 +95,8 @@ public actor PocketTtsSession {
         self.stepModel = stepModel
         self.flowModel = flowModel
         self.mimiModel = mimiModel
+        self.condLayerKeys = condLayerKeys
+        self.flowlmLayerKeys = flowlmLayerKeys
         self.bosEmb = bosEmb
         self.temperature = temperature
         self.rng = SeededRNG(seed: seed)
@@ -172,7 +178,8 @@ public actor PocketTtsSession {
         // Clone voice KV snapshot and prefill text tokens only
         var kvState = try PocketTtsSynthesizer.cloneKVCacheState(voiceKVSnapshot)
         kvState = try await PocketTtsSynthesizer.prefillKVCacheText(
-            state: kvState, textEmbeddings: textEmbeddings, model: condModel
+            state: kvState, textEmbeddings: textEmbeddings, model: condModel,
+            layerKeys: condLayerKeys
         )
 
         // Generation loop
@@ -190,7 +197,8 @@ public actor PocketTtsSession {
                 sequence: sequence,
                 bosEmb: bosEmb,
                 state: &localKV,
-                model: stepModel
+                model: stepModel,
+                layerKeys: flowlmLayerKeys
             )
             kvState = localKV
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
@@ -60,6 +60,7 @@ public actor PocketTtsSession {
     private let mimiModel: MLModel
     private let condLayerKeys: PocketTtsLayerKeys
     private let flowlmLayerKeys: PocketTtsLayerKeys
+    private let mimiKeys: PocketTtsMimiKeys
 
     // Persistent state
     private let voiceKVSnapshot: PocketTtsSynthesizer.KVCacheState
@@ -84,6 +85,7 @@ public actor PocketTtsSession {
         mimiModel: MLModel,
         condLayerKeys: PocketTtsLayerKeys,
         flowlmLayerKeys: PocketTtsLayerKeys,
+        mimiKeys: PocketTtsMimiKeys,
         bosEmb: MLMultiArray,
         temperature: Float,
         seed: UInt64
@@ -97,6 +99,7 @@ public actor PocketTtsSession {
         self.mimiModel = mimiModel
         self.condLayerKeys = condLayerKeys
         self.flowlmLayerKeys = flowlmLayerKeys
+        self.mimiKeys = mimiKeys
         self.bosEmb = bosEmb
         self.temperature = temperature
         self.rng = SeededRNG(seed: seed)
@@ -227,7 +230,8 @@ public actor PocketTtsSession {
             let frameSamples = try await PocketTtsSynthesizer.runMimiDecoder(
                 latent: latent,
                 state: &localMimi,
-                model: mimiModel
+                model: mimiModel,
+                mimiKeys: mimiKeys
             )
             mimiState = localMimi
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
@@ -194,16 +194,15 @@ public actor PocketTtsSession {
         for step in 0..<maxGenLen {
             if Task.isCancelled { break }
 
-            // FlowLM step with local KV cache copy-in/copy-out
-            var localKV = kvState
+            // FlowLM step. `kvState` is function-local (not actor-isolated),
+            // so it can be passed `inout` to the async free function directly.
             let (transformerOut, eosLogit) = try await PocketTtsSynthesizer.runFlowLMStep(
                 sequence: sequence,
                 bosEmb: bosEmb,
-                state: &localKV,
+                state: &kvState,
                 model: stepModel,
                 layerKeys: flowlmLayerKeys
             )
-            kvState = localKV
 
             // EOS detection
             if eosLogit > PocketTtsConstants.eosThreshold && eosStep == nil {

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
@@ -17,8 +17,7 @@ extension PocketTtsSynthesizer {
         ///  - `16`: attention heads
         ///  - `64`: dims per head (16 × 64 = 1024 total)
         ///
-        /// `N` is 6 for the legacy English / 6L packs, and 24 for `*_24l`
-        /// packs.
+        /// `N` is 6 for base packs and 24 for `*_24l` packs.
         var caches: [MLMultiArray]
         /// `N` position counters (one per layer) tracking the next write slot
         /// in each cache.
@@ -264,10 +263,10 @@ extension PocketTtsSynthesizer {
     /// limit can't hold multiple chunks' worth of context.
     ///
     /// Two voice paths:
-    ///  - **Snapshot** (v2 packs): drop pre-baked K/V into cache, skip
-    ///    `cond_step` voice prefill entirely.
-    ///  - **Flat audio prompt** (legacy English): feed every voice token
-    ///    through `cond_step`.
+    ///  - **Snapshot** (on-disk v2 voice prebakes): drop pre-baked K/V into
+    ///    cache, skip `cond_step` voice prefill entirely.
+    ///  - **Flat audio prompt** (runtime cloned voices via `mimi_encoder`):
+    ///    feed every voice token through `cond_step`.
     /// Text prefill runs identically in both cases.
     static func prefillKVCache(
         voiceData: PocketTtsVoiceData,

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
@@ -181,22 +181,109 @@ extension PocketTtsSynthesizer {
         return state
     }
 
+    /// Build a `KVCacheState` from a pre-baked v2 voice snapshot.
+    ///
+    /// Each layer's source cache `[2, 1, seqLen, 16, 64]` is copied into the
+    /// first `seqLen` positions of a fresh `[2, 1, kvCacheMaxLen, 16, 64]`
+    /// allocation. The K block (outer dim 0) and V block (outer dim 1) are
+    /// copied independently because the dest seq capacity is larger than
+    /// the source — they don't lie at adjacent offsets in the dest.
+    /// `position{i}` is initialized from the snapshot's per-layer offset
+    /// (typically equal to `seqLen`).
+    static func kvCacheStateFromSnapshot(
+        _ snapshot: PocketTtsVoiceCacheSnapshot,
+        layers: Int
+    ) throws -> KVCacheState {
+        guard snapshot.layers.count == layers else {
+            throw PocketTTSError.processingFailed(
+                "voice snapshot layer count \(snapshot.layers.count) != model layer count \(layers)"
+            )
+        }
+        let destSeq = PocketTtsConstants.kvCacheMaxLen
+        let srcSeq = snapshot.cacheSeqLen
+        guard srcSeq <= destSeq else {
+            throw PocketTTSError.processingFailed(
+                "voice snapshot seqLen \(srcSeq) exceeds model capacity \(destSeq)"
+            )
+        }
+
+        // For shape [2, 1, seq, 16, 64] row-major:
+        //   K block size = 1 * seq * 16 * 64 floats
+        //   V block size = same
+        let perKVFloats = 1 * srcSeq * 16 * 64
+        let destPerKVFloats = 1 * destSeq * 16 * 64
+        let copyBytes = perKVFloats * MemoryLayout<Float>.size
+
+        let shape: [NSNumber] = [
+            2, 1, NSNumber(value: destSeq), 16, 64,
+        ]
+
+        var caches: [MLMultiArray] = []
+        var positions: [MLMultiArray] = []
+        caches.reserveCapacity(layers)
+        positions.reserveCapacity(layers)
+
+        for layerIdx in 0..<layers {
+            let source = snapshot.layers[layerIdx]
+            // Source flat array MUST equal 2 * perKVFloats elements.
+            guard source.cache.count == 2 * perKVFloats else {
+                throw PocketTTSError.processingFailed(
+                    "voice snapshot layer \(layerIdx) has \(source.cache.count) floats, expected \(2 * perKVFloats)"
+                )
+            }
+
+            let cache = try MLMultiArray(shape: shape, dataType: .float32)
+            let cachePtr = cache.dataPointer.bindMemory(to: Float.self, capacity: cache.count)
+            cachePtr.initialize(repeating: 0, count: cache.count)
+
+            // Copy K (source[0..perKVFloats) → dest[0..perKVFloats))
+            // Copy V (source[perKVFloats..2*perKVFloats) → dest[destPerKVFloats..destPerKVFloats+perKVFloats))
+            source.cache.withUnsafeBufferPointer { src in
+                guard let srcBase = src.baseAddress else { return }
+                memcpy(cachePtr, srcBase, copyBytes)
+                memcpy(
+                    cachePtr.advanced(by: destPerKVFloats),
+                    srcBase.advanced(by: perKVFloats),
+                    copyBytes)
+            }
+            caches.append(cache)
+
+            let pos = try MLMultiArray(shape: [1], dataType: .float32)
+            pos[0] = NSNumber(value: Float(source.offset))
+            positions.append(pos)
+        }
+
+        return KVCacheState(caches: caches, positions: positions)
+    }
+
     /// Prefill the KV cache with voice and text conditioning tokens.
     ///
     /// Processes voice tokens first, then text tokens. This ordering is critical —
     /// the model was trained with voice conditioning before text, so reversing it
     /// produces garbage. Each chunk gets a fresh cache because the 512-position
     /// limit can't hold multiple chunks' worth of context.
+    ///
+    /// Two voice paths:
+    ///  - **Snapshot** (v2 packs): drop pre-baked K/V into cache, skip
+    ///    `cond_step` voice prefill entirely.
+    ///  - **Flat audio prompt** (legacy English): feed every voice token
+    ///    through `cond_step`.
+    /// Text prefill runs identically in both cases.
     static func prefillKVCache(
         voiceData: PocketTtsVoiceData,
         textEmbeddings: [[Float]],
         model: MLModel,
         layerKeys: PocketTtsLayerKeys
     ) async throws -> KVCacheState {
-        let emptyState = try emptyKVCacheState(layers: layerKeys.layerCount)
-        var state = try await prefillKVCacheVoice(
-            state: emptyState, voiceData: voiceData, model: model, layerKeys: layerKeys
-        )
+        var state: KVCacheState
+        if let snapshot = voiceData.cacheSnapshot {
+            state = try kvCacheStateFromSnapshot(snapshot, layers: layerKeys.layerCount)
+        } else {
+            let emptyState = try emptyKVCacheState(layers: layerKeys.layerCount)
+            state = try await prefillKVCacheVoice(
+                state: emptyState, voiceData: voiceData, model: model, layerKeys: layerKeys
+            )
+        }
         state = try await prefillKVCacheText(
             state: state, textEmbeddings: textEmbeddings, model: model, layerKeys: layerKeys
         )

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
@@ -17,7 +17,8 @@ extension PocketTtsSynthesizer {
         ///  - `16`: attention heads
         ///  - `64`: dims per head (16 × 64 = 1024 total)
         ///
-        /// `N` is 6 for base packs and 24 for `*_24l` packs.
+        /// `N` is 6 for the legacy English / 6L packs, and 24 for `*_24l`
+        /// packs.
         var caches: [MLMultiArray]
         /// `N` position counters (one per layer) tracking the next write slot
         /// in each cache.
@@ -263,10 +264,10 @@ extension PocketTtsSynthesizer {
     /// limit can't hold multiple chunks' worth of context.
     ///
     /// Two voice paths:
-    ///  - **Snapshot** (on-disk v2 voice prebakes): drop pre-baked K/V into
-    ///    cache, skip `cond_step` voice prefill entirely.
-    ///  - **Flat audio prompt** (runtime cloned voices via `mimi_encoder`):
-    ///    feed every voice token through `cond_step`.
+    ///  - **Snapshot** (v2 packs): drop pre-baked K/V into cache, skip
+    ///    `cond_step` voice prefill entirely.
+    ///  - **Flat audio prompt** (legacy English): feed every voice token
+    ///    through `cond_step`.
     /// Text prefill runs identically in both cases.
     static func prefillKVCache(
         voiceData: PocketTtsVoiceData,

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
@@ -9,20 +9,24 @@ extension PocketTtsSynthesizer {
     /// for every processed token. This avoids recomputing K/V for past tokens —
     /// each new step only computes its own K/V, then reads all cached K/V via attention.
     struct KVCacheState {
-        /// 6 KV cache arrays, each shaped `[2, 1, kvCacheMaxLen, 16, 64]`:
+        /// `N` KV cache arrays (one per transformer layer), each shaped
+        /// `[2, 1, kvCacheMaxLen, 16, 64]`:
         ///  - `2`: K and V tensors (index 0 = keys, index 1 = values)
         ///  - `1`: batch size
         ///  - `kvCacheMaxLen` (512): pre-allocated position slots
         ///  - `16`: attention heads
         ///  - `64`: dims per head (16 × 64 = 1024 total)
+        ///
+        /// `N` is 6 for the legacy English / 6L packs, and 24 for `*_24l`
+        /// packs.
         var caches: [MLMultiArray]
-        /// 6 position counters (one per layer) tracking the next write slot in the cache.
+        /// `N` position counters (one per layer) tracking the next write slot
+        /// in each cache.
         var positions: [MLMultiArray]
     }
 
     /// Create an empty KV cache state (all zeros, positions at 0).
-    static func emptyKVCacheState() throws -> KVCacheState {
-        let layers = PocketTtsConstants.kvCacheLayers
+    static func emptyKVCacheState(layers: Int) throws -> KVCacheState {
         let shape: [NSNumber] = [
             2, 1, NSNumber(value: PocketTtsConstants.kvCacheMaxLen), 16, 64,
         ]
@@ -96,13 +100,15 @@ extension PocketTtsSynthesizer {
     static func runCondStep(
         conditioning: MLMultiArray,
         state: inout KVCacheState,
-        model: MLModel
+        model: MLModel,
+        layerKeys: PocketTtsLayerKeys
     ) async throws {
+        let layers = layerKeys.layerCount
         var inputDict: [String: Any] = [
             "conditioning": conditioning
         ]
 
-        for i in 0..<PocketTtsConstants.kvCacheLayers {
+        for i in 0..<layers {
             inputDict["cache\(i)"] = state.caches[i]
             inputDict["position\(i)"] = state.positions[i]
         }
@@ -110,16 +116,16 @@ extension PocketTtsSynthesizer {
         let input = try MLDictionaryFeatureProvider(dictionary: inputDict)
         let output = try await model.compatPrediction(from: input, options: MLPredictionOptions())
 
-        for i in 0..<PocketTtsConstants.kvCacheLayers {
-            guard let newCache = output.featureValue(for: CondStepKeys.cacheKeys[i])?.multiArrayValue
+        for i in 0..<layers {
+            guard let newCache = output.featureValue(for: layerKeys.cacheKeys[i])?.multiArrayValue
             else {
                 throw PocketTTSError.processingFailed(
-                    "Missing cond_step cache output: \(CondStepKeys.cacheKeys[i])")
+                    "Missing cond_step cache output: \(layerKeys.cacheKeys[i])")
             }
-            guard let newPos = output.featureValue(for: CondStepKeys.positionKeys[i])?.multiArrayValue
+            guard let newPos = output.featureValue(for: layerKeys.positionKeys[i])?.multiArrayValue
             else {
                 throw PocketTTSError.processingFailed(
-                    "Missing cond_step position output: \(CondStepKeys.positionKeys[i])")
+                    "Missing cond_step position output: \(layerKeys.positionKeys[i])")
             }
             state.caches[i] = newCache
             state.positions[i] = newPos
@@ -133,7 +139,8 @@ extension PocketTtsSynthesizer {
     static func prefillKVCacheVoice(
         state: KVCacheState,
         voiceData: PocketTtsVoiceData,
-        model: MLModel
+        model: MLModel,
+        layerKeys: PocketTtsLayerKeys
     ) async throws -> KVCacheState {
         var state = state
         let dim = PocketTtsConstants.embeddingDim
@@ -145,7 +152,8 @@ extension PocketTtsSynthesizer {
                 offset: tokenIdx * dim,
                 dim: dim
             )
-            try await runCondStep(conditioning: token, state: &state, model: model)
+            try await runCondStep(
+                conditioning: token, state: &state, model: model, layerKeys: layerKeys)
         }
 
         return state
@@ -158,14 +166,16 @@ extension PocketTtsSynthesizer {
     static func prefillKVCacheText(
         state: KVCacheState,
         textEmbeddings: [[Float]],
-        model: MLModel
+        model: MLModel,
+        layerKeys: PocketTtsLayerKeys
     ) async throws -> KVCacheState {
         var state = state
         let dim = PocketTtsConstants.embeddingDim
 
         for embedding in textEmbeddings {
             let token = try createConditioningToken(from: embedding, offset: 0, dim: dim)
-            try await runCondStep(conditioning: token, state: &state, model: model)
+            try await runCondStep(
+                conditioning: token, state: &state, model: model, layerKeys: layerKeys)
         }
 
         return state
@@ -180,14 +190,15 @@ extension PocketTtsSynthesizer {
     static func prefillKVCache(
         voiceData: PocketTtsVoiceData,
         textEmbeddings: [[Float]],
-        model: MLModel
+        model: MLModel,
+        layerKeys: PocketTtsLayerKeys
     ) async throws -> KVCacheState {
-        let emptyState = try emptyKVCacheState()
+        let emptyState = try emptyKVCacheState(layers: layerKeys.layerCount)
         var state = try await prefillKVCacheVoice(
-            state: emptyState, voiceData: voiceData, model: model
+            state: emptyState, voiceData: voiceData, model: model, layerKeys: layerKeys
         )
         state = try await prefillKVCacheText(
-            state: state, textEmbeddings: textEmbeddings, model: model
+            state: state, textEmbeddings: textEmbeddings, model: model, layerKeys: layerKeys
         )
 
         let finalPos = state.positions[0][0].floatValue
@@ -223,14 +234,22 @@ extension PocketTtsSynthesizer {
         sequence: MLMultiArray,
         bosEmb: MLMultiArray,
         state: inout KVCacheState,
-        model: MLModel
+        model: MLModel,
+        layerKeys: PocketTtsLayerKeys
     ) async throws -> (transformerOut: MLMultiArray, eosLogit: Float) {
+        guard let transformerKey = layerKeys.transformerOut, let eosKey = layerKeys.eosLogit
+        else {
+            throw PocketTTSError.processingFailed(
+                "flowlm_step layer keys missing transformer/eos outputs")
+        }
+
+        let layers = layerKeys.layerCount
         var inputDict: [String: Any] = [
             "sequence": sequence,
             "bos_emb": bosEmb,
         ]
 
-        for i in 0..<PocketTtsConstants.kvCacheLayers {
+        for i in 0..<layers {
             inputDict["cache\(i)"] = state.caches[i]
             inputDict["position\(i)"] = state.positions[i]
         }
@@ -239,30 +258,30 @@ extension PocketTtsSynthesizer {
         let output = try await model.compatPrediction(from: input, options: MLPredictionOptions())
 
         // Extract transformer output
-        guard let transformerOut = output.featureValue(for: FlowLMStepKeys.transformerOut)?.multiArrayValue
+        guard let transformerOut = output.featureValue(for: transformerKey)?.multiArrayValue
         else {
             throw PocketTTSError.processingFailed("Missing flowlm_step transformer output")
         }
 
         // Extract EOS logit
-        guard let eosArray = output.featureValue(for: FlowLMStepKeys.eosLogit)?.multiArrayValue
+        guard let eosArray = output.featureValue(for: eosKey)?.multiArrayValue
         else {
             throw PocketTTSError.processingFailed("Missing flowlm_step EOS logit")
         }
         let eosLogit = eosArray[0].floatValue
 
         // Update caches and positions
-        for i in 0..<PocketTtsConstants.kvCacheLayers {
+        for i in 0..<layers {
             guard
-                let newCache = output.featureValue(for: FlowLMStepKeys.cacheKeys[i])?.multiArrayValue
+                let newCache = output.featureValue(for: layerKeys.cacheKeys[i])?.multiArrayValue
             else {
                 throw PocketTTSError.processingFailed(
-                    "Missing flowlm_step cache output: \(FlowLMStepKeys.cacheKeys[i])")
+                    "Missing flowlm_step cache output: \(layerKeys.cacheKeys[i])")
             }
-            guard let newPos = output.featureValue(for: FlowLMStepKeys.positionKeys[i])?.multiArrayValue
+            guard let newPos = output.featureValue(for: layerKeys.positionKeys[i])?.multiArrayValue
             else {
                 throw PocketTTSError.processingFailed(
-                    "Missing flowlm_step position output: \(FlowLMStepKeys.positionKeys[i])")
+                    "Missing flowlm_step position output: \(layerKeys.positionKeys[i])")
             }
             state.caches[i] = newCache
             state.positions[i] = newPos

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
@@ -17,8 +17,7 @@ extension PocketTtsSynthesizer {
         ///  - `16`: attention heads
         ///  - `64`: dims per head (16 × 64 = 1024 total)
         ///
-        /// `N` is 6 for the legacy English / 6L packs, and 24 for `*_24l`
-        /// packs.
+        /// `N` is 6 for 6L packs and 24 for `*_24l` packs.
         var caches: [MLMultiArray]
         /// `N` position counters (one per layer) tracking the next write slot
         /// in each cache.
@@ -264,9 +263,9 @@ extension PocketTtsSynthesizer {
     /// limit can't hold multiple chunks' worth of context.
     ///
     /// Two voice paths:
-    ///  - **Snapshot** (v2 packs): drop pre-baked K/V into cache, skip
+    ///  - **Snapshot** (shipped voices): drop pre-baked K/V into cache, skip
     ///    `cond_step` voice prefill entirely.
-    ///  - **Flat audio prompt** (legacy English): feed every voice token
+    ///  - **Flat audio prompt** (cloned voices): feed every voice token
     ///    through `cond_step`.
     /// Text prefill runs identically in both cases.
     static func prefillKVCache(

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
@@ -52,42 +52,30 @@ extension PocketTtsSynthesizer {
 
     /// Clone a KV cache state for independent use.
     static func cloneKVCacheState(_ state: KVCacheState) throws -> KVCacheState {
-        var newCaches: [MLMultiArray] = []
-        var newPositions: [MLMultiArray] = []
-        newCaches.reserveCapacity(state.caches.count)
-        newPositions.reserveCapacity(state.positions.count)
+        KVCacheState(
+            caches: try state.caches.map(deepCopy),
+            positions: try state.positions.map(deepCopy)
+        )
+    }
 
-        for cache in state.caches {
-            let copy = try MLMultiArray(shape: cache.shape, dataType: cache.dataType)
-            let byteSize: Int
-            switch cache.dataType {
-            case .float16:
-                byteSize = cache.count * MemoryLayout<UInt16>.size
-            default:
-                byteSize = cache.count * MemoryLayout<Float>.size
-            }
-            if byteSize > 0 {
-                copy.dataPointer.copyMemory(from: cache.dataPointer, byteCount: byteSize)
-            }
-            newCaches.append(copy)
+    /// Deep-copy an `MLMultiArray`, preserving shape and dtype.
+    ///
+    /// Handles fp16 (UInt16-sized) and fp32-or-other (Float-sized) data
+    /// types, and gracefully no-ops for zero-element tensors (e.g. Mimi's
+    /// `res*_conv1_prev: [1, 128, 0]`).
+    static func deepCopy(_ array: MLMultiArray) throws -> MLMultiArray {
+        let copy = try MLMultiArray(shape: array.shape, dataType: array.dataType)
+        let byteSize: Int
+        switch array.dataType {
+        case .float16:
+            byteSize = array.count * MemoryLayout<UInt16>.size
+        default:
+            byteSize = array.count * MemoryLayout<Float>.size
         }
-
-        for pos in state.positions {
-            let copy = try MLMultiArray(shape: pos.shape, dataType: pos.dataType)
-            let byteSize: Int
-            switch pos.dataType {
-            case .float16:
-                byteSize = pos.count * MemoryLayout<UInt16>.size
-            default:
-                byteSize = pos.count * MemoryLayout<Float>.size
-            }
-            if byteSize > 0 {
-                copy.dataPointer.copyMemory(from: pos.dataPointer, byteCount: byteSize)
-            }
-            newPositions.append(copy)
+        if byteSize > 0 {
+            copy.dataPointer.copyMemory(from: array.dataPointer, byteCount: byteSize)
         }
-
-        return KVCacheState(caches: newCaches, positions: newPositions)
+        return copy
     }
 
     /// Run the conditioning step model for a single token, updating the KV cache in place.

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
@@ -16,11 +16,11 @@ extension PocketTtsSynthesizer {
     /// Create the initial Mimi decoder state from the constants directory.
     ///
     /// Tensor shapes come from the loaded model's input descriptions, not a
-    /// manifest, so legacy English (`attn*_cache: [2,1,8,256,64]`) and v2
-    /// multi-language packs (`attn*_cache: [2,1,256,8,64]`, no
-    /// `attn*_end_offset` inputs) both load through one path. `.bin` files
-    /// must be Float32 with element count matching the model's declared
-    /// shape; missing files mean a zero-initialized tensor.
+    /// manifest, so 6L and 24L packs (which have different `attn*_cache`
+    /// shapes and may differ in the presence of `attn*_end_offset` inputs)
+    /// both load through one path. `.bin` files must be Float32 with
+    /// element count matching the model's declared shape; missing files
+    /// mean a zero-initialized tensor.
     static func loadMimiInitialState(
         from repoDirectory: URL,
         mimiKeys: PocketTtsMimiKeys

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
@@ -15,57 +15,55 @@ extension PocketTtsSynthesizer {
 
     /// Create the initial Mimi decoder state from the constants directory.
     ///
-    /// Loads pre-computed initial state tensors from `.bin` files,
-    /// using `manifest.json` for shape metadata.
-    static func loadMimiInitialState(from repoDirectory: URL) throws -> MimiState {
+    /// Tensor shapes come from the loaded model's input descriptions, not a
+    /// manifest, so legacy English (`attn*_cache: [2,1,8,256,64]`) and v2
+    /// multi-language packs (`attn*_cache: [2,1,256,8,64]`, no
+    /// `attn*_end_offset` inputs) both load through one path. `.bin` files
+    /// must be Float32 with element count matching the model's declared
+    /// shape; missing files mean a zero-initialized tensor.
+    static func loadMimiInitialState(
+        from repoDirectory: URL,
+        mimiKeys: PocketTtsMimiKeys
+    ) throws -> MimiState {
         let constantsDir = repoDirectory.appendingPathComponent(ModelNames.PocketTTS.constantsBinDir)
         let stateDir = constantsDir.appendingPathComponent("mimi_init_state")
-        let manifestURL = constantsDir.appendingPathComponent("manifest.json")
-
-        // Parse manifest for mimi_init_state shapes
-        let manifestData = try Data(contentsOf: manifestURL)
-        guard let manifest = try JSONSerialization.jsonObject(with: manifestData) as? [String: Any],
-            let mimiManifest = manifest["mimi_init_state"] as? [String: Any]
-        else {
-            throw PocketTTSError.processingFailed("Failed to parse mimi_init_state from manifest.json")
-        }
 
         var tensors: [String: MLMultiArray] = [:]
 
-        for (name, info) in mimiManifest {
-            guard let infoDict = info as? [String: Any],
-                let shapeArray = infoDict["shape"] as? [Int],
-                let byteCount = infoDict["bytes"] as? Int
-            else {
+        for (name, shapeInts) in mimiKeys.stateShapes {
+            let shape = shapeInts.map { NSNumber(value: $0) }
+            let array = try MLMultiArray(shape: shape, dataType: .float32)
+
+            // Zero-length tensors (e.g. `res*_conv1_prev: [1, 128, 0]`) are
+            // empty pass-throughs — nothing to load.
+            if shapeInts.contains(0) {
+                tensors[name] = array
                 continue
             }
 
-            let shape = shapeArray.map { NSNumber(value: $0) }
-            let array = try MLMultiArray(shape: shape, dataType: .float32)
+            let elementCount = shapeInts.reduce(1, *)
+            let dstPtr = array.dataPointer.bindMemory(to: Float.self, capacity: elementCount)
+            // Default to zero in case the .bin file is absent (offset scalars,
+            // attention caches in zero-init packs, etc.).
+            dstPtr.initialize(repeating: 0, count: elementCount)
 
-            // Some tensors (e.g., res{0,1,2}_conv1_prev) have zero-length shapes
-            // and are empty pass-throughs — skip loading binary data for those.
-            if byteCount > 0 && !shapeArray.contains(0) {
-                let binURL = stateDir.appendingPathComponent("\(name).bin")
+            let binURL = stateDir.appendingPathComponent("\(name).bin")
+            if FileManager.default.fileExists(atPath: binURL.path) {
                 let data = try Data(contentsOf: binURL)
-                let floatCount = byteCount / MemoryLayout<Float>.size
-                let dstPtr = array.dataPointer.bindMemory(to: Float.self, capacity: floatCount)
-                data.withUnsafeBytes { rawBuffer in
-                    let srcPtr = rawBuffer.bindMemory(to: Float.self)
-                    dstPtr.update(from: srcPtr.baseAddress!, count: floatCount)
+                let expectedBytes = elementCount * MemoryLayout<Float>.size
+                if data.count == expectedBytes {
+                    data.withUnsafeBytes { rawBuffer in
+                        let srcPtr = rawBuffer.bindMemory(to: Float.self)
+                        dstPtr.update(from: srcPtr.baseAddress!, count: elementCount)
+                    }
                 }
+                // Mismatched bin sizes (e.g. English-packed `attn*_cache.bin`
+                // for a v2 model with the same byte count but different shape)
+                // fall back to zero-init, which is the correct empty-cache
+                // initial value anyway.
             }
 
             tensors[name] = array
-        }
-
-        // Ensure offset scalars exist
-        for key in ["attn0_offset", "attn0_end_offset", "attn1_offset", "attn1_end_offset"] {
-            if tensors[key] == nil {
-                let scalar = try MLMultiArray(shape: [1], dataType: .float32)
-                scalar[0] = NSNumber(value: Float(0))
-                tensors[key] = scalar
-            }
         }
 
         return MimiState(tensors: tensors)
@@ -104,7 +102,8 @@ extension PocketTtsSynthesizer {
     static func runMimiDecoder(
         latent: [Float],
         state: inout MimiState,
-        model: MLModel
+        model: MLModel,
+        mimiKeys: PocketTtsMimiKeys
     ) async throws -> [Float] {
         // Create latent input: [1, 32]
         let latentDim = PocketTtsConstants.latentDim
@@ -116,17 +115,23 @@ extension PocketTtsSynthesizer {
             latentPtr.update(from: base, count: latentDim)
         }
 
-        // Build input dictionary
+        // Build input dictionary — only include keys the model actually accepts
+        // so that legacy-English-only tensors (e.g. `attn*_end_offset`) don't
+        // surface to v2 packs that omit those inputs.
         var inputDict: [String: Any] = ["latent": latentArray]
-        for (key, array) in state.tensors {
-            inputDict[key] = array
+        for (inputName, _) in mimiKeys.stateMapping {
+            guard let array = state.tensors[inputName] else {
+                throw PocketTTSError.processingFailed(
+                    "Mimi state missing tensor '\(inputName)'")
+            }
+            inputDict[inputName] = array
         }
 
         let input = try MLDictionaryFeatureProvider(dictionary: inputDict)
         let output = try await model.compatPrediction(from: input, options: MLPredictionOptions())
 
         // Extract audio output [1, 1, 1920]
-        guard let audioArray = output.featureValue(for: MimiKeys.audioOutput)?.multiArrayValue else {
+        guard let audioArray = output.featureValue(for: mimiKeys.audioOutput)?.multiArrayValue else {
             throw PocketTTSError.processingFailed("Missing Mimi audio output")
         }
 
@@ -134,7 +139,7 @@ extension PocketTtsSynthesizer {
         let samples = readFloatArray(from: audioArray, count: sampleCount)
 
         // Update streaming state
-        for (inputName, outputName) in mimiStateMapping {
+        for (inputName, outputName) in mimiKeys.stateMapping {
             guard let updated = output.featureValue(for: outputName)?.multiArrayValue else {
                 throw PocketTTSError.processingFailed(
                     "Missing Mimi state output: \(outputName) (for \(inputName))")

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
@@ -16,11 +16,11 @@ extension PocketTtsSynthesizer {
     /// Create the initial Mimi decoder state from the constants directory.
     ///
     /// Tensor shapes come from the loaded model's input descriptions, not a
-    /// manifest, so 6L and 24L packs (which have different `attn*_cache`
-    /// shapes and may differ in the presence of `attn*_end_offset` inputs)
-    /// both load through one path. `.bin` files must be Float32 with
-    /// element count matching the model's declared shape; missing files
-    /// mean a zero-initialized tensor.
+    /// manifest, so legacy English (`attn*_cache: [2,1,8,256,64]`) and v2
+    /// multi-language packs (`attn*_cache: [2,1,256,8,64]`, no
+    /// `attn*_end_offset` inputs) both load through one path. `.bin` files
+    /// must be Float32 with element count matching the model's declared
+    /// shape; missing files mean a zero-initialized tensor.
     static func loadMimiInitialState(
         from repoDirectory: URL,
         mimiKeys: PocketTtsMimiKeys

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
@@ -68,19 +68,9 @@ extension PocketTtsSynthesizer {
     /// Clone a Mimi state for independent use.
     static func cloneMimiState(_ state: MimiState) throws -> MimiState {
         var newTensors: [String: MLMultiArray] = [:]
+        newTensors.reserveCapacity(state.tensors.count)
         for (key, array) in state.tensors {
-            let copy = try MLMultiArray(shape: array.shape, dataType: array.dataType)
-            let byteSize: Int
-            switch array.dataType {
-            case .float16:
-                byteSize = array.count * MemoryLayout<UInt16>.size
-            default:
-                byteSize = array.count * MemoryLayout<Float>.size
-            }
-            if byteSize > 0 {
-                copy.dataPointer.copyMemory(from: array.dataPointer, byteCount: byteSize)
-            }
-            newTensors[key] = copy
+            newTensors[key] = try deepCopy(array)
         }
         return MimiState(tensors: newTensors)
     }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Mimi.swift
@@ -16,11 +16,9 @@ extension PocketTtsSynthesizer {
     /// Create the initial Mimi decoder state from the constants directory.
     ///
     /// Tensor shapes come from the loaded model's input descriptions, not a
-    /// manifest, so legacy English (`attn*_cache: [2,1,8,256,64]`) and v2
-    /// multi-language packs (`attn*_cache: [2,1,256,8,64]`, no
-    /// `attn*_end_offset` inputs) both load through one path. `.bin` files
-    /// must be Float32 with element count matching the model's declared
-    /// shape; missing files mean a zero-initialized tensor.
+    /// manifest. `.bin` files must be Float32 with element count matching
+    /// the model's declared shape; missing files mean a zero-initialized
+    /// tensor.
     static func loadMimiInitialState(
         from repoDirectory: URL,
         mimiKeys: PocketTtsMimiKeys
@@ -57,10 +55,8 @@ extension PocketTtsSynthesizer {
                         dstPtr.update(from: srcPtr.baseAddress!, count: elementCount)
                     }
                 }
-                // Mismatched bin sizes (e.g. English-packed `attn*_cache.bin`
-                // for a v2 model with the same byte count but different shape)
-                // fall back to zero-init, which is the correct empty-cache
-                // initial value anyway.
+                // Mismatched bin sizes fall back to zero-init, which is
+                // the correct empty-cache initial value anyway.
             }
 
             tensors[name] = array
@@ -115,9 +111,7 @@ extension PocketTtsSynthesizer {
             latentPtr.update(from: base, count: latentDim)
         }
 
-        // Build input dictionary — only include keys the model actually accepts
-        // so that legacy-English-only tensors (e.g. `attn*_end_offset`) don't
-        // surface to v2 packs that omit those inputs.
+        // Build input dictionary from discovered state mapping.
         var inputDict: [String: Any] = ["latent": latentArray]
         for (inputName, _) in mimiKeys.stateMapping {
             guard let array = state.tensors[inputName] else {

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
@@ -15,52 +15,8 @@ extension PocketTtsSynthesizer {
     }
 
     /// CoreML output key names for the conditioning and generation step models
-    /// are discovered at model-load time via `PocketTtsLayerKeys.discover(...)`
-    /// because CoreML auto-generates names that differ between 6L and 24L
-    /// language packs. See `PocketTtsLayerKeys.swift`.
-
-    /// CoreML output key names for the Mimi decoder model.
-    enum MimiKeys {
-        static let audioOutput = "var_821"
-    }
-
-    /// Mimi decoder streaming state key mappings (input name → output name).
-    ///
-    /// 26 state tensors that carry the decoder's streaming context across frames:
-    /// - Upsampling: `upsample_partial` — partial output buffer for upsampling layers
-    /// - Attention: `attn{0,1}_cache/offset/end_offset` — causal attention KV caches
-    /// - Convolutions: `conv*_prev/first` — causal conv padding buffers
-    /// - Residual blocks: `res{0,1,2}_conv{0,1}_prev/first` — residual conv state
-    /// - Transposed convs: `convtr{0,1,2}_partial` — transposed conv overlap buffers
-    ///
-    /// 3 zero-length tensors (`res{0,1,2}_conv1_prev`) are pass-throughs where
-    /// input and output names are identical.
-    static let mimiStateMapping: [(input: String, output: String)] = [
-        ("upsample_partial", "var_82"),
-        ("attn0_cache", "var_262"),
-        ("attn0_offset", "var_840"),
-        ("attn0_end_offset", "new_end_offset_1"),
-        ("attn1_cache", "var_479"),
-        ("attn1_offset", "var_843"),
-        ("attn1_end_offset", "new_end_offset"),
-        ("conv0_prev", "var_607"),
-        ("conv0_first", "conv0_first"),
-        ("convtr0_partial", "var_634"),
-        ("res0_conv0_prev", "var_660"),
-        ("res0_conv0_first", "res0_conv0_first"),
-        ("res0_conv1_prev", "res0_conv1_prev"),
-        ("res0_conv1_first", "res0_conv1_first"),
-        ("convtr1_partial", "var_700"),
-        ("res1_conv0_prev", "var_726"),
-        ("res1_conv0_first", "res1_conv0_first"),
-        ("res1_conv1_prev", "res1_conv1_prev"),
-        ("res1_conv1_first", "res1_conv1_first"),
-        ("convtr2_partial", "var_766"),
-        ("res2_conv0_prev", "var_792"),
-        ("res2_conv0_first", "res2_conv0_first"),
-        ("res2_conv1_prev", "res2_conv1_prev"),
-        ("res2_conv1_first", "res2_conv1_first"),
-        ("conv_final_prev", "var_824"),
-        ("conv_final_first", "conv_final_first"),
-    ]
+    /// are discovered at model-load time via `PocketTtsLayerKeys.discover(...)`.
+    /// Mimi decoder I/O is discovered at model-load via `PocketTtsMimiKeys.discover(...)`.
+    /// Both use discovery because CoreML auto-generates `var_NNN` names that
+    /// differ between English/v2 packs and 6L/24L variants.
 }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
@@ -14,44 +14,10 @@ extension PocketTtsSynthesizer {
         public let eosStep: Int?
     }
 
-    /// CoreML output key names for the conditioning step model.
-    ///
-    /// These names are auto-generated during CoreML model tracing and must match
-    /// the compiled `.mlmodelc` exactly. They only change when models are re-converted.
-    enum CondStepKeys {
-        static let cacheKeys: [String] = [
-            "new_cache_1_internal_tensor_assign_2",
-            "new_cache_3_internal_tensor_assign_2",
-            "new_cache_5_internal_tensor_assign_2",
-            "new_cache_7_internal_tensor_assign_2",
-            "new_cache_9_internal_tensor_assign_2",
-            "new_cache_internal_tensor_assign_2",
-        ]
-        static let positionKeys: [String] = [
-            "var_445", "var_864", "var_1283", "var_1702", "var_2121", "var_2365",
-        ]
-    }
-
-    /// CoreML output key names for the generation step model.
-    ///
-    /// Auto-generated during CoreML model tracing. Must match the compiled model.
-    enum FlowLMStepKeys {
-        /// CoreML assigned this output the name "input" during model tracing —
-        /// it is the transformer hidden state output, not an input tensor.
-        static let transformerOut = "input"
-        static let eosLogit = "var_2582"
-        static let cacheKeys: [String] = [
-            "new_cache_1_internal_tensor_assign_2",
-            "new_cache_3_internal_tensor_assign_2",
-            "new_cache_5_internal_tensor_assign_2",
-            "new_cache_7_internal_tensor_assign_2",
-            "new_cache_9_internal_tensor_assign_2",
-            "new_cache_internal_tensor_assign_2",
-        ]
-        static let positionKeys: [String] = [
-            "var_458", "var_877", "var_1296", "var_1715", "var_2134", "var_2553",
-        ]
-    }
+    /// CoreML output key names for the conditioning and generation step models
+    /// are discovered at model-load time via `PocketTtsLayerKeys.discover(...)`
+    /// because CoreML auto-generates names that differ between 6L and 24L
+    /// language packs. See `PocketTtsLayerKeys.swift`.
 
     /// CoreML output key names for the Mimi decoder model.
     enum MimiKeys {

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
@@ -10,7 +10,11 @@ extension PocketTtsSynthesizer {
         public let samples: [Float]
         /// Number of 80ms frames generated.
         public let frameCount: Int
-        /// Generation step at which EOS was detected (nil if max length reached).
+        /// Generation step at which EOS was detected.
+        ///
+        /// Currently always `nil` — buffered synthesis runs on top of the
+        /// streaming pipeline which doesn't surface per-chunk EOS through
+        /// its frame stream. Retained for source-compatibility.
         public let eosStep: Int?
     }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+Types.swift
@@ -18,5 +18,5 @@ extension PocketTtsSynthesizer {
     /// are discovered at model-load time via `PocketTtsLayerKeys.discover(...)`.
     /// Mimi decoder I/O is discovered at model-load via `PocketTtsMimiKeys.discover(...)`.
     /// Both use discovery because CoreML auto-generates `var_NNN` names that
-    /// differ between English/v2 packs and 6L/24L variants.
+    /// differ across language packs and 6L/24L variants.
 }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -535,10 +535,11 @@ public struct PocketTtsSynthesizer {
         let seedValue = seed ?? UInt64.random(in: 0...UInt64.max)
 
         // One-time voice prefill. Two paths matching `prefillKVCache`:
-        //  - Pre-baked snapshot (cacheSnapshot != nil): drop pre-baked K/V
-        //    straight into the cache, skip cond_step entirely.
-        //  - Flat audio prompt (cloned voice): feed every voice token through
-        //    cond_step. Cloned voices never carry a cacheSnapshot.
+        //  - v2 packs (cacheSnapshot != nil): drop pre-baked K/V into cache,
+        //    skip cond_step entirely (`promptLength == 0`, so the loop in
+        //    `prefillKVCacheVoice` would be a no-op anyway).
+        //  - Flat audio prompt (legacy English): feed every voice token
+        //    through cond_step.
         let voiceKVSnapshot: KVCacheState
         if let snapshot = voiceData.cacheSnapshot {
             voiceKVSnapshot = try kvCacheStateFromSnapshot(

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -534,12 +534,23 @@ public struct PocketTtsSynthesizer {
         let bosEmb = try createBosEmbedding(constants.bosEmbedding)
         let seedValue = seed ?? UInt64.random(in: 0...UInt64.max)
 
-        // One-time voice prefill
-        let emptyState = try emptyKVCacheState(layers: condLayerKeys.layerCount)
-        let voiceKVSnapshot = try await prefillKVCacheVoice(
-            state: emptyState, voiceData: voiceData, model: condModel,
-            layerKeys: condLayerKeys
-        )
+        // One-time voice prefill. Two paths matching `prefillKVCache`:
+        //  - v2 packs (cacheSnapshot != nil): drop pre-baked K/V into cache,
+        //    skip cond_step entirely (`promptLength == 0`, so the loop in
+        //    `prefillKVCacheVoice` would be a no-op anyway).
+        //  - Flat audio prompt (legacy English): feed every voice token
+        //    through cond_step.
+        let voiceKVSnapshot: KVCacheState
+        if let snapshot = voiceData.cacheSnapshot {
+            voiceKVSnapshot = try kvCacheStateFromSnapshot(
+                snapshot, layers: condLayerKeys.layerCount)
+        } else {
+            let emptyState = try emptyKVCacheState(layers: condLayerKeys.layerCount)
+            voiceKVSnapshot = try await prefillKVCacheVoice(
+                state: emptyState, voiceData: voiceData, model: condModel,
+                layerKeys: condLayerKeys
+            )
+        }
 
         logger.info(
             "Session voice prefill at position \(Int(voiceKVSnapshot.positions[0][0].floatValue))"
@@ -1039,11 +1050,16 @@ public struct PocketTtsSynthesizer {
     // MARK: - Embedding
 
     /// Look up text token embeddings from the embedding table.
+    ///
+    /// Vocab size is derived from the actual loaded table because v2 language
+    /// packs ship per-language `text_embed_table` with potentially different
+    /// row counts (`PocketTtsConstants.vocabSize` only matches the legacy
+    /// English pack).
     static func embedTokens(
         _ tokenIds: [Int], constants: PocketTtsConstantsBundle
     ) -> [[Float]] {
         let dim = PocketTtsConstants.embeddingDim
-        let vocabSize = PocketTtsConstants.vocabSize
+        let vocabSize = constants.textEmbedTable.count / dim
         return tokenIds.map { id in
             guard id >= 0, id < vocabSize else {
                 logger.warning("Token ID \(id) out of range [0, \(vocabSize)), clamping")

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -535,11 +535,10 @@ public struct PocketTtsSynthesizer {
         let seedValue = seed ?? UInt64.random(in: 0...UInt64.max)
 
         // One-time voice prefill. Two paths matching `prefillKVCache`:
-        //  - v2 packs (cacheSnapshot != nil): drop pre-baked K/V into cache,
-        //    skip cond_step entirely (`promptLength == 0`, so the loop in
-        //    `prefillKVCacheVoice` would be a no-op anyway).
-        //  - Flat audio prompt (legacy English): feed every voice token
-        //    through cond_step.
+        //  - Pre-baked snapshot (cacheSnapshot != nil): drop pre-baked K/V
+        //    straight into the cache, skip cond_step entirely.
+        //  - Flat audio prompt (cloned voice): feed every voice token through
+        //    cond_step. Cloned voices never carry a cacheSnapshot.
         let voiceKVSnapshot: KVCacheState
         if let snapshot = voiceData.cacheSnapshot {
             voiceKVSnapshot = try kvCacheStateFromSnapshot(

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -76,10 +76,11 @@ public struct PocketTtsSynthesizer {
         let mimiModel = try await store.mimiDecoder()
         let condLayerKeys = try await store.condStepLayerKeys()
         let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
+        let mimiKeys = try await store.mimiDecoderKeys()
 
         // 5. Load Mimi initial state (continuous across chunks)
         let repoDir = try await store.repoDir()
-        var mimiState = try loadMimiInitialState(from: repoDir)
+        var mimiState = try loadMimiInitialState(from: repoDir, mimiKeys: mimiKeys)
 
         // 6. Create BOS embedding
         let bosEmb = try createBosEmbedding(constants.bosEmbedding)
@@ -148,7 +149,8 @@ public struct PocketTtsSynthesizer {
                 let frameSamples = try await runMimiDecoder(
                     latent: latent,
                     state: &mimiState,
-                    model: mimiModel
+                    model: mimiModel,
+                    mimiKeys: mimiKeys
                 )
                 audioChunks.append(frameSamples)
 
@@ -235,10 +237,11 @@ public struct PocketTtsSynthesizer {
         let mimiModel = try await store.mimiDecoder()
         let condLayerKeys = try await store.condStepLayerKeys()
         let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
+        let mimiKeys = try await store.mimiDecoderKeys()
 
         // 5. Load Mimi initial state (continuous across chunks)
         let repoDir = try await store.repoDir()
-        var mimiState = try loadMimiInitialState(from: repoDir)
+        var mimiState = try loadMimiInitialState(from: repoDir, mimiKeys: mimiKeys)
 
         // 6. Create BOS embedding
         let bosEmb = try createBosEmbedding(constants.bosEmbedding)
@@ -308,7 +311,8 @@ public struct PocketTtsSynthesizer {
                 let frameSamples = try await runMimiDecoder(
                     latent: latent,
                     state: &mimiState,
-                    model: mimiModel
+                    model: mimiModel,
+                    mimiKeys: mimiKeys
                 )
                 audioChunks.append(frameSamples)
 
@@ -415,8 +419,9 @@ public struct PocketTtsSynthesizer {
         let mimiModel = try await store.mimiDecoder()
         let condLayerKeys = try await store.condStepLayerKeys()
         let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
+        let mimiKeys = try await store.mimiDecoderKeys()
         let repoDir = try await store.repoDir()
-        let mimiInitialState = try loadMimiInitialState(from: repoDir)
+        let mimiInitialState = try loadMimiInitialState(from: repoDir, mimiKeys: mimiKeys)
         let bosEmb = try createBosEmbedding(constants.bosEmbedding)
         let seedValue = seed ?? UInt64.random(in: 0...UInt64.max)
         let chunkCount = chunks.count
@@ -433,6 +438,7 @@ public struct PocketTtsSynthesizer {
             mimiModel: mimiModel,
             condLayerKeys: condLayerKeys,
             flowlmLayerKeys: flowlmLayerKeys,
+            mimiKeys: mimiKeys,
             mimiInitialState: mimiInitialState,
             bosEmb: bosEmb,
             seedValue: seedValue,
@@ -472,8 +478,9 @@ public struct PocketTtsSynthesizer {
         let mimiModel = try await store.mimiDecoder()
         let condLayerKeys = try await store.condStepLayerKeys()
         let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
+        let mimiKeys = try await store.mimiDecoderKeys()
         let repoDir = try await store.repoDir()
-        let mimiInitialState = try loadMimiInitialState(from: repoDir)
+        let mimiInitialState = try loadMimiInitialState(from: repoDir, mimiKeys: mimiKeys)
         let bosEmb = try createBosEmbedding(constants.bosEmbedding)
         let seedValue = seed ?? UInt64.random(in: 0...UInt64.max)
         let chunkCount = chunks.count
@@ -488,6 +495,7 @@ public struct PocketTtsSynthesizer {
             mimiModel: mimiModel,
             condLayerKeys: condLayerKeys,
             flowlmLayerKeys: flowlmLayerKeys,
+            mimiKeys: mimiKeys,
             mimiInitialState: mimiInitialState,
             bosEmb: bosEmb,
             seedValue: seedValue,
@@ -520,8 +528,9 @@ public struct PocketTtsSynthesizer {
         let mimiModel = try await store.mimiDecoder()
         let condLayerKeys = try await store.condStepLayerKeys()
         let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
+        let mimiKeys = try await store.mimiDecoderKeys()
         let repoDir = try await store.repoDir()
-        let mimiState = try loadMimiInitialState(from: repoDir)
+        let mimiState = try loadMimiInitialState(from: repoDir, mimiKeys: mimiKeys)
         let bosEmb = try createBosEmbedding(constants.bosEmbedding)
         let seedValue = seed ?? UInt64.random(in: 0...UInt64.max)
 
@@ -546,6 +555,7 @@ public struct PocketTtsSynthesizer {
             mimiModel: mimiModel,
             condLayerKeys: condLayerKeys,
             flowlmLayerKeys: flowlmLayerKeys,
+            mimiKeys: mimiKeys,
             bosEmb: bosEmb,
             temperature: temperature,
             seed: seedValue
@@ -571,6 +581,7 @@ public struct PocketTtsSynthesizer {
         let mimiModel: MLModel
         let condLayerKeys: PocketTtsLayerKeys
         let flowlmLayerKeys: PocketTtsLayerKeys
+        let mimiKeys: PocketTtsMimiKeys
         var mimiState: MimiState
         let bosEmb: MLMultiArray
         var rng: SeededRNG
@@ -587,6 +598,7 @@ public struct PocketTtsSynthesizer {
             mimiModel: MLModel,
             condLayerKeys: PocketTtsLayerKeys,
             flowlmLayerKeys: PocketTtsLayerKeys,
+            mimiKeys: PocketTtsMimiKeys,
             mimiInitialState: MimiState,
             bosEmb: MLMultiArray,
             seedValue: UInt64,
@@ -602,6 +614,7 @@ public struct PocketTtsSynthesizer {
             self.mimiModel = mimiModel
             self.condLayerKeys = condLayerKeys
             self.flowlmLayerKeys = flowlmLayerKeys
+            self.mimiKeys = mimiKeys
             self.mimiState = mimiInitialState
             self.bosEmb = bosEmb
             self.rng = SeededRNG(seed: seedValue)
@@ -637,7 +650,8 @@ public struct PocketTtsSynthesizer {
             let result = try await PocketTtsSynthesizer.runMimiDecoder(
                 latent: latent,
                 state: &localState,
-                model: mimiModel
+                model: mimiModel,
+                mimiKeys: mimiKeys
             )
             mimiState = localState
             return result

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -74,6 +74,8 @@ public struct PocketTtsSynthesizer {
         let stepModel = try await store.flowlmStep()
         let flowModel = try await store.flowDecoder()
         let mimiModel = try await store.mimiDecoder()
+        let condLayerKeys = try await store.condStepLayerKeys()
+        let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
 
         // 5. Load Mimi initial state (continuous across chunks)
         let repoDir = try await store.repoDir()
@@ -101,7 +103,8 @@ public struct PocketTtsSynthesizer {
             var kvState = try await prefillKVCache(
                 voiceData: voiceData,
                 textEmbeddings: textEmbeddings,
-                model: condModel
+                model: condModel,
+                layerKeys: condLayerKeys
             )
             let prefillElapsed = Date().timeIntervalSince(prefillStart)
             logger.info(
@@ -120,7 +123,8 @@ public struct PocketTtsSynthesizer {
                     sequence: sequence,
                     bosEmb: bosEmb,
                     state: &kvState,
-                    model: stepModel
+                    model: stepModel,
+                    layerKeys: flowlmLayerKeys
                 )
 
                 if eosLogit > PocketTtsConstants.eosThreshold && eosStep == nil {
@@ -229,6 +233,8 @@ public struct PocketTtsSynthesizer {
         let stepModel = try await store.flowlmStep()
         let flowModel = try await store.flowDecoder()
         let mimiModel = try await store.mimiDecoder()
+        let condLayerKeys = try await store.condStepLayerKeys()
+        let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
 
         // 5. Load Mimi initial state (continuous across chunks)
         let repoDir = try await store.repoDir()
@@ -256,7 +262,8 @@ public struct PocketTtsSynthesizer {
             var kvState = try await prefillKVCache(
                 voiceData: voiceData,
                 textEmbeddings: textEmbeddings,
-                model: condModel
+                model: condModel,
+                layerKeys: condLayerKeys
             )
             let prefillElapsed = Date().timeIntervalSince(prefillStart)
             logger.info(
@@ -275,7 +282,8 @@ public struct PocketTtsSynthesizer {
                     sequence: sequence,
                     bosEmb: bosEmb,
                     state: &kvState,
-                    model: stepModel
+                    model: stepModel,
+                    layerKeys: flowlmLayerKeys
                 )
 
                 if eosLogit > PocketTtsConstants.eosThreshold && eosStep == nil {
@@ -405,6 +413,8 @@ public struct PocketTtsSynthesizer {
         let stepModel = try await store.flowlmStep()
         let flowModel = try await store.flowDecoder()
         let mimiModel = try await store.mimiDecoder()
+        let condLayerKeys = try await store.condStepLayerKeys()
+        let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
         let repoDir = try await store.repoDir()
         let mimiInitialState = try loadMimiInitialState(from: repoDir)
         let bosEmb = try createBosEmbedding(constants.bosEmbedding)
@@ -421,6 +431,8 @@ public struct PocketTtsSynthesizer {
             stepModel: stepModel,
             flowModel: flowModel,
             mimiModel: mimiModel,
+            condLayerKeys: condLayerKeys,
+            flowlmLayerKeys: flowlmLayerKeys,
             mimiInitialState: mimiInitialState,
             bosEmb: bosEmb,
             seedValue: seedValue,
@@ -458,6 +470,8 @@ public struct PocketTtsSynthesizer {
         let stepModel = try await store.flowlmStep()
         let flowModel = try await store.flowDecoder()
         let mimiModel = try await store.mimiDecoder()
+        let condLayerKeys = try await store.condStepLayerKeys()
+        let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
         let repoDir = try await store.repoDir()
         let mimiInitialState = try loadMimiInitialState(from: repoDir)
         let bosEmb = try createBosEmbedding(constants.bosEmbedding)
@@ -472,6 +486,8 @@ public struct PocketTtsSynthesizer {
             stepModel: stepModel,
             flowModel: flowModel,
             mimiModel: mimiModel,
+            condLayerKeys: condLayerKeys,
+            flowlmLayerKeys: flowlmLayerKeys,
             mimiInitialState: mimiInitialState,
             bosEmb: bosEmb,
             seedValue: seedValue,
@@ -502,15 +518,18 @@ public struct PocketTtsSynthesizer {
         let stepModel = try await store.flowlmStep()
         let flowModel = try await store.flowDecoder()
         let mimiModel = try await store.mimiDecoder()
+        let condLayerKeys = try await store.condStepLayerKeys()
+        let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
         let repoDir = try await store.repoDir()
         let mimiState = try loadMimiInitialState(from: repoDir)
         let bosEmb = try createBosEmbedding(constants.bosEmbedding)
         let seedValue = seed ?? UInt64.random(in: 0...UInt64.max)
 
         // One-time voice prefill
-        let emptyState = try emptyKVCacheState()
+        let emptyState = try emptyKVCacheState(layers: condLayerKeys.layerCount)
         let voiceKVSnapshot = try await prefillKVCacheVoice(
-            state: emptyState, voiceData: voiceData, model: condModel
+            state: emptyState, voiceData: voiceData, model: condModel,
+            layerKeys: condLayerKeys
         )
 
         logger.info(
@@ -525,6 +544,8 @@ public struct PocketTtsSynthesizer {
             stepModel: stepModel,
             flowModel: flowModel,
             mimiModel: mimiModel,
+            condLayerKeys: condLayerKeys,
+            flowlmLayerKeys: flowlmLayerKeys,
             bosEmb: bosEmb,
             temperature: temperature,
             seed: seedValue
@@ -548,6 +569,8 @@ public struct PocketTtsSynthesizer {
         let stepModel: MLModel
         let flowModel: MLModel
         let mimiModel: MLModel
+        let condLayerKeys: PocketTtsLayerKeys
+        let flowlmLayerKeys: PocketTtsLayerKeys
         var mimiState: MimiState
         let bosEmb: MLMultiArray
         var rng: SeededRNG
@@ -562,6 +585,8 @@ public struct PocketTtsSynthesizer {
             stepModel: MLModel,
             flowModel: MLModel,
             mimiModel: MLModel,
+            condLayerKeys: PocketTtsLayerKeys,
+            flowlmLayerKeys: PocketTtsLayerKeys,
             mimiInitialState: MimiState,
             bosEmb: MLMultiArray,
             seedValue: UInt64,
@@ -575,6 +600,8 @@ public struct PocketTtsSynthesizer {
             self.stepModel = stepModel
             self.flowModel = flowModel
             self.mimiModel = mimiModel
+            self.condLayerKeys = condLayerKeys
+            self.flowlmLayerKeys = flowlmLayerKeys
             self.mimiState = mimiInitialState
             self.bosEmb = bosEmb
             self.rng = SeededRNG(seed: seedValue)
@@ -626,7 +653,8 @@ public struct PocketTtsSynthesizer {
                 sequence: sequence,
                 bosEmb: bosEmb,
                 state: &localState,
-                model: stepModel
+                model: stepModel,
+                layerKeys: flowlmLayerKeys
             )
             kvState = localState
             return result
@@ -650,7 +678,8 @@ public struct PocketTtsSynthesizer {
                     var kvState = try await PocketTtsSynthesizer.prefillKVCache(
                         voiceData: voiceData,
                         textEmbeddings: textEmbeddings,
-                        model: condModel
+                        model: condModel,
+                        layerKeys: condLayerKeys
                     )
 
                     let maxGenLen = PocketTtsSynthesizer.estimateMaxFrames(text: chunkText)

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -1,6 +1,5 @@
 @preconcurrency import CoreML
 import Foundation
-import OSLog
 
 /// PocketTTS flow-matching language model synthesizer.
 ///
@@ -55,146 +54,13 @@ public struct PocketTtsSynthesizer {
         deEss: Bool = true
     ) async throws -> SynthesisResult {
         let store = try currentModelStore()
-
-        logger.info("PocketTTS synthesizing: '\(text)'")
-
-        // 1. Load constants and voice
-        let constants = try await store.constants()
         let voiceData = try await store.voiceData(for: voice)
-
-        // 2. Split text into chunks that fit within KV cache capacity
-        let chunks = chunkText(text, tokenizer: constants.tokenizer)
-        logger.info("Split into \(chunks.count) chunk(s)")
-
-        // 3. Set up random number generator (seeded or system entropy)
-        var rng = SeededRNG(seed: seed ?? UInt64.random(in: 0...UInt64.max))
-
-        // 4. Load models
-        let condModel = try await store.condStep()
-        let stepModel = try await store.flowlmStep()
-        let flowModel = try await store.flowDecoder()
-        let mimiModel = try await store.mimiDecoder()
-        let condLayerKeys = try await store.condStepLayerKeys()
-        let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
-        let mimiKeys = try await store.mimiDecoderKeys()
-
-        // 5. Load Mimi initial state (continuous across chunks)
-        let repoDir = try await store.repoDir()
-        var mimiState = try loadMimiInitialState(from: repoDir, mimiKeys: mimiKeys)
-
-        // 6. Create BOS embedding
-        let bosEmb = try createBosEmbedding(constants.bosEmbedding)
-
-        // 7. Generate audio for each chunk
-        var audioChunks: [[Float]] = []
-        var lastEosStep: Int?
-
-        let genStart = Date()
-
-        for (chunkIdx, chunkText) in chunks.enumerated() {
-            let (normalizedChunk, framesAfterEos) = normalizeText(chunkText)
-            logger.info("Chunk \(chunkIdx + 1)/\(chunks.count): '\(normalizedChunk)'")
-
-            // Tokenize and embed this chunk
-            let tokenIds = constants.tokenizer.encode(normalizedChunk)
-            let textEmbeddings = embedTokens(tokenIds, constants: constants)
-
-            // Fresh KV cache per chunk
-            let prefillStart = Date()
-            var kvState = try await prefillKVCache(
-                voiceData: voiceData,
-                textEmbeddings: textEmbeddings,
-                model: condModel,
-                layerKeys: condLayerKeys
-            )
-            let prefillElapsed = Date().timeIntervalSince(prefillStart)
-            logger.info(
-                "Chunk \(chunkIdx + 1) prefill: \(String(format: "%.2f", prefillElapsed))s (\(tokenIds.count) tokens)"
-            )
-
-            // Generation loop for this chunk
-            let maxGenLen = estimateMaxFrames(text: chunkText)
-            var eosStep: Int?
-            var sequence = try createNaNSequence()
-            let totalFramesAfterEos =
-                framesAfterEos + PocketTtsConstants.extraFramesAfterDetection
-
-            for step in 0..<maxGenLen {
-                let (transformerOut, eosLogit) = try await runFlowLMStep(
-                    sequence: sequence,
-                    bosEmb: bosEmb,
-                    state: &kvState,
-                    model: stepModel,
-                    layerKeys: flowlmLayerKeys
-                )
-
-                if eosLogit > PocketTtsConstants.eosThreshold && eosStep == nil {
-                    eosStep = step
-                    logger.info("Chunk \(chunkIdx + 1) EOS at step \(step)")
-                }
-                if let eos = eosStep, step >= eos + totalFramesAfterEos {
-                    break
-                }
-
-                let latent = try await flowDecode(
-                    transformerOut: transformerOut,
-                    numSteps: PocketTtsConstants.numLsdSteps,
-                    temperature: temperature,
-                    model: flowModel,
-                    rng: &rng
-                )
-
-                // Mimi state is continuous across chunks
-                // (denormalize + quantize baked into mimi_decoder model)
-                let frameSamples = try await runMimiDecoder(
-                    latent: latent,
-                    state: &mimiState,
-                    model: mimiModel,
-                    mimiKeys: mimiKeys
-                )
-                audioChunks.append(frameSamples)
-
-                sequence = try createSequenceFromLatent(latent)
-
-                if step % 20 == 0 {
-                    logger.info("Chunk \(chunkIdx + 1) step \(step)...")
-                }
-            }
-
-            lastEosStep = eosStep
-        }
-
-        let genElapsed = Date().timeIntervalSince(genStart)
-        logger.info(
-            "Generated \(audioChunks.count) frames in \(String(format: "%.2f", genElapsed))s")
-
-        // 8. Concatenate audio (no peak normalization — preserve natural levels)
-        var allSamples = audioChunks.flatMap { $0 }
-
-        // De-essing
-        if deEss {
-            AudioPostProcessor.applyTtsPostProcessing(
-                &allSamples,
-                sampleRate: Float(PocketTtsConstants.audioSampleRate),
-                deEssAmount: -3.0,
-                smoothing: false
-            )
-        }
-
-        // 9. Encode WAV
-        let audioData = try AudioWAV.data(
-            from: allSamples,
-            sampleRate: Double(PocketTtsConstants.audioSampleRate)
-        )
-
-        let duration = Double(allSamples.count) / Double(PocketTtsConstants.audioSampleRate)
-        logger.info("Audio duration: \(String(format: "%.2f", duration))s")
-
-        return SynthesisResult(
-            audio: audioData,
-            samples: allSamples,
-            frameCount: audioChunks.count,
-            eosStep: lastEosStep
+        return try await synthesize(
+            text: text,
+            voiceData: voiceData,
+            temperature: temperature,
+            seed: seed,
+            deEss: deEss
         )
     }
 
@@ -407,46 +273,13 @@ public struct PocketTtsSynthesizer {
         seed: UInt64? = nil
     ) async throws -> AsyncThrowingStream<AudioFrame, Error> {
         let store = try currentModelStore()
-
-        logger.info("PocketTTS streaming synthesis: '\(text)'")
-
-        let constants = try await store.constants()
         let voiceData = try await store.voiceData(for: voice)
-        let chunks = chunkText(text, tokenizer: constants.tokenizer)
-        let condModel = try await store.condStep()
-        let stepModel = try await store.flowlmStep()
-        let flowModel = try await store.flowDecoder()
-        let mimiModel = try await store.mimiDecoder()
-        let condLayerKeys = try await store.condStepLayerKeys()
-        let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
-        let mimiKeys = try await store.mimiDecoderKeys()
-        let repoDir = try await store.repoDir()
-        let mimiInitialState = try loadMimiInitialState(from: repoDir, mimiKeys: mimiKeys)
-        let bosEmb = try createBosEmbedding(constants.bosEmbedding)
-        let seedValue = seed ?? UInt64.random(in: 0...UInt64.max)
-        let chunkCount = chunks.count
-
-        logger.info("Streaming \(chunkCount) chunk(s)")
-
-        let generator = StreamingGenerator(
-            constants: constants,
+        return try await synthesizeStreaming(
+            text: text,
             voiceData: voiceData,
-            chunks: chunks,
-            condModel: condModel,
-            stepModel: stepModel,
-            flowModel: flowModel,
-            mimiModel: mimiModel,
-            condLayerKeys: condLayerKeys,
-            flowlmLayerKeys: flowlmLayerKeys,
-            mimiKeys: mimiKeys,
-            mimiInitialState: mimiInitialState,
-            bosEmb: bosEmb,
-            seedValue: seedValue,
-            chunkCount: chunkCount,
-            temperature: temperature
+            temperature: temperature,
+            seed: seed
         )
-
-        return makeStream(generator: generator)
     }
 
     /// Synthesize audio as a stream using custom voice data.

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -82,124 +82,26 @@ public struct PocketTtsSynthesizer {
         seed: UInt64? = nil,
         deEss: Bool = true
     ) async throws -> SynthesisResult {
-        let store = try currentModelStore()
-
         logger.info("PocketTTS synthesizing with custom voice: '\(text)'")
-
-        // 1. Load constants (voice provided directly)
-        let constants = try await store.constants()
-
-        // 2. Split text into chunks that fit within KV cache capacity
-        let chunks = chunkText(text, tokenizer: constants.tokenizer)
-        logger.info("Split into \(chunks.count) chunk(s)")
-
-        // 3. Set up random number generator (seeded or system entropy)
-        var rng = SeededRNG(seed: seed ?? UInt64.random(in: 0...UInt64.max))
-
-        // 4. Load models
-        let condModel = try await store.condStep()
-        let stepModel = try await store.flowlmStep()
-        let flowModel = try await store.flowDecoder()
-        let mimiModel = try await store.mimiDecoder()
-        let condLayerKeys = try await store.condStepLayerKeys()
-        let flowlmLayerKeys = try await store.flowLMStepLayerKeys()
-        let mimiKeys = try await store.mimiDecoderKeys()
-
-        // 5. Load Mimi initial state (continuous across chunks)
-        let repoDir = try await store.repoDir()
-        var mimiState = try loadMimiInitialState(from: repoDir, mimiKeys: mimiKeys)
-
-        // 6. Create BOS embedding
-        let bosEmb = try createBosEmbedding(constants.bosEmbedding)
-
-        // 7. Generate audio for each chunk
-        var audioChunks: [[Float]] = []
-        var lastEosStep: Int?
-
         let genStart = Date()
 
-        for (chunkIdx, chunkText) in chunks.enumerated() {
-            let (normalizedChunk, framesAfterEos) = normalizeText(chunkText)
-            logger.info("Chunk \(chunkIdx + 1)/\(chunks.count): '\(normalizedChunk)'")
+        // Buffer the streaming output. Both APIs share one chunk loop now,
+        // so any change to prefill/generation logic only needs to land once.
+        let stream = try await synthesizeStreaming(
+            text: text, voiceData: voiceData, temperature: temperature, seed: seed
+        )
 
-            // Tokenize and embed this chunk
-            let tokenIds = constants.tokenizer.encode(normalizedChunk)
-            let textEmbeddings = embedTokens(tokenIds, constants: constants)
-
-            // Fresh KV cache per chunk
-            let prefillStart = Date()
-            var kvState = try await prefillKVCache(
-                voiceData: voiceData,
-                textEmbeddings: textEmbeddings,
-                model: condModel,
-                layerKeys: condLayerKeys
-            )
-            let prefillElapsed = Date().timeIntervalSince(prefillStart)
-            logger.info(
-                "Chunk \(chunkIdx + 1) prefill: \(String(format: "%.2f", prefillElapsed))s (\(tokenIds.count) tokens)"
-            )
-
-            // Generation loop for this chunk
-            let maxGenLen = estimateMaxFrames(text: chunkText)
-            var eosStep: Int?
-            var sequence = try createNaNSequence()
-            let totalFramesAfterEos =
-                framesAfterEos + PocketTtsConstants.extraFramesAfterDetection
-
-            for step in 0..<maxGenLen {
-                let (transformerOut, eosLogit) = try await runFlowLMStep(
-                    sequence: sequence,
-                    bosEmb: bosEmb,
-                    state: &kvState,
-                    model: stepModel,
-                    layerKeys: flowlmLayerKeys
-                )
-
-                if eosLogit > PocketTtsConstants.eosThreshold && eosStep == nil {
-                    eosStep = step
-                    logger.info("Chunk \(chunkIdx + 1) EOS at step \(step)")
-                }
-
-                if let eos = eosStep, step >= eos + totalFramesAfterEos {
-                    break
-                }
-
-                let latent = try await flowDecode(
-                    transformerOut: transformerOut,
-                    numSteps: PocketTtsConstants.numLsdSteps,
-                    temperature: temperature,
-                    model: flowModel,
-                    rng: &rng
-                )
-
-                // Mimi state is continuous across chunks
-                // (denormalize + quantize baked into mimi_decoder model)
-                let frameSamples = try await runMimiDecoder(
-                    latent: latent,
-                    state: &mimiState,
-                    model: mimiModel,
-                    mimiKeys: mimiKeys
-                )
-                audioChunks.append(frameSamples)
-
-                sequence = try createSequenceFromLatent(latent)
-
-                if step % 20 == 0 {
-                    logger.info("Chunk \(chunkIdx + 1) step \(step)...")
-                }
-            }
-
-            lastEosStep = eosStep
+        var allSamples: [Float] = []
+        var frameCount = 0
+        for try await frame in stream {
+            allSamples.append(contentsOf: frame.samples)
+            frameCount += 1
         }
 
         let genElapsed = Date().timeIntervalSince(genStart)
-        logger.info(
-            "Generated \(audioChunks.count) frames in \(String(format: "%.2f", genElapsed))s")
+        logger.info("Generated \(frameCount) frames in \(String(format: "%.2f", genElapsed))s")
 
-        // 8. Concatenate audio (no peak normalization — preserve natural levels)
-        var allSamples = audioChunks.flatMap { $0 }
-
-        // De-essing
+        // De-essing (no peak normalization — preserve natural levels)
         if deEss {
             AudioPostProcessor.applyTtsPostProcessing(
                 &allSamples,
@@ -209,7 +111,7 @@ public struct PocketTtsSynthesizer {
             )
         }
 
-        // 9. Encode WAV
+        // Encode WAV
         let audioData = try AudioWAV.data(
             from: allSamples,
             sampleRate: Double(PocketTtsConstants.audioSampleRate)
@@ -221,8 +123,8 @@ public struct PocketTtsSynthesizer {
         return SynthesisResult(
             audio: audioData,
             samples: allSamples,
-            frameCount: audioChunks.count,
-            eosStep: lastEosStep
+            frameCount: frameCount,
+            eosStep: nil
         )
     }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -368,10 +368,10 @@ public struct PocketTtsSynthesizer {
         let seedValue = seed ?? UInt64.random(in: 0...UInt64.max)
 
         // One-time voice prefill. Two paths matching `prefillKVCache`:
-        //  - v2 packs (cacheSnapshot != nil): drop pre-baked K/V into cache,
-        //    skip cond_step entirely (`promptLength == 0`, so the loop in
-        //    `prefillKVCacheVoice` would be a no-op anyway).
-        //  - Flat audio prompt (legacy English): feed every voice token
+        //  - Shipped voices (cacheSnapshot != nil): drop pre-baked K/V into
+        //    cache, skip cond_step entirely (`promptLength == 0`, so the
+        //    loop in `prefillKVCacheVoice` would be a no-op anyway).
+        //  - Cloned voices (flat audio prompt): feed every voice token
         //    through cond_step.
         let voiceKVSnapshot: KVCacheState
         if let snapshot = voiceData.cacheSnapshot {
@@ -884,10 +884,10 @@ public struct PocketTtsSynthesizer {
 
     /// Look up text token embeddings from the embedding table.
     ///
-    /// Vocab size is derived from the actual loaded table because v2 language
-    /// packs ship per-language `text_embed_table` with potentially different
-    /// row counts (`PocketTtsConstants.vocabSize` only matches the legacy
-    /// English pack).
+    /// Vocab size is derived from the actual loaded table because each
+    /// language pack ships its own `text_embed_table` with potentially
+    /// different row counts (`PocketTtsConstants.vocabSize` is only the
+    /// English row count).
     static func embedTokens(
         _ tokenIds: [Int], constants: PocketTtsConstantsBundle
     ) -> [[Float]] {

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
@@ -37,9 +37,6 @@ public enum PocketTtsConstants {
 
     // MARK: - KV cache
 
-    /// Default number of transformer layers for the legacy English (6L) pack.
-    /// For multi-language packs, prefer `PocketTtsLanguage.transformerLayers`.
-    public static let kvCacheLayers: Int = 6
     /// Max KV cache positions: voice (~125) + text (≤50) + generated frames.
     public static let kvCacheMaxLen: Int = 512
 

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
@@ -54,10 +54,9 @@ public enum PocketTtsConstants {
 /// Supported PocketTTS language packs (matches upstream
 /// `kyutai/pocket-tts/languages/<id>/` folder names exactly).
 ///
-/// File layout on `FluidInference/pocket-tts-coreml`: every language ships
-/// under `v2/<id>/` with the four `.mlmodelc` packages plus
-/// `constants_bin/`. The `mimi_encoder.mlmodelc` (voice cloning) lives at
-/// the repo root and is shared across all languages.
+/// File layout on `FluidInference/pocket-tts-coreml`:
+/// - `english`: legacy root layout (`mimi_decoder_v2.mlmodelc` etc.)
+/// - other languages: `v2/<id>/` subtree with `mimi_decoder.mlmodelc`
 public enum PocketTtsLanguage: String, Sendable, CaseIterable {
     case english
     case french24L = "french_24l"
@@ -80,9 +79,10 @@ public enum PocketTtsLanguage: String, Sendable, CaseIterable {
         }
     }
 
-    /// HF subdirectory under the pocket-tts-coreml repo root
-    /// (`v2/<rawValue>` for every language).
-    public var repoSubdirectory: String {
-        "v2/\(rawValue)"
+    /// HF subdirectory under the pocket-tts-coreml repo root.
+    /// English returns `nil` to preserve the legacy root-level layout
+    /// (avoids forcing existing caches to re-download).
+    public var repoSubdirectory: String? {
+        self == .english ? nil : "v2/\(rawValue)"
     }
 }

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
@@ -37,7 +37,8 @@ public enum PocketTtsConstants {
 
     // MARK: - KV cache
 
-    /// Number of transformer layers, each with its own KV cache.
+    /// Default number of transformer layers for the legacy English (6L) pack.
+    /// For multi-language packs, prefer `PocketTtsLanguage.transformerLayers`.
     public static let kvCacheLayers: Int = 6
     /// Max KV cache positions: voice (~125) + text (≤50) + generated frames.
     public static let kvCacheMaxLen: Int = 512
@@ -51,4 +52,40 @@ public enum PocketTtsConstants {
     // MARK: - Repository
 
     public static let defaultModelsSubdirectory: String = "Models"
+}
+
+/// Supported PocketTTS language packs (matches upstream
+/// `kyutai/pocket-tts/languages/<id>/` folder names exactly).
+///
+/// File layout on `FluidInference/pocket-tts-coreml`:
+/// - `english`: legacy root layout (`mimi_decoder_v2.mlmodelc` etc.)
+/// - other languages: `v2/<id>/` subtree with `mimi_decoder.mlmodelc`
+public enum PocketTtsLanguage: String, Sendable, CaseIterable {
+    case english
+    case french24L = "french_24l"
+    case german
+    case german24L = "german_24l"
+    case italian
+    case italian24L = "italian_24l"
+    case portuguese
+    case portuguese24L = "portuguese_24l"
+    case spanish
+    case spanish24L = "spanish_24l"
+
+    /// Number of transformer layers in this language pack (6 or 24).
+    public var transformerLayers: Int {
+        switch self {
+        case .english, .german, .italian, .portuguese, .spanish:
+            return 6
+        case .french24L, .german24L, .italian24L, .portuguese24L, .spanish24L:
+            return 24
+        }
+    }
+
+    /// HF subdirectory under the pocket-tts-coreml repo root.
+    /// English returns `nil` to preserve the legacy root-level layout
+    /// (avoids forcing existing caches to re-download).
+    public var repoSubdirectory: String? {
+        self == .english ? nil : "v2/\(rawValue)"
+    }
 }

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
@@ -54,9 +54,10 @@ public enum PocketTtsConstants {
 /// Supported PocketTTS language packs (matches upstream
 /// `kyutai/pocket-tts/languages/<id>/` folder names exactly).
 ///
-/// File layout on `FluidInference/pocket-tts-coreml`:
-/// - `english`: legacy root layout (`mimi_decoder_v2.mlmodelc` etc.)
-/// - other languages: `v2/<id>/` subtree with `mimi_decoder.mlmodelc`
+/// File layout on `FluidInference/pocket-tts-coreml`: every language ships
+/// under `v2/<id>/` with the four `.mlmodelc` packages plus
+/// `constants_bin/`. The `mimi_encoder.mlmodelc` (voice cloning) lives at
+/// the repo root and is shared across all languages.
 public enum PocketTtsLanguage: String, Sendable, CaseIterable {
     case english
     case french24L = "french_24l"
@@ -79,10 +80,9 @@ public enum PocketTtsLanguage: String, Sendable, CaseIterable {
         }
     }
 
-    /// HF subdirectory under the pocket-tts-coreml repo root.
-    /// English returns `nil` to preserve the legacy root-level layout
-    /// (avoids forcing existing caches to re-download).
-    public var repoSubdirectory: String? {
-        self == .english ? nil : "v2/\(rawValue)"
+    /// HF subdirectory under the pocket-tts-coreml repo root
+    /// (`v2/<rawValue>` for every language).
+    public var repoSubdirectory: String {
+        "v2/\(rawValue)"
     }
 }

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
@@ -54,9 +54,7 @@ public enum PocketTtsConstants {
 /// Supported PocketTTS language packs (matches upstream
 /// `kyutai/pocket-tts/languages/<id>/` folder names exactly).
 ///
-/// File layout on `FluidInference/pocket-tts-coreml`:
-/// - `english`: legacy root layout (`mimi_decoder_v2.mlmodelc` etc.)
-/// - other languages: `v2/<id>/` subtree with `mimi_decoder.mlmodelc`
+/// All packs live under `v2/<id>/` on `FluidInference/pocket-tts-coreml`.
 public enum PocketTtsLanguage: String, Sendable, CaseIterable {
     case english
     case french24L = "french_24l"
@@ -80,9 +78,7 @@ public enum PocketTtsLanguage: String, Sendable, CaseIterable {
     }
 
     /// HF subdirectory under the pocket-tts-coreml repo root.
-    /// English returns `nil` to preserve the legacy root-level layout
-    /// (avoids forcing existing caches to re-download).
-    public var repoSubdirectory: String? {
-        self == .english ? nil : "v2/\(rawValue)"
+    public var repoSubdirectory: String {
+        "v2/\(rawValue)"
     }
 }

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsManager.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsManager.swift
@@ -20,18 +20,26 @@ public actor PocketTtsManager {
     private var defaultVoice: String
     private var isInitialized = false
 
+    /// The language pack this manager loads. Immutable for the lifetime of the
+    /// manager — to switch languages, create a new `PocketTtsManager`.
+    public nonisolated let language: PocketTtsLanguage
+
     /// Creates a new PocketTTS manager.
     ///
     /// - Parameters:
     ///   - defaultVoice: Default voice identifier (default: "alba").
+    ///   - language: Which upstream language pack to load. Defaults to
+    ///     `.english` for backward compatibility.
     ///   - directory: Optional override for the base cache directory.
     ///     When `nil`, uses the default platform cache location.
     public init(
         defaultVoice: String = PocketTtsConstants.defaultVoice,
+        language: PocketTtsLanguage = .english,
         directory: URL? = nil
     ) {
-        self.modelStore = PocketTtsModelStore(directory: directory)
+        self.modelStore = PocketTtsModelStore(language: language, directory: directory)
         self.defaultVoice = defaultVoice
+        self.language = language
     }
 
     public var isAvailable: Bool {

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -147,6 +147,8 @@ public struct TTS {
         var voiceFilePath: String? = nil
         var saveVoicePath: String? = nil
         var pocketLanguage: PocketTtsLanguage = .english
+        // PocketTTS deterministic-seed mode (uses session API for fixed RNG).
+        var pocketSeed: UInt64? = nil
 
         var i = 0
         while i < arguments.count {
@@ -232,17 +234,23 @@ public struct TTS {
                 }
             case "--language":
                 if i + 1 < arguments.count {
-                    let raw = arguments[i + 1]
+                    let raw = arguments[i + 1].lowercased()
                     if let parsed = PocketTtsLanguage(rawValue: raw) {
                         pocketLanguage = parsed
                     } else {
                         let supported = PocketTtsLanguage.allCases
                             .map { $0.rawValue }
                             .joined(separator: ", ")
-                        logger.warning(
-                            "Unknown PocketTTS language '\(raw)'. Supported: \(supported). Falling back to english."
+                        logger.error(
+                            "Unknown PocketTTS language '\(arguments[i + 1])'. Supported: \(supported)"
                         )
+                        return
                     }
+                    i += 1
+                }
+            case "--seed":
+                if i + 1 < arguments.count {
+                    pocketSeed = UInt64(arguments[i + 1]) ?? 42
                     i += 1
                 }
             default:
@@ -277,7 +285,7 @@ public struct TTS {
                 text: text, output: output, voice: voice, deEss: deEss,
                 metricsPath: metricsPath, cloneVoicePath: cloneVoicePath,
                 voiceFilePath: voiceFilePath, saveVoicePath: saveVoicePath,
-                language: pocketLanguage)
+                language: pocketLanguage, seed: pocketSeed)
             return
         }
 
@@ -527,7 +535,8 @@ public struct TTS {
         text: String, output: String, voice: String, deEss: Bool,
         metricsPath: String?, cloneVoicePath: String?,
         voiceFilePath: String?, saveVoicePath: String?,
-        language: PocketTtsLanguage
+        language: PocketTtsLanguage,
+        seed: UInt64? = nil
     ) async {
         do {
             let tStart = Date()
@@ -565,7 +574,30 @@ public struct TTS {
 
             let tSynth0 = Date()
             let wav: Data
-            if let voiceData = voiceData {
+            if let seed = seed {
+                logger.info("PocketTTS deterministic mode: seed=\(seed)")
+                let session: PocketTtsSession
+                if let voiceData = voiceData {
+                    session = try await manager.makeSession(
+                        voiceData: voiceData,
+                        temperature: PocketTtsConstants.temperature,
+                        seed: seed)
+                } else {
+                    session = try await manager.makeSession(
+                        voice: pocketVoice,
+                        temperature: PocketTtsConstants.temperature,
+                        seed: seed)
+                }
+                session.enqueue(text)
+                session.finish()
+                var allSamples: [Float] = []
+                for try await frame in session.frames {
+                    allSamples.append(contentsOf: frame.samples)
+                }
+                wav = try AudioWAV.data(
+                    from: allSamples,
+                    sampleRate: Double(PocketTtsConstants.audioSampleRate))
+            } else if let voiceData = voiceData {
                 wav = try await manager.synthesize(
                     text: text, voiceData: voiceData, deEss: deEss)
             } else {
@@ -839,6 +871,7 @@ public struct TTS {
                                    german, german_24l, italian, italian_24l,
                                    portuguese, portuguese_24l, spanish, spanish_24l
                                    Note: French is 24-layer only (no 6-layer pack upstream)
+              --seed N             Deterministic-mode seed (uses session API for fixed RNG)
 
             Lexicon file format:
               # Comments start with #

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -146,6 +146,7 @@ public struct TTS {
         var cloneVoicePath: String? = nil
         var voiceFilePath: String? = nil
         var saveVoicePath: String? = nil
+        var pocketLanguage: PocketTtsLanguage = .english
 
         var i = 0
         while i < arguments.count {
@@ -229,6 +230,21 @@ public struct TTS {
                     saveVoicePath = arguments[i + 1]
                     i += 1
                 }
+            case "--language":
+                if i + 1 < arguments.count {
+                    let raw = arguments[i + 1]
+                    if let parsed = PocketTtsLanguage(rawValue: raw) {
+                        pocketLanguage = parsed
+                    } else {
+                        let supported = PocketTtsLanguage.allCases
+                            .map { $0.rawValue }
+                            .joined(separator: ", ")
+                        logger.warning(
+                            "Unknown PocketTTS language '\(raw)'. Supported: \(supported). Falling back to english."
+                        )
+                    }
+                    i += 1
+                }
             default:
                 if text == nil {
                     text = argument
@@ -260,7 +276,8 @@ public struct TTS {
             await runPocketTts(
                 text: text, output: output, voice: voice, deEss: deEss,
                 metricsPath: metricsPath, cloneVoicePath: cloneVoicePath,
-                voiceFilePath: voiceFilePath, saveVoicePath: saveVoicePath)
+                voiceFilePath: voiceFilePath, saveVoicePath: saveVoicePath,
+                language: pocketLanguage)
             return
         }
 
@@ -509,14 +526,17 @@ public struct TTS {
     private static func runPocketTts(
         text: String, output: String, voice: String, deEss: Bool,
         metricsPath: String?, cloneVoicePath: String?,
-        voiceFilePath: String?, saveVoicePath: String?
+        voiceFilePath: String?, saveVoicePath: String?,
+        language: PocketTtsLanguage
     ) async {
         do {
             let tStart = Date()
             let pocketVoice =
                 voice == TtsConstants.recommendedVoice
                 ? PocketTtsConstants.defaultVoice : voice
-            let manager = PocketTtsManager(defaultVoice: pocketVoice)
+            let manager = PocketTtsManager(
+                defaultVoice: pocketVoice, language: language)
+            logger.info("PocketTTS language: \(language.rawValue)")
 
             let tLoad0 = Date()
             try await manager.initialize()
@@ -812,6 +832,13 @@ public struct TTS {
               --clone-voice FILE   Clone voice from audio file (WAV, MP3, M4A, etc.)
               --voice-file FILE    Load previously saved voice .bin file
               --save-voice FILE    Save cloned voice to .bin file for later use
+
+            PocketTTS Language Packs:
+              --language ID        Language pack (default: english)
+                                   Supported: english, french_24l,
+                                   german, german_24l, italian, italian_24l,
+                                   portuguese, portuguese_24l, spanish, spanish_24l
+                                   Note: French is 24-layer only (no 6-layer pack upstream)
 
             Lexicon file format:
               # Comments start with #

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -13,15 +13,6 @@ public struct TTS {
         return formatter.string(fromByteCount: Int64(bytes))
     }
 
-    private static func label(for variant: ModelNames.TTS.Variant) -> String {
-        switch variant {
-        case .fiveSecond:
-            return "5s"
-        case .fifteenSecond:
-            return "15s"
-        }
-    }
-
     private static func ensureArtifactsRoot() throws -> URL {
         let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
         let root = cwd.appendingPathComponent(artifactsDirectoryName, isDirectory: true)
@@ -210,9 +201,6 @@ public struct TTS {
                     }
                     i += 1
                 }
-            case "--auto-download":
-                // No-op: downloads are always ensured by the CLI
-                ()
             case "--benchmark":
                 benchmarkMode = true
             case "--no-deess":
@@ -326,14 +314,7 @@ public struct TTS {
             let tSynth1 = Date()
 
             // Write WAV
-            let outURL = {
-                let expanded = (output as NSString).expandingTildeInPath
-                if expanded.hasPrefix("/") {
-                    return URL(fileURLWithPath: expanded)
-                }
-                let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-                return cwd.appendingPathComponent(expanded)
-            }()
+            let outURL = resolveInputURL(output)
             try FileManager.default.createDirectory(
                 at: outURL.deletingLastPathComponent(), withIntermediateDirectories: true)
             try wav.write(to: outURL)
@@ -348,7 +329,7 @@ public struct TTS {
                     for variant in variants {
                         if let footprint = diagnostics.variantFootprints[variant] {
                             logger.info(
-                                "Model bundle \(label(for: variant)) size: \(formatBytes(footprint)) (\(footprint) bytes)"
+                                "Model bundle \(variantPreferenceLabel(variant)) size: \(formatBytes(footprint)) (\(footprint) bytes)"
                             )
                         }
                     }
@@ -643,16 +624,7 @@ public struct TTS {
             }
             let tSynth1 = Date()
 
-            let outURL = {
-                let expanded = (output as NSString).expandingTildeInPath
-                if expanded.hasPrefix("/") {
-                    return URL(fileURLWithPath: expanded)
-                }
-                let cwd = URL(
-                    fileURLWithPath: FileManager.default.currentDirectoryPath,
-                    isDirectory: true)
-                return cwd.appendingPathComponent(expanded)
-            }()
+            let outURL = resolveInputURL(output)
             try FileManager.default.createDirectory(
                 at: outURL.deletingLastPathComponent(),
                 withIntermediateDirectories: true)

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -531,6 +531,58 @@ public struct TTS {
         }
     }
 
+    /// Run PocketTTS in deterministic-seed mode through the session API,
+    /// applying the same de-essing post-processing as the non-seed path.
+    private static func runPocketSeededSynthesis(
+        manager: PocketTtsManager,
+        text: String,
+        voice: String,
+        voiceData: PocketTtsVoiceData?,
+        seed: UInt64,
+        deEss: Bool
+    ) async throws -> Data {
+        logger.info("PocketTTS deterministic mode: seed=\(seed)")
+        let session = try await makePocketSeededSession(
+            manager: manager, voice: voice, voiceData: voiceData, seed: seed)
+        session.enqueue(text)
+        session.finish()
+        var allSamples: [Float] = []
+        for try await frame in session.frames {
+            allSamples.append(contentsOf: frame.samples)
+        }
+        if deEss {
+            AudioPostProcessor.applyTtsPostProcessing(
+                &allSamples,
+                sampleRate: Float(PocketTtsConstants.audioSampleRate),
+                deEssAmount: -3.0,
+                smoothing: false)
+        }
+        return try AudioWAV.data(
+            from: allSamples,
+            sampleRate: Double(PocketTtsConstants.audioSampleRate))
+    }
+
+    /// Pick the right `makeSession` overload based on whether a custom
+    /// `PocketTtsVoiceData` was supplied (cloned/loaded voice) or we should
+    /// fall back to a named voice from the language pack.
+    private static func makePocketSeededSession(
+        manager: PocketTtsManager,
+        voice: String,
+        voiceData: PocketTtsVoiceData?,
+        seed: UInt64
+    ) async throws -> PocketTtsSession {
+        if let voiceData = voiceData {
+            return try await manager.makeSession(
+                voiceData: voiceData,
+                temperature: PocketTtsConstants.temperature,
+                seed: seed)
+        }
+        return try await manager.makeSession(
+            voice: voice,
+            temperature: PocketTtsConstants.temperature,
+            seed: seed)
+    }
+
     private static func runPocketTts(
         text: String, output: String, voice: String, deEss: Bool,
         metricsPath: String?, cloneVoicePath: String?,
@@ -575,28 +627,13 @@ public struct TTS {
             let tSynth0 = Date()
             let wav: Data
             if let seed = seed {
-                logger.info("PocketTTS deterministic mode: seed=\(seed)")
-                let session: PocketTtsSession
-                if let voiceData = voiceData {
-                    session = try await manager.makeSession(
-                        voiceData: voiceData,
-                        temperature: PocketTtsConstants.temperature,
-                        seed: seed)
-                } else {
-                    session = try await manager.makeSession(
-                        voice: pocketVoice,
-                        temperature: PocketTtsConstants.temperature,
-                        seed: seed)
-                }
-                session.enqueue(text)
-                session.finish()
-                var allSamples: [Float] = []
-                for try await frame in session.frames {
-                    allSamples.append(contentsOf: frame.samples)
-                }
-                wav = try AudioWAV.data(
-                    from: allSamples,
-                    sampleRate: Double(PocketTtsConstants.audioSampleRate))
+                wav = try await runPocketSeededSynthesis(
+                    manager: manager,
+                    text: text,
+                    voice: pocketVoice,
+                    voiceData: voiceData,
+                    seed: seed,
+                    deEss: deEss)
             } else if let voiceData = voiceData {
                 wav = try await manager.synthesize(
                     text: text, voiceData: voiceData, deEss: deEss)

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsLanguageTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsLanguageTests.swift
@@ -12,10 +12,37 @@ final class PocketTtsLanguageTests: XCTestCase {
 
     // MARK: - PocketTtsLanguage.repoSubdirectory
 
-    func testAllLanguagesUseV2Subdirectory() {
-        // Every language pack — including English — ships under
-        // `v2/<rawValue>/`. There's no longer a "legacy root" layout.
-        for lang in PocketTtsLanguage.allCases {
+    func testEnglishHasNoRepoSubdirectory() {
+        // English keeps the legacy root-level layout so existing caches stay
+        // valid without re-downloading into a `v2/english/` folder.
+        XCTAssertNil(PocketTtsLanguage.english.repoSubdirectory)
+    }
+
+    func testNonEnglishLanguagesUseV2Subdirectory() {
+        let expected: [(PocketTtsLanguage, String)] = [
+            (.french24L, "v2/french_24l"),
+            (.german, "v2/german"),
+            (.german24L, "v2/german_24l"),
+            (.italian, "v2/italian"),
+            (.italian24L, "v2/italian_24l"),
+            (.portuguese, "v2/portuguese"),
+            (.portuguese24L, "v2/portuguese_24l"),
+            (.spanish, "v2/spanish"),
+            (.spanish24L, "v2/spanish_24l"),
+        ]
+        for (lang, path) in expected {
+            XCTAssertEqual(
+                lang.repoSubdirectory, path,
+                "Unexpected repoSubdirectory for \(lang.rawValue)")
+        }
+    }
+
+    func testAllNonEnglishLanguagesAreCovered() {
+        // Guard against silent additions to the enum that forget to update
+        // the v2/<id>/ mapping above.
+        let nonEnglish = PocketTtsLanguage.allCases.filter { $0 != .english }
+        XCTAssertEqual(nonEnglish.count, 9)
+        for lang in nonEnglish {
             XCTAssertEqual(
                 lang.repoSubdirectory, "v2/\(lang.rawValue)",
                 "Language \(lang.rawValue) does not follow v2/<rawValue> convention")
@@ -46,14 +73,44 @@ final class PocketTtsLanguageTests: XCTestCase {
         }
     }
 
-    // MARK: - ModelNames.PocketTTS.requiredModels
+    // MARK: - ModelNames.PocketTTS.requiredModels(for:)
 
-    func testRequiredModelsContainsAllPackComponents() {
-        let models = ModelNames.PocketTTS.requiredModels
+    func testEnglishRequiredModelsUsesLegacyMimi() {
+        // English keeps `mimi_decoder_v2.mlmodelc` for backward-compat with
+        // the original repo layout on HuggingFace.
+        let models = ModelNames.PocketTTS.requiredModels(for: .english)
+        XCTAssertTrue(models.contains(ModelNames.PocketTTS.mimiDecoderLegacyFile))
+        XCTAssertFalse(models.contains(ModelNames.PocketTTS.mimiDecoderV2File))
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.condStepFile))
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.flowlmStepFile))
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.flowDecoderFile))
-        XCTAssertTrue(models.contains(ModelNames.PocketTTS.mimiDecoderFile))
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.constantsBinDir))
+    }
+
+    func testNonEnglishRequiredModelsUsesNewMimi() {
+        // Other languages ship `mimi_decoder.mlmodelc` (not the legacy `_v2`).
+        for lang in PocketTtsLanguage.allCases where lang != .english {
+            let models = ModelNames.PocketTTS.requiredModels(for: lang)
+            XCTAssertTrue(
+                models.contains(ModelNames.PocketTTS.mimiDecoderV2File),
+                "\(lang.rawValue) should require mimi_decoder.mlmodelc")
+            XCTAssertFalse(
+                models.contains(ModelNames.PocketTTS.mimiDecoderLegacyFile),
+                "\(lang.rawValue) should NOT require legacy mimi_decoder_v2.mlmodelc")
+        }
+    }
+
+    // MARK: - ModelNames.PocketTTS.mimiDecoderFile(for:)
+
+    func testMimiDecoderFilenameDispatch() {
+        XCTAssertEqual(
+            ModelNames.PocketTTS.mimiDecoderFile(for: .english),
+            ModelNames.PocketTTS.mimiDecoderLegacyFile)
+        for lang in PocketTtsLanguage.allCases where lang != .english {
+            XCTAssertEqual(
+                ModelNames.PocketTTS.mimiDecoderFile(for: lang),
+                ModelNames.PocketTTS.mimiDecoderV2File,
+                "\(lang.rawValue) should use mimi_decoder.mlmodelc")
+        }
     }
 }

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsLanguageTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsLanguageTests.swift
@@ -12,37 +12,10 @@ final class PocketTtsLanguageTests: XCTestCase {
 
     // MARK: - PocketTtsLanguage.repoSubdirectory
 
-    func testEnglishHasNoRepoSubdirectory() {
-        // English keeps the legacy root-level layout so existing caches stay
-        // valid without re-downloading into a `v2/english/` folder.
-        XCTAssertNil(PocketTtsLanguage.english.repoSubdirectory)
-    }
-
-    func testNonEnglishLanguagesUseV2Subdirectory() {
-        let expected: [(PocketTtsLanguage, String)] = [
-            (.french24L, "v2/french_24l"),
-            (.german, "v2/german"),
-            (.german24L, "v2/german_24l"),
-            (.italian, "v2/italian"),
-            (.italian24L, "v2/italian_24l"),
-            (.portuguese, "v2/portuguese"),
-            (.portuguese24L, "v2/portuguese_24l"),
-            (.spanish, "v2/spanish"),
-            (.spanish24L, "v2/spanish_24l"),
-        ]
-        for (lang, path) in expected {
-            XCTAssertEqual(
-                lang.repoSubdirectory, path,
-                "Unexpected repoSubdirectory for \(lang.rawValue)")
-        }
-    }
-
-    func testAllNonEnglishLanguagesAreCovered() {
-        // Guard against silent additions to the enum that forget to update
-        // the v2/<id>/ mapping above.
-        let nonEnglish = PocketTtsLanguage.allCases.filter { $0 != .english }
-        XCTAssertEqual(nonEnglish.count, 9)
-        for lang in nonEnglish {
+    func testAllLanguagesUseV2Subdirectory() {
+        // Every language pack — including English — ships under
+        // `v2/<rawValue>/`. There's no longer a "legacy root" layout.
+        for lang in PocketTtsLanguage.allCases {
             XCTAssertEqual(
                 lang.repoSubdirectory, "v2/\(lang.rawValue)",
                 "Language \(lang.rawValue) does not follow v2/<rawValue> convention")
@@ -73,44 +46,14 @@ final class PocketTtsLanguageTests: XCTestCase {
         }
     }
 
-    // MARK: - ModelNames.PocketTTS.requiredModels(for:)
+    // MARK: - ModelNames.PocketTTS.requiredModels
 
-    func testEnglishRequiredModelsUsesLegacyMimi() {
-        // English keeps `mimi_decoder_v2.mlmodelc` for backward-compat with
-        // the original repo layout on HuggingFace.
-        let models = ModelNames.PocketTTS.requiredModels(for: .english)
-        XCTAssertTrue(models.contains(ModelNames.PocketTTS.mimiDecoderLegacyFile))
-        XCTAssertFalse(models.contains(ModelNames.PocketTTS.mimiDecoderV2File))
+    func testRequiredModelsContainsAllPackComponents() {
+        let models = ModelNames.PocketTTS.requiredModels
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.condStepFile))
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.flowlmStepFile))
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.flowDecoderFile))
+        XCTAssertTrue(models.contains(ModelNames.PocketTTS.mimiDecoderFile))
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.constantsBinDir))
-    }
-
-    func testNonEnglishRequiredModelsUsesNewMimi() {
-        // Other languages ship `mimi_decoder.mlmodelc` (not the legacy `_v2`).
-        for lang in PocketTtsLanguage.allCases where lang != .english {
-            let models = ModelNames.PocketTTS.requiredModels(for: lang)
-            XCTAssertTrue(
-                models.contains(ModelNames.PocketTTS.mimiDecoderV2File),
-                "\(lang.rawValue) should require mimi_decoder.mlmodelc")
-            XCTAssertFalse(
-                models.contains(ModelNames.PocketTTS.mimiDecoderLegacyFile),
-                "\(lang.rawValue) should NOT require legacy mimi_decoder_v2.mlmodelc")
-        }
-    }
-
-    // MARK: - ModelNames.PocketTTS.mimiDecoderFile(for:)
-
-    func testMimiDecoderFilenameDispatch() {
-        XCTAssertEqual(
-            ModelNames.PocketTTS.mimiDecoderFile(for: .english),
-            ModelNames.PocketTTS.mimiDecoderLegacyFile)
-        for lang in PocketTtsLanguage.allCases where lang != .english {
-            XCTAssertEqual(
-                ModelNames.PocketTTS.mimiDecoderFile(for: lang),
-                ModelNames.PocketTTS.mimiDecoderV2File,
-                "\(lang.rawValue) should use mimi_decoder.mlmodelc")
-        }
     }
 }

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsLanguageTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsLanguageTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Pure-logic unit tests for PocketTTS multi-language plumbing.
+///
+/// These tests exercise the path/filename/layer-count derivation that drives
+/// HuggingFace downloads and CoreML model selection. They do not require any
+/// model files or network access.
+final class PocketTtsLanguageTests: XCTestCase {
+
+    // MARK: - PocketTtsLanguage.repoSubdirectory
+
+    func testEnglishHasNoRepoSubdirectory() {
+        // English keeps the legacy root-level layout so existing caches stay
+        // valid without re-downloading into a `v2/english/` folder.
+        XCTAssertNil(PocketTtsLanguage.english.repoSubdirectory)
+    }
+
+    func testNonEnglishLanguagesUseV2Subdirectory() {
+        let expected: [(PocketTtsLanguage, String)] = [
+            (.french24L, "v2/french_24l"),
+            (.german, "v2/german"),
+            (.german24L, "v2/german_24l"),
+            (.italian, "v2/italian"),
+            (.italian24L, "v2/italian_24l"),
+            (.portuguese, "v2/portuguese"),
+            (.portuguese24L, "v2/portuguese_24l"),
+            (.spanish, "v2/spanish"),
+            (.spanish24L, "v2/spanish_24l"),
+        ]
+        for (lang, path) in expected {
+            XCTAssertEqual(
+                lang.repoSubdirectory, path,
+                "Unexpected repoSubdirectory for \(lang.rawValue)")
+        }
+    }
+
+    func testAllNonEnglishLanguagesAreCovered() {
+        // Guard against silent additions to the enum that forget to update
+        // the v2/<id>/ mapping above.
+        let nonEnglish = PocketTtsLanguage.allCases.filter { $0 != .english }
+        XCTAssertEqual(nonEnglish.count, 9)
+        for lang in nonEnglish {
+            XCTAssertEqual(
+                lang.repoSubdirectory, "v2/\(lang.rawValue)",
+                "Language \(lang.rawValue) does not follow v2/<rawValue> convention")
+        }
+    }
+
+    // MARK: - PocketTtsLanguage.transformerLayers
+
+    func testTransformerLayerCounts() {
+        // 6L variants (English plus 4 base non-English packs)
+        let sixLayer: [PocketTtsLanguage] = [
+            .english, .german, .italian, .portuguese, .spanish,
+        ]
+        for lang in sixLayer {
+            XCTAssertEqual(
+                lang.transformerLayers, 6,
+                "\(lang.rawValue) should be a 6-layer pack")
+        }
+
+        // 24L variants (note: French ships only the 24L variant upstream)
+        let twentyFourLayer: [PocketTtsLanguage] = [
+            .french24L, .german24L, .italian24L, .portuguese24L, .spanish24L,
+        ]
+        for lang in twentyFourLayer {
+            XCTAssertEqual(
+                lang.transformerLayers, 24,
+                "\(lang.rawValue) should be a 24-layer pack")
+        }
+    }
+
+    func testEveryLanguageHasValidLayerCount() {
+        // Sanity guard: enum may grow but every variant must be 6 or 24.
+        for lang in PocketTtsLanguage.allCases {
+            XCTAssertTrue(
+                lang.transformerLayers == 6 || lang.transformerLayers == 24,
+                "Unexpected layer count \(lang.transformerLayers) for \(lang.rawValue)")
+        }
+    }
+
+    // MARK: - ModelNames.PocketTTS.requiredModels(for:)
+
+    func testEnglishRequiredModelsUsesLegacyMimi() {
+        // English keeps `mimi_decoder_v2.mlmodelc` for backward-compat with
+        // the original repo layout on HuggingFace.
+        let models = ModelNames.PocketTTS.requiredModels(for: .english)
+        XCTAssertTrue(models.contains(ModelNames.PocketTTS.mimiDecoderLegacyFile))
+        XCTAssertFalse(models.contains(ModelNames.PocketTTS.mimiDecoderV2File))
+        XCTAssertTrue(models.contains(ModelNames.PocketTTS.condStepFile))
+        XCTAssertTrue(models.contains(ModelNames.PocketTTS.flowlmStepFile))
+        XCTAssertTrue(models.contains(ModelNames.PocketTTS.flowDecoderFile))
+        XCTAssertTrue(models.contains(ModelNames.PocketTTS.constantsBinDir))
+    }
+
+    func testNonEnglishRequiredModelsUsesNewMimi() {
+        // Other languages ship `mimi_decoder.mlmodelc` (not the legacy `_v2`).
+        for lang in PocketTtsLanguage.allCases where lang != .english {
+            let models = ModelNames.PocketTTS.requiredModels(for: lang)
+            XCTAssertTrue(
+                models.contains(ModelNames.PocketTTS.mimiDecoderV2File),
+                "\(lang.rawValue) should require mimi_decoder.mlmodelc")
+            XCTAssertFalse(
+                models.contains(ModelNames.PocketTTS.mimiDecoderLegacyFile),
+                "\(lang.rawValue) should NOT require legacy mimi_decoder_v2.mlmodelc")
+        }
+    }
+
+    func testRequiredModelsAlwaysHasFiveEntries() {
+        // 4 model directories + 1 constants_bin/ directory.
+        for lang in PocketTtsLanguage.allCases {
+            let models = ModelNames.PocketTTS.requiredModels(for: lang)
+            XCTAssertEqual(
+                models.count, 5,
+                "\(lang.rawValue) requiredModels should have 5 entries")
+        }
+    }
+
+    // MARK: - ModelNames.PocketTTS.mimiDecoderFile(for:)
+
+    func testMimiDecoderFilenameDispatch() {
+        XCTAssertEqual(
+            ModelNames.PocketTTS.mimiDecoderFile(for: .english),
+            ModelNames.PocketTTS.mimiDecoderLegacyFile)
+        for lang in PocketTtsLanguage.allCases where lang != .english {
+            XCTAssertEqual(
+                ModelNames.PocketTTS.mimiDecoderFile(for: lang),
+                ModelNames.PocketTTS.mimiDecoderV2File,
+                "\(lang.rawValue) should use mimi_decoder.mlmodelc")
+        }
+    }
+
+    // MARK: - Backward-compat alias
+
+    func testLegacyRequiredModelsMatchesEnglish() {
+        // The legacy `requiredModels` (no language arg) must remain identical
+        // to the English-language set so old callers keep working.
+        XCTAssertEqual(
+            ModelNames.PocketTTS.requiredModels,
+            ModelNames.PocketTTS.requiredModels(for: .english))
+    }
+}

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsLanguageTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsLanguageTests.swift
@@ -73,15 +73,6 @@ final class PocketTtsLanguageTests: XCTestCase {
         }
     }
 
-    func testEveryLanguageHasValidLayerCount() {
-        // Sanity guard: enum may grow but every variant must be 6 or 24.
-        for lang in PocketTtsLanguage.allCases {
-            XCTAssertTrue(
-                lang.transformerLayers == 6 || lang.transformerLayers == 24,
-                "Unexpected layer count \(lang.transformerLayers) for \(lang.rawValue)")
-        }
-    }
-
     // MARK: - ModelNames.PocketTTS.requiredModels(for:)
 
     func testEnglishRequiredModelsUsesLegacyMimi() {
@@ -109,16 +100,6 @@ final class PocketTtsLanguageTests: XCTestCase {
         }
     }
 
-    func testRequiredModelsAlwaysHasFiveEntries() {
-        // 4 model directories + 1 constants_bin/ directory.
-        for lang in PocketTtsLanguage.allCases {
-            let models = ModelNames.PocketTTS.requiredModels(for: lang)
-            XCTAssertEqual(
-                models.count, 5,
-                "\(lang.rawValue) requiredModels should have 5 entries")
-        }
-    }
-
     // MARK: - ModelNames.PocketTTS.mimiDecoderFile(for:)
 
     func testMimiDecoderFilenameDispatch() {
@@ -131,15 +112,5 @@ final class PocketTtsLanguageTests: XCTestCase {
                 ModelNames.PocketTTS.mimiDecoderV2File,
                 "\(lang.rawValue) should use mimi_decoder.mlmodelc")
         }
-    }
-
-    // MARK: - Backward-compat alias
-
-    func testLegacyRequiredModelsMatchesEnglish() {
-        // The legacy `requiredModels` (no language arg) must remain identical
-        // to the English-language set so old callers keep working.
-        XCTAssertEqual(
-            ModelNames.PocketTTS.requiredModels,
-            ModelNames.PocketTTS.requiredModels(for: .english))
     }
 }

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsLanguageTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsLanguageTests.swift
@@ -12,37 +12,9 @@ final class PocketTtsLanguageTests: XCTestCase {
 
     // MARK: - PocketTtsLanguage.repoSubdirectory
 
-    func testEnglishHasNoRepoSubdirectory() {
-        // English keeps the legacy root-level layout so existing caches stay
-        // valid without re-downloading into a `v2/english/` folder.
-        XCTAssertNil(PocketTtsLanguage.english.repoSubdirectory)
-    }
-
-    func testNonEnglishLanguagesUseV2Subdirectory() {
-        let expected: [(PocketTtsLanguage, String)] = [
-            (.french24L, "v2/french_24l"),
-            (.german, "v2/german"),
-            (.german24L, "v2/german_24l"),
-            (.italian, "v2/italian"),
-            (.italian24L, "v2/italian_24l"),
-            (.portuguese, "v2/portuguese"),
-            (.portuguese24L, "v2/portuguese_24l"),
-            (.spanish, "v2/spanish"),
-            (.spanish24L, "v2/spanish_24l"),
-        ]
-        for (lang, path) in expected {
-            XCTAssertEqual(
-                lang.repoSubdirectory, path,
-                "Unexpected repoSubdirectory for \(lang.rawValue)")
-        }
-    }
-
-    func testAllNonEnglishLanguagesAreCovered() {
-        // Guard against silent additions to the enum that forget to update
-        // the v2/<id>/ mapping above.
-        let nonEnglish = PocketTtsLanguage.allCases.filter { $0 != .english }
-        XCTAssertEqual(nonEnglish.count, 9)
-        for lang in nonEnglish {
+    func testAllLanguagesUseV2Subdirectory() {
+        // Every language pack lives under `v2/<rawValue>/` on the HF repo.
+        for lang in PocketTtsLanguage.allCases {
             XCTAssertEqual(
                 lang.repoSubdirectory, "v2/\(lang.rawValue)",
                 "Language \(lang.rawValue) does not follow v2/<rawValue> convention")
@@ -52,7 +24,7 @@ final class PocketTtsLanguageTests: XCTestCase {
     // MARK: - PocketTtsLanguage.transformerLayers
 
     func testTransformerLayerCounts() {
-        // 6L variants (English plus 4 base non-English packs)
+        // 6L variants
         let sixLayer: [PocketTtsLanguage] = [
             .english, .german, .italian, .portuguese, .spanish,
         ]
@@ -73,44 +45,14 @@ final class PocketTtsLanguageTests: XCTestCase {
         }
     }
 
-    // MARK: - ModelNames.PocketTTS.requiredModels(for:)
+    // MARK: - ModelNames.PocketTTS.requiredModels
 
-    func testEnglishRequiredModelsUsesLegacyMimi() {
-        // English keeps `mimi_decoder_v2.mlmodelc` for backward-compat with
-        // the original repo layout on HuggingFace.
-        let models = ModelNames.PocketTTS.requiredModels(for: .english)
-        XCTAssertTrue(models.contains(ModelNames.PocketTTS.mimiDecoderLegacyFile))
-        XCTAssertFalse(models.contains(ModelNames.PocketTTS.mimiDecoderV2File))
+    func testRequiredModels() {
+        let models = ModelNames.PocketTTS.requiredModels
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.condStepFile))
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.flowlmStepFile))
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.flowDecoderFile))
+        XCTAssertTrue(models.contains(ModelNames.PocketTTS.mimiDecoderFile))
         XCTAssertTrue(models.contains(ModelNames.PocketTTS.constantsBinDir))
-    }
-
-    func testNonEnglishRequiredModelsUsesNewMimi() {
-        // Other languages ship `mimi_decoder.mlmodelc` (not the legacy `_v2`).
-        for lang in PocketTtsLanguage.allCases where lang != .english {
-            let models = ModelNames.PocketTTS.requiredModels(for: lang)
-            XCTAssertTrue(
-                models.contains(ModelNames.PocketTTS.mimiDecoderV2File),
-                "\(lang.rawValue) should require mimi_decoder.mlmodelc")
-            XCTAssertFalse(
-                models.contains(ModelNames.PocketTTS.mimiDecoderLegacyFile),
-                "\(lang.rawValue) should NOT require legacy mimi_decoder_v2.mlmodelc")
-        }
-    }
-
-    // MARK: - ModelNames.PocketTTS.mimiDecoderFile(for:)
-
-    func testMimiDecoderFilenameDispatch() {
-        XCTAssertEqual(
-            ModelNames.PocketTTS.mimiDecoderFile(for: .english),
-            ModelNames.PocketTTS.mimiDecoderLegacyFile)
-        for lang in PocketTtsLanguage.allCases where lang != .english {
-            XCTAssertEqual(
-                ModelNames.PocketTTS.mimiDecoderFile(for: lang),
-                ModelNames.PocketTTS.mimiDecoderV2File,
-                "\(lang.rawValue) should use mimi_decoder.mlmodelc")
-        }
     }
 }

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsSessionTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsSessionTests.swift
@@ -45,7 +45,8 @@ final class PocketTtsSessionTests: XCTestCase {
     // MARK: - KV Cache Clone Tests
 
     func testCloneKVCacheStateProducesIndependentCopy() throws {
-        let original = try PocketTtsSynthesizer.emptyKVCacheState()
+        let original = try PocketTtsSynthesizer.emptyKVCacheState(
+            layers: PocketTtsLanguage.english.transformerLayers)
 
         // Write a known value into the original
         let ptr = original.caches[0].dataPointer.bindMemory(to: Float.self, capacity: 1)
@@ -70,7 +71,8 @@ final class PocketTtsSessionTests: XCTestCase {
     }
 
     func testCloneKVCacheStatePreservesShape() throws {
-        let original = try PocketTtsSynthesizer.emptyKVCacheState()
+        let original = try PocketTtsSynthesizer.emptyKVCacheState(
+            layers: PocketTtsLanguage.english.transformerLayers)
         let clone = try PocketTtsSynthesizer.cloneKVCacheState(original)
 
         XCTAssertEqual(clone.caches.count, original.caches.count)


### PR DESCRIPTION
## Summary

Adds first-class support for PocketTTS language packs upstream `kyutai/pocket-tts` just published, tracking issue #49. Users pick a language at manager construction; all packs (including English) are downloaded from `v2/<lang>/` on `FluidInference/pocket-tts-coreml`.

The `v2/` packs ship **int8-quantized `.mlmodelc`** for `cond_step`, `flowlm_step`, `flow_decoder`, and `mimi_decoder` — meaningfully smaller download + lower runtime memory than the previous fp16 root-level packs, with no measurable quality regression on shipped voices.

### Supported languages

| ID              | Layers | HF subtree           |
|-----------------|--------|----------------------|
| `english`       | 6      | `v2/english`         |
| `french_24l`    | 24     | `v2/french_24l`      |
| `german`        | 6      | `v2/german`          |
| `german_24l`    | 24     | `v2/german_24l`      |
| `italian`       | 6      | `v2/italian`         |
| `italian_24l`   | 24     | `v2/italian_24l`     |
| `portuguese`    | 6      | `v2/portuguese`      |
| `portuguese_24l`| 24     | `v2/portuguese_24l`  |
| `spanish`       | 6      | `v2/spanish`         |
| `spanish_24l`   | 24     | `v2/spanish_24l`     |

French ships 24-layer only upstream; no 6-layer French pack exists.

## Changes

- **int8-quantized v2 `.mlmodelc`**: all four per-language CoreML packages (`cond_step`, `flowlm_step`, `flow_decoder`, `mimi_decoder`) are int8-quantized. The `mimi_encoder` (voice cloning, language-agnostic) is unchanged.
- **`PocketTtsLanguage`**: new enum (10 cases) with `repoSubdirectory` (always `"v2/<rawValue>"`) and `transformerLayers` (6 or 24).
- **`ModelNames.PocketTTS`**: single `mimiDecoderFile = "mimi_decoder.mlmodelc"` and single `requiredModels` set covering all language packs uniformly.
- **`PocketTtsLayerKeys`**: discovers KV-cache I/O names at runtime so 6L and 24L packs share the same inference path. `discover(...)` requires `expectedLayers: Int` (6 or 24) for early sanity-check.
- **`PocketTtsMimiKeys`**: discovers the Mimi decoder's audio output + per-state input→output pairing dynamically (pass-through inputs first, then shape-bucket pairing in canonical order).
- **Voice safetensors prebakes**: every language pack ships `<voice>.safetensors` containing pre-computed LM transformer KV cache snapshots (per-layer `[2, 1, seqLen, 16, 64]` F32 + I64 offset). `PocketTtsConstantsLoader.loadVoiceSnapshot` parses the safetensors header (8-byte LE u64 + JSON) and extracts per-layer cache + offset tensors. `PocketTtsSynthesizer.kvCacheStateFromSnapshot` copies K/V blocks into the runtime `[2, 1, kvCacheMaxLen, 16, 64]` state independently. Skips the per-token `cond_step` voice prefill.
- **`PocketTtsResourceDownloader`**: `ensureModels(language:)` always fetches the requested `v2/<lang>/` subtree via `DownloadUtils.downloadSubdirectory`. `ensureVoice` downloads `<voice>.safetensors`. `ensureMimiEncoder()` lazily fetches the language-agnostic encoder for voice cloning without pulling a full language pack.
- **`PocketTtsModelStore` / `PocketTtsManager` / `PocketTtsSession` / `PocketTtsSynthesizer`**: language threaded through load + constants + KV-cache sizing. Voice data is cached per `(language, voice)`. Mimi keys discovered + cached per language.
- **Voice cloning across languages**: Mimi encoder is shared; cloned `PocketTtsVoiceData` from one language's manager can be fed to another.
- **CLI**: `fluidaudiocli tts --backend pocket --language <id>` (default `english`). Unknown values log the supported list and fall back to English.
- **Docs**: `Documentation/TTS/PocketTTS.md` gains a Languages section + cross-language cloning example.

## Tests

- `PocketTtsLanguageTests` — pure-logic cases covering `repoSubdirectory`, `transformerLayers`, and `requiredModels`. No model download / no network.
- Full PocketTTS test suite: 16/16 passing (`swift test --filter PocketTts`).

## Test plan

- [x] `swift build` — clean Release build
- [x] `swift format lint --recursive --configuration .swift-format` — clean (no new warnings)
- [x] `swift test --filter PocketTts` — 16/16 pass
- [x] Manual: `tts "Hello world" --backend pocket --output /tmp/en.wav`
- [x] Manual: `tts "Hola, esto es una prueba en español." --backend pocket --language spanish --voice alba`
- [x] Manual: `tts --backend pocket --language german --voice alba`
- [x] Manual: `tts --backend pocket --language italian --voice alba`
- [x] Manual: `tts --backend pocket --language portuguese --voice alba`
- [ ] Manual: 24L variants (french_24l, *_24l) — code path is layer-count agnostic but not exercised locally due to disk constraints

## Non-goals

- Runtime language switching on a live `PocketTtsManager` (create a new manager instead).
- Auto-inferring language from text.
- French 6-layer (upstream did not ship it).

Closes #49