### PR TITLE
docs(models): drop Parakeet CTC Japanese + ASR/TTS row cleanups

### DIFF
--- a/Documentation/Models.md
+++ b/Documentation/Models.md
@@ -11,8 +11,7 @@ A guide to each CoreML model pipeline in FluidAudio.
 | **Parakeet TDT v2** | Batch speech-to-text, English only (0.6B params). TDT architecture. | First ASR model added. |
 | **Parakeet TDT v3** | Batch speech-to-text, 25 European languages (0.6B params). Default ASR model. | Released after v2 to add multilingual support. |
 | **Parakeet TDT-CTC-110M** | Hybrid TDT-CTC batch model (110M params). 3.01% WER on LibriSpeech test-clean. 96.5x RTFx on M2 Mac. Fused preprocessor+encoder for reduced memory footprint. iOS compatible. | Smaller, faster alternative to v3 with competitive accuracy. |
-| **Parakeet CTC Japanese** | Batch speech-to-text, Japanese only (0.6B params). CTC architecture. 6.85% CER on JSUT dataset. 10.1x RTFx on M2 Mac. | First Japanese ASR model. Uses CTC greedy decoder. |
-| **Parakeet TDT Japanese** | Batch speech-to-text, Japanese only (0.6B params). TDT architecture. 6.85% CER on JSUT dataset. 10.8x RTFx on M2 Mac. Hybrid model (CTC preprocessor/encoder + TDT decoder/joint). | Alternative Japanese decoder using TDT for same quality but faster |
+| **Parakeet TDT Japanese** | Batch speech-to-text, Japanese only (0.6B params). Hybrid model: INT8 CTC-trained preprocessor + encoder paired with a TDT decoder + joint. 6.85% CER on JSUT, 10.8x RTFx on M2. | CTC-only Japanese inference was removed in 846924a1d; only the preprocessor + encoder from the original CTC repo are reused. |
 | **Parakeet CTC Chinese** | Batch speech-to-text, Mandarin Chinese (0.6B params). CTC architecture. 8.37% mean CER on THCHS-30 dataset. Int8 encoder (0.55GB) or FP32 (1.1GB). | First Mandarin Chinese ASR model. Uses CTC greedy decoder. |
 
 TDT models process audio in chunks (~15s with overlap) as batch operations.
