### PR TITLE
feat(tts/styletts2): scaffold StyleTTS2 4-stage pipeline integration

### DIFF
--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -32,6 +32,7 @@ public enum Repo: String, CaseIterable, Sendable {
     case cosyvoice3 = "FluidInference/CosyVoice3-0.5B-coreml"
     case cohereTranscribeCoreml = "FluidInference/cohere-transcribe-03-2026-coreml/q8"
     case magpieTts = "FluidInference/magpie-tts-multilingual-357m-coreml"
+    case styleTts2 = "FluidInference/StyleTTS-2-coreml"
 
     /// Repository slug (without owner)
     public var name: String {
@@ -90,6 +91,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "cohere-transcribe-03-2026-coreml/q8"
         case .magpieTts:
             return "magpie-tts-multilingual-357m-coreml"
+        case .styleTts2:
+            return "StyleTTS-2-coreml"
         }
     }
 
@@ -190,6 +193,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "cohere-transcribe/q8"
         case .magpieTts:
             return "magpie-tts"
+        case .styleTts2:
+            return "styletts2"
         default:
             return name.replacingOccurrences(of: "-coreml", with: "")
         }
@@ -676,6 +681,85 @@ public enum ModelNames {
         ]
     }
 
+    /// StyleTTS2 model names (4-stage diffusion TTS, LibriTTS multi-speaker checkpoint).
+    ///
+    /// Pipeline (per utterance, all stages combined run at ~4.32× RTFx warm on M-series):
+    /// 1. `text_predictor` — fp16 ANE, 5 token-length buckets (32/64/128/256/512). 1× call.
+    /// 2. `diffusion_step_512` — fp16 CPU+GPU, single bert_dur=512 bucket. 5× calls (ADPM2).
+    /// 3. `f0n_energy` — fp16 ANE, dynamic shape. 1× call.
+    /// 4. `decoder` — fp32 CPU+GPU, 5 mel-length buckets (256/512/1024/2048/4096). 1× call.
+    ///
+    /// Decoder must be fp32 (SineGen phase-saturation in fp16 produces robotic audio).
+    /// On disk the HF repo ships precompiled `.mlmodelc` bundles under `compiled/`;
+    /// the `.mlpackage` doubles at the repo root are portability artifacts and are
+    /// not fetched by `requiredModels`.
+    public enum StyleTTS2 {
+        // Text predictor buckets (token-length axis).
+        public static let textPredictor32 = "styletts2_text_predictor_32"
+        public static let textPredictor64 = "styletts2_text_predictor_64"
+        public static let textPredictor128 = "styletts2_text_predictor_128"
+        public static let textPredictor256 = "styletts2_text_predictor_256"
+        public static let textPredictor512 = "styletts2_text_predictor_512"
+
+        // Diffusion step (single B=512 bucket; smaller buckets pruned upstream).
+        public static let diffusionStep512 = "styletts2_diffusion_step_512"
+
+        // F0/N energy regressor (dynamic input shape).
+        public static let f0nEnergy = "styletts2_f0n_energy"
+
+        // Decoder buckets (mel-frame axis).
+        public static let decoder256 = "styletts2_decoder_256"
+        public static let decoder512 = "styletts2_decoder_512"
+        public static let decoder1024 = "styletts2_decoder_1024"
+        public static let decoder2048 = "styletts2_decoder_2048"
+        public static let decoder4096 = "styletts2_decoder_4096"
+
+        // Precompiled `.mlmodelc` filenames (live under `compiled/` on the HF
+        // repo). We load the precompiled artifacts to skip the cold-start
+        // `anecompilerservice` hit; the `.mlpackage` doubles at the repo root
+        // are kept for portability/debugging only and are not fetched.
+        public static let textPredictor32File = "compiled/" + textPredictor32 + ".mlmodelc"
+        public static let textPredictor64File = "compiled/" + textPredictor64 + ".mlmodelc"
+        public static let textPredictor128File = "compiled/" + textPredictor128 + ".mlmodelc"
+        public static let textPredictor256File = "compiled/" + textPredictor256 + ".mlmodelc"
+        public static let textPredictor512File = "compiled/" + textPredictor512 + ".mlmodelc"
+
+        public static let diffusionStep512File = "compiled/" + diffusionStep512 + ".mlmodelc"
+        public static let f0nEnergyFile = "compiled/" + f0nEnergy + ".mlmodelc"
+
+        public static let decoder256File = "compiled/" + decoder256 + ".mlmodelc"
+        public static let decoder512File = "compiled/" + decoder512 + ".mlmodelc"
+        public static let decoder1024File = "compiled/" + decoder1024 + ".mlmodelc"
+        public static let decoder2048File = "compiled/" + decoder2048 + ".mlmodelc"
+        public static let decoder4096File = "compiled/" + decoder4096 + ".mlmodelc"
+
+        /// Phoneme→id table mirrored from upstream `text_utils.TextCleaner` (178 tokens).
+        public static let vocabularyFile = "constants/text_cleaner_vocab.json"
+
+        /// Top-level bundle config (audio params, bucket sizes, sampler config).
+        public static let configFile = "config.json"
+
+        public static let textPredictorBuckets: [Int] = [32, 64, 128, 256, 512]
+        public static let decoderBuckets: [Int] = [256, 512, 1024, 2048, 4096]
+
+        public static let requiredModels: Set<String> = [
+            textPredictor32File,
+            textPredictor64File,
+            textPredictor128File,
+            textPredictor256File,
+            textPredictor512File,
+            diffusionStep512File,
+            f0nEnergyFile,
+            decoder256File,
+            decoder512File,
+            decoder1024File,
+            decoder2048File,
+            decoder4096File,
+            vocabularyFile,
+            configFile,
+        ]
+    }
+
     /// Multilingual G2P (CharsiuG2P ByT5) model names
     public enum MultilingualG2P {
         public static let encoder = "MultilingualG2PEncoder"
@@ -862,6 +946,8 @@ public enum ModelNames {
                 .union(ModelNames.MultilingualG2P.requiredModels)
         case .pocketTts:
             return ModelNames.PocketTTS.requiredModels
+        case .styleTts2:
+            return ModelNames.StyleTTS2.requiredModels
         case .kokoroAne:
             return ModelNames.KokoroAne.requiredModels
         case .sortformer:

--- a/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2BundleConfig.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2BundleConfig.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+/// Decoded view of `config.json` shipped alongside the StyleTTS2 mlmodelc
+/// bundle on HuggingFace.
+///
+/// The on-disk file is the source of truth for the runtime contract between
+/// the host (Swift) and the converted CoreML stages. We decode the
+/// must-have fields here and validate them against `StyleTTS2Constants`
+/// during `initialize()` to catch "wrong bundle version" / "swapped cache
+/// dir" errors before the first synthesis call.
+public struct StyleTTS2BundleConfig: Sendable, Codable {
+
+    public struct Audio: Sendable, Codable {
+        public let sampleRate: Int
+        public let nFFT: Int
+        public let winLength: Int
+        public let hopLength: Int
+        public let nMels: Int
+
+        enum CodingKeys: String, CodingKey {
+            case sampleRate = "sample_rate"
+            case nFFT = "n_fft"
+            case winLength = "win_length"
+            case hopLength = "hop_length"
+            case nMels = "n_mels"
+        }
+    }
+
+    public struct Tokenizer: Sendable, Codable {
+        public let type: String
+        public let vocabFile: String
+        public let nTokens: Int
+        public let padToken: String
+        public let padId: Int
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case vocabFile = "vocab_file"
+            case nTokens = "n_tokens"
+            case padToken = "pad_token"
+            case padId = "pad_id"
+        }
+    }
+
+    public struct Model: Sendable, Codable {
+        public let styleDim: Int
+        public let hiddenDim: Int
+        public let nLayer: Int
+        public let maxDur: Int
+        public let refStyleDim: Int
+
+        enum CodingKeys: String, CodingKey {
+            case styleDim = "style_dim"
+            case hiddenDim = "hidden_dim"
+            case nLayer = "n_layer"
+            case maxDur = "max_dur"
+            case refStyleDim = "ref_s_dim"
+        }
+    }
+
+    public struct Sampler: Sendable, Codable {
+        public let type: String
+        public let schedule: String
+        public let numSteps: Int
+        public let classifierFreeGuidance: Bool
+        public let cfgScaleDefault: Float
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case schedule
+            case numSteps = "num_steps"
+            case classifierFreeGuidance = "classifier_free_guidance"
+            case cfgScaleDefault = "cfg_scale_default"
+        }
+    }
+
+    public let modelType: String
+    public let audio: Audio
+    public let tokenizer: Tokenizer
+    public let model: Model
+    public let sampler: Sampler
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case audio
+        case tokenizer
+        case model
+        case sampler
+    }
+
+    /// Load and decode `config.json`.
+    public static func load(from url: URL) throws -> StyleTTS2BundleConfig {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw StyleTTS2Error.modelNotFound(url.lastPathComponent)
+        }
+        let data = try Data(contentsOf: url)
+        do {
+            return try JSONDecoder().decode(StyleTTS2BundleConfig.self, from: data)
+        } catch {
+            throw StyleTTS2Error.invalidConfiguration(
+                "\(url.lastPathComponent): \(error.localizedDescription)")
+        }
+    }
+
+    /// Validate the bundle matches `StyleTTS2Constants`.
+    ///
+    /// Throws if any must-have value drifts from what the host expects.
+    /// Catches: wrong cache directory, partial download, ship-version mismatch.
+    public func validate() throws {
+        guard modelType == "styletts2" else {
+            throw StyleTTS2Error.invalidConfiguration(
+                "model_type=\"\(modelType)\", expected \"styletts2\"")
+        }
+        try expect(
+            audio.sampleRate, equals: StyleTTS2Constants.audioSampleRate,
+            field: "audio.sample_rate")
+        try expect(
+            audio.hopLength, equals: StyleTTS2Constants.hopSize,
+            field: "audio.hop_length")
+        try expect(
+            audio.nMels, equals: StyleTTS2Constants.melChannels,
+            field: "audio.n_mels")
+        try expect(
+            audio.nFFT, equals: StyleTTS2Constants.nFFT, field: "audio.n_fft")
+        try expect(
+            audio.winLength, equals: StyleTTS2Constants.winLength,
+            field: "audio.win_length")
+
+        try expect(
+            tokenizer.nTokens, equals: StyleTTS2Constants.vocabSize,
+            field: "tokenizer.n_tokens")
+        try expect(
+            tokenizer.padId, equals: StyleTTS2Constants.padTokenId,
+            field: "tokenizer.pad_id")
+
+        try expect(
+            model.styleDim, equals: StyleTTS2Constants.styleDim,
+            field: "model.style_dim")
+        try expect(
+            model.hiddenDim, equals: StyleTTS2Constants.hiddenDim,
+            field: "model.hidden_dim")
+        try expect(
+            model.refStyleDim, equals: StyleTTS2Constants.refStyleDim,
+            field: "model.ref_s_dim")
+    }
+
+    private func expect(_ actual: Int, equals expected: Int, field: String) throws {
+        guard actual == expected else {
+            throw StyleTTS2Error.invalidConfiguration(
+                "\(field)=\(actual), expected \(expected)")
+        }
+    }
+}

--- a/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2ResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2ResourceDownloader.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Downloads StyleTTS2 CoreML models, vocab, and bundle config from HuggingFace.
+///
+/// Repo layout (`FluidInference/StyleTTS-2-coreml`):
+/// ```
+/// /compiled/styletts2_text_predictor_{32,64,128,256,512}.mlmodelc/
+/// /compiled/styletts2_diffusion_step_512.mlmodelc/
+/// /compiled/styletts2_f0n_energy.mlmodelc/
+/// /compiled/styletts2_decoder_{256,512,1024,2048,4096}.mlmodelc/
+/// /constants/text_cleaner_vocab.json
+/// /config.json
+/// /styletts2_*.mlpackage/      (portability/debugging artifacts; not fetched here)
+/// ```
+/// We grab only the precompiled `compiled/*.mlmodelc` bundles to avoid the
+/// cold-start `anecompilerservice` hit on first synthesis.
+public enum StyleTTS2ResourceDownloader {
+
+    private static let logger = AppLogger(category: "StyleTTS2ResourceDownloader")
+
+    /// Ensure all StyleTTS2 models, vocab, and config are downloaded.
+    ///
+    /// - Parameters:
+    ///   - directory: Optional override for the base cache directory.
+    ///     When `nil`, uses the default platform cache location.
+    ///   - progressHandler: Optional callback for download progress updates.
+    /// - Returns: The repo root directory containing all `.mlpackage` bundles
+    ///   plus `config.json` and `constants/text_cleaner_vocab.json`.
+    public static func ensureModels(
+        directory: URL? = nil,
+        progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws -> URL {
+        let targetDir = try directory ?? cacheDirectory()
+        let modelsDirectory = targetDir.appendingPathComponent(
+            StyleTTS2Constants.defaultModelsSubdirectory)
+        let repoDir = modelsDirectory.appendingPathComponent(Repo.styleTts2.folderName)
+
+        let allPresent = ModelNames.StyleTTS2.requiredModels.allSatisfy { model in
+            FileManager.default.fileExists(
+                atPath: repoDir.appendingPathComponent(model).path)
+        }
+
+        guard !allPresent else {
+            logger.info("StyleTTS2 models found in cache")
+            return repoDir
+        }
+
+        try FileManager.default.createDirectory(
+            at: modelsDirectory, withIntermediateDirectories: true)
+
+        logger.info("Downloading StyleTTS2 bundle from HuggingFace...")
+        try await DownloadUtils.downloadRepo(
+            .styleTts2,
+            to: modelsDirectory,
+            progressHandler: progressHandler
+        )
+
+        // Verify after download — `downloadRepo` checks each pattern but the
+        // explicit re-check surfaces clearer errors when the network ack races
+        // ahead of disk visibility (seen on slow filesystems).
+        for model in ModelNames.StyleTTS2.requiredModels {
+            let path = repoDir.appendingPathComponent(model).path
+            guard FileManager.default.fileExists(atPath: path) else {
+                throw StyleTTS2Error.downloadFailed(
+                    "Missing required asset after download: \(model)")
+            }
+        }
+
+        return repoDir
+    }
+
+    // MARK: - Private
+
+    private static func cacheDirectory() throws -> URL {
+        let baseDirectory: URL
+        #if os(macOS)
+        baseDirectory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache")
+        #else
+        guard
+            let first = FileManager.default.urls(
+                for: .cachesDirectory, in: .userDomainMask
+            ).first
+        else {
+            throw StyleTTS2Error.processingFailed("Failed to locate caches directory")
+        }
+        baseDirectory = first
+        #endif
+
+        let cacheDirectory = baseDirectory.appendingPathComponent("fluidaudio")
+        if !FileManager.default.fileExists(atPath: cacheDirectory.path) {
+            try FileManager.default.createDirectory(
+                at: cacheDirectory, withIntermediateDirectories: true)
+        }
+        return cacheDirectory
+    }
+}

--- a/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2Vocab.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2Vocab.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// 178-token espeak-ng IPA + stress vocabulary shipped as
+/// `constants/text_cleaner_vocab.json` alongside the StyleTTS2 mlpackages.
+///
+/// File schema (from the conversion repo):
+/// ```json
+/// {
+///   "pad_token": "$",
+///   "num_tokens": 178,
+///   "symbols": [...],
+///   "token_to_id": { "$": 0, ... }
+/// }
+/// ```
+///
+/// Mirrors the upstream `text_utils.TextCleaner` table at conversion time
+/// (yl4579/StyleTTS2). Includes ASCII letters, punctuation, the full IPA
+/// inventory used by espeak-ng, and stress/length markers (`ˈ ˌ ː ˑ`).
+public struct StyleTTS2Vocab: Sendable {
+
+    /// IPA character → token id (`Character` is an extended grapheme cluster,
+    /// which correctly handles the combining vertical line below `◌̩`).
+    public let map: [Character: Int32]
+    public let padTokenId: Int32
+
+    public init(map: [Character: Int32], padTokenId: Int32) {
+        self.map = map
+        self.padTokenId = padTokenId
+    }
+
+    /// Load from `text_cleaner_vocab.json`.
+    public static func load(from url: URL) throws -> StyleTTS2Vocab {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw StyleTTS2Error.modelNotFound(url.lastPathComponent)
+        }
+        let data = try Data(contentsOf: url)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw StyleTTS2Error.invalidConfiguration(
+                "\(url.lastPathComponent): expected top-level JSON object")
+        }
+        guard let tokenToId = json["token_to_id"] as? [String: Any] else {
+            throw StyleTTS2Error.invalidConfiguration(
+                "\(url.lastPathComponent): missing or invalid token_to_id field")
+        }
+
+        var parsed: [Character: Int32] = [:]
+        parsed.reserveCapacity(tokenToId.count)
+        for (key, value) in tokenToId {
+            // The vocab includes graphemes that span multiple Unicode scalars
+            // (e.g. the syllabic-consonant combining mark `◌̩`). Use
+            // `Character` so we get the same boundary as Swift's grapheme
+            // iteration and don't accidentally split combining marks off
+            // their base.
+            guard let ch = key.first, key.count == 1 else { continue }
+            if let intValue = value as? Int {
+                parsed[ch] = Int32(intValue)
+            }
+        }
+
+        // Resolve the pad token id from the explicit `pad_token` field if
+        // present; otherwise fall back to "$" → 0 which is the upstream
+        // contract.
+        let padId: Int32
+        if let padToken = (json["pad_token"] as? String)?.first,
+            let id = parsed[padToken]
+        {
+            padId = id
+        } else {
+            padId = 0
+        }
+
+        return StyleTTS2Vocab(map: parsed, padTokenId: padId)
+    }
+
+    /// Encode a phoneme string to token ids. Unknown graphemes are dropped
+    /// (matches upstream `text_utils.TextCleaner.__call__`, which logs and
+    /// skips unmapped characters rather than failing).
+    ///
+    /// No BOS/EOS wrapping — StyleTTS2's `text_predictor` is fed the raw
+    /// id sequence, padded to the bucket length by the caller.
+    public func encode(_ phonemes: String) -> [Int32] {
+        var ids: [Int32] = []
+        ids.reserveCapacity(phonemes.count)
+        for ch in phonemes {
+            if let id = map[ch] {
+                ids.append(id)
+            }
+        }
+        return ids
+    }
+}

