### PR TITLE
fix: avoid misleading confidence warning in SlidingWindowAsrManager.finish()

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -251,16 +251,11 @@ public actor SlidingWindowAsrManager {
             if !volatileTranscript.isEmpty { parts.append(volatileTranscript) }
             finalText = parts.joined(separator: " ")
         } else if !accumulatedTokens.isEmpty,
-            let finalResult = await asrManager?.processTranscriptionResult(
-                tokenIds: accumulatedTokens,
-                timestamps: [],
-                confidences: [],  // No per-token confidences needed for final text
-                encoderSequenceLength: 0,
-                audioSamples: [],  // Not needed for final text conversion
-                processingTime: 0
-            )
+            let reconstructedText = await asrManager?.convertTokensToText(accumulatedTokens)
         {
-            finalText = finalResult.text
+            // finish() only needs the merged text. Re-entering ASRResult processing here
+            // fabricates a missing-confidence warning even though no confidence score is required.
+            finalText = reconstructedText
         } else {
             var parts: [String] = []
             if !confirmedTranscript.isEmpty { parts.append(confirmedTranscript) }


### PR DESCRIPTION
### Why is this change needed?
`SlidingWindowAsrManager.finish()` reconstructs final text by calling `processTranscriptionResult(...)` with empty `timestamps` and `confidences`.

That path only needs token-to-text reconstruction, but it also runs confidence calculation, which logs:

`Expected token confidences but got none - this should not happen`

In practice this shows up during normal finalization even though nothing is actually wrong.

### What changed?
Use `convertTokensToText(accumulatedTokens)` directly in `finish()` when only the merged final text is needed.

This keeps behavior the same for the returned transcription while avoiding a misleading warning during normal shutdown.

### Validation
- `swift test --filter SlidingWindowAsrManagerTests`
- Reproduced locally from an app integration path before the patch; warning no longer appears after the change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
