### PR TITLE
fix: remove module_map from MachTaskSelfWrapper subspec

### DIFF
--- a/FluidAudio.podspec
+++ b/FluidAudio.podspec
@@ -52,7 +52,6 @@ Pod::Spec.new do |spec|
     mach.source_files = "Sources/MachTaskSelfWrapper/**/*.{c,h}"
     mach.public_header_files = "Sources/MachTaskSelfWrapper/include/MachTaskSelf.h"
     mach.header_mappings_dir = "Sources/MachTaskSelfWrapper"
-    mach.module_map = "Sources/MachTaskSelfWrapper/include/module.modulemap"
   end
 
   spec.subspec "Core" do |core|

--- a/Sources/FluidAudio/Shared/SystemInfo.swift
+++ b/Sources/FluidAudio/Shared/SystemInfo.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(MachTaskSelfWrapper)
 import MachTaskSelfWrapper
+#endif
 import OSLog
 
 #if canImport(Darwin)

--- a/Sources/FluidAudioCLI/FluidAudioCLI.swift
+++ b/Sources/FluidAudioCLI/FluidAudioCLI.swift
@@ -2,7 +2,9 @@
 import AVFoundation
 import FluidAudio
 import Foundation
+#if canImport(MachTaskSelfWrapper)
 import MachTaskSelfWrapper
+#endif
 
 // Using @main instead of main.swift for Swift 6 compatibility.
 // This provides an explicit async context and clear isolation semantics.


### PR DESCRIPTION
## Summary

- Remove `mach.module_map` from the `MachTaskSelfWrapper` subspec — CocoaPods does not allow `module_map` on subspecs
- Guard `import MachTaskSelfWrapper` with `#if canImport(MachTaskSelfWrapper)`, matching the existing `FastClusterWrapper` pattern
- In CocoaPods builds, the C headers are already exposed via the umbrella header, so the explicit module import is only needed under SwiftPM

## Verification

- `pod lib lint FluidAudio.podspec --allow-warnings` — **passed**
- `swift build` — **passed**

Fixes #545
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