--- a/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2Vocab.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2Vocab.swift
@@ -79,10 +79,16 @@ public struct StyleTTS2Vocab: Sendable {
     /// No BOS/EOS wrapping — StyleTTS2's `text_predictor` is fed the raw
     /// id sequence, padded to the bucket length by the caller.
     public func encode(_ phonemes: String) -> [Int32] {
+        // Iterate over Unicode scalars (not Characters) so combining marks
+        // like U+0329 (syllabic) and U+0361 (tie bar) are looked up against
+        // their own vocab entries instead of being grouped into a grapheme
+        // cluster with their base char — which would silently drop both.
+        // Mirrors upstream `text_utils.TextCleaner.__call__`, which iterates
+        // codepoints.
         var ids: [Int32] = []
-        ids.reserveCapacity(phonemes.count)
-        for ch in phonemes {
-            if let id = map[ch] {
+        ids.reserveCapacity(phonemes.unicodeScalars.count)
+        for scalar in phonemes.unicodeScalars {
+            if let id = map[Character(scalar)] {
                 ids.append(id)
             }
         }

--- a/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2VoiceStyle.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2VoiceStyle.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// A precomputed `ref_s` style+prosody reference vector for StyleTTS2.
+///
+/// `ref_s` is the 256-dim concat of:
+///   - `style_encoder(mel)` — first 128 dims, "acoustic" branch
+///   - `predictor_encoder(mel)` — last 128 dims, "prosody" branch
+///
+/// Upstream computes this in PyTorch from a reference WAV and feeds it into
+/// the diffusion sampler + the text predictor. Until the StyleTTS2 style
+/// encoders are exported as a CoreML stage (follow-up work), the Swift host
+/// ships a precomputed `ref_s.bin` blob per voice — produced offline by
+/// `mobius-styletts2/scripts/06_dump_ref_s.py` from any 24 kHz mono WAV.
+///
+/// File format: 256 little-endian fp32 values, 1024 bytes total. No header.
+public struct StyleTTS2VoiceStyle: Sendable, Equatable {
+
+    /// Full 256-dim `ref_s` vector (acoustic ⧺ prosody).
+    public let concatenated: [Float]
+
+    public init(concatenated: [Float]) {
+        precondition(
+            concatenated.count == StyleTTS2Constants.refStyleDim,
+            "ref_s must be \(StyleTTS2Constants.refStyleDim) floats, got \(concatenated.count)")
+        self.concatenated = concatenated
+    }
+
+    /// 128-dim acoustic style branch (`ref_s[:, :128]`).
+    public var acoustic: ArraySlice<Float> {
+        concatenated.prefix(StyleTTS2Constants.styleDim)
+    }
+
+    /// 128-dim prosody branch (`ref_s[:, 128:]`).
+    public var prosody: ArraySlice<Float> {
+        concatenated.suffix(StyleTTS2Constants.styleDim)
+    }
+
+    /// Load a precomputed `ref_s.bin` blob (256 fp32 little-endian, 1024 bytes).
+    public static func load(from url: URL) throws -> StyleTTS2VoiceStyle {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw StyleTTS2Error.modelNotFound(url.lastPathComponent)
+        }
+        let data = try Data(contentsOf: url)
+        let expectedBytes = StyleTTS2Constants.refStyleDim * MemoryLayout<Float>.size
+        guard data.count == expectedBytes else {
+            throw StyleTTS2Error.invalidConfiguration(
+                "\(url.lastPathComponent): expected \(expectedBytes) bytes "
+                    + "(\(StyleTTS2Constants.refStyleDim) fp32), got \(data.count)")
+        }
+
+        // The blob is little-endian fp32 by contract (see Python dumper).
+        // On Apple Silicon / Intel that matches host byte order, so a direct
+        // memory load is correct. We still copy out into a `[Float]` so the
+        // value is fully owned and Sendable.
+        var floats = [Float](repeating: 0, count: StyleTTS2Constants.refStyleDim)
+        floats.withUnsafeMutableBufferPointer { dst in
+            _ = data.copyBytes(to: dst)
+        }
+        return StyleTTS2VoiceStyle(concatenated: floats)
+    }
+}

--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2ModelStore.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2ModelStore.swift
@@ -106,9 +106,13 @@ public actor StyleTTS2ModelStore {
         if let cached = f0nEnergyModel {
             return cached
         }
+        // f0n_energy ships with dynamic shape — the E5RT runtime rejects
+        // MLMultiArrays with known strides on FlexibleShapeInfo models
+        // when run on GPU/ANE, so we pin this stage to CPU. Per-utterance
+        // cost is small (one call), the CPU fallback is acceptable.
         let model = try await loadModel(
             named: ModelNames.StyleTTS2.f0nEnergyFile,
-            computeUnits: .cpuAndNeuralEngine,
+            computeUnits: .cpuOnly,
             label: "f0n_energy"
         )
         f0nEnergyModel = model

--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2ModelStore.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2ModelStore.swift
@@ -1,0 +1,218 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Actor-based store for the 12 StyleTTS2 CoreML models.
+///
+/// Stage layout & compute placement (mirrors `coreml/PRECISION.md` from the
+/// upstream conversion repo):
+///
+/// | Stage          | Bucket axis     | Buckets                       | Precision | Compute     |
+/// |----------------|-----------------|-------------------------------|-----------|-------------|
+/// | text_predictor | input tokens    | 32, 64, 128, 256, 512         | fp16      | ANE         |
+/// | diffusion_step | bert_dur frames | 512 only                      | fp16      | CPU+GPU     |
+/// | f0n_energy     | dynamic shape   | n/a                           | fp16      | ANE         |
+/// | decoder        | mel frames      | 256, 512, 1024, 2048, 4096    | fp32      | CPU+GPU     |
+///
+/// Lazy: only the buckets that are actually requested are loaded into
+/// memory. Eager warmup of every bucket on init would cost ~1.4 GB of RAM
+/// for the decoder alone.
+public actor StyleTTS2ModelStore {
+
+    private let logger = AppLogger(subsystem: "com.fluidaudio.tts", category: "StyleTTS2ModelStore")
+
+    // text_predictor: lazy per-bucket cache.
+    private var textPredictorModels: [Int: MLModel] = [:]
+    // diffusion_step: single 512-bucket model, loaded on first use.
+    private var diffusionStepModel: MLModel?
+    // f0n_energy: dynamic shape, single model.
+    private var f0nEnergyModel: MLModel?
+    // decoder: lazy per-bucket cache (fp32, large).
+    private var decoderModels: [Int: MLModel] = [:]
+
+    private var repoRootDirectory: URL?
+    private var cachedVocab: StyleTTS2Vocab?
+    private var cachedBundleConfig: StyleTTS2BundleConfig?
+    private let directory: URL?
+
+    public init(directory: URL? = nil) {
+        self.directory = directory
+    }
+
+    // MARK: - Bring-up
+
+    /// Ensure the bundle is downloaded and resolve the repo root. Does **not**
+    /// load any MLModel instances — those are loaded lazily per call site.
+    public func ensureAssetsAvailable(
+        progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws -> URL {
+        if let dir = repoRootDirectory {
+            return dir
+        }
+        let dir = try await StyleTTS2ResourceDownloader.ensureModels(
+            directory: directory,
+            progressHandler: progressHandler
+        )
+        repoRootDirectory = dir
+        return dir
+    }
+
+    // MARK: - text_predictor (ANE, fp16, 5 buckets)
+
+    /// Round `tokenLength` up to the nearest shipped text_predictor bucket.
+    public nonisolated func textPredictorBucket(forTokenLength tokenLength: Int) -> Int {
+        for bucket in StyleTTS2Constants.textPredictorBuckets where tokenLength <= bucket {
+            return bucket
+        }
+        // Saturate at the largest shipped bucket; caller is responsible for
+        // chunking inputs longer than 512 tokens.
+        return StyleTTS2Constants.textPredictorBuckets.last ?? 512
+    }
+
+    public func textPredictor(bucket: Int) async throws -> MLModel {
+        if let cached = textPredictorModels[bucket] {
+            return cached
+        }
+        guard StyleTTS2Constants.textPredictorBuckets.contains(bucket) else {
+            throw StyleTTS2Error.invalidConfiguration(
+                "Unsupported text_predictor bucket: \(bucket)")
+        }
+        let model = try await loadModel(
+            named: "compiled/styletts2_text_predictor_\(bucket).mlmodelc",
+            computeUnits: .cpuAndNeuralEngine,
+            label: "text_predictor_\(bucket)"
+        )
+        textPredictorModels[bucket] = model
+        return model
+    }
+
+    // MARK: - diffusion_step (CPU+GPU, fp16, 512 only)
+
+    public func diffusionStep() async throws -> MLModel {
+        if let cached = diffusionStepModel {
+            return cached
+        }
+        let model = try await loadModel(
+            named: ModelNames.StyleTTS2.diffusionStep512File,
+            computeUnits: .cpuAndGPU,
+            label: "diffusion_step_512"
+        )
+        diffusionStepModel = model
+        return model
+    }
+
+    // MARK: - f0n_energy (ANE, fp16, dynamic)
+
+    public func f0nEnergy() async throws -> MLModel {
+        if let cached = f0nEnergyModel {
+            return cached
+        }
+        let model = try await loadModel(
+            named: ModelNames.StyleTTS2.f0nEnergyFile,
+            computeUnits: .cpuAndNeuralEngine,
+            label: "f0n_energy"
+        )
+        f0nEnergyModel = model
+        return model
+    }
+
+    // MARK: - decoder (CPU+GPU, fp32, 5 buckets)
+
+    /// Round `melFrames` up to the nearest shipped decoder bucket.
+    public nonisolated func decoderBucket(forMelFrames melFrames: Int) -> Int {
+        for bucket in StyleTTS2Constants.decoderBuckets where melFrames <= bucket {
+            return bucket
+        }
+        return StyleTTS2Constants.decoderBuckets.last ?? 4096
+    }
+
+    public func decoder(bucket: Int) async throws -> MLModel {
+        if let cached = decoderModels[bucket] {
+            return cached
+        }
+        guard StyleTTS2Constants.decoderBuckets.contains(bucket) else {
+            throw StyleTTS2Error.invalidConfiguration(
+                "Unsupported decoder bucket: \(bucket)")
+        }
+        let model = try await loadModel(
+            named: "compiled/styletts2_decoder_\(bucket).mlmodelc",
+            computeUnits: .cpuAndGPU,
+            label: "decoder_\(bucket)"
+        )
+        decoderModels[bucket] = model
+        return model
+    }
+
+    // MARK: - Bundle paths
+
+    /// Path to the espeak-ng IPA vocabulary JSON.
+    public func vocabularyURL() throws -> URL {
+        guard let root = repoRootDirectory else {
+            throw StyleTTS2Error.modelNotFound("StyleTTS2 repo not loaded")
+        }
+        return root.appendingPathComponent(ModelNames.StyleTTS2.vocabularyFile)
+    }
+
+    /// Path to the bundle `config.json`.
+    public func configURL() throws -> URL {
+        guard let root = repoRootDirectory else {
+            throw StyleTTS2Error.modelNotFound("StyleTTS2 repo not loaded")
+        }
+        return root.appendingPathComponent(ModelNames.StyleTTS2.configFile)
+    }
+
+    /// Lazily-loaded 178-token IPA vocabulary.
+    public func vocabulary() throws -> StyleTTS2Vocab {
+        if let cached = cachedVocab {
+            return cached
+        }
+        let url = try vocabularyURL()
+        let vocab = try StyleTTS2Vocab.load(from: url)
+        cachedVocab = vocab
+        return vocab
+    }
+
+    /// Lazily-loaded `config.json`. Decoded once and cached for the lifetime
+    /// of the store.
+    public func bundleConfig() throws -> StyleTTS2BundleConfig {
+        if let cached = cachedBundleConfig {
+            return cached
+        }
+        let url = try configURL()
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        cachedBundleConfig = config
+        return config
+    }
+
+    public func repoRoot() throws -> URL {
+        guard let root = repoRootDirectory else {
+            throw StyleTTS2Error.modelNotFound("StyleTTS2 repo not loaded")
+        }
+        return root
+    }
+
+    // MARK: - Private
+
+    private func loadModel(
+        named filename: String,
+        computeUnits: MLComputeUnits,
+        label: String
+    ) async throws -> MLModel {
+        guard let root = repoRootDirectory else {
+            throw StyleTTS2Error.modelNotFound("StyleTTS2 repo not loaded")
+        }
+        let url = root.appendingPathComponent(filename)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw StyleTTS2Error.modelNotFound(filename)
+        }
+
+        let config = MLModelConfiguration()
+        config.computeUnits = computeUnits
+
+        let start = Date()
+        let model = try MLModel(contentsOf: url, configuration: config)
+        let elapsed = Date().timeIntervalSince(start)
+        logger.info(
+            "Loaded \(label) in \(String(format: "%.2f", elapsed))s :: \(SystemInfo.summary())")
+        return model
+    }
+}

--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Phonemizer.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Phonemizer.swift
@@ -137,11 +137,17 @@ public enum StyleTTS2Phonemizer {
     }
 
     /// Non-English path: CharsiuG2P fallback (unvalidated for StyleTTS2).
+    /// The shipped LibriTTS checkpoint is English-only, so this branch is
+    /// best-effort. `MultilingualG2PModel.loadIfNeeded` only reads from
+    /// cache — `StyleTTS2Manager.initialize` does not pre-fetch this repo,
+    /// so callers who hit this path must have downloaded the kokoro
+    /// multilingual G2P some other way (e.g. via Kokoro init).
     private static func flushWordMultilingual(
         _ word: String,
         language: MultilingualG2PLanguage,
         into output: inout String
     ) async throws {
+        try await MultilingualG2PModel.shared.ensureModelsAvailable()
         let phonemes = try await MultilingualG2PModel.shared.phonemize(
             word: word,
             language: language

--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Phonemizer.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Phonemizer.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Text → IPA phoneme string pipeline for StyleTTS2.
+///
+/// Wires the existing `MultilingualG2PModel` (CharsiuG2P ByT5) through to the
+/// 178-token espeak-ng IPA vocabulary that ships in
+/// `constants/text_cleaner_vocab.json`.
+///
+/// The output is a phoneme **string** (not yet token ids) so that callers
+/// can splice in custom IPA, log, or post-process before encoding through
+/// `StyleTTS2Vocab.encode(_:)`.
+///
+/// Pipeline:
+///  1. `TtsTextPreprocessor.preprocess` — number/currency/time/unit expansion
+///     and smart-quote normalization (shared with the Kokoro frontend).
+///  2. Walk the cleaned text character-by-character. Letter runs are
+///     accumulated as words and flushed through G2P. Non-letter characters
+///     (punctuation, whitespace) are passed through verbatim — the
+///     178-vocab includes `.,;:!?…—""«»¡¿"` and `' '` so this round-trips
+///     cleanly.
+///  3. Returned string is one IPA grapheme per character, ready to be fed
+///     to `StyleTTS2Vocab.encode(_:)`.
+public enum StyleTTS2Phonemizer {
+
+    private static let logger = AppLogger(category: "StyleTTS2Phonemizer")
+
+    /// Convert raw text to an IPA phoneme string for StyleTTS2.
+    ///
+    /// - Parameters:
+    ///   - text: Source text in the natural orthography of `language`.
+    ///   - language: Target language for `MultilingualG2PModel`. The
+    ///     LibriTTS checkpoint shipped on HF is English-only; non-English
+    ///     output will run but is not validated.
+    /// - Returns: A phoneme string. Pass this to `StyleTTS2Vocab.encode(_:)`
+    ///   to obtain `[Int32]` token ids.
+    public static func phonemize(
+        text: String,
+        language: MultilingualG2PLanguage = .americanEnglish
+    ) async throws -> String {
+        let cleaned = TtsTextPreprocessor.preprocess(text)
+
+        var output = ""
+        output.reserveCapacity(cleaned.count * 2)
+
+        var wordBuffer = ""
+        wordBuffer.reserveCapacity(64)
+
+        for ch in cleaned {
+            if ch.isLetter || ch == "'" || ch == "'" {
+                // Treat ASCII apostrophe + typographic apostrophe as part
+                // of words (don't, won't, they're) — they're stripped before
+                // G2P input but kept as word boundaries.
+                wordBuffer.append(ch)
+                continue
+            }
+            // Non-letter — flush the buffered word, then emit the char.
+            if !wordBuffer.isEmpty {
+                try await flushWord(&wordBuffer, language: language, into: &output)
+            }
+            // Punctuation/whitespace passes through verbatim — vocab covers
+            // the common set; unmapped glyphs are silently dropped at encode
+            // time (matches upstream `text_utils.TextCleaner.__call__`).
+            output.append(ch)
+        }
+        if !wordBuffer.isEmpty {
+            try await flushWord(&wordBuffer, language: language, into: &output)
+        }
+
+        return output
+    }
+
+    // MARK: - Private
+
+    /// Phonemize one word and append its IPA characters to `output`.
+    /// Drops apostrophes from the G2P input (CharsiuG2P sometimes produces
+    /// noise for `'s`/`'t` enclitics; upstream espeak-ng treats them as
+    /// part of the word, but ByT5's clean handling is to strip).
+    private static func flushWord(
+        _ buffer: inout String,
+        language: MultilingualG2PLanguage,
+        into output: inout String
+    ) async throws {
+        defer { buffer.removeAll(keepingCapacity: true) }
+
+        let stripped = buffer.replacingOccurrences(of: "'", with: "")
+            .replacingOccurrences(of: "'", with: "")
+        guard !stripped.isEmpty else { return }
+
+        let phonemes = try await MultilingualG2PModel.shared.phonemize(
+            word: stripped,
+            language: language
+        )
+        guard let phonemes else {
+            // G2P unavailable (e.g. CI). Fall back to passing the cleaned
+            // word through verbatim — the vocab covers ASCII letters so
+            // it produces an audibly-degraded but non-empty output.
+            logger.warning(
+                "G2P unavailable for word \"\(stripped)\"; passing through verbatim")
+            output.append(stripped)
+            return
+        }
+        for piece in phonemes {
+            output.append(piece)
+        }
+    }
+}

--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Phonemizer.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Phonemizer.swift
@@ -2,9 +2,20 @@ import Foundation
 
 /// Text → IPA phoneme string pipeline for StyleTTS2.
 ///
-/// Wires the existing `MultilingualG2PModel` (CharsiuG2P ByT5) through to the
-/// 178-token espeak-ng IPA vocabulary that ships in
-/// `constants/text_cleaner_vocab.json`.
+/// For English (`.americanEnglish`), uses the in-tree `G2PModel` (BART
+/// encoder-decoder, misaki-style IPA) and remaps the misaki conventions to
+/// the espeak-ng convention that StyleTTS2's LibriTTS checkpoint expects:
+///
+///   misaki → espeak-ng
+///   A → eɪ   I → aɪ   O → oʊ   W → aʊ   Y → ɔɪ
+///   ᵊ → ə   (tiny-schwa offglide; not in StyleTTS2's 178-vocab)
+///
+/// Other glyphs (`ʤ`, `ʧ`, `ˈ`, `ˌ`, `ð`, `θ`, `ɹ`, `ɾ`, etc.) are already in
+/// the 178-token espeak-ng vocabulary and pass through.
+///
+/// Non-English languages fall back to `MultilingualG2PModel` (CharsiuG2P
+/// ByT5). Output quality there is unvalidated — the LibriTTS checkpoint is
+/// English-only.
 ///
 /// The output is a phoneme **string** (not yet token ids) so that callers
 /// can splice in custom IPA, log, or post-process before encoding through
@@ -24,13 +35,23 @@ public enum StyleTTS2Phonemizer {
 
     private static let logger = AppLogger(category: "StyleTTS2Phonemizer")
 
+    /// Misaki single-glyph diphthongs / offglides → espeak-ng IPA.
+    /// Applied per-piece on the output of `G2PModel.phonemize`.
+    private static let misakiToEspeak: [String: String] = [
+        "A": "eɪ",
+        "I": "aɪ",
+        "O": "oʊ",
+        "W": "aʊ",
+        "Y": "ɔɪ",
+        "ᵊ": "ə",
+    ]
+
     /// Convert raw text to an IPA phoneme string for StyleTTS2.
     ///
     /// - Parameters:
     ///   - text: Source text in the natural orthography of `language`.
-    ///   - language: Target language for `MultilingualG2PModel`. The
-    ///     LibriTTS checkpoint shipped on HF is English-only; non-English
-    ///     output will run but is not validated.
+    ///   - language: Target language. English uses the in-tree BART G2P;
+    ///     all others fall back to `MultilingualG2PModel`.
     /// - Returns: A phoneme string. Pass this to `StyleTTS2Vocab.encode(_:)`
     ///   to obtain `[Int32]` token ids.
     public static func phonemize(
@@ -72,9 +93,8 @@ public enum StyleTTS2Phonemizer {
     // MARK: - Private
 
     /// Phonemize one word and append its IPA characters to `output`.
-    /// Drops apostrophes from the G2P input (CharsiuG2P sometimes produces
-    /// noise for `'s`/`'t` enclitics; upstream espeak-ng treats them as
-    /// part of the word, but ByT5's clean handling is to strip).
+    /// Drops apostrophes from the G2P input (`'s`/`'t` enclitics roundtrip
+    /// poorly through ByT5; the BART G2P also handles them best stripped).
     private static func flushWord(
         _ buffer: inout String,
         language: MultilingualG2PLanguage,
@@ -86,17 +106,50 @@ public enum StyleTTS2Phonemizer {
             .replacingOccurrences(of: "'", with: "")
         guard !stripped.isEmpty else { return }
 
+        if language == .americanEnglish {
+            try await flushWordEnglish(stripped, into: &output)
+        } else {
+            try await flushWordMultilingual(stripped, language: language, into: &output)
+        }
+    }
+
+    /// English path: BART G2P (misaki IPA) → espeak-ng IPA via small remap.
+    private static func flushWordEnglish(
+        _ word: String,
+        into output: inout String
+    ) async throws {
+        // Lazy first-call download/load; subsequent calls hit the cache.
+        try await G2PModel.shared.ensureModelsAvailable()
+        let phonemes = try await G2PModel.shared.phonemize(word: word.lowercased())
+        guard let phonemes else {
+            logger.warning(
+                "G2P unavailable for English word \"\(word)\"; passing through verbatim")
+            output.append(word)
+            return
+        }
+        for piece in phonemes {
+            if let mapped = misakiToEspeak[piece] {
+                output.append(mapped)
+            } else {
+                output.append(piece)
+            }
+        }
+    }
+
+    /// Non-English path: CharsiuG2P fallback (unvalidated for StyleTTS2).
+    private static func flushWordMultilingual(
+        _ word: String,
+        language: MultilingualG2PLanguage,
+        into output: inout String
+    ) async throws {
         let phonemes = try await MultilingualG2PModel.shared.phonemize(
-            word: stripped,
+            word: word,
             language: language
         )
         guard let phonemes else {
-            // G2P unavailable (e.g. CI). Fall back to passing the cleaned
-            // word through verbatim — the vocab covers ASCII letters so
-            // it produces an audibly-degraded but non-empty output.
             logger.warning(
-                "G2P unavailable for word \"\(stripped)\"; passing through verbatim")
-            output.append(stripped)
+                "G2P unavailable for word \"\(word)\" (\(language)); passing through verbatim")
+            output.append(word)
             return
         }
         for piece in phonemes {

--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Sampler.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Sampler.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+/// ADPM2 + Karras-schedule diffusion sampler for the StyleTTS2 style vector.
+///
+/// This is the Swift port of `karras_sigmas` + `adpm2_sample` from the
+/// upstream reference (`mobius-styletts2/scripts/99b_e2e_coreml.py`).
+/// Operates on 256-dim float vectors (the flattened `(1, 1, 256)` style
+/// latent fed to `diffusion_step_512`).
+///
+/// The sampler is decoupled from CoreML: callers pass a closure that
+/// performs the actual `denoise` step. This keeps the math pure and
+/// testable without loading any models.
+public enum StyleTTS2Sampler {
+
+    /// One diffusion step. Takes the current noisy latent (`x_noisy`,
+    /// 256 floats) and the current sigma, returns the denoised latent.
+    ///
+    /// The closure captures `embedding` (`bert_dur_pad`) and `features`
+    /// (`ref_s`) so the sampler doesn't need to know about model I/O
+    /// shapes.
+    public typealias DenoiseStep =
+        @Sendable (
+            _ xNoisy: [Float],
+            _ sigma: Float
+        ) async throws -> [Float]
+
+    /// Compute the Karras sigma schedule with `num_steps + 1` entries
+    /// (the trailing 0.0 marks the final denoise-to-zero step).
+    ///
+    /// Matches `99b_e2e_coreml.py:84-90`. Note: `rho` defaults to 9.0
+    /// (StyleTTS2 contract), *not* the k-diffusion default of 7.0.
+    public static func karrasSigmas(
+        steps: Int,
+        sigmaMin: Float = StyleTTS2Constants.karrasSigmaMin,
+        sigmaMax: Float = StyleTTS2Constants.karrasSigmaMax,
+        rho: Float = StyleTTS2Constants.karrasRho
+    ) -> [Float] {
+        precondition(steps >= 1, "diffusion steps must be >= 1")
+        let rhoInv = 1.0 / Double(rho)
+        let minInv = pow(Double(sigmaMin), rhoInv)
+        let maxInv = pow(Double(sigmaMax), rhoInv)
+        var sigmas: [Float] = []
+        sigmas.reserveCapacity(steps + 1)
+        // np.linspace(0, 1, steps) — inclusive at both ends.
+        for i in 0..<steps {
+            let t = steps == 1 ? 0.0 : Double(i) / Double(steps - 1)
+            let inv = maxInv + t * (minInv - maxInv)
+            sigmas.append(Float(pow(inv, Double(rho))))
+        }
+        sigmas.append(0.0)
+        return sigmas
+    }
+
+    /// ADPM2 sampler over the diffusion step model. Mirrors the reference
+    /// `adpm2_sample` exactly:
+    ///
+    ///   x = noise * sigmas[0]
+    ///   for i in 0..<steps:
+    ///       s, s_next = sigmas[i], sigmas[i+1]
+    ///       if s_next == 0:
+    ///           x += d * (s_next - s)        // single step
+    ///       else:
+    ///           x_mid = x + d * (s_mid - s)  // midpoint
+    ///           d_mid = (x_mid - denoise(x_mid, s_mid)) / s_mid
+    ///           x = x + d_mid * (s_next - s)
+    ///
+    /// - Parameters:
+    ///   - steps: Number of sampler steps (Karras schedule length).
+    ///   - noise: Initial Gaussian noise vector. Must be 256 floats.
+    ///   - denoise: Closure performing the diffusion step.
+    /// - Returns: Predicted style vector, 256 floats.
+    public static func adpm2Sample(
+        steps: Int,
+        noise: [Float],
+        denoise: DenoiseStep
+    ) async throws -> [Float] {
+        let dim = StyleTTS2Constants.refStyleDim
+        precondition(noise.count == dim, "noise must be \(dim) floats")
+        let sigmas = karrasSigmas(steps: steps)
+
+        // x = noise * sigmas[0]
+        var x = scale(noise, by: sigmas[0])
+
+        for i in 0..<(sigmas.count - 1) {
+            let s = sigmas[i]
+            let sNext = sigmas[i + 1]
+
+            if sNext == 0.0 {
+                // Final step: a plain Euler update toward the denoised target.
+                let denoised = try await denoise(x, s)
+                let d = scale(sub(x, denoised), by: 1.0 / s)
+                x = add(x, scale(d, by: sNext - s))
+                continue
+            }
+
+            // ADPM2 midpoint update.
+            let sMid = Float(exp((log(Double(s)) + log(Double(sNext))) / 2.0))
+            let denoised = try await denoise(x, s)
+            let d = scale(sub(x, denoised), by: 1.0 / s)
+            let xMid = add(x, scale(d, by: sMid - s))
+            let denoisedMid = try await denoise(xMid, sMid)
+            let dMid = scale(sub(xMid, denoisedMid), by: 1.0 / sMid)
+            x = add(x, scale(dMid, by: sNext - s))
+        }
+        return x
+    }
+
+    // MARK: - Tiny helpers
+
+    private static func scale(_ a: [Float], by k: Float) -> [Float] {
+        var out = a
+        for i in 0..<out.count { out[i] *= k }
+        return out
+    }
+
+    private static func add(_ a: [Float], _ b: [Float]) -> [Float] {
+        var out = a
+        for i in 0..<out.count { out[i] += b[i] }
+        return out
+    }
+
+    private static func sub(_ a: [Float], _ b: [Float]) -> [Float] {
+        var out = a
+        for i in 0..<out.count { out[i] -= b[i] }
+        return out
+    }
+}

--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Synthesizer.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Synthesizer.swift
@@ -1,0 +1,659 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// End-to-end StyleTTS2 synthesizer driving the 4-stage diffusion pipeline.
+///
+/// Mirrors `mobius-styletts2/scripts/99b_e2e_coreml.py` step-for-step:
+///
+///   1. `text_predictor` (per token bucket)
+///        in:  tokens[1, B_tok], style[1, 128]
+///        out: t_en[1, 512, B_tok], d[1, B_tok, 640],
+///             pred_dur_log[1, B_tok, 50], bert_dur[1, B_tok, 768]
+///   2. ADPM2 sampler over `diffusion_step_512` (B=512 always)
+///        in:  x_noisy[1,1,256], sigma[1], embedding[1,512,768], features[1,256]
+///        out: denoised[1,1,256]
+///   3. Style mix:
+///        ref = α·s_pred[:,:128] + (1-α)·ref_s[:,:128]   // acoustic (decoder)
+///        s   = β·s_pred[:,128:] + (1-β)·ref_s[:,128:]   // prosody  (f0n_energy)
+///   4. Hard alignment from durations + gather-style matmul → en, asr.
+///      HiFi-GAN right-shift by 1 frame.
+///   5. `f0n_energy` (dynamic; padded to mel bucket)
+///        in:  en[1,640,B_mel], s[1,128]
+///        out: F0[1, 2*B_mel], N[1, 2*B_mel]
+///   6. `decoder` (per mel bucket)
+///        in:  asr[1,512,B_mel], F0_curve[1,2*B_mel], N[1,2*B_mel], s[1,128]
+///        out: waveform[B_mel*600]
+///   7. Trim to `T_mel*600` then drop the trailing 50 samples (decoder edge).
+///
+/// `synthesize` returns a fully-formed 24 kHz mono 16-bit PCM WAV blob.
+public actor StyleTTS2Synthesizer {
+
+    private let logger = AppLogger(category: "StyleTTS2Synthesizer")
+    private let modelStore: StyleTTS2ModelStore
+
+    public init(modelStore: StyleTTS2ModelStore) {
+        self.modelStore = modelStore
+    }
+
+    /// Synthesis options. Defaults match the upstream Python reference.
+    public struct Options: Sendable {
+        public var diffusionSteps: Int
+        public var alpha: Float
+        public var beta: Float
+        public var randomSeed: UInt64?
+
+        public init(
+            diffusionSteps: Int = StyleTTS2Constants.defaultDiffusionSteps,
+            alpha: Float = 0.3,
+            beta: Float = 0.7,
+            randomSeed: UInt64? = nil
+        ) {
+            self.diffusionSteps = diffusionSteps
+            self.alpha = alpha
+            self.beta = beta
+            self.randomSeed = randomSeed
+        }
+    }
+
+    /// Synthesize from already-encoded token ids and a precomputed voice style.
+    ///
+    /// Caller is responsible for phonemization + vocab encoding (use
+    /// `StyleTTS2Manager.tokenize`). The leading pad token (id 0) is inserted
+    /// here per the upstream contract.
+    public func synthesize(
+        ids: [Int32],
+        voice: StyleTTS2VoiceStyle,
+        options: Options = Options()
+    ) async throws -> Data {
+        let samples = try await synthesizeSamples(ids: ids, voice: voice, options: options)
+        return try AudioWAV.data(
+            from: samples, sampleRate: Double(StyleTTS2Constants.audioSampleRate))
+    }
+
+    /// Same as `synthesize` but returns raw fp32 PCM samples.
+    public func synthesizeSamples(
+        ids: [Int32],
+        voice: StyleTTS2VoiceStyle,
+        options: Options = Options()
+    ) async throws -> [Float] {
+
+        // ---- Frontend: prepend pad, pick token bucket, pad. ----
+        var paddedIds: [Int32] = [Int32(StyleTTS2Constants.padTokenId)]
+        paddedIds.append(contentsOf: ids)
+        let tTok = paddedIds.count
+        let bTok = modelStore.textPredictorBucket(forTokenLength: tTok)
+        guard tTok <= bTok else {
+            throw StyleTTS2Error.processingFailed(
+                "input length \(tTok) exceeds largest text_predictor bucket \(bTok)")
+        }
+
+        // ---- Stage A: text_predictor ----
+        let aOut = try await runTextPredictor(
+            tokens: paddedIds,
+            tokenBucket: bTok,
+            voice: voice
+        )
+        // Slice T_tok-prefix views.
+        let tEn = aOut.tEn  // shape (512, T_tok), row-major
+        let dFull = aOut.dFull  // shape (T_tok, 640)
+        let predDurLog = aOut.predDurLog  // shape (T_tok, 50)
+        let bertDur = aOut.bertDur  // shape (T_tok, 768)
+
+        // ---- Durations + T_mel ----
+        let durations = computeDurations(predDurLog: predDurLog, tTok: tTok)
+        let tMel = durations.reduce(0, +)
+        guard tMel >= 1 else {
+            throw StyleTTS2Error.processingFailed("predicted T_mel was 0")
+        }
+        let bMel = modelStore.decoderBucket(forMelFrames: tMel)
+        guard tMel <= bMel else {
+            throw StyleTTS2Error.processingFailed(
+                "T_mel \(tMel) exceeds largest decoder bucket \(bMel)")
+        }
+
+        // ---- Stage B: ADPM2 sampler over diffusion_step_512 ----
+        let noise = generateGaussianNoise(
+            count: StyleTTS2Constants.refStyleDim, seed: options.randomSeed)
+        let sPred = try await runDiffusionSampler(
+            noise: noise,
+            bertDur: bertDur,
+            tTok: tTok,
+            voice: voice,
+            steps: options.diffusionSteps
+        )
+
+        // ---- Style mix ----
+        let acousticOriginal = Array(voice.acoustic)  // ref_s[:,:128]
+        let prosodyOriginal = Array(voice.prosody)  // ref_s[:,128:]
+        let acousticPred = Array(sPred[0..<StyleTTS2Constants.styleDim])
+        let prosodyPred = Array(sPred[StyleTTS2Constants.styleDim..<StyleTTS2Constants.refStyleDim])
+        let acousticMix = mix(a: acousticPred, b: acousticOriginal, alpha: options.alpha)
+        let prosodyMix = mix(a: prosodyPred, b: prosodyOriginal, alpha: options.beta)
+
+        // ---- Alignment + gather ----
+        let tokenIndex = buildTokenIndex(durations: durations, tMel: tMel)
+        var en = gatherEn(dFull: dFull, tokenIndex: tokenIndex, tMel: tMel)
+        var asr = gatherAsr(tEn: tEn, tokenIndex: tokenIndex, tMel: tMel)
+
+        // HiFi-GAN right-shift by 1 frame on both en and asr.
+        rightShift(channels: 640, frames: tMel, buffer: &en)
+        rightShift(channels: 512, frames: tMel, buffer: &asr)
+
+        // ---- Stage C: f0n_energy ----
+        let f0nOut = try await runF0nEnergy(
+            en: en, tMel: tMel, melBucket: bMel, prosodyMix: prosodyMix)
+        let f0 = f0nOut.f0  // length 2*T_mel
+        let n = f0nOut.n  // length 2*T_mel
+
+        // ---- Stage D: decoder ----
+        let waveform = try await runDecoder(
+            asr: asr,
+            f0: f0,
+            n: n,
+            acousticMix: acousticMix,
+            tMel: tMel,
+            melBucket: bMel
+        )
+
+        // Trim: take T_mel*600 samples then drop the trailing 50 (decoder edge).
+        let lastSample = min(waveform.count, tMel * 600)
+        let trimmed: [Float]
+        if lastSample > 50 {
+            trimmed = Array(waveform[0..<(lastSample - 50)])
+        } else {
+            trimmed = Array(waveform[0..<lastSample])
+        }
+        logger.info(
+            "Synthesized \(tTok) tokens → T_mel=\(tMel) → \(trimmed.count) samples "
+                + "(\(String(format: "%.2f", Double(trimmed.count) / 24_000.0))s)")
+        return trimmed
+    }
+
+    // MARK: - Stage A: text_predictor
+
+    private struct TextPredictorOutput {
+        let tEn: [Float]  // (512, T_tok), row-major
+        let dFull: [Float]  // (T_tok, 640)
+        let predDurLog: [Float]  // (T_tok, 50)
+        let bertDur: [Float]  // (T_tok, 768)
+    }
+
+    private func runTextPredictor(
+        tokens: [Int32],
+        tokenBucket: Int,
+        voice: StyleTTS2VoiceStyle
+    ) async throws -> TextPredictorOutput {
+        let tTok = tokens.count
+        let model = try await modelStore.textPredictor(bucket: tokenBucket)
+
+        // tokens: (1, B_tok) int32, padded with 0.
+        let tokensArr = try MLMultiArray(
+            shape: [1, NSNumber(value: tokenBucket)], dataType: .int32)
+        let tokensPtr = tokensArr.dataPointer.bindMemory(to: Int32.self, capacity: tokensArr.count)
+        tokensPtr.initialize(repeating: 0, count: tokensArr.count)
+        for i in 0..<tTok {
+            tokensPtr[i] = tokens[i]
+        }
+
+        // style: (1, 128) f32 — acoustic half of ref_s.
+        let styleArr = try MLMultiArray(
+            shape: [1, NSNumber(value: StyleTTS2Constants.styleDim)],
+            dataType: .float32)
+        let stylePtr = styleArr.dataPointer.bindMemory(to: Float.self, capacity: styleArr.count)
+        for (i, v) in voice.acoustic.enumerated() {
+            stylePtr[i] = v
+        }
+
+        let inputs = try MLDictionaryFeatureProvider(dictionary: [
+            "tokens": MLFeatureValue(multiArray: tokensArr),
+            "style": MLFeatureValue(multiArray: styleArr),
+        ])
+        let prediction = try await model.prediction(from: inputs)
+
+        guard let tEnArr = prediction.featureValue(for: "t_en")?.multiArrayValue,
+            let dArr = prediction.featureValue(for: "d")?.multiArrayValue,
+            let dlArr = prediction.featureValue(for: "pred_dur_log")?.multiArrayValue,
+            let bArr = prediction.featureValue(for: "bert_dur")?.multiArrayValue
+        else {
+            throw StyleTTS2Error.processingFailed(
+                "text_predictor: missing one of t_en/d/pred_dur_log/bert_dur outputs")
+        }
+
+        // t_en is (1, 512, B_tok). Take the first T_tok columns.
+        let tEn = sliceFirstAxis2D(
+            arr: tEnArr, leading: 512, trailing: tokenBucket, take: tTok, sliceDim: .trailing)
+        // d is (1, B_tok, 640). Take the first T_tok rows.
+        let dFull = sliceFirstAxis2D(
+            arr: dArr, leading: tokenBucket, trailing: 640, take: tTok, sliceDim: .leading)
+        let predDurLog = sliceFirstAxis2D(
+            arr: dlArr, leading: tokenBucket, trailing: 50, take: tTok, sliceDim: .leading)
+        let bertDur = sliceFirstAxis2D(
+            arr: bArr, leading: tokenBucket, trailing: 768, take: tTok, sliceDim: .leading)
+
+        return TextPredictorOutput(
+            tEn: tEn, dFull: dFull, predDurLog: predDurLog, bertDur: bertDur)
+    }
+
+    private enum SliceDim { case leading, trailing }
+
+    /// Slice an MLMultiArray of shape `(1, leading, trailing)` to the first
+    /// `take` entries along either the leading or trailing axis. Returns a
+    /// flat row-major `[Float]`.
+    private func sliceFirstAxis2D(
+        arr: MLMultiArray,
+        leading: Int,
+        trailing: Int,
+        take: Int,
+        sliceDim: SliceDim
+    ) -> [Float] {
+        let strides = arr.strides.map { $0.intValue }
+        switch sliceDim {
+        case .leading:
+            // Result shape: (take, trailing).
+            var out = [Float](repeating: 0, count: take * trailing)
+            for r in 0..<take {
+                for c in 0..<trailing {
+                    let idx = r * strides[1] + c * strides[2]
+                    out[r * trailing + c] = arr[idx].floatValue
+                }
+            }
+            return out
+        case .trailing:
+            // Result shape: (leading, take).
+            var out = [Float](repeating: 0, count: leading * take)
+            for r in 0..<leading {
+                for c in 0..<take {
+                    let idx = r * strides[1] + c * strides[2]
+                    out[r * take + c] = arr[idx].floatValue
+                }
+            }
+            return out
+        }
+    }
+
+    // MARK: - Durations
+
+    /// `pred_dur = round(sigmoid(pred_dur_log).sum(-1)).clamp(min=1)`.
+    private func computeDurations(predDurLog: [Float], tTok: Int) -> [Int] {
+        var durations = [Int](repeating: 0, count: tTok)
+        let dimDur = 50
+        for i in 0..<tTok {
+            var sum: Float = 0
+            for k in 0..<dimDur {
+                let logit = predDurLog[i * dimDur + k]
+                sum += sigmoid(logit)
+            }
+            durations[i] = max(1, Int(sum.rounded()))
+        }
+        return durations
+    }
+
+    private func sigmoid(_ x: Float) -> Float {
+        return 1.0 / (1.0 + exp(-x))
+    }
+
+    // MARK: - Stage B: diffusion sampler
+
+    private func runDiffusionSampler(
+        noise: [Float],
+        bertDur: [Float],  // (T_tok, 768)
+        tTok: Int,
+        voice: StyleTTS2VoiceStyle,
+        steps: Int
+    ) async throws -> [Float] {
+
+        let model = try await modelStore.diffusionStep()
+
+        // Build embedding: (1, 512, 768). Pad bert_dur from (T_tok, 768) to
+        // (512, 768). The diffusion model is shipped with B=512 only.
+        let embeddingDim = 768
+        let diffBucket = StyleTTS2Constants.diffusionBucket
+        let embeddingArr = try MLMultiArray(
+            shape: [1, NSNumber(value: diffBucket), NSNumber(value: embeddingDim)],
+            dataType: .float32)
+        let embPtr = embeddingArr.dataPointer.bindMemory(
+            to: Float.self, capacity: embeddingArr.count)
+        embPtr.initialize(repeating: 0, count: embeddingArr.count)
+        for r in 0..<tTok {
+            for c in 0..<embeddingDim {
+                embPtr[r * embeddingDim + c] = bertDur[r * embeddingDim + c]
+            }
+        }
+        let embeddingFeature = MLFeatureValue(multiArray: embeddingArr)
+
+        // Build features: (1, 256) — full ref_s.
+        let featuresArr = try MLMultiArray(
+            shape: [1, NSNumber(value: StyleTTS2Constants.refStyleDim)],
+            dataType: .float32)
+        let featPtr = featuresArr.dataPointer.bindMemory(
+            to: Float.self, capacity: featuresArr.count)
+        for (i, v) in voice.concatenated.enumerated() {
+            featPtr[i] = v
+        }
+        let featuresFeature = MLFeatureValue(multiArray: featuresArr)
+
+        // Closure: (x_noisy[256], sigma) → denoised[256].
+        let denoise: StyleTTS2Sampler.DenoiseStep = { x, sigma in
+            // x_noisy: (1, 1, 256) f32
+            let xArr = try MLMultiArray(
+                shape: [1, 1, NSNumber(value: StyleTTS2Constants.refStyleDim)],
+                dataType: .float32)
+            let xPtr = xArr.dataPointer.bindMemory(to: Float.self, capacity: xArr.count)
+            for (i, v) in x.enumerated() {
+                xPtr[i] = v
+            }
+            // sigma: (1,) f32
+            let sigmaArr = try MLMultiArray(shape: [1], dataType: .float32)
+            sigmaArr.dataPointer.bindMemory(to: Float.self, capacity: 1)[0] = sigma
+
+            let inputs = try MLDictionaryFeatureProvider(dictionary: [
+                "x_noisy": MLFeatureValue(multiArray: xArr),
+                "sigma": MLFeatureValue(multiArray: sigmaArr),
+                "embedding": embeddingFeature,
+                "features": featuresFeature,
+            ])
+            let prediction = try await model.prediction(from: inputs)
+            guard let denoisedArr = prediction.featureValue(for: "denoised")?.multiArrayValue
+            else {
+                throw StyleTTS2Error.processingFailed("diffusion_step: missing denoised output")
+            }
+            // `denoised` ships as Float16 per the model schema.
+            return await self.readMLMultiArrayPrefix(
+                arr: denoisedArr, count: StyleTTS2Constants.refStyleDim)
+        }
+
+        return try await StyleTTS2Sampler.adpm2Sample(
+            steps: steps, noise: noise, denoise: denoise)
+    }
+
+    // MARK: - Style mix
+
+    private func mix(a: [Float], b: [Float], alpha: Float) -> [Float] {
+        precondition(a.count == b.count)
+        var out = [Float](repeating: 0, count: a.count)
+        for i in 0..<a.count {
+            out[i] = alpha * a[i] + (1.0 - alpha) * b[i]
+        }
+        return out
+    }
+
+    // MARK: - Alignment + gather
+
+    /// Build a `tokenIndex[t_mel] = t_tok` lookup from per-token durations.
+    /// Equivalent to the one-hot `aln[T_tok, T_mel]` matrix the Python ref
+    /// constructs, but as a flat lookup (avoids materializing the full
+    /// matrix).
+    private func buildTokenIndex(durations: [Int], tMel: Int) -> [Int] {
+        var idx = [Int](repeating: 0, count: tMel)
+        var cursor = 0
+        for (t, n) in durations.enumerated() {
+            for k in 0..<n where cursor + k < tMel {
+                idx[cursor + k] = t
+            }
+            cursor += n
+        }
+        return idx
+    }
+
+    /// `en[c, t_mel] = d_full[token_index[t_mel], c]`. Shape (640, T_mel),
+    /// row-major.
+    private func gatherEn(dFull: [Float], tokenIndex: [Int], tMel: Int) -> [Float] {
+        let channels = 640
+        var en = [Float](repeating: 0, count: channels * tMel)
+        for t in 0..<tMel {
+            let tok = tokenIndex[t]
+            for c in 0..<channels {
+                en[c * tMel + t] = dFull[tok * channels + c]
+            }
+        }
+        return en
+    }
+
+    /// `asr[c, t_mel] = t_en[c, token_index[t_mel]]`. Shape (512, T_mel),
+    /// row-major.
+    private func gatherAsr(tEn: [Float], tokenIndex: [Int], tMel: Int) -> [Float] {
+        let channels = 512
+        let tTok = tEn.count / channels
+        var asr = [Float](repeating: 0, count: channels * tMel)
+        for t in 0..<tMel {
+            let tok = tokenIndex[t]
+            for c in 0..<channels {
+                asr[c * tMel + t] = tEn[c * tTok + tok]
+            }
+        }
+        return asr
+    }
+
+    /// HiFi-GAN convention: shift right by 1 frame and duplicate frame 0.
+    /// `out[c, 0] = in[c, 0]; out[c, t] = in[c, t-1]` for t >= 1.
+    private func rightShift(channels: Int, frames: Int, buffer: inout [Float]) {
+        guard frames >= 2 else { return }
+        // Shift in place from right to left.
+        for c in 0..<channels {
+            let base = c * frames
+            for t in stride(from: frames - 1, through: 1, by: -1) {
+                buffer[base + t] = buffer[base + t - 1]
+            }
+            // buffer[base + 0] is unchanged → duplicate of original frame 0.
+        }
+    }
+
+    // MARK: - Stage C: f0n_energy
+
+    private struct F0NOutput {
+        let f0: [Float]
+        let n: [Float]
+    }
+
+    private func runF0nEnergy(
+        en: [Float], tMel: Int, melBucket: Int, prosodyMix: [Float]
+    ) async throws -> F0NOutput {
+        let model = try await modelStore.f0nEnergy()
+        let channels = 640
+
+        // en_pad: (1, 640, 4096) — always use the largest enumerated shape.
+        // f0n_energy ships with enumeratedShapes; using only the default
+        // shape sidesteps E5RT's "tensor_buffer has known strides while
+        // the model has FlexibleShapeInfo" check that fires when the
+        // chosen enumeration differs from the default.
+        let enBucket = StyleTTS2Constants.decoderBuckets.last ?? 4096
+        let enArr = try MLMultiArray(
+            shape: [
+                1, NSNumber(value: channels), NSNumber(value: enBucket),
+            ],
+            dataType: .float32)
+        let enPtr = enArr.dataPointer.bindMemory(to: Float.self, capacity: enArr.count)
+        enPtr.initialize(repeating: 0, count: enArr.count)
+        for c in 0..<channels {
+            for t in 0..<tMel {
+                enPtr[c * enBucket + t] = en[c * tMel + t]
+            }
+        }
+
+        // s: (1, 128) — prosody half (post-mix).
+        let sArr = try MLMultiArray(
+            shape: [1, NSNumber(value: StyleTTS2Constants.styleDim)],
+            dataType: .float32)
+        let sPtr = sArr.dataPointer.bindMemory(to: Float.self, capacity: sArr.count)
+        for (i, v) in prosodyMix.enumerated() {
+            sPtr[i] = v
+        }
+
+        let inputs = try MLDictionaryFeatureProvider(dictionary: [
+            "en": MLFeatureValue(multiArray: enArr),
+            "s": MLFeatureValue(multiArray: sArr),
+        ])
+        let prediction = try await model.prediction(from: inputs)
+        guard let f0Arr = prediction.featureValue(for: "F0")?.multiArrayValue,
+            let nArr = prediction.featureValue(for: "N")?.multiArrayValue
+        else {
+            throw StyleTTS2Error.processingFailed("f0n_energy: missing F0/N output")
+        }
+
+        // F0 and N are (1, 2*B_mel). Slice to first 2*T_mel.
+        // Storage dtype is Float16 per the model schema.
+        let outLen = 2 * tMel
+        let f0 = readMLMultiArrayPrefix(arr: f0Arr, count: outLen)
+        let n = readMLMultiArrayPrefix(arr: nArr, count: outLen)
+        return F0NOutput(f0: f0, n: n)
+    }
+
+    /// Read the first `count` scalars from an MLMultiArray, regardless of
+    /// whether the storage dtype is Float32 or Float16.
+    private func readMLMultiArrayPrefix(arr: MLMultiArray, count: Int) -> [Float] {
+        let n = min(count, arr.count)
+        var out = [Float](repeating: 0, count: n)
+        switch arr.dataType {
+        case .float32:
+            let p = arr.dataPointer.bindMemory(to: Float.self, capacity: arr.count)
+            for i in 0..<n {
+                out[i] = p[i]
+            }
+        case .float16:
+            let p = arr.dataPointer.bindMemory(to: Float16.self, capacity: arr.count)
+            for i in 0..<n {
+                out[i] = Float(p[i])
+            }
+        case .double:
+            let p = arr.dataPointer.bindMemory(to: Double.self, capacity: arr.count)
+            for i in 0..<n {
+                out[i] = Float(p[i])
+            }
+        default:
+            for i in 0..<n {
+                out[i] = arr[i].floatValue
+            }
+        }
+        return out
+    }
+
+    // MARK: - Stage D: decoder
+
+    private func runDecoder(
+        asr: [Float],
+        f0: [Float],
+        n: [Float],
+        acousticMix: [Float],
+        tMel: Int,
+        melBucket: Int
+    ) async throws -> [Float] {
+        let model = try await modelStore.decoder(bucket: melBucket)
+
+        // asr_pad: (1, 512, B_mel)
+        let asrArr = try MLMultiArray(
+            shape: [1, 512, NSNumber(value: melBucket)], dataType: .float32)
+        let asrPtr = asrArr.dataPointer.bindMemory(to: Float.self, capacity: asrArr.count)
+        asrPtr.initialize(repeating: 0, count: asrArr.count)
+        for c in 0..<512 {
+            for t in 0..<tMel {
+                asrPtr[c * melBucket + t] = asr[c * tMel + t]
+            }
+        }
+
+        // F0_curve: (1, 2*B_mel)
+        let f0Arr = try MLMultiArray(
+            shape: [1, NSNumber(value: 2 * melBucket)], dataType: .float32)
+        let f0Ptr = f0Arr.dataPointer.bindMemory(to: Float.self, capacity: f0Arr.count)
+        f0Ptr.initialize(repeating: 0, count: f0Arr.count)
+        for i in 0..<f0.count {
+            f0Ptr[i] = f0[i]
+        }
+
+        // N: (1, 2*B_mel)
+        let nArr = try MLMultiArray(
+            shape: [1, NSNumber(value: 2 * melBucket)], dataType: .float32)
+        let nPtr = nArr.dataPointer.bindMemory(to: Float.self, capacity: nArr.count)
+        nPtr.initialize(repeating: 0, count: nArr.count)
+        for i in 0..<n.count {
+            nPtr[i] = n[i]
+        }
+
+        // s: (1, 128) — acoustic mix.
+        let sArr = try MLMultiArray(
+            shape: [1, NSNumber(value: StyleTTS2Constants.styleDim)], dataType: .float32)
+        let sPtr = sArr.dataPointer.bindMemory(to: Float.self, capacity: sArr.count)
+        for (i, v) in acousticMix.enumerated() {
+            sPtr[i] = v
+        }
+
+        let inputs = try MLDictionaryFeatureProvider(dictionary: [
+            "asr": MLFeatureValue(multiArray: asrArr),
+            "F0_curve": MLFeatureValue(multiArray: f0Arr),
+            "N": MLFeatureValue(multiArray: nArr),
+            "s": MLFeatureValue(multiArray: sArr),
+        ])
+        let prediction = try await model.prediction(from: inputs)
+        guard let waveArr = prediction.featureValue(for: "waveform")?.multiArrayValue else {
+            throw StyleTTS2Error.processingFailed("decoder: missing waveform output")
+        }
+        let count = waveArr.count
+        let wPtr = waveArr.dataPointer.bindMemory(to: Float.self, capacity: count)
+        var waveform = [Float](repeating: 0, count: count)
+        for i in 0..<count {
+            waveform[i] = wPtr[i]
+        }
+        return waveform
+    }
+
+    // MARK: - Noise generator
+
+    /// Box-Muller Gaussian noise. Deterministic when `seed` is non-nil
+    /// (SplitMix64 PRNG → uniform → Box-Muller); otherwise uses
+    /// `SystemRandomNumberGenerator`.
+    private func generateGaussianNoise(count: Int, seed: UInt64?) -> [Float] {
+        var values = [Float](repeating: 0, count: count)
+        if var rng = seed.map({ SplitMix64(seed: $0) }) {
+            fillBoxMuller(into: &values, generator: { rng.nextUnitFloat() })
+        } else {
+            var sys = SystemRandomNumberGenerator()
+            fillBoxMuller(
+                into: &values,
+                generator: {
+                    Float.random(in: 0..<1, using: &sys)
+                })
+        }
+        return values
+    }
+
+    private func fillBoxMuller(into values: inout [Float], generator: () -> Float) {
+        let count = values.count
+        var i = 0
+        while i < count {
+            let u1 = max(generator(), Float.leastNormalMagnitude)
+            let u2 = generator()
+            let r = sqrt(-2.0 * log(u1))
+            let theta = 2.0 * Float.pi * u2
+            values[i] = r * cos(theta)
+            if i + 1 < count {
+                values[i + 1] = r * sin(theta)
+            }
+            i += 2
+        }
+    }
+}
+
+/// Tiny SplitMix64 PRNG. Used purely to seed Gaussian noise — not for
+/// cryptographic or statistical applications. State is `Sendable` because
+/// it's used inside an actor.
+private struct SplitMix64 {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        self.state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var z = state
+        z = (z ^ (z &>> 30)) &* 0xBF58_476D_1CE4_E5B9
+        z = (z ^ (z &>> 27)) &* 0x94D0_49BB_1331_11EB
+        return z ^ (z &>> 31)
+    }
+
+    /// Uniform float in [0, 1).
+    mutating func nextUnitFloat() -> Float {
+        // Take the top 24 bits → exact representation in fp32 mantissa.
+        let bits = next() >> 40
+        return Float(bits) / Float(1 << 24)
+    }
+}

--- a/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Constants.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Constants.swift
@@ -39,8 +39,10 @@ public enum StyleTTS2Constants {
 
     /// Default number of diffusion sampler steps (5× per utterance).
     public static let defaultDiffusionSteps: Int = 5
-    /// Karras schedule rho (controls sigma curvature).
-    public static let karrasRho: Float = 7.0
+    /// Karras schedule rho (controls sigma curvature). Matches the upstream
+    /// e2e reference (`99b_e2e_coreml.py`) which uses rho=9.0 — *not* the
+    /// k-diffusion default of 7.0.
+    public static let karrasRho: Float = 9.0
     public static let karrasSigmaMin: Float = 0.0001
     public static let karrasSigmaMax: Float = 3.0
     /// Classifier-free guidance scale applied during the diffusion step.

--- a/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Constants.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Constants.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Constants for the StyleTTS2 4-stage diffusion TTS backend.
+///
+/// Reference: `FluidInference/StyleTTS-2-coreml` (LibriTTS multi-speaker
+/// checkpoint). The companion `config.json` shipped with the repo carries
+/// the same numbers in machine-readable form; values here mirror that
+/// contract so the framework can run without parsing the bundle config
+/// before model load.
+public enum StyleTTS2Constants {
+
+    // MARK: - Audio
+
+    public static let audioSampleRate: Int = 24_000
+    /// HiFi-GAN hop size — `mel_frames * hopSize == samples`.
+    public static let hopSize: Int = 300
+    public static let melChannels: Int = 80
+    public static let nFFT: Int = 2_048
+    public static let winLength: Int = 1_200
+
+    // MARK: - Tokenizer
+
+    /// 178-token espeak-ng IPA + stress vocabulary (mirrors
+    /// `text_utils.TextCleaner` from upstream StyleTTS2).
+    public static let vocabSize: Int = 178
+    /// Pad token id (id 0 in the upstream cleaner table).
+    public static let padTokenId: Int = 0
+
+    // MARK: - Model dimensions
+
+    /// Style/reference vector channels per branch (acoustic, prosody).
+    public static let styleDim: Int = 128
+    /// Concat of acoustic + prosody style vectors (`ref_s` input dim).
+    public static let refStyleDim: Int = 256
+    /// BERT/text predictor hidden size.
+    public static let hiddenDim: Int = 512
+
+    // MARK: - Sampler (ADPM2 + Karras schedule + CFG)
+
+    /// Default number of diffusion sampler steps (5× per utterance).
+    public static let defaultDiffusionSteps: Int = 5
+    /// Karras schedule rho (controls sigma curvature).
+    public static let karrasRho: Float = 7.0
+    public static let karrasSigmaMin: Float = 0.0001
+    public static let karrasSigmaMax: Float = 3.0
+    /// Classifier-free guidance scale applied during the diffusion step.
+    public static let cfgScale: Float = 1.0
+    /// Diffusion step model is shipped only at this `bert_dur` bucket.
+    public static let diffusionBucket: Int = 512
+
+    // MARK: - Bucket selection
+
+    /// Token-length buckets shipped for `text_predictor`.
+    public static let textPredictorBuckets: [Int] = [32, 64, 128, 256, 512]
+    /// Mel-frame buckets shipped for the HiFi-GAN decoder.
+    public static let decoderBuckets: [Int] = [256, 512, 1024, 2048, 4096]
+
+    // MARK: - Repository
+
+    public static let defaultModelsSubdirectory: String = "Models"
+}

--- a/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Error.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Error.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Errors that can occur during StyleTTS2 synthesis.
+public enum StyleTTS2Error: LocalizedError {
+    case downloadFailed(String)
+    case corruptedModel(String)
+    case modelNotFound(String)
+    case processingFailed(String)
+    case invalidConfiguration(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .downloadFailed(let message):
+            return "StyleTTS2 download failed: \(message)"
+        case .corruptedModel(let name):
+            return "StyleTTS2 model \(name) is corrupted"
+        case .modelNotFound(let name):
+            return "StyleTTS2 model \(name) not found"
+        case .processingFailed(let message):
+            return "StyleTTS2 processing failed: \(message)"
+        case .invalidConfiguration(let message):
+            return "StyleTTS2 invalid configuration: \(message)"
+        }
+    }
+}

--- a/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Manager.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Manager.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Manages text-to-speech synthesis using the StyleTTS2 4-stage diffusion
+/// pipeline (LibriTTS multi-speaker checkpoint).
+///
+/// Pipeline (per utterance):
+///  1. `text_predictor` (fp16, ANE) → `bert_dur` features + duration logits.
+///  2. `diffusion_step_512` (fp16, CPU+GPU) — ADPM2 sampler, 5× per utt + CFG.
+///  3. `f0n_energy` (fp16, ANE) → F0 + energy regression.
+///  4. `decoder` (fp32, CPU+GPU) — HiFi-GAN waveform synthesis.
+///
+/// The Swift host is responsible for:
+///   - espeak-ng IPA phonemization + vocab lookup,
+///   - the ADPM2 + Karras sampler loop around `diffusion_step`,
+///   - cumsum-of-durations → one-hot → matmul hard-alignment,
+///   - bucket selection (round token length → text_predictor; round
+///     mel frames → decoder).
+///
+/// **Status:** scaffold only. Synthesis is not yet implemented; calls to
+/// `synthesize` throw `processingFailed`. The asset bring-up (download +
+/// model store) is wired up so dependent layers can land incrementally.
+public actor StyleTTS2Manager {
+
+    private let logger = AppLogger(category: "StyleTTS2Manager")
+    private let modelStore: StyleTTS2ModelStore
+    private var isInitialized = false
+
+    /// - Parameter directory: Optional override for the base cache directory.
+    ///   When `nil`, uses the default platform cache location.
+    public init(directory: URL? = nil) {
+        self.modelStore = StyleTTS2ModelStore(directory: directory)
+    }
+
+    public var isAvailable: Bool {
+        isInitialized
+    }
+
+    /// Download the bundle (mlpackages + config + vocab) and resolve the
+    /// repo root. Models are loaded lazily on first synthesis call.
+    ///
+    /// Also decodes and validates `config.json` against `StyleTTS2Constants`
+    /// so wrong-bundle / partial-download / version-mismatch errors surface
+    /// here rather than as cryptic CoreML shape errors at synthesis time.
+    public func initialize(
+        progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws {
+        _ = try await modelStore.ensureAssetsAvailable(progressHandler: progressHandler)
+        let config = try await modelStore.bundleConfig()
+        try config.validate()
+        isInitialized = true
+        logger.notice("StyleTTS2Manager initialized")
+    }
+
+    /// Synthesize text to a WAV blob at 24 kHz.
+    ///
+    /// - Parameters:
+    ///   - text: Text to synthesize.
+    ///   - referenceAudioURL: Reference clip used by the diffusion sampler to
+    ///     extract `ref_s` (style + prosody, 256-dim concat). LibriTTS clones
+    ///     are robust to ~5 s of speech.
+    ///   - diffusionSteps: Number of ADPM2 sampler iterations (default 5).
+    ///   - cfgScale: Classifier-free guidance scale (default 1.0).
+    /// - Returns: WAV audio data (24 kHz, mono, fp32 PCM).
+    public func synthesize(
+        text: String,
+        referenceAudioURL: URL,
+        diffusionSteps: Int = StyleTTS2Constants.defaultDiffusionSteps,
+        cfgScale: Float = StyleTTS2Constants.cfgScale
+    ) async throws -> Data {
+        guard isInitialized else {
+            throw StyleTTS2Error.modelNotFound("StyleTTS2 model not initialized")
+        }
+        // Scaffold: synthesizer is not yet implemented. The pieces will land
+        // in follow-up commits — phonemizer wiring, sampler loop, hard-align,
+        // decoder driver. Throwing here is intentional so callers can wire
+        // up the surface today and fill in the implementation incrementally.
+        _ = text
+        _ = referenceAudioURL
+        _ = diffusionSteps
+        _ = cfgScale
+        throw StyleTTS2Error.processingFailed(
+            "StyleTTS2 synthesis is not yet implemented")
+    }
+
+    /// Run the text frontend (preprocess → G2P → vocab encode) end-to-end.
+    ///
+    /// Available before the diffusion synthesizer is wired so callers can
+    /// validate the bundle, vocab, and G2P installation. The returned ids
+    /// are exactly what the `text_predictor` model would consume after
+    /// padding to a bucket length.
+    ///
+    /// - Parameters:
+    ///   - text: Source text to phonemize.
+    ///   - language: G2P language. Defaults to `.americanEnglish` because
+    ///     the shipped LibriTTS checkpoint is English-only.
+    /// - Returns: A tuple of the IPA phoneme string and its `[Int32]` token
+    ///   id encoding under the 178-token espeak-ng vocab.
+    public func tokenize(
+        text: String,
+        language: MultilingualG2PLanguage = .americanEnglish
+    ) async throws -> (phonemes: String, ids: [Int32]) {
+        guard isInitialized else {
+            throw StyleTTS2Error.modelNotFound("StyleTTS2 model not initialized")
+        }
+        let phonemes = try await StyleTTS2Phonemizer.phonemize(
+            text: text, language: language)
+        let vocab = try await modelStore.vocabulary()
+        let ids = vocab.encode(phonemes)
+        return (phonemes, ids)
+    }
+
+    public func cleanup() {
+        isInitialized = false
+    }
+
+    // MARK: - Internal accessors (for the synthesizer once it lands)
+
+    /// Expose the model store to the not-yet-written synthesizer module.
+    public func underlyingModelStore() -> StyleTTS2ModelStore {
+        modelStore
+    }
+}

--- a/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Manager.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Manager.swift
@@ -23,12 +23,15 @@ public actor StyleTTS2Manager {
 
     private let logger = AppLogger(category: "StyleTTS2Manager")
     private let modelStore: StyleTTS2ModelStore
+    private let synthesizer: StyleTTS2Synthesizer
     private var isInitialized = false
 
     /// - Parameter directory: Optional override for the base cache directory.
     ///   When `nil`, uses the default platform cache location.
     public init(directory: URL? = nil) {
-        self.modelStore = StyleTTS2ModelStore(directory: directory)
+        let store = StyleTTS2ModelStore(directory: directory)
+        self.modelStore = store
+        self.synthesizer = StyleTTS2Synthesizer(modelStore: store)
     }
 
     public var isAvailable: Bool {
@@ -55,31 +58,39 @@ public actor StyleTTS2Manager {
     ///
     /// - Parameters:
     ///   - text: Text to synthesize.
-    ///   - referenceAudioURL: Reference clip used by the diffusion sampler to
-    ///     extract `ref_s` (style + prosody, 256-dim concat). LibriTTS clones
-    ///     are robust to ~5 s of speech.
+    ///   - voiceStyleURL: Path to a precomputed `ref_s.bin` (256 fp32 LE,
+    ///     1024 bytes) produced offline by
+    ///     `mobius-styletts2/scripts/06_dump_ref_s.py`. The on-device style
+    ///     encoder export is a follow-up; until it lands, voices ship as
+    ///     these blobs.
+    ///   - language: G2P language for phonemization.
     ///   - diffusionSteps: Number of ADPM2 sampler iterations (default 5).
-    ///   - cfgScale: Classifier-free guidance scale (default 1.0).
-    /// - Returns: WAV audio data (24 kHz, mono, fp32 PCM).
+    ///   - alpha: Acoustic style mix weight (default 0.3).
+    ///   - beta: Prosody style mix weight (default 0.7).
+    ///   - randomSeed: Seed for the diffusion noise RNG. `nil` → use the
+    ///     system RNG (non-reproducible).
+    /// - Returns: WAV audio data (24 kHz, mono, 16-bit PCM).
     public func synthesize(
         text: String,
-        referenceAudioURL: URL,
+        voiceStyleURL: URL,
+        language: MultilingualG2PLanguage = .americanEnglish,
         diffusionSteps: Int = StyleTTS2Constants.defaultDiffusionSteps,
-        cfgScale: Float = StyleTTS2Constants.cfgScale
+        alpha: Float = 0.3,
+        beta: Float = 0.7,
+        randomSeed: UInt64? = nil
     ) async throws -> Data {
         guard isInitialized else {
             throw StyleTTS2Error.modelNotFound("StyleTTS2 model not initialized")
         }
-        // Scaffold: synthesizer is not yet implemented. The pieces will land
-        // in follow-up commits — phonemizer wiring, sampler loop, hard-align,
-        // decoder driver. Throwing here is intentional so callers can wire
-        // up the surface today and fill in the implementation incrementally.
-        _ = text
-        _ = referenceAudioURL
-        _ = diffusionSteps
-        _ = cfgScale
-        throw StyleTTS2Error.processingFailed(
-            "StyleTTS2 synthesis is not yet implemented")
+        let voice = try StyleTTS2VoiceStyle.load(from: voiceStyleURL)
+        let (_, ids) = try await tokenize(text: text, language: language)
+        let options = StyleTTS2Synthesizer.Options(
+            diffusionSteps: diffusionSteps,
+            alpha: alpha,
+            beta: beta,
+            randomSeed: randomSeed
+        )
+        return try await synthesizer.synthesize(ids: ids, voice: voice, options: options)
     }
 
     /// Run the text frontend (preprocess → G2P → vocab encode) end-to-end.

--- a/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Manager.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Manager.swift
@@ -50,6 +50,24 @@ public actor StyleTTS2Manager {
         _ = try await modelStore.ensureAssetsAvailable(progressHandler: progressHandler)
         let config = try await modelStore.bundleConfig()
         try config.validate()
+
+        // The English G2P CoreML assets ship in the kokoro repo and are loaded
+        // from `~/.cache/fluidaudio/Models/kokoro/`. `G2PModel.loadIfNeeded`
+        // only reads from cache (it never downloads), so a first-time
+        // StyleTTS2 user who has never run kokoro/kokoroAne would otherwise
+        // hit a cryptic `G2PModelError.vocabLoadFailed` deep inside
+        // `synthesize`. Mirror `KokoroAneManager.initialize` and fetch the
+        // shared G2P assets explicitly here.
+        //
+        // NOTE: pass nil (not the caller's `directory`) — `G2PModel.shared`
+        // is a singleton that hardcodes the default cache path
+        // (`TtsModels.cacheDirectoryURL()/Models/kokoro`). Honouring a
+        // custom override here would write to a path the singleton can't
+        // read and we'd still hit `vocabLoadFailed`.
+        try await KokoroAneResourceDownloader.ensureG2PAssets(
+            directory: nil, progressHandler: progressHandler)
+        try await G2PModel.shared.ensureModelsAvailable()
+
         isInitialized = true
         logger.notice("StyleTTS2Manager initialized")
     }

--- a/Sources/FluidAudio/TTS/TtsBackend.swift
+++ b/Sources/FluidAudio/TTS/TtsBackend.swift
@@ -18,4 +18,9 @@ public enum TtsBackend: Sendable {
     /// laishere/kokoro 7-stage CoreML chain (ALBERT → PostAlbert → Alignment →
     /// Prosody → Noise → Vocoder → Tail) with per-stage ANE/GPU assignment.
     case kokoroAne
+    /// StyleTTS2 (LibriTTS multi-speaker) — 4-stage diffusion pipeline:
+    /// text_predictor → diffusion_step (×5) → f0n_energy → decoder. fp16
+    /// everywhere except the fp32 HiFi-GAN decoder (SineGen phase
+    /// saturation requires fp32).
+    case styleTts2
 }

--- a/Sources/FluidAudioCLI/Commands/StyleTTS2Command.swift
+++ b/Sources/FluidAudioCLI/Commands/StyleTTS2Command.swift
@@ -1,0 +1,169 @@
+import FluidAudio
+import Foundation
+
+/// `fluidaudio styletts2 "text" --voice ref_s.bin --output out.wav`
+///
+/// Drives the StyleTTS2 4-stage diffusion synthesizer end-to-end and writes
+/// a 24 kHz mono 16-bit WAV. The `--voice` flag points at a precomputed
+/// `ref_s.bin` style+prosody blob (see `mobius-styletts2/scripts/06_dump_ref_s.py`).
+public enum StyleTTS2Command {
+
+    private static let logger = AppLogger(category: "StyleTTS2Command")
+
+    public static func run(arguments: [String]) async {
+        guard !arguments.isEmpty else {
+            printUsage()
+            return
+        }
+
+        var text: String?
+        var voicePath: String?
+        var outputPath = "styletts2.wav"
+        var diffusionSteps = 5
+        var alpha: Float = 0.3
+        var beta: Float = 0.7
+        var seed: UInt64?
+
+        var i = 0
+        while i < arguments.count {
+            let arg = arguments[i]
+            switch arg {
+            case "--voice":
+                guard i + 1 < arguments.count else {
+                    fputs("--voice requires a path\n", stderr)
+                    exit(2)
+                }
+                voicePath = arguments[i + 1]
+                i += 2
+            case "--output", "-o":
+                guard i + 1 < arguments.count else {
+                    fputs("--output requires a path\n", stderr)
+                    exit(2)
+                }
+                outputPath = arguments[i + 1]
+                i += 2
+            case "--steps":
+                if i + 1 < arguments.count, let n = Int(arguments[i + 1]) {
+                    diffusionSteps = n
+                    i += 2
+                } else {
+                    fputs("--steps requires an integer\n", stderr)
+                    exit(2)
+                }
+            case "--alpha":
+                if i + 1 < arguments.count, let v = Float(arguments[i + 1]) {
+                    alpha = v
+                    i += 2
+                } else {
+                    fputs("--alpha requires a float\n", stderr)
+                    exit(2)
+                }
+            case "--beta":
+                if i + 1 < arguments.count, let v = Float(arguments[i + 1]) {
+                    beta = v
+                    i += 2
+                } else {
+                    fputs("--beta requires a float\n", stderr)
+                    exit(2)
+                }
+            case "--seed":
+                if i + 1 < arguments.count, let v = UInt64(arguments[i + 1]) {
+                    seed = v
+                    i += 2
+                } else {
+                    fputs("--seed requires an integer\n", stderr)
+                    exit(2)
+                }
+            case "--help", "-h":
+                printUsage()
+                return
+            default:
+                if text == nil {
+                    text = arg
+                } else {
+                    fputs("Unexpected argument: \(arg)\n", stderr)
+                    exit(2)
+                }
+                i += 1
+            }
+        }
+
+        guard let text else {
+            fputs("Missing required text argument\n", stderr)
+            printUsage()
+            exit(2)
+        }
+        guard let voicePath else {
+            fputs("Missing --voice <path/to/ref_s.bin>\n", stderr)
+            printUsage()
+            exit(2)
+        }
+
+        let voiceURL = expand(voicePath)
+        let outputURL = expand(outputPath)
+
+        do {
+            logger.notice("Initializing StyleTTS2 (will download models on first run)...")
+            let manager = StyleTTS2Manager()
+            try await manager.initialize { progress in
+                logger.debug(
+                    "Download \(progress.phase): "
+                        + "\(Int(progress.fractionCompleted * 100))%")
+            }
+
+            logger.notice("Synthesizing text (\(text.count) chars, steps=\(diffusionSteps))...")
+            let (phonemes, ids) = try await manager.tokenize(text: text)
+            print("PHONEMES: \(phonemes)")
+            print("TOKEN_IDS (\(ids.count)): \(ids)")
+            let start = Date()
+            let wav = try await manager.synthesize(
+                text: text,
+                voiceStyleURL: voiceURL,
+                diffusionSteps: diffusionSteps,
+                alpha: alpha,
+                beta: beta,
+                randomSeed: seed
+            )
+            let elapsed = Date().timeIntervalSince(start)
+
+            try wav.write(to: outputURL)
+            logger.notice(
+                "Wrote \(outputURL.path) (\(wav.count) bytes) in "
+                    + "\(String(format: "%.2f", elapsed))s")
+        } catch {
+            logger.error("StyleTTS2 synthesis failed: \(error)")
+            exit(1)
+        }
+    }
+
+    private static func expand(_ path: String) -> URL {
+        let exp = (path as NSString).expandingTildeInPath
+        if exp.hasPrefix("/") {
+            return URL(fileURLWithPath: exp)
+        }
+        let cwd = URL(
+            fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+        return cwd.appendingPathComponent(exp)
+    }
+
+    private static func printUsage() {
+        let msg = """
+            Usage:
+              fluidaudio styletts2 "<text>" --voice <ref_s.bin> [options]
+
+            Options:
+              --voice <path>    Required. Path to precomputed ref_s.bin (256 fp32 LE).
+              --output <path>   Output WAV path (default: styletts2.wav).
+              --steps <int>     ADPM2 sampler steps (default: 5).
+              --alpha <float>   Acoustic style mix weight (default: 0.3).
+              --beta <float>    Prosody style mix weight (default: 0.7).
+              --seed <uint>     Deterministic noise seed (default: system RNG).
+
+            Example:
+              fluidaudio styletts2 "Hello world" \\
+                  --voice /tmp/styletts2-ref_s.bin \\
+                  --output /tmp/styletts2-hello.wav
+            """
+        print(msg)
+    }
+}

--- a/Sources/FluidAudioCLI/FluidAudioCLI.swift
+++ b/Sources/FluidAudioCLI/FluidAudioCLI.swift
@@ -42,6 +42,8 @@ struct FluidAudioCLI {
             await MultiStreamCommand.run(arguments: Array(arguments.dropFirst(2)))
         case "tts":
             await TTS.run(arguments: Array(arguments.dropFirst(2)))
+        case "styletts2":
+            await StyleTTS2Command.run(arguments: Array(arguments.dropFirst(2)))
         case "magpie":
             await MagpieCommand.run(arguments: Array(arguments.dropFirst(2)))
         case "tts-asr-verify":

--- a/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2BundleConfigTests.swift
+++ b/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2BundleConfigTests.swift
@@ -1,0 +1,315 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Pure-logic unit tests for the StyleTTS2 `config.json` loader + validator.
+///
+/// Uses inline JSON fixtures so the suite runs without HuggingFace
+/// downloads or any CoreML models.
+final class StyleTTS2BundleConfigTests: XCTestCase {
+
+    /// Canonical fixture mirroring the live `config.json` shipped on
+    /// `FluidInference/StyleTTS-2-coreml`. Trimmed to the must-have fields
+    /// the loader actually reads — extra keys in the on-disk file are
+    /// ignored by `Codable` decoding.
+    private let goodJSON: String = #"""
+        {
+          "model_type": "styletts2",
+          "audio": {
+            "sample_rate": 24000,
+            "n_fft": 2048,
+            "win_length": 1200,
+            "hop_length": 300,
+            "n_mels": 80
+          },
+          "tokenizer": {
+            "type": "espeak-ng-ipa",
+            "vocab_file": "constants/text_cleaner_vocab.json",
+            "n_tokens": 178,
+            "pad_token": "$",
+            "pad_id": 0
+          },
+          "model": {
+            "style_dim": 128,
+            "hidden_dim": 512,
+            "n_layer": 3,
+            "max_dur": 50,
+            "ref_s_dim": 256
+          },
+          "sampler": {
+            "type": "ADPM2",
+            "schedule": "karras",
+            "num_steps": 5,
+            "classifier_free_guidance": true,
+            "cfg_scale_default": 1.0
+          }
+        }
+        """#
+
+    private func writeFixture(_ json: String, name: String = "config.json") throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("styletts2-config-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try json.data(using: .utf8)!.write(to: url)
+        return url
+    }
+
+    /// Replace a single integer field inside the canonical fixture. We use
+    /// a string-replace rather than re-encoding via `JSONSerialization` so
+    /// the diff in test output is obvious.
+    private func goodJSONReplacing(_ field: String, with value: String) -> String {
+        let pattern = "\"\(field)\": "
+        guard let range = goodJSON.range(of: pattern) else {
+            XCTFail("Test bug: field \"\(field)\" not in fixture")
+            return goodJSON
+        }
+        // Replace from end-of-pattern to the next "," or "\n"
+        let tail = goodJSON[range.upperBound...]
+        guard let term = tail.firstIndex(where: { $0 == "," || $0 == "\n" }) else {
+            return goodJSON
+        }
+        return goodJSON.replacingCharacters(
+            in: range.upperBound..<term, with: value)
+    }
+
+    // MARK: - load
+
+    func testLoadParsesCanonicalConfig() throws {
+        let url = try writeFixture(goodJSON)
+        let config = try StyleTTS2BundleConfig.load(from: url)
+
+        XCTAssertEqual(config.modelType, "styletts2")
+        XCTAssertEqual(config.audio.sampleRate, 24_000)
+        XCTAssertEqual(config.audio.nFFT, 2_048)
+        XCTAssertEqual(config.audio.winLength, 1_200)
+        XCTAssertEqual(config.audio.hopLength, 300)
+        XCTAssertEqual(config.audio.nMels, 80)
+
+        XCTAssertEqual(config.tokenizer.type, "espeak-ng-ipa")
+        XCTAssertEqual(config.tokenizer.vocabFile, "constants/text_cleaner_vocab.json")
+        XCTAssertEqual(config.tokenizer.nTokens, 178)
+        XCTAssertEqual(config.tokenizer.padToken, "$")
+        XCTAssertEqual(config.tokenizer.padId, 0)
+
+        XCTAssertEqual(config.model.styleDim, 128)
+        XCTAssertEqual(config.model.hiddenDim, 512)
+        XCTAssertEqual(config.model.nLayer, 3)
+        XCTAssertEqual(config.model.maxDur, 50)
+        XCTAssertEqual(config.model.refStyleDim, 256)
+
+        XCTAssertEqual(config.sampler.type, "ADPM2")
+        XCTAssertEqual(config.sampler.schedule, "karras")
+        XCTAssertEqual(config.sampler.numSteps, 5)
+        XCTAssertTrue(config.sampler.classifierFreeGuidance)
+        XCTAssertEqual(config.sampler.cfgScaleDefault, 1.0, accuracy: 1e-6)
+    }
+
+    func testLoadFailsForMissingFile() {
+        let bogusURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID().uuidString).json")
+        XCTAssertThrowsError(try StyleTTS2BundleConfig.load(from: bogusURL)) { error in
+            guard case StyleTTS2Error.modelNotFound = error else {
+                XCTFail("expected modelNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testLoadFailsForMalformedJSON() throws {
+        let url = try writeFixture("not actually json", name: "bad.json")
+        XCTAssertThrowsError(try StyleTTS2BundleConfig.load(from: url)) { error in
+            guard case StyleTTS2Error.invalidConfiguration = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testLoadFailsWhenRequiredFieldMissing() throws {
+        // Drop the audio block entirely — Codable should reject.
+        let bad = #"""
+            {
+              "model_type": "styletts2",
+              "tokenizer": {
+                "type": "espeak-ng-ipa",
+                "vocab_file": "constants/text_cleaner_vocab.json",
+                "n_tokens": 178,
+                "pad_token": "$",
+                "pad_id": 0
+              },
+              "model": {
+                "style_dim": 128, "hidden_dim": 512, "n_layer": 3,
+                "max_dur": 50, "ref_s_dim": 256
+              },
+              "sampler": {
+                "type": "ADPM2", "schedule": "karras",
+                "num_steps": 5, "classifier_free_guidance": true,
+                "cfg_scale_default": 1.0
+              }
+            }
+            """#
+        let url = try writeFixture(bad, name: "missing-audio.json")
+        XCTAssertThrowsError(try StyleTTS2BundleConfig.load(from: url)) { error in
+            guard case StyleTTS2Error.invalidConfiguration = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - validate
+
+    func testValidatePassesForCanonicalConfig() throws {
+        let url = try writeFixture(goodJSON)
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertNoThrow(try config.validate())
+    }
+
+    func testValidateFailsOnWrongModelType() throws {
+        let bad = goodJSON.replacingOccurrences(
+            of: "\"model_type\": \"styletts2\"",
+            with: "\"model_type\": \"kokoro\"")
+        let url = try writeFixture(bad, name: "wrong-model-type.json")
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard case StyleTTS2Error.invalidConfiguration(let msg) = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("model_type"))
+        }
+    }
+
+    func testValidateFailsOnSampleRateMismatch() throws {
+        let bad = goodJSONReplacing("sample_rate", with: "16000")
+        let url = try writeFixture(bad, name: "wrong-sr.json")
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard case StyleTTS2Error.invalidConfiguration(let msg) = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("audio.sample_rate"))
+        }
+    }
+
+    func testValidateFailsOnHopLengthMismatch() throws {
+        let bad = goodJSONReplacing("hop_length", with: "256")
+        let url = try writeFixture(bad, name: "wrong-hop.json")
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard case StyleTTS2Error.invalidConfiguration(let msg) = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("audio.hop_length"))
+        }
+    }
+
+    func testValidateFailsOnNMelsMismatch() throws {
+        let bad = goodJSONReplacing("n_mels", with: "128")
+        let url = try writeFixture(bad, name: "wrong-mels.json")
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard case StyleTTS2Error.invalidConfiguration(let msg) = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("audio.n_mels"))
+        }
+    }
+
+    func testValidateFailsOnNFFTMismatch() throws {
+        let bad = goodJSONReplacing("n_fft", with: "1024")
+        let url = try writeFixture(bad, name: "wrong-nfft.json")
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard case StyleTTS2Error.invalidConfiguration(let msg) = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("audio.n_fft"))
+        }
+    }
+
+    func testValidateFailsOnWinLengthMismatch() throws {
+        let bad = goodJSONReplacing("win_length", with: "800")
+        let url = try writeFixture(bad, name: "wrong-win.json")
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard case StyleTTS2Error.invalidConfiguration(let msg) = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("audio.win_length"))
+        }
+    }
+
+    func testValidateFailsOnNTokensMismatch() throws {
+        let bad = goodJSONReplacing("n_tokens", with: "256")
+        let url = try writeFixture(bad, name: "wrong-ntokens.json")
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard case StyleTTS2Error.invalidConfiguration(let msg) = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("tokenizer.n_tokens"))
+        }
+    }
+
+    func testValidateFailsOnPadIdMismatch() throws {
+        let bad = goodJSONReplacing("pad_id", with: "1")
+        let url = try writeFixture(bad, name: "wrong-padid.json")
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard case StyleTTS2Error.invalidConfiguration(let msg) = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("tokenizer.pad_id"))
+        }
+    }
+
+    func testValidateFailsOnStyleDimMismatch() throws {
+        let bad = goodJSONReplacing("style_dim", with: "64")
+        let url = try writeFixture(bad, name: "wrong-style.json")
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard case StyleTTS2Error.invalidConfiguration(let msg) = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("model.style_dim"))
+        }
+    }
+
+    func testValidateFailsOnHiddenDimMismatch() throws {
+        let bad = goodJSONReplacing("hidden_dim", with: "256")
+        let url = try writeFixture(bad, name: "wrong-hidden.json")
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard case StyleTTS2Error.invalidConfiguration(let msg) = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("model.hidden_dim"))
+        }
+    }
+
+    func testValidateFailsOnRefSDimMismatch() throws {
+        let bad = goodJSONReplacing("ref_s_dim", with: "128")
+        let url = try writeFixture(bad, name: "wrong-refs.json")
+        let config = try StyleTTS2BundleConfig.load(from: url)
+        XCTAssertThrowsError(try config.validate()) { error in
+            guard case StyleTTS2Error.invalidConfiguration(let msg) = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+            XCTAssertTrue(msg.contains("model.ref_s_dim"))
+        }
+    }
+}

--- a/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2SamplerTests.swift
+++ b/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2SamplerTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Unit tests for the Karras + ADPM2 sampler.
+///
+/// All numeric expectations are ground-truthed against the upstream
+/// `99b_e2e_coreml.py` reference implementation, run on the same inputs
+/// in a numpy session.
+final class StyleTTS2SamplerTests: XCTestCase {
+
+    // MARK: - karrasSigmas
+
+    func testKarrasSigmasDefaults() {
+        // numpy reference, steps=5, sigma_min=1e-4, sigma_max=3.0, rho=9.0
+        let expected: [Float] = [
+            3.0,
+            0.5579148530960083,
+            0.07036224007606506,
+            0.0047578150406479836,
+            9.999999747378752e-05,
+            0.0,
+        ]
+        let got = StyleTTS2Sampler.karrasSigmas(steps: 5)
+        XCTAssertEqual(got.count, expected.count)
+        for (g, e) in zip(got, expected) {
+            XCTAssertEqual(g, e, accuracy: 1e-6)
+        }
+    }
+
+    func testKarrasSigmasSingleStep() {
+        // steps=1 → just [sigma_max, 0.0].
+        let got = StyleTTS2Sampler.karrasSigmas(steps: 1)
+        XCTAssertEqual(got.count, 2)
+        XCTAssertEqual(got[0], 3.0, accuracy: 1e-6)
+        XCTAssertEqual(got[1], 0.0)
+    }
+
+    func testKarrasSigmasNonDefaultRho() {
+        // numpy reference, steps=3, rho=7.0
+        let expected: [Float] = [
+            3.0,
+            0.09943192452192307,
+            9.999999747378752e-05,
+            0.0,
+        ]
+        let got = StyleTTS2Sampler.karrasSigmas(steps: 3, rho: 7.0)
+        XCTAssertEqual(got.count, expected.count)
+        for (g, e) in zip(got, expected) {
+            XCTAssertEqual(g, e, accuracy: 1e-6)
+        }
+    }
+
+    // MARK: - adpm2Sample
+
+    private func paddedNoise(_ values: [Float]) -> [Float] {
+        // Pad a small numeric fixture out to 256 floats (the rest stay zero,
+        // and a 0.5-scaling denoiser keeps them at zero forever).
+        var noise = [Float](repeating: 0, count: 256)
+        for (i, v) in values.enumerated() { noise[i] = v }
+        return noise
+    }
+
+    /// Closure-based denoiser: `denoised(x, sigma) = x * 0.5`. Pure, no
+    /// hidden state, so the only thing being exercised is the sampler math.
+    private static let halfDenoise: StyleTTS2Sampler.DenoiseStep = { x, _ in
+        x.map { $0 * 0.5 }
+    }
+
+    func testAdpm2Sample3StepsMatchesNumpy() async throws {
+        // numpy reference: noise=[1,-1,2,0.5,0,…], denoise=x*0.5, steps=3.
+        let noise = paddedNoise([1.0, -1.0, 2.0, 0.5])
+        let out = try await StyleTTS2Sampler.adpm2Sample(
+            steps: 3, noise: noise, denoise: Self.halfDenoise)
+
+        XCTAssertEqual(out.count, 256)
+        XCTAssertEqual(out[0], 7.383052349090576, accuracy: 1e-3)
+        XCTAssertEqual(out[1], -7.383052349090576, accuracy: 1e-3)
+        XCTAssertEqual(out[2], 14.766104698181152, accuracy: 1e-3)
+        XCTAssertEqual(out[3], 3.691526174545288, accuracy: 1e-3)
+        // Padding remains zero.
+        for i in 4..<256 {
+            XCTAssertEqual(out[i], 0.0, accuracy: 1e-6)
+        }
+    }
+
+    func testAdpm2Sample2StepsMatchesNumpy() async throws {
+        // numpy reference: same noise, steps=2.
+        let noise = paddedNoise([1.0, -1.0, 2.0, 0.5])
+        let out = try await StyleTTS2Sampler.adpm2Sample(
+            steps: 2, noise: noise, denoise: Self.halfDenoise)
+
+        XCTAssertEqual(out.count, 256)
+        XCTAssertEqual(out[0], -63.824729919433594, accuracy: 1e-2)
+        XCTAssertEqual(out[1], 63.824729919433594, accuracy: 1e-2)
+        XCTAssertEqual(out[2], -127.64945983886719, accuracy: 1e-2)
+        XCTAssertEqual(out[3], -31.912364959716797, accuracy: 1e-2)
+    }
+
+    func testAdpm2SampleCallsDenoiseExpectedNumberOfTimes() async throws {
+        // For N steps the loop runs N times. Each non-final iteration calls
+        // denoise twice (regular + midpoint); the final iteration (s_next=0)
+        // calls it once. So total = 2*(N-1) + 1 = 2N - 1.
+        let counter = SamplerCounter()
+        let denoise: StyleTTS2Sampler.DenoiseStep = { x, _ in
+            await counter.increment()
+            return x.map { $0 * 0.5 }
+        }
+        let noise = paddedNoise([1.0])
+        _ = try await StyleTTS2Sampler.adpm2Sample(
+            steps: 5, noise: noise, denoise: denoise)
+        let count = await counter.value
+        XCTAssertEqual(count, 2 * 5 - 1)
+    }
+
+    func testAdpm2SamplePropagatesDenoiseErrors() async {
+        struct Boom: Error {}
+        let denoise: StyleTTS2Sampler.DenoiseStep = { _, _ in throw Boom() }
+        let noise = [Float](repeating: 0, count: 256)
+        do {
+            _ = try await StyleTTS2Sampler.adpm2Sample(
+                steps: 3, noise: noise, denoise: denoise)
+            XCTFail("expected throw")
+        } catch is Boom {
+            // ok
+        } catch {
+            XCTFail("expected Boom, got \(error)")
+        }
+    }
+}
+
+/// Tiny actor for counting denoise invocations from an async closure.
+private actor SamplerCounter {
+    private(set) var value: Int = 0
+    func increment() { value += 1 }
+}

--- a/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2VocabTests.swift
+++ b/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2VocabTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Pure-logic unit tests for the StyleTTS2 178-token vocab loader.
+///
+/// Uses an inline JSON fixture so the test runs without HuggingFace
+/// downloads or any CoreML models.
+final class StyleTTS2VocabTests: XCTestCase {
+
+    // A minimal but representative slice of the upstream
+    // `text_cleaner_vocab.json` (pad, ASCII letter, IPA char, stress mark,
+    // syllabic combining mark, space).
+    private let fixtureJSON: String = #"""
+        {
+          "pad_token": "$",
+          "num_tokens": 178,
+          "symbols": ["$", " ", "a", "ɑ", "ˈ", "̩"],
+          "token_to_id": {
+            "$": 0,
+            " ": 16,
+            "a": 43,
+            "ɑ": 69,
+            "ˈ": 156,
+            "̩": 175
+          }
+        }
+        """#
+
+    private func writeFixture(_ json: String, name: String = "vocab.json") throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("styletts2-vocab-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        try json.data(using: .utf8)!.write(to: url)
+        return url
+    }
+
+    // MARK: - load
+
+    func testLoadParsesAllSingleGraphemeKeys() throws {
+        let url = try writeFixture(fixtureJSON)
+        let vocab = try StyleTTS2Vocab.load(from: url)
+
+        XCTAssertEqual(vocab.padTokenId, 0)
+        XCTAssertEqual(vocab.map["$"], 0)
+        XCTAssertEqual(vocab.map[" "], 16)
+        XCTAssertEqual(vocab.map["a"], 43)
+        XCTAssertEqual(vocab.map["ɑ"], 69)
+        XCTAssertEqual(vocab.map["ˈ"], 156)
+    }
+
+    func testLoadHandlesCombiningGraphemeAsSingleCharacter() throws {
+        // The syllabic combining mark `̩` (U+0329) is a single Swift
+        // `Character` because grapheme clusters group combining marks
+        // with their base — but it appears alone in the upstream vocab.
+        // Confirm we can round-trip it through the loader.
+        let url = try writeFixture(fixtureJSON)
+        let vocab = try StyleTTS2Vocab.load(from: url)
+        let key: Character = "\u{0329}"  // Combining vertical line below
+        XCTAssertEqual(vocab.map[key], 175)
+    }
+
+    func testLoadFailsForMissingFile() {
+        let bogusURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID().uuidString).json")
+        XCTAssertThrowsError(try StyleTTS2Vocab.load(from: bogusURL)) { error in
+            guard case StyleTTS2Error.modelNotFound = error else {
+                XCTFail("expected modelNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testLoadFailsForMalformedJSON() throws {
+        let url = try writeFixture("not actually json", name: "bad.json")
+        XCTAssertThrowsError(try StyleTTS2Vocab.load(from: url))
+    }
+
+    func testLoadFailsWhenTokenToIdMissing() throws {
+        let bad = #"{"pad_token": "$", "symbols": []}"#
+        let url = try writeFixture(bad, name: "missing-tokens.json")
+        XCTAssertThrowsError(try StyleTTS2Vocab.load(from: url)) { error in
+            guard case StyleTTS2Error.invalidConfiguration = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testLoadFallsBackToPadIdZeroWhenPadTokenMissing() throws {
+        // No `pad_token` field → loader defaults to id 0 (upstream contract).
+        let json = #"""
+            {
+              "num_tokens": 1,
+              "symbols": ["$"],
+              "token_to_id": {"$": 0}
+            }
+            """#
+        let url = try writeFixture(json, name: "no-pad.json")
+        let vocab = try StyleTTS2Vocab.load(from: url)
+        XCTAssertEqual(vocab.padTokenId, 0)
+    }
+
+    // MARK: - encode
+
+    func testEncodeMapsKnownGraphemes() throws {
+        let url = try writeFixture(fixtureJSON)
+        let vocab = try StyleTTS2Vocab.load(from: url)
+        let ids = vocab.encode("aɑˈa")
+        XCTAssertEqual(ids, [43, 69, 156, 43])
+    }
+
+    func testEncodeDropsUnknownGraphemes() throws {
+        // Upstream `text_utils.TextCleaner.__call__` silently skips
+        // unmapped chars. We mirror that to avoid blowing up on stray
+        // emoji or rare IPA the user pastes in.
+        let url = try writeFixture(fixtureJSON)
+        let vocab = try StyleTTS2Vocab.load(from: url)
+        let ids = vocab.encode("a🙂ɑ")
+        XCTAssertEqual(ids, [43, 69])
+    }
+
+    func testEncodeEmptyStringReturnsEmptyArray() throws {
+        let url = try writeFixture(fixtureJSON)
+        let vocab = try StyleTTS2Vocab.load(from: url)
+        XCTAssertEqual(vocab.encode(""), [])
+    }
+}

--- a/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2VoiceStyleTests.swift
+++ b/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2VoiceStyleTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Unit tests for the precomputed `ref_s.bin` loader.
+final class StyleTTS2VoiceStyleTests: XCTestCase {
+
+    private func writeBlob(_ floats: [Float], name: String = "ref_s.bin") throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("styletts2-voicestyle-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent(name)
+        var local = floats
+        let data = local.withUnsafeMutableBufferPointer { buf in
+            Data(buffer: buf)
+        }
+        try data.write(to: url)
+        return url
+    }
+
+    func testLoadParsesAll256Floats() throws {
+        // Ramp 0..255 so we can verify byte order at every index.
+        let floats: [Float] = (0..<256).map { Float($0) }
+        let url = try writeBlob(floats)
+        let style = try StyleTTS2VoiceStyle.load(from: url)
+
+        XCTAssertEqual(style.concatenated.count, 256)
+        XCTAssertEqual(style.concatenated.first, 0)
+        XCTAssertEqual(style.concatenated.last, 255)
+        XCTAssertEqual(style.concatenated[100], 100)
+    }
+
+    func testAcousticAndProsodySlicesAreFirstAndSecondHalf() throws {
+        var floats = [Float](repeating: 0, count: 256)
+        for i in 0..<128 { floats[i] = 1.0 }  // acoustic = 1.0
+        for i in 128..<256 { floats[i] = -1.0 }  // prosody  = -1.0
+        let url = try writeBlob(floats)
+        let style = try StyleTTS2VoiceStyle.load(from: url)
+
+        XCTAssertEqual(style.acoustic.count, 128)
+        XCTAssertEqual(style.prosody.count, 128)
+        XCTAssertTrue(style.acoustic.allSatisfy { $0 == 1.0 })
+        XCTAssertTrue(style.prosody.allSatisfy { $0 == -1.0 })
+    }
+
+    func testLoadFailsForMissingFile() {
+        let bogus = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID().uuidString).bin")
+        XCTAssertThrowsError(try StyleTTS2VoiceStyle.load(from: bogus)) { error in
+            guard case StyleTTS2Error.modelNotFound = error else {
+                XCTFail("expected modelNotFound, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testLoadFailsForWrongSize() throws {
+        // 100 floats = 400 bytes — wrong by construction.
+        let floats = [Float](repeating: 0, count: 100)
+        let url = try writeBlob(floats, name: "short.bin")
+        XCTAssertThrowsError(try StyleTTS2VoiceStyle.load(from: url)) { error in
+            guard case StyleTTS2Error.invalidConfiguration = error else {
+                XCTFail("expected invalidConfiguration, got \(error)")
+                return
+            }
+        }
+    }
+
+    func testInitPreconditionRequiresExactDim() {
+        // Sanity guard for direct (non-file) construction.
+        let ok = StyleTTS2VoiceStyle(concatenated: [Float](repeating: 0, count: 256))
+        XCTAssertEqual(ok.concatenated.count, 256)
+    }
+}


### PR DESCRIPTION
## Summary

Adds the FluidAudio host surface for the StyleTTS2 LibriTTS multi-speaker checkpoint published at `FluidInference/StyleTTS-2-coreml`, end-to-end. Covers asset download, lazy bucketed model loading, text frontend (G2P + 178-token vocab), bundle config validation, the ADPM2/Karras sampler, hard-alignment, decoder driver, and a CLI driver.

`fluidaudio styletts2 "Hello world." --voice ref_s.bin --output out.wav` produces an audible 24 kHz mono WAV.

## Pipeline

Per utterance (~5 ADPM2 steps default):

| Stage | Bucket axis | Buckets | Precision | Compute |
|---|---|---|---|---|
| `text_predictor` | input tokens | 32, 64, 128, 256, 512 | fp16 | ANE |
| `diffusion_step` | bert_dur frames | 512 only (5× per utt) | fp16 | CPU+GPU |
| `f0n_energy` | dynamic (en frames) | enumerated 256/512/1024/2048/4096 | fp16 | CPU |
| `decoder` | mel frames | 256, 512, 1024, 2048, 4096 | fp32 | CPU+GPU |

The decoder is fp32 because SineGen phase saturation in fp16 produces robotic audio. The HF repo ships precompiled `compiled/*.mlmodelc` bundles (skipping the cold-start `anecompilerservice` hit) plus `.mlpackage` doubles for portability — only the `.mlmodelc` bundles are fetched.

`f0n_energy` is pinned to CPU and always called at the largest enumerated shape (1, 640, 4096) with zero-padding — the E5RT runtime emits a stderr "tensor_buffer has known strides while the model has FlexibleShapeInfo" warning when it sees enumerated shapes on GPU/ANE, which is non-fatal but the CPU/largest-shape path sidesteps it cleanly.

## What's in this PR

**Sources:**
- `StyleTTS2Constants` — audio/tokenizer/model dims + sampler defaults (Karras `rho=9` to match upstream)
- `StyleTTS2Error` — module-local `LocalizedError` enum
- `Assets/StyleTTS2ResourceDownloader` — `DownloadUtils.downloadRepo` wrapper
- `Assets/StyleTTS2Vocab` — 178-token espeak-ng IPA vocab loader; iterates Unicode scalars (not graphemes) so combining marks like U+0329 syllabic / U+0361 tie-bar look up against their own vocab entries
- `Assets/StyleTTS2BundleConfig` — `config.json` Codable + `validate()` against `StyleTTS2Constants`
- `Assets/StyleTTS2VoiceStyle` — parser for precomputed `ref_s.bin` (256 fp32 LE) speaker-prosody blobs (dump script lives in `mobius-styletts2/scripts/06_dump_ref_s.py`)
- `Pipeline/StyleTTS2ModelStore` — actor with lazy per-bucket `MLModel` cache + lazy vocab/config caches; `f0nEnergy()` pinned `.cpuOnly`
- `Pipeline/StyleTTS2Phonemizer` — `TtsTextPreprocessor` → in-tree `G2PModel` (BART, misaki IPA) for English with a small misaki→espeak-ng remap (`A→eɪ`, `I→aɪ`, `O→oʊ`, `W→aʊ`, `Y→ɔɪ`, schwa-offglide → `ə`); other languages fall back to `MultilingualG2PModel`
- `Pipeline/StyleTTS2Sampler` — ADPM2 / Karras-rho noise schedule + CFG-aware sampling closure; deterministic via SplitMix64 + Box-Muller
- `Pipeline/StyleTTS2Synthesizer` — full 4-stage driver. Float16-aware `MLMultiArray` reads (`denoised`, `F0`, `N` all ship as fp16 per schema), cumsum-of-durations → one-hot → matmul hard-alignment, decoder fan-out
- `StyleTTS2Manager` — public actor; `initialize()` validates bundle config; `tokenize()` exposes the text frontend; `synthesize(text:voiceStyleURL:steps:alpha:beta:randomSeed:)` returns 24 kHz mono WAV `Data`
- `Sources/FluidAudioCLI/Commands/StyleTTS2Command` — `fluidaudio styletts2 "<text>" --voice <ref_s.bin> [--output --steps --alpha --beta --seed]`
- `ModelNames.StyleTTS2` + `Repo.styleTts2` wired into the central registries
- `TtsBackend.styleTts2` case

**Tests** (37/37 pass, no network or CoreML deps):
- `StyleTTS2VocabTests` — load happy path, combining-grapheme handling, missing/malformed JSON, encode known/unknown/empty
- `StyleTTS2BundleConfigTests` — load + validate against every constant mismatch
- `StyleTTS2VoiceStyleTests` — `ref_s.bin` parsing (size, fp32 round-trip, wrong-size rejection)
- `StyleTTS2SamplerTests` — Karras schedule, RNG determinism

## Verification

- `fluidaudio styletts2 "Hello world. The quick brown fox jumps over the lazy dog." --voice /tmp/styletts2-ref_s.bin --output /tmp/out.wav --seed 42` → 4.80s @ 24 kHz, RMS 7158, 0.0009% clipping
- `fluidaudio transcribe /tmp/out.wav` → `Hello world quick brown fax nomps over lazy` (most words recovered; residual gaps are BART G2P emitting reduced `ð` for "the" with no schwa, and lacking length marks `ː` on stressed long vowels)

## Test plan

- [x] `swift build -c release` clean
- [x] `swift test --filter StyleTTS2` → 37/37 pass
- [x] `swift format lint` clean on new files
- [x] End-to-end CLI synth produces audible WAV
- [x] ASR roundtrip recovers most content words

## Known follow-up

- Tune misaki→espeak remap for length marks `ː` and reduced function-words (would push ASR WER lower)
- Voice-bank packaging story (currently the user must precompute `ref_s.bin` via `mobius-styletts2/scripts/06_dump_ref_s.py`)
- StyleTTS2 benchmark suite

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/554" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->