### PR TITLE
docs(models): fix Cohere Transcribe Model Sources link target

### DIFF
--- a/Documentation/Models.md
+++ b/Documentation/Models.md
@@ -87,7 +87,7 @@ Models we converted and tested but are not supported: too large for on-device de
 | Parakeet CTC 110M | [FluidInference/parakeet-ctc-110m-coreml](https://huggingface.co/FluidInference/parakeet-ctc-110m-coreml) |
 | Parakeet CTC 0.6B | [FluidInference/parakeet-ctc-0.6b-coreml](https://huggingface.co/FluidInference/parakeet-ctc-0.6b-coreml) |
 | Parakeet EOU | [FluidInference/parakeet-realtime-eou-120m-coreml](https://huggingface.co/FluidInference/parakeet-realtime-eou-120m-coreml) (subdirs: `/160ms`, `/320ms`, `/1280ms`) |
-| Cohere Transcribe (INT8 hybrid, default) | [FluidInference/cohere-transcribe-03-2026-coreml/q8](https://huggingface.co/FluidInference/cohere-transcribe-03-2026-coreml) |
+| Cohere Transcribe (INT8 hybrid, default) | [FluidInference/cohere-transcribe-03-2026-coreml](https://huggingface.co/FluidInference/cohere-transcribe-03-2026-coreml) (variant: `/q8`) |
 | Qwen3-ASR | [FluidInference/qwen3-asr-0.6b-coreml](https://huggingface.co/FluidInference/qwen3-asr-0.6b-coreml) (variants: `/f32`, `/int8`) |
 | Silero VAD | [FluidInference/silero-vad-coreml](https://huggingface.co/FluidInference/silero-vad-coreml) |
 | Diarization (Pyannote) | [FluidInference/speaker-diarization-coreml](https://huggingface.co/FluidInference/speaker-diarization-coreml) |


### PR DESCRIPTION
## Summary

Follow-up fix for [Devin Review on #551](https://github.com/FluidInference/FluidAudio/pull/551#pullrequestreview-4192652442):

The Cohere Transcribe Model Sources row had a Markdown link whose text included `/q8` but whose URL pointed at the repo root, so clicking landed at the root instead of the `q8` subdirectory. Move the subdir into a parenthetical `(variant: \`/q8\`)` suffix to match the existing **Qwen3-ASR** and **Parakeet EOU** rows in the same table, and drop the mismatched suffix from the link text.

```diff
-| Cohere Transcribe (INT8 hybrid, default) | [FluidInference/cohere-transcribe-03-2026-coreml/q8](https://huggingface.co/FluidInference/cohere-transcribe-03-2026-coreml) |
+| Cohere Transcribe (INT8 hybrid, default) | [FluidInference/cohere-transcribe-03-2026-coreml](https://huggingface.co/FluidInference/cohere-transcribe-03-2026-coreml) (variant: \`/q8\`) |
```

## Test plan

- [x] Docs-only change.
- [x] Verified the link target now matches the displayed link text and the surrounding row pattern (Qwen3-ASR / Parakeet EOU).
- [x] No code paths touched.