### PR TITLE
feat(tts/kokoro): add MultiArrayPool drain for memory release

### DIFF
--- a/Sources/FluidAudio/TTS/Kokoro/KokoroTtsManager.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/KokoroTtsManager.swift
@@ -227,6 +227,19 @@ public final class KokoroTtsManager {
         ensuredVoices.removeAll(keepingCapacity: false)
     }
 
+    /// Drain the synthesizer's static `MultiArrayPool` so the per-chunk
+    /// preallocated buffers it retains (input_ids, attention_mask, phases,
+    /// source_noise) are released. Independent of `cleanup()` — leaves the
+    /// loaded Core ML models in place so the next synthesize call doesn't
+    /// pay another cold-start cost.
+    ///
+    /// Useful between long renders, on memory-pressure warnings, or any
+    /// time the manager is idle for more than a few seconds. The pool
+    /// refills on demand on the next synthesize.
+    public func purgeCachedBuffers() async {
+        await KokoroSynthesizer.purgePoolBuffers()
+    }
+
     private func voiceName(for speakerId: Int) -> String {
         if speakerId == defaultSpeakerId {
             return defaultVoice

--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Postprocess/KokoroSynthesizer+Types.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Postprocess/KokoroSynthesizer+Types.swift
@@ -45,6 +45,47 @@ extension KokoroSynthesizer {
         }
     }
 
+    /// Predicted duration for a single phoneme/input token, derived from the model's `pred_dur` output.
+    /// Times are in seconds, measured from the start of the chunk's audio (`ChunkInfo.samples`).
+    public struct TokenTiming: Sendable {
+        /// Phoneme glyph from the chunker's vocabulary lookup.
+        public let phoneme: String
+        /// Cumulative start time in seconds, measured from the start of this chunk's audio.
+        public let startTime: TimeInterval
+        /// End time in seconds, measured from the start of this chunk's audio.
+        public let endTime: TimeInterval
+        /// Raw frame count from the model's `pred_dur` output.
+        /// One frame = `TtsConstants.kokoroFrameSamples` (600) samples = 25 ms at 24 kHz.
+        public let frames: Float
+
+        public init(phoneme: String, startTime: TimeInterval, endTime: TimeInterval, frames: Float) {
+            self.phoneme = phoneme
+            self.startTime = startTime
+            self.endTime = endTime
+            self.frames = frames
+        }
+    }
+
+    /// Word-level timing aggregated from `TokenTiming`s using the chunker's phoneme→atom alignment.
+    /// Times are in seconds, measured from the start of the chunk's audio (`ChunkInfo.samples`).
+    public struct WordTiming: Sendable {
+        /// Source word/atom text — matches an entry in `ChunkInfo.atoms`.
+        public let word: String
+        /// Index into `ChunkInfo.atoms` for traceability.
+        public let atomIndex: Int
+        /// Start time in seconds, measured from the start of this chunk's audio.
+        public let startTime: TimeInterval
+        /// End time in seconds, measured from the start of this chunk's audio.
+        public let endTime: TimeInterval
+
+        public init(word: String, atomIndex: Int, startTime: TimeInterval, endTime: TimeInterval) {
+            self.word = word
+            self.atomIndex = atomIndex
+            self.startTime = startTime
+            self.endTime = endTime
+        }
+    }
+
     public struct ChunkInfo: Sendable {
         public let index: Int
         public let text: String
@@ -55,6 +96,12 @@ extension KokoroSynthesizer {
         public let tokenCount: Int
         public let samples: [Float]
         public let variant: ModelNames.TTS.Variant
+        /// Per-phoneme timing derived from the model's duration predictor.
+        /// `nil` when the underlying Core ML model didn't expose `pred_dur` for this chunk.
+        public let tokenTimings: [TokenTiming]?
+        /// Per-word timing aggregated from `tokenTimings` via the chunker's phoneme→atom alignment.
+        /// `nil` when `tokenTimings` is nil or alignment couldn't be built.
+        public let wordTimings: [WordTiming]?
 
         public init(
             index: Int,
@@ -65,7 +112,9 @@ extension KokoroSynthesizer {
             pauseAfterMs: Int,
             tokenCount: Int,
             samples: [Float],
-            variant: ModelNames.TTS.Variant
+            variant: ModelNames.TTS.Variant,
+            tokenTimings: [TokenTiming]? = nil,
+            wordTimings: [WordTiming]? = nil
         ) {
             self.index = index
             self.text = text
@@ -76,6 +125,8 @@ extension KokoroSynthesizer {
             self.tokenCount = tokenCount
             self.samples = samples
             self.variant = variant
+            self.tokenTimings = tokenTimings
+            self.wordTimings = wordTimings
         }
     }
 

--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Preprocess/KokoroChunker.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Preprocess/KokoroChunker.swift
@@ -9,6 +9,11 @@ struct TextChunk: Sendable {
     let words: [String]
     let atoms: [String]
     let phonemes: [String]
+    /// For each entry in `atoms`, the range of indices in `phonemes` that produced it.
+    /// Always satisfies `phonemeRanges.count == atoms.count`. Inter-atom separator phonemes
+    /// (single-space tokens between words) are not covered by any range and therefore are
+    /// not attributed to any atom.
+    let phonemeRanges: [Range<Int>]
     let totalFrames: Float
     let pauseAfterMs: Int
     let text: String
@@ -296,6 +301,7 @@ enum KokoroChunker {
         var chunkWords: [String] = []
         var chunkAtoms: [String] = []
         var chunkPhonemes: [String] = []
+        var chunkPhonemeRanges: [Range<Int>] = []
         var chunkTokenCount = 0
         var needsWordSeparator = false
         var missing: Set<String> = []
@@ -315,6 +321,7 @@ enum KokoroChunker {
                     words: chunkWords,
                     atoms: chunkAtoms,
                     phonemes: chunkPhonemes,
+                    phonemeRanges: chunkPhonemeRanges,
                     totalFrames: 0,
                     pauseAfterMs: 0,
                     text: textValue
@@ -323,6 +330,7 @@ enum KokoroChunker {
             chunkWords.removeAll(keepingCapacity: true)
             chunkAtoms.removeAll(keepingCapacity: true)
             chunkPhonemes.removeAll(keepingCapacity: true)
+            chunkPhonemeRanges.removeAll(keepingCapacity: true)
             chunkTokenCount = 0
             needsWordSeparator = false
         }
@@ -426,10 +434,12 @@ enum KokoroChunker {
                     chunkTokenCount += 1
                 }
 
+                let wordPhonemeStart = chunkPhonemes.count
                 chunkPhonemes.append(contentsOf: resolvedPhonemes)
                 chunkTokenCount += resolvedPhonemes.count
                 chunkWords.append(original)
                 chunkAtoms.append(original)
+                chunkPhonemeRanges.append(wordPhonemeStart..<chunkPhonemes.count)
                 needsWordSeparator = true
                 wordIndex += 1
 
@@ -438,9 +448,11 @@ enum KokoroChunker {
                 if chunkTokenCount + 1 > capacity && !chunkPhonemes.isEmpty {
                     flushChunk()
                 }
+                let punctPhonemeStart = chunkPhonemes.count
                 chunkPhonemes.append(symbol)
                 chunkTokenCount += 1
                 chunkAtoms.append(symbol)
+                chunkPhonemeRanges.append(punctPhonemeStart..<chunkPhonemes.count)
                 needsWordSeparator = false
             }
         }

--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer+Memory.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer+Memory.swift
@@ -78,6 +78,25 @@ extension KokoroSynthesizer {
             storage[key] = pool
         }
 
+        /// Drop every cached `MLMultiArray` so the underlying buffers can be
+        /// reclaimed by the system. The pool is empty after this call —
+        /// subsequent `rent` calls will allocate fresh arrays as needed.
+        ///
+        /// Use this to release the high-water-mark memory the pool retains
+        /// after a render finishes (per-chunk source noise, attention masks,
+        /// reference style buffers, etc.). Long-running synthesis processes
+        /// can otherwise hold hundreds of MB indefinitely even when idle.
+        func drain() {
+            storage.removeAll(keepingCapacity: false)
+        }
+
+        /// Number of arrays currently retained, summed across every shape
+        /// bucket. Useful for diagnostics — log before/after `drain()` to
+        /// confirm the pool actually shrank.
+        var cachedCount: Int {
+            storage.values.reduce(0) { $0 + $1.count }
+        }
+
         private func zero(_ array: MLMultiArray) {
             let elementCount = array.count
             guard elementCount > 0 else { return }

--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer.swift
@@ -250,13 +250,15 @@ public struct KokoroSynthesizer {
     }
 
     /// Synthesize a single chunk of text using precomputed token IDs.
+    /// Returns the audio samples, model prediction time, and (when the model exposes it) the
+    /// per-input-token duration prediction sliced to the true input length (padding excluded).
     private static func synthesizeChunk(
         _ chunk: TextChunk,
         inputIds: [Int32],
         variant: ModelNames.TTS.Variant,
         targetTokens: Int,
         referenceVector: [Float]
-    ) async throws -> ([Float], TimeInterval) {
+    ) async throws -> (samples: [Float], predictionTime: TimeInterval, predDur: [Float]?) {
         guard !inputIds.isEmpty else {
             throw TTSError.processingFailed("No input IDs generated for chunk: \(chunk.words.joined(separator: " "))")
         }
@@ -413,6 +415,7 @@ public struct KokoroSynthesizer {
 
         // Compute audio length from pred_dur (model's audio_length_samples output is broken)
         var effectiveCount = audioArrayUnwrapped.count
+        var perTokenDurations: [Float]? = nil
 
         if let predDurArray = output.featureValue(for: "pred_dur")?.multiArrayValue {
             // Sum pred_dur to get total frames
@@ -426,6 +429,18 @@ public struct KokoroSynthesizer {
             let predictedSamples = Int(round(totalFrames * 600.0))
             if predictedSamples > 0 {
                 effectiveCount = min(predictedSamples, audioArrayUnwrapped.count)
+            }
+
+            // Capture the per-token slice for downstream timing assembly. The model returns
+            // `pred_dur` padded to `targetTokens`; slice to the true input length so callers
+            // see one entry per real input token (matching `chunk.phonemes`).
+            let trueLen = min(inputIds.count, targetTokens, predDurArray.count)
+            if trueLen > 0 {
+                var slice = [Float](repeating: 0, count: trueLen)
+                for i in 0..<trueLen {
+                    slice[i] = predDurPtr[i]
+                }
+                perTokenDurations = slice
             }
         }
 
@@ -468,7 +483,7 @@ public struct KokoroSynthesizer {
         }
 
         await recycleModelArrays()
-        return (samples, predictionTime)
+        return (samples, predictionTime, perTokenDurations)
     }
 
     /// Main synthesis function returning audio bytes only.
@@ -556,6 +571,7 @@ public struct KokoroSynthesizer {
             let index: Int
             let samples: [Float]
             let predictionTime: TimeInterval
+            let predDur: [Float]?
         }
 
         let embeddingDimension = try await modelCache.referenceEmbeddingDimension()
@@ -592,6 +608,7 @@ public struct KokoroSynthesizer {
         )
         let chunkTemplates = entries.map { $0.template }
         var chunkSampleBuffers = Array(repeating: [Float](), count: totalChunks)
+        var chunkPredDurations: [[Float]?] = Array(repeating: nil, count: totalChunks)
         var allSamples: [Float] = []
         let crossfadeMs = 8
         let samplesPerMillisecond = Double(TtsConstants.audioSampleRate) / 1_000.0
@@ -617,7 +634,7 @@ public struct KokoroSynthesizer {
                     Self.logger.info("Chunk \(chunkIndex + 1) text: '\(template.text)'")
                     Self.logger.info(
                         "Chunk \(chunkIndex + 1) using Kokoro \(variantDescription(template.variant)) model")
-                    let (chunkSamples, predictionTime) = try await synthesizeChunk(
+                    let chunkOutput = try await synthesizeChunk(
                         chunk,
                         inputIds: inputIds,
                         variant: template.variant,
@@ -625,8 +642,9 @@ public struct KokoroSynthesizer {
                         referenceVector: referenceVector)
                     return ChunkSynthesisResult(
                         index: chunkIndex,
-                        samples: chunkSamples,
-                        predictionTime: predictionTime)
+                        samples: chunkOutput.samples,
+                        predictionTime: chunkOutput.predictionTime,
+                        predDur: chunkOutput.predDur)
                 }
             }
 
@@ -645,6 +663,7 @@ public struct KokoroSynthesizer {
             let index = output.index
             let chunkSamples = output.samples
             chunkSampleBuffers[index] = chunkSamples
+            chunkPredDurations[index] = output.predDur
             totalPredictionTime += output.predictionTime
 
             Self.logger.info(
@@ -781,8 +800,21 @@ public struct KokoroSynthesizer {
             sampleRate: Double(TtsConstants.audioSampleRate)
         )
 
-        let chunkInfos = zip(chunkTemplates, chunkSampleBuffers).map { template, samples in
-            ChunkInfo(
+        let chunkInfos = entries.enumerated().map { (i, entry) -> ChunkInfo in
+            let template = entry.template
+            let samples = chunkSampleBuffers[i]
+            let predDur = chunkPredDurations[i]
+            let tokenTimings: [TokenTiming]? = predDur.flatMap {
+                buildTokenTimings(predDur: $0, phonemes: entry.chunk.phonemes)
+            }
+            let wordTimings: [WordTiming]? = tokenTimings.flatMap { tt in
+                buildWordTimings(
+                    tokenTimings: tt,
+                    atoms: entry.chunk.atoms,
+                    phonemeRanges: entry.chunk.phonemeRanges
+                )
+            }
+            return ChunkInfo(
                 index: template.index,
                 text: template.text,
                 wordCount: template.wordCount,
@@ -791,7 +823,9 @@ public struct KokoroSynthesizer {
                 pauseAfterMs: template.pauseAfterMs,
                 tokenCount: template.tokenCount,
                 samples: samples,
-                variant: template.variant
+                variant: template.variant,
+                tokenTimings: tokenTimings,
+                wordTimings: wordTimings
             )
         }
 
@@ -827,8 +861,29 @@ public struct KokoroSynthesizer {
             return baseResult
         }
 
+        let timingScale = 1.0 / TimeInterval(factor)
         let adjustedChunks = baseResult.chunks.map { chunk -> ChunkInfo in
             let stretched = adjustSamples(chunk.samples, factor: factor)
+            let scaledTokenTimings = chunk.tokenTimings.map { timings in
+                timings.map { t in
+                    TokenTiming(
+                        phoneme: t.phoneme,
+                        startTime: t.startTime * timingScale,
+                        endTime: t.endTime * timingScale,
+                        frames: t.frames
+                    )
+                }
+            }
+            let scaledWordTimings = chunk.wordTimings.map { timings in
+                timings.map { w in
+                    WordTiming(
+                        word: w.word,
+                        atomIndex: w.atomIndex,
+                        startTime: w.startTime * timingScale,
+                        endTime: w.endTime * timingScale
+                    )
+                }
+            }
             return ChunkInfo(
                 index: chunk.index,
                 text: chunk.text,
@@ -838,7 +893,9 @@ public struct KokoroSynthesizer {
                 pauseAfterMs: chunk.pauseAfterMs,
                 tokenCount: chunk.tokenCount,
                 samples: stretched,
-                variant: chunk.variant
+                variant: chunk.variant,
+                tokenTimings: scaledTokenTimings,
+                wordTimings: scaledWordTimings
             )
         }
 
@@ -885,6 +942,72 @@ public struct KokoroSynthesizer {
             index += step
         }
         return compressed
+    }
+
+    /// Convert raw `pred_dur` values into per-phoneme `TokenTiming`s.
+    ///
+    /// `predDur` and `phonemes` must have the same length (the synthesizer slices
+    /// `pred_dur` to the true input length before passing it in). Returns nil if
+    /// the alignment is mismatched or either array is empty.
+    static func buildTokenTimings(
+        predDur: [Float],
+        phonemes: [String]
+    ) -> [TokenTiming]? {
+        guard predDur.count == phonemes.count, !predDur.isEmpty else { return nil }
+
+        let frameSeconds =
+            TimeInterval(TtsConstants.kokoroFrameSamples) / TimeInterval(TtsConstants.audioSampleRate)
+        var timings: [TokenTiming] = []
+        timings.reserveCapacity(predDur.count)
+        var cumulativeFrames: Float = 0.0
+
+        for i in 0..<predDur.count {
+            let startTime = TimeInterval(cumulativeFrames) * frameSeconds
+            cumulativeFrames += predDur[i]
+            let endTime = TimeInterval(cumulativeFrames) * frameSeconds
+            timings.append(
+                TokenTiming(
+                    phoneme: phonemes[i],
+                    startTime: startTime,
+                    endTime: endTime,
+                    frames: predDur[i]
+                )
+            )
+        }
+        return timings
+    }
+
+    /// Aggregate `TokenTiming`s into per-atom `WordTiming`s using the chunker's phoneme→atom alignment.
+    ///
+    /// `phonemeRanges[i]` describes which slice of `tokenTimings` corresponds to `atoms[i]`.
+    /// Atoms whose ranges fall outside the available timings (e.g. truncation cases) are skipped.
+    static func buildWordTimings(
+        tokenTimings: [TokenTiming],
+        atoms: [String],
+        phonemeRanges: [Range<Int>]
+    ) -> [WordTiming]? {
+        guard atoms.count == phonemeRanges.count, !atoms.isEmpty else { return nil }
+
+        var timings: [WordTiming] = []
+        timings.reserveCapacity(atoms.count)
+
+        for (atomIndex, range) in phonemeRanges.enumerated() {
+            guard range.lowerBound < tokenTimings.count else { continue }
+            let endIndex = min(range.upperBound, tokenTimings.count)
+            guard range.lowerBound < endIndex else { continue }
+
+            let startTime = tokenTimings[range.lowerBound].startTime
+            let endTime = tokenTimings[endIndex - 1].endTime
+            timings.append(
+                WordTiming(
+                    word: atoms[atomIndex],
+                    atomIndex: atomIndex,
+                    startTime: startTime,
+                    endTime: endTime
+                )
+            )
+        }
+        return timings.isEmpty ? nil : timings
     }
 
     static func removeDelimiterCharacters(from text: String) -> String {

--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer.swift
@@ -944,6 +944,24 @@ public struct KokoroSynthesizer {
         return compressed
     }
 
+    /// Drain the static `MultiArrayPool` so the high-water-mark buffers it
+    /// retains between synthesis calls (per-chunk source noise, attention
+    /// masks, reference style, etc.) are released back to the system. Cheap
+    /// to call repeatedly; the pool refills on demand on the next synthesize.
+    ///
+    /// Use this between renders, on memory-pressure warnings, or alongside
+    /// `KokoroTtsManager.cleanup()` to fully release transient state.
+    public static func purgePoolBuffers() async {
+        await multiArrayPool.drain()
+    }
+
+    /// Diagnostic — number of `MLMultiArray` instances currently retained by
+    /// the pool. Multiplying by per-instance shape gives an order-of-magnitude
+    /// estimate of pool memory.
+    public static func pooledArrayCount() async -> Int {
+        await multiArrayPool.cachedCount
+    }
+
     /// Convert raw `pred_dur` values into per-phoneme `TokenTiming`s.
     ///
     /// `predDur` and `phonemes` must have the same length (the synthesizer slices

--- a/Tests/FluidAudioTests/TTS/KokoroChunkerPhonemeRangesTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroChunkerPhonemeRangesTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Verifies the `phonemeRanges` field added to `TextChunk` so per-word timing aggregation
+/// downstream can attribute synthesizer output back to source atoms.
+final class KokoroChunkerPhonemeRangesTests: XCTestCase {
+
+    private let allowed: Set<String> = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "n", "o", "r", "t", " ", ".", ","]
+
+    func testWordRangesAlignWithAtoms() async throws {
+        let lexicon: [String: [String]] = [
+            "hi": ["h", "i"],
+            "bye": ["b", "i"],
+        ]
+
+        let chunks = try await KokoroChunker.chunk(
+            text: "hi bye",
+            wordToPhonemes: lexicon,
+            caseSensitiveLexicon: [:],
+            customLexicon: nil,
+            targetTokens: 120,
+            hasLanguageToken: false,
+            allowedPhonemes: allowed,
+            phoneticOverrides: []
+        )
+
+        XCTAssertEqual(chunks.count, 1)
+        guard let chunk = chunks.first else {
+            XCTFail("missing chunk output")
+            return
+        }
+
+        // atoms.count and phonemeRanges.count must always match.
+        XCTAssertEqual(chunk.atoms.count, chunk.phonemeRanges.count)
+
+        // For "hi bye": phonemes laid out as [h, i, " ", b, i] with separator at index 2.
+        // atoms[0]="hi" → [0..<2], atoms[1]="bye" → [3..<5]; separator excluded.
+        XCTAssertEqual(chunk.atoms, ["hi", "bye"])
+        XCTAssertEqual(chunk.phonemeRanges[0], 0..<2)
+        XCTAssertEqual(chunk.phonemeRanges[1], 3..<5)
+
+        // Each range must reference real phoneme indices.
+        for range in chunk.phonemeRanges {
+            XCTAssertGreaterThanOrEqual(range.lowerBound, 0)
+            XCTAssertLessThanOrEqual(range.upperBound, chunk.phonemes.count)
+            XCTAssertLessThan(range.lowerBound, range.upperBound)
+        }
+    }
+
+    func testPunctuationGetsItsOwnRange() async throws {
+        let lexicon: [String: [String]] = [
+            "hi": ["h", "i"],
+            "bye": ["b", "i"],
+        ]
+
+        let chunks = try await KokoroChunker.chunk(
+            text: "hi, bye",
+            wordToPhonemes: lexicon,
+            caseSensitiveLexicon: [:],
+            customLexicon: nil,
+            targetTokens: 120,
+            hasLanguageToken: false,
+            allowedPhonemes: allowed,
+            phoneticOverrides: []
+        )
+
+        XCTAssertEqual(chunks.count, 1)
+        guard let chunk = chunks.first else {
+            XCTFail("missing chunk output")
+            return
+        }
+        XCTAssertEqual(chunk.atoms.count, chunk.phonemeRanges.count)
+
+        // Expect atoms ["hi", ",", "bye"]; punctuation atom is its own one-phoneme range.
+        guard let commaIndex = chunk.atoms.firstIndex(of: ",") else {
+            XCTFail("comma atom missing")
+            return
+        }
+        let commaRange = chunk.phonemeRanges[commaIndex]
+        XCTAssertEqual(commaRange.count, 1)
+        XCTAssertEqual(chunk.phonemes[commaRange.lowerBound], ",")
+    }
+
+    func testRangesMonotonicAndNonOverlapping() async throws {
+        let lexicon: [String: [String]] = [
+            "one": ["o", "n"],
+            "two": ["t"],
+            "three": ["t", "h", "r"],
+        ]
+
+        let chunks = try await KokoroChunker.chunk(
+            text: "one two three",
+            wordToPhonemes: lexicon,
+            caseSensitiveLexicon: [:],
+            customLexicon: nil,
+            targetTokens: 120,
+            hasLanguageToken: false,
+            allowedPhonemes: allowed,
+            phoneticOverrides: []
+        )
+
+        XCTAssertEqual(chunks.count, 1)
+        guard let chunk = chunks.first else {
+            XCTFail("missing chunk output")
+            return
+        }
+        XCTAssertEqual(chunk.atoms.count, chunk.phonemeRanges.count)
+
+        for i in 1..<chunk.phonemeRanges.count {
+            XCTAssertGreaterThanOrEqual(
+                chunk.phonemeRanges[i].lowerBound,
+                chunk.phonemeRanges[i - 1].upperBound,
+                "ranges must not overlap"
+            )
+        }
+    }
+}

--- a/Tests/FluidAudioTests/TTS/KokoroTokenTimingTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroTokenTimingTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Unit coverage for the timing-derivation helpers introduced alongside `pred_dur` exposure.
+/// These are pure functions on synthesized inputs — no Core ML model required.
+final class KokoroTokenTimingTests: XCTestCase {
+
+    // MARK: - buildTokenTimings
+
+    /// One frame is `kokoroFrameSamples / audioSampleRate` seconds. Verify the helper
+    /// uses both constants correctly so future tweaks to either don't silently drift timings.
+    func testTokenTimingsUseFrameAndSampleRateConstants() throws {
+        let predDur: [Float] = [2.0, 1.0, 3.0]
+        let phonemes = ["a", "b", "c"]
+
+        let timings = try XCTUnwrap(
+            KokoroSynthesizer.buildTokenTimings(predDur: predDur, phonemes: phonemes)
+        )
+        XCTAssertEqual(timings.count, 3)
+
+        let frameSeconds =
+            TimeInterval(TtsConstants.kokoroFrameSamples) / TimeInterval(TtsConstants.audioSampleRate)
+        XCTAssertEqual(timings[0].startTime, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(timings[0].endTime, 2.0 * frameSeconds, accuracy: 1e-9)
+        XCTAssertEqual(timings[1].startTime, 2.0 * frameSeconds, accuracy: 1e-9)
+        XCTAssertEqual(timings[1].endTime, 3.0 * frameSeconds, accuracy: 1e-9)
+        XCTAssertEqual(timings[2].startTime, 3.0 * frameSeconds, accuracy: 1e-9)
+        XCTAssertEqual(timings[2].endTime, 6.0 * frameSeconds, accuracy: 1e-9)
+    }
+
+    func testTokenTimingsCarryPhonemeAndFrames() throws {
+        let predDur: [Float] = [1.5, 2.5]
+        let phonemes = ["h", "ɛ"]
+
+        let timings = try XCTUnwrap(
+            KokoroSynthesizer.buildTokenTimings(predDur: predDur, phonemes: phonemes)
+        )
+        XCTAssertEqual(timings.map(\.phoneme), phonemes)
+        XCTAssertEqual(timings.map(\.frames), predDur)
+    }
+
+    func testTokenTimingsMonotonic() throws {
+        let predDur: [Float] = [4, 1, 2, 3, 1]
+        let phonemes = ["a", "b", "c", "d", "e"]
+
+        let timings = try XCTUnwrap(
+            KokoroSynthesizer.buildTokenTimings(predDur: predDur, phonemes: phonemes)
+        )
+        for i in 1..<timings.count {
+            XCTAssertGreaterThanOrEqual(timings[i].startTime, timings[i - 1].endTime)
+        }
+    }
+
+    func testTokenTimingsLastEndMatchesTotalFrames() throws {
+        let predDur: [Float] = [3, 7, 2, 5]
+        let phonemes = ["a", "b", "c", "d"]
+
+        let timings = try XCTUnwrap(
+            KokoroSynthesizer.buildTokenTimings(predDur: predDur, phonemes: phonemes)
+        )
+        let frameSeconds =
+            TimeInterval(TtsConstants.kokoroFrameSamples) / TimeInterval(TtsConstants.audioSampleRate)
+        let totalFrames = predDur.reduce(0, +)
+        XCTAssertEqual(timings.last?.endTime ?? 0, TimeInterval(totalFrames) * frameSeconds, accuracy: 1e-9)
+    }
+
+    func testTokenTimingsReturnsNilOnLengthMismatch() {
+        XCTAssertNil(
+            KokoroSynthesizer.buildTokenTimings(predDur: [1.0, 2.0], phonemes: ["a"])
+        )
+        XCTAssertNil(
+            KokoroSynthesizer.buildTokenTimings(predDur: [1.0], phonemes: ["a", "b"])
+        )
+    }
+
+    func testTokenTimingsReturnsNilOnEmpty() {
+        XCTAssertNil(
+            KokoroSynthesizer.buildTokenTimings(predDur: [], phonemes: [])
+        )
+    }
+
+    // MARK: - buildWordTimings
+
+    func testWordTimingsAggregateAcrossPhonemeRanges() throws {
+        let frameSeconds =
+            TimeInterval(TtsConstants.kokoroFrameSamples) / TimeInterval(TtsConstants.audioSampleRate)
+
+        // 5 phonemes split as: word "hi" = [0..<2], punct "," = [2..<3], word "bye" = [3..<5]
+        let predDur: [Float] = [2, 3, 1, 4, 2]
+        let phonemes = ["h", "ɪ", ",", "b", "aɪ"]
+        let atoms = ["hi", ",", "bye"]
+        let phonemeRanges: [Range<Int>] = [0..<2, 2..<3, 3..<5]
+
+        let tokenTimings = try XCTUnwrap(
+            KokoroSynthesizer.buildTokenTimings(predDur: predDur, phonemes: phonemes)
+        )
+        let wordTimings = try XCTUnwrap(
+            KokoroSynthesizer.buildWordTimings(
+                tokenTimings: tokenTimings,
+                atoms: atoms,
+                phonemeRanges: phonemeRanges
+            )
+        )
+
+        XCTAssertEqual(wordTimings.count, 3)
+
+        XCTAssertEqual(wordTimings[0].word, "hi")
+        XCTAssertEqual(wordTimings[0].atomIndex, 0)
+        XCTAssertEqual(wordTimings[0].startTime, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(wordTimings[0].endTime, 5.0 * frameSeconds, accuracy: 1e-9)
+
+        XCTAssertEqual(wordTimings[1].word, ",")
+        XCTAssertEqual(wordTimings[1].atomIndex, 1)
+        XCTAssertEqual(wordTimings[1].startTime, 5.0 * frameSeconds, accuracy: 1e-9)
+        XCTAssertEqual(wordTimings[1].endTime, 6.0 * frameSeconds, accuracy: 1e-9)
+
+        XCTAssertEqual(wordTimings[2].word, "bye")
+        XCTAssertEqual(wordTimings[2].atomIndex, 2)
+        XCTAssertEqual(wordTimings[2].startTime, 6.0 * frameSeconds, accuracy: 1e-9)
+        XCTAssertEqual(wordTimings[2].endTime, 12.0 * frameSeconds, accuracy: 1e-9)
+    }
+
+    func testWordTimingsSkipAtomsBeyondAvailableTokens() throws {
+        // Truncation case: tokenTimings shorter than the chunker's full atom set.
+        let predDur: [Float] = [1, 1]
+        let phonemes = ["a", "b"]
+        let tokenTimings = try XCTUnwrap(
+            KokoroSynthesizer.buildTokenTimings(predDur: predDur, phonemes: phonemes)
+        )
+        let atoms = ["one", "two", "three"]
+        let phonemeRanges: [Range<Int>] = [0..<1, 1..<2, 2..<3]  // third atom out of range
+
+        let wordTimings = try XCTUnwrap(
+            KokoroSynthesizer.buildWordTimings(
+                tokenTimings: tokenTimings,
+                atoms: atoms,
+                phonemeRanges: phonemeRanges
+            )
+        )
+        XCTAssertEqual(wordTimings.count, 2)
+        XCTAssertEqual(wordTimings.map(\.word), ["one", "two"])
+    }
+
+    func testWordTimingsClipPartialRange() throws {
+        // Atom range partially overlaps available tokens — should clip end to last available token.
+        let predDur: [Float] = [1, 2, 3]
+        let phonemes = ["a", "b", "c"]
+        let tokenTimings = try XCTUnwrap(
+            KokoroSynthesizer.buildTokenTimings(predDur: predDur, phonemes: phonemes)
+        )
+        let atoms = ["partial"]
+        let phonemeRanges: [Range<Int>] = [1..<5]  // upperBound past available tokens
+
+        let wordTimings = try XCTUnwrap(
+            KokoroSynthesizer.buildWordTimings(
+                tokenTimings: tokenTimings,
+                atoms: atoms,
+                phonemeRanges: phonemeRanges
+            )
+        )
+        XCTAssertEqual(wordTimings.count, 1)
+        XCTAssertEqual(wordTimings[0].startTime, tokenTimings[1].startTime, accuracy: 1e-9)
+        XCTAssertEqual(wordTimings[0].endTime, tokenTimings[2].endTime, accuracy: 1e-9)
+    }
+
+    func testWordTimingsReturnsNilOnLengthMismatch() throws {
+        let tokenTimings = try XCTUnwrap(
+            KokoroSynthesizer.buildTokenTimings(predDur: [1, 1], phonemes: ["a", "b"])
+        )
+        XCTAssertNil(
+            KokoroSynthesizer.buildWordTimings(
+                tokenTimings: tokenTimings,
+                atoms: ["x"],
+                phonemeRanges: [0..<1, 1..<2]   // atoms.count != phonemeRanges.count
+            )
+        )
+    }
+
+    func testWordTimingsReturnsNilWhenEveryRangeOutOfBounds() throws {
+        let tokenTimings = try XCTUnwrap(
+            KokoroSynthesizer.buildTokenTimings(predDur: [1, 1], phonemes: ["a", "b"])
+        )
+        XCTAssertNil(
+            KokoroSynthesizer.buildWordTimings(
+                tokenTimings: tokenTimings,
+                atoms: ["x", "y"],
+                phonemeRanges: [5..<6, 7..<8]   // both ranges past tokenTimings.count
+            )
+        )
+    }
+}


### PR DESCRIPTION
### Why is this change needed?

`KokoroSynthesizer.multiArrayPool` is a static singleton that preallocates per-chunk MLMultiArray buffers (input_ids, attention_mask, phases, source_noise) and recycles them on `recycle()`. Recycling returns arrays to the pool but doesn't shrink it — the pool retains the high-water mark of every shape ever rented for the lifetime of the process.

In practice this means a long-running TTS app that renders multi-chapter audio holds hundreds of MB indefinitely even when idle. The 15s variant's `source_noise` shape `[1, 360_000, 9]` (Float16) alone is ~6.5 MB per slot; with `count: max(1, totalChunks)` preallocation that adds up fast across a chapter.

There's currently no public way to release those buffers. This PR adds one.

### What changed

```swift
// MultiArrayPool — internal
func drain() { storage.removeAll(keepingCapacity: false) }
var cachedCount: Int { storage.values.reduce(0) { $0 + $1.count } }

// KokoroSynthesizer — public
public static func purgePoolBuffers() async { await multiArrayPool.drain() }
public static func pooledArrayCount() async -> Int { await multiArrayPool.cachedCount }

// KokoroTtsManager — public convenience
public func purgeCachedBuffers() async { await KokoroSynthesizer.purgePoolBuffers() }
```

### How to use it

`drain()` is independent of `KokoroTtsManager.cleanup()`:

- `manager.purgeCachedBuffers()` — release pool buffers, **keep models loaded**. Good for between-render cleanup or memory-pressure responses.
- `manager.cleanup()` — release the loaded Core ML models. Heavier teardown.
- Both — full release; next synthesize pays full cold-start cost.

The pool refills on demand on the next `rent`/`preallocate`, so calling drain mid-app is safe.

### Source compatibility

Fully additive — no existing types or signatures change.

### Tests

Existing test suite (1526 tests) passes unchanged. The new APIs are best exercised via runtime memory observation (`pooledArrayCount()` returns 0 after `drain()`), which the existing test infrastructure doesn't easily measure. Happy to add a unit test on the pool's internal `cachedCount` if you'd like.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