@@ -79,8 +78,7 @@ Models we converted and tested but are not supported: too large for on-device de
 | Parakeet TDT v3 | [FluidInference/parakeet-tdt-0.6b-v3-coreml](https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml) |
 | Parakeet TDT v2 | [FluidInference/parakeet-tdt-0.6b-v2-coreml](https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v2-coreml) |
 | Parakeet TDT-CTC-110M | [FluidInference/parakeet-tdt-ctc-110m-coreml](https://huggingface.co/FluidInference/parakeet-tdt-ctc-110m-coreml) |
-| Parakeet CTC Japanese | [FluidInference/parakeet-ctc-0.6b-ja-coreml](https://huggingface.co/FluidInference/parakeet-ctc-0.6b-ja-coreml) |
-| Parakeet TDT Japanese | [FluidInference/parakeet-ctc-0.6b-ja-coreml](https://huggingface.co/FluidInference/parakeet-ctc-0.6b-ja-coreml) (hybrid: CTC preprocessor/encoder + TDT v2 decoder/joint) |
+| Parakeet TDT Japanese | [FluidInference/parakeet-0.6b-ja-coreml](https://huggingface.co/FluidInference/parakeet-0.6b-ja-coreml) (hybrid: CTC preprocessor/encoder + TDT decoder/joint) |
 | Parakeet CTC Chinese | [FluidInference/parakeet-ctc-0.6b-zh-cn-coreml](https://huggingface.co/FluidInference/parakeet-ctc-0.6b-zh-cn-coreml) |
 | Parakeet CTC 110M | [FluidInference/parakeet-ctc-110m-coreml](https://huggingface.co/FluidInference/parakeet-ctc-110m-coreml) |
 | Parakeet CTC 0.6B | [FluidInference/parakeet-ctc-0.6b-coreml](https://huggingface.co/FluidInference/parakeet-ctc-0.6b-coreml) |

--- a/Documentation/Models.md
+++ b/Documentation/Models.md
@@ -4,7 +4,9 @@ A guide to each CoreML model pipeline in FluidAudio.
 
 ## ASR Models
 
-### Batch Transcription (Near Real-Time)
+### Sliding-Window Transcription (Near Real-Time)
+
+Long-form audio processed via `SlidingWindowAsrManager` — chunked, overlapped, and stitched. Distinct from the **Streaming Transcription** section below, which uses cache-aware encoders that emit partials as audio arrives.
 
 | Model | Description | Context |
 |-------|-------------|---------|
@@ -14,13 +16,13 @@ A guide to each CoreML model pipeline in FluidAudio.
 | **Parakeet TDT Japanese** | Batch speech-to-text, Japanese only (0.6B params). Hybrid model: INT8 CTC-trained preprocessor + encoder paired with a TDT decoder + joint. 6.85% CER on JSUT, 10.8x RTFx on M2. | CTC-only Japanese inference was removed in 846924a1d; only the preprocessor + encoder from the original CTC repo are reused. |
 | **Parakeet CTC Chinese** | Batch speech-to-text, Mandarin Chinese (0.6B params). CTC architecture. 8.37% mean CER on THCHS-30 dataset. Int8 encoder (0.55GB) or FP32 (1.1GB). | First Mandarin Chinese ASR model. Uses CTC greedy decoder. |
 
-TDT models process audio in chunks (~15s with overlap) as batch operations.
+TDT/CTC models above are wrapped by `SlidingWindowAsrManager`, which chunks audio (~15s with overlap) and stitches the per-chunk transcripts.
 
 ### Streaming Transcription (True Real-Time)
 
 | Model | Description | Context |
 |-------|-------------|---------|
-| **Parakeet EOU** | Streaming speech-to-text with end-of-utterance detection (120M params). Processes 160ms/320ms frames for true real-time results as the user speaks. | Added after TDT was released & for streaming. Smaller model (120M vs 0.6B). |
+| **Parakeet EOU** | Streaming speech-to-text with end-of-utterance detection (120M params). Three chunk-size variants — 160ms / 320ms / 1280ms — for ultra-low-latency to higher-accuracy streaming. | Added after TDT was released & for streaming. Smaller model (120M vs 0.6B). |
 | **Nemotron Speech Streaming 0.6B** | RNNT streaming ASR with 4 chunk size variants (80ms, 160ms, 560ms, 1120ms). English-only (0.6B params). Int8 encoder quantization. Supports ultra-low latency (80ms chunks) to high accuracy (1120ms chunks). | Larger streaming model for better accuracy and quality |
 
 ### Custom Vocabulary / Keyword Spotting
@@ -49,7 +51,7 @@ TDT models process audio in chunks (~15s with overlap) as batch operations.
 | Model | Description | Context |
 |-------|-------------|---------|
 | **Kokoro TTS** | Text-to-speech synthesis (82M params), 48 voices, minimal RAM usage on iOS. Generates all frames at once via flow matching over mel spectrograms + Vocos vocoder. Uses CoreML G2P model for phonemization. | First TTS backend added + support custom pronounces |
-| **Kokoro ANE (7-stage)** | Same Kokoro 82M weights split into 7 CoreML stages so the ANE-friendly layers (Albert / PostAlbert / Alignment / Vocoder) stay resident on the Neural Engine while Prosody / Noise / Tail run on CPU+GPU. 3-11× RTFx vs. the single-graph Kokoro. Single voice (`af_heart`), ≤510 IPA phonemes per call, no chunker / SSML / custom lexicon. | ANE-optimized variant derived from [laishere/kokoro-coreml](https://github.com/laishere/kokoro-coreml) |
+| **Kokoro ANE (7-stage)** | Same Kokoro 82M weights split into 7 CoreML stages so the ANE-friendly layers (Albert / PostAlbert / Alignment / Vocoder) stay resident on the Neural Engine while Prosody / Noise / Tail run on CPU+GPU. 3-11× RTFx vs. the single-graph Kokoro. Single voice (`af_heart`), ≤510 IPA phonemes per call, no chunker / SSML / custom lexicon. | ANE-optimized variant derived (with permission) from [laishere/kokoro-coreml](https://github.com/laishere/kokoro-coreml) |
 | **PocketTTS** | Second TTS backend (~155M params). Autoregressive frame-by-frame generation with dynamic audio chunking. No phoneme stage, works directly on text tokens. | Supports streaming, minimal RAM usage, excellent quality |
 
 ## Not Production Ready


### PR DESCRIPTION
## Summary

`Documentation/Models.md` cleanup pass:

- **Drop Parakeet CTC Japanese.** CTC-only inference for Japanese was deleted in 846924a1d; only the INT8 CTC-trained preprocessor + encoder from the parakeet-0.6b-ja-coreml repo are reused as the acoustic frontend, paired with a TDT decoder + joint (see `ModelNames.TDTJa` and the comment on `Repo.parakeetJa` in `Sources/FluidAudio/ModelNames.swift:11-14`). Fold the relevant detail into the surviving **Parakeet TDT Japanese** row.
- **Fix Japanese HF path.** Was the stale `parakeet-ctc-0.6b-ja-coreml`, now correctly points at [`parakeet-0.6b-ja-coreml`](https://huggingface.co/FluidInference/parakeet-0.6b-ja-coreml) — matches `Repo.parakeetJa`.
- **Rename ASR section** `Batch Transcription (Near Real-Time)` → `Sliding-Window Transcription (Near Real-Time)` to match the actual implementation (`SlidingWindowAsrManager` wrapping TDT/CTC chunks). Add a short blurb contrasting it with the Streaming section so the distinction is explicit instead of implied.
- **Parakeet EOU row:** add the missing **1280ms** chunk-size variant (`Repo.parakeetEou1280`; `StreamingEouAsrManager.swift:7` explicitly documents 160ms / 320ms / 1280ms support). Rephrase to highlight the latency/accuracy spectrum.
- **Kokoro ANE row:** clarify that the variant was derived from `laishere/kokoro-coreml` **with permission** (not just lifted).

## Test plan

- [x] Docs-only change; verified rendered tables in `Documentation/Models.md`.
- [x] All HF paths and chunk-size variants cross-checked against `Sources/FluidAudio/ModelNames.swift` and `Sources/FluidAudio/ASR/Parakeet/Streaming/EOU/StreamingEouAsrManager.swift`.
- [x] No code paths touched; CI build/test/format remain unaffected.