### PR TITLE
docs(tts): add TTS-only status outline and StyleTTS2 registry rows

### DIFF
--- a/Documentation/Models.md
+++ b/Documentation/Models.md
@@ -55,6 +55,7 @@ TDT/CTC models above are wrapped by `SlidingWindowAsrManager`, which chunks audi
 | **Kokoro TTS** | Text-to-speech synthesis (82M params), 48 voices, minimal RAM usage on iOS. Generates all frames at once via flow matching over mel spectrograms + Vocos vocoder. Uses CoreML G2P model for phonemization. | First TTS backend added + support custom pronounces |
 | **Kokoro ANE (7-stage)** | Same Kokoro 82M weights split into 7 CoreML stages so the ANE-friendly layers (Albert / PostAlbert / Alignment / Vocoder) stay resident on the Neural Engine while Prosody / Noise / Tail run on CPU+GPU. 3-11× RTFx vs. the single-graph Kokoro. Single voice (`af_heart`), ≤510 IPA phonemes per call, no chunker / SSML / custom lexicon. | ANE-optimized variant derived (with permission) from [laishere/kokoro-coreml](https://github.com/laishere/kokoro-coreml) |
 | **PocketTTS** | Second TTS backend (~155M params). Autoregressive frame-by-frame generation with dynamic audio chunking. No phoneme stage, works directly on text tokens. | Supports streaming, minimal RAM usage, excellent quality |
+| **StyleTTS2** ([FluidAudio#554](https://github.com/FluidInference/FluidAudio/pull/554), [mobius#46](https://github.com/FluidInference/mobius/pull/46), [HF](https://huggingface.co/FluidInference/StyleTTS-2-coreml)) | English TTS via 4-stage diffusion pipeline: `text_predictor` (fp16, ANE) → `diffusion_step_512` (fp16, CPU+GPU; ADPM2 + Karras-rho, 5 steps + CFG) → `f0n_energy` (fp16, ANE) → `decoder` (fp32, CPU+GPU; HiFi-GAN @ 24 kHz). 178-token espeak-ng IPA vocab. English G2P routes through the in-tree Kokoro BART (misaki → espeak-ng remap); non-English falls back to `MultilingualG2PModel` but is unvalidated against the LibriTTS checkpoint. Voices ship offline as `ref_s.bin` blobs (256 fp32 LE) until the on-device style encoder lands. | Beta. English-only checkpoint. See [Documentation/TTS/README.md](TTS/README.md) for the full TTS index. |
 
 ## Not Production Ready
 
@@ -96,6 +97,7 @@ Models we converted and tested but are not supported: too large for on-device de
 | Kokoro TTS | [FluidInference/kokoro-82m-coreml](https://huggingface.co/FluidInference/kokoro-82m-coreml) |
 | Kokoro ANE (7-stage) | [FluidInference/kokoro-82m-coreml/tree/main/ANE](https://huggingface.co/FluidInference/kokoro-82m-coreml/tree/main/ANE) |
 | PocketTTS | [FluidInference/pocket-tts-coreml](https://huggingface.co/FluidInference/pocket-tts-coreml) |
+| StyleTTS2 | [FluidInference/StyleTTS-2-coreml](https://huggingface.co/FluidInference/StyleTTS-2-coreml) |
 | Magpie TTS Multilingual | [FluidInference/magpie-tts-multilingual-357m-coreml](https://huggingface.co/FluidInference/magpie-tts-multilingual-357m-coreml) |
 | CosyVoice3 (Mandarin) | [FluidInference/CosyVoice3-0.5B-coreml](https://huggingface.co/FluidInference/CosyVoice3-0.5B-coreml) |
 | Nemotron Streaming | [FluidInference/nemotron-speech-streaming-en-0.6b-coreml](https://huggingface.co/FluidInference/nemotron-speech-streaming-en-0.6b-coreml) |

--- a/Documentation/TTS/README.md
+++ b/Documentation/TTS/README.md
@@ -11,22 +11,22 @@ canonical model registry across the whole library see
 |----------|--------------------|
 | Real-time English TTS, multi-voice, SSML, custom lexicon | **Kokoro** |
 | Lowest latency / Apple Silicon ANE-resident, single voice | **Kokoro ANE (7-stage)** |
-| Streaming frame-by-frame English TTS, no phoneme stage | **PocketTTS** |
+| Streaming frame-by-frame TTS — English + 5 European languages, no phoneme stage | **PocketTTS** |
 | English expressive / studio-quality, voice-style cloning | **StyleTTS2** *(beta)* |
-| Multilingual (en/es/de/fr/it/vi/zh/hi), 5 built-in speakers | **Magpie** *(slow, RTFx ≈ 0.04)* |
+| Multilingual (en/es/de/fr/it/vi/zh/hi), 5 built-in speakers | **Magpie** *(slow)* |
 | Mandarin zero-shot voice cloning | **CosyVoice3** *(slow, RTFx < 1.0)* |
 
 If you want real-time on Apple Silicon today, pick **Kokoro** or
 **PocketTTS**. The other backends are shipped but carry caveats called
-out below.
+out below. The other models were converted base on the request of our community.
 
 ## Status Matrix
 
 | Backend | Status | Languages | Voices | RTFx (M-series) | Memory | Highlights | Caveats | Deep dive |
 |---------|--------|-----------|--------|-----------------|--------|-----------|---------|-----------|
-| **Kokoro** | Production | English (LibriTTS-trained) | 48 | > 1.0× | Low (iOS-friendly) | Flow-matching mel + Vocos vocoder. SSML, custom lexicon, long-form chunker. CoreML G2P. | One-shot synthesis (no streaming). | [Kokoro.md](Kokoro.md) |
-| **Kokoro ANE (7-stage)** | Production | English | 1 (`af_heart`) | 3–11× faster than Kokoro | Low | Same 82M weights split into 7 CoreML stages so ANE-friendly layers stay resident on the Neural Engine. | ≤ 510 IPA phonemes per call. No SSML / chunker / custom lexicon. Single voice. | [KokoroAne.md](KokoroAne.md) |
-| **PocketTTS** | Production | English | Built-in pool (~155M params) | > 1.0× streaming | Low | Autoregressive frame-by-frame with dynamic audio chunking. No phoneme stage — works directly on text tokens. Streams. | English-only. | [PocketTTS.md](PocketTTS.md) |
+| **Kokoro** | Ready | English | 48 | > 1.0× | Low (iOS-friendly) | Flow-matching mel + Vocos vocoder. SSML, custom lexicon, long-form chunker. CoreML G2P. | One-shot synthesis (no streaming). | [Kokoro.md](Kokoro.md) |
+| **Kokoro ANE (7-stage)** | Ready | English | 1 (`af_heart`) | 3–11× faster than Kokoro | Low | Same 82M weights split into 7 CoreML stages so ANE-friendly layers stay resident on the Neural Engine. | ≤ 510 IPA phonemes per call. No SSML / chunker / custom lexicon. Single voice. | [KokoroAne.md](KokoroAne.md) |
+| **PocketTTS** | Ready | English + German / Italian / Portuguese / Spanish / French (v2 packs, 6L and 24L variants; French is 24L only) | 21 built-in voices shared across packs (per-language acoustic embeddings) + voice cloning via Mimi encoder | > 1.0× streaming | Low | Autoregressive frame-by-frame with dynamic audio chunking. No phoneme stage — works directly on text tokens. Streams. Voice cloning is language-agnostic (clone once, reuse across language packs). | One manager per language (no auto language detection); pronunciation is fully model-internal — no IPA / SSML `<phoneme>` / custom-lexicon control. | [PocketTTS.md](PocketTTS.md) |
 | **StyleTTS2** | Beta (English) | English (LibriTTS multi-speaker) | Per-utterance ref-style blob (`ref_s.bin`, 256 fp32) | > 1.0× typical | Medium | 4-stage diffusion pipeline: `text_predictor` (ANE) → `diffusion_step_512` (CPU+GPU, ADPM2 + Karras) → `f0n_energy` (ANE) → `decoder` (CPU+GPU, HiFi-GAN). 178-token espeak-ng IPA vocab. English G2P via in-tree Kokoro BART (misaki → espeak remap). | English-only checkpoint. Style-encoder export pending — voices ship as offline `ref_s.bin` blobs. Multilingual G2P fallback exists but is unvalidated. | *(no per-model doc yet — see this README + [`Sources/FluidAudio/TTS/StyleTTS2/`](../../Sources/FluidAudio/TTS/StyleTTS2/))* |
 | **Magpie TTS Multilingual** | Not production-ready (slow) | en/es/de/fr/it/vi/zh/hi (8) | 5 built-in | ≈ 0.04× (~25× slower than realtime) | Medium-large | NeMo Magpie 357M, 4-model CoreML pipeline + pure-Swift Local Transformer (Accelerate + BNNS). Custom IPA override via `\|...\|`. ASR-clean on 4/5 speakers. | ~30 s cold first synth; ~96 s warm for an 8-word sentence on M-series. Throughput / MLX backend / CFG perf / Japanese support pending. | [Magpie.md](Magpie.md) |
 | **CosyVoice3 (Mandarin)** | Beta (slow) | Mandarin Chinese | Zero-shot from voice prompt | < 1.0× typical | Large | FunAudioLLM CosyVoice3 0.5B zero-shot voice cloning. 4-model CoreML pipeline (Qwen2 LLM prefill + stateful decode + CFM Flow + HiFT vocoder). Swift-native Qwen2 BPE + mmap'd fp16 embedding tables. | Flow stays fp32 / `cpuAndGPU` (fp16 + ANE NaNs through fused `layer_norm`). HiFT sinegen falls back to CPU. Voice prompt assets (speech IDs / mel / spk-emb) precomputed offline. API may change. CLI tags backend `[BETA — slow, RTFx < 1.0]`. | [CosyVoice3.md](CosyVoice3.md) |
@@ -59,10 +59,33 @@ out below.
 
 ### PocketTTS
 
-- **Manager:** `PocketTtsSynthesizer` (`Sources/FluidAudio/TTS/PocketTTS/`)
+- **Manager:** `PocketTtsManager` / `PocketTtsSynthesizer`
+  (`Sources/FluidAudio/TTS/PocketTTS/`)
 - **Architecture:** ~155M autoregressive frame-by-frame model, dynamic
   audio chunking, no phoneme stage (works directly on text tokens).
-- **Streams:** yes — frame-by-frame.
+  4 CoreML models (`cond_step`, flow LM, flow decoder, Mimi decoder).
+- **Streams:** yes — frame-by-frame, with `makeSession()` for persistent
+  voice prefill across multiple utterances.
+- **Languages (v2 packs, converted from
+  [kyutai/pocket-tts](https://huggingface.co/kyutai/pocket-tts)):**
+
+  | Language | Pack IDs | Notes |
+  |----------|----------|-------|
+  | English | `english` | 6-layer, repo root (legacy layout) |
+  | German | `german`, `german_24l` | 6L + 24L |
+  | Italian | `italian`, `italian_24l` | 6L + 24L |
+  | Portuguese | `portuguese`, `portuguese_24l` | 6L + 24L |
+  | Spanish | `spanish`, `spanish_24l` | 6L + 24L |
+  | French | `french_24l` | 24L only (no 6L upstream) |
+
+  24-layer packs are higher quality but slower and larger. There is no
+  automatic language detection — pick the manager that matches your
+  input text. Voice names (`alba`, `anna`, `eve`, `michael`, …) are
+  shared across packs; the underlying acoustic embeddings are
+  per-language.
+- **Voice cloning:** the Mimi encoder is language-agnostic, so you can
+  clone a voice once and reuse the resulting `PocketTtsVoiceData`
+  across managers configured with different language packs.
 - **HF:** [`FluidInference/pocket-tts-coreml`](https://huggingface.co/FluidInference/pocket-tts-coreml)
 - **More:** [PocketTTS.md](PocketTTS.md)
 

--- a/Documentation/TTS/README.md
+++ b/Documentation/TTS/README.md
@@ -1,0 +1,164 @@
+# TTS Backends — Status & Index
+
+A single page to clarify which text-to-speech backend in FluidAudio is in
+what state, what each is good at, and where to read more. For the
+canonical model registry across the whole library see
+[`../Models.md`](../Models.md); this page is the TTS-only deep view.
+
+## TL;DR Recommendations
+
+| Use case | Recommended backend |
+|----------|--------------------|
+| Real-time English TTS, multi-voice, SSML, custom lexicon | **Kokoro** |
+| Lowest latency / Apple Silicon ANE-resident, single voice | **Kokoro ANE (7-stage)** |
+| Streaming frame-by-frame English TTS, no phoneme stage | **PocketTTS** |
+| English expressive / studio-quality, voice-style cloning | **StyleTTS2** *(beta)* |
+| Multilingual (en/es/de/fr/it/vi/zh/hi), 5 built-in speakers | **Magpie** *(slow, RTFx ≈ 0.04)* |
+| Mandarin zero-shot voice cloning | **CosyVoice3** *(slow, RTFx < 1.0)* |
+
+If you want real-time on Apple Silicon today, pick **Kokoro** or
+**PocketTTS**. The other backends are shipped but carry caveats called
+out below.
+
+## Status Matrix
+
+| Backend | Status | Languages | Voices | RTFx (M-series) | Memory | Highlights | Caveats | Deep dive |
+|---------|--------|-----------|--------|-----------------|--------|-----------|---------|-----------|
+| **Kokoro** | Production | English (LibriTTS-trained) | 48 | > 1.0× | Low (iOS-friendly) | Flow-matching mel + Vocos vocoder. SSML, custom lexicon, long-form chunker. CoreML G2P. | One-shot synthesis (no streaming). | [Kokoro.md](Kokoro.md) |
+| **Kokoro ANE (7-stage)** | Production | English | 1 (`af_heart`) | 3–11× faster than Kokoro | Low | Same 82M weights split into 7 CoreML stages so ANE-friendly layers stay resident on the Neural Engine. | ≤ 510 IPA phonemes per call. No SSML / chunker / custom lexicon. Single voice. | [KokoroAne.md](KokoroAne.md) |
+| **PocketTTS** | Production | English | Built-in pool (~155M params) | > 1.0× streaming | Low | Autoregressive frame-by-frame with dynamic audio chunking. No phoneme stage — works directly on text tokens. Streams. | English-only. | [PocketTTS.md](PocketTTS.md) |
+| **StyleTTS2** | Beta (English) | English (LibriTTS multi-speaker) | Per-utterance ref-style blob (`ref_s.bin`, 256 fp32) | > 1.0× typical | Medium | 4-stage diffusion pipeline: `text_predictor` (ANE) → `diffusion_step_512` (CPU+GPU, ADPM2 + Karras) → `f0n_energy` (ANE) → `decoder` (CPU+GPU, HiFi-GAN). 178-token espeak-ng IPA vocab. English G2P via in-tree Kokoro BART (misaki → espeak remap). | English-only checkpoint. Style-encoder export pending — voices ship as offline `ref_s.bin` blobs. Multilingual G2P fallback exists but is unvalidated. | *(no per-model doc yet — see this README + [`Sources/FluidAudio/TTS/StyleTTS2/`](../../Sources/FluidAudio/TTS/StyleTTS2/))* |
+| **Magpie TTS Multilingual** | Not production-ready (slow) | en/es/de/fr/it/vi/zh/hi (8) | 5 built-in | ≈ 0.04× (~25× slower than realtime) | Medium-large | NeMo Magpie 357M, 4-model CoreML pipeline + pure-Swift Local Transformer (Accelerate + BNNS). Custom IPA override via `\|...\|`. ASR-clean on 4/5 speakers. | ~30 s cold first synth; ~96 s warm for an 8-word sentence on M-series. Throughput / MLX backend / CFG perf / Japanese support pending. | [Magpie.md](Magpie.md) |
+| **CosyVoice3 (Mandarin)** | Beta (slow) | Mandarin Chinese | Zero-shot from voice prompt | < 1.0× typical | Large | FunAudioLLM CosyVoice3 0.5B zero-shot voice cloning. 4-model CoreML pipeline (Qwen2 LLM prefill + stateful decode + CFM Flow + HiFT vocoder). Swift-native Qwen2 BPE + mmap'd fp16 embedding tables. | Flow stays fp32 / `cpuAndGPU` (fp16 + ANE NaNs through fused `layer_norm`). HiFT sinegen falls back to CPU. Voice prompt assets (speech IDs / mel / spk-emb) precomputed offline. API may change. CLI tags backend `[BETA — slow, RTFx < 1.0]`. | [CosyVoice3.md](CosyVoice3.md) |
+
+> RTFx > 1.0× means faster than realtime (1 s of audio in < 1 s of compute).
+
+## Per-Backend Details
+
+### Kokoro
+
+- **Manager:** `KokoroTtsManager` (`Sources/FluidAudio/TTS/Kokoro/`)
+- **Phonemizer:** in-tree CoreML BART G2P (`G2PModel`) for English, Misaki-style IPA, then re-encoded into Kokoro's vocab.
+- **Synthesis:** flow matching over mel spectrograms in one pass + Vocos vocoder.
+- **Strengths:** multi-voice, SSML, custom lexicon, long-form chunker, low memory.
+- **HF:** [`FluidInference/kokoro-82m-coreml`](https://huggingface.co/FluidInference/kokoro-82m-coreml)
+- **More:** [Kokoro.md](Kokoro.md), [SSML.md](SSML.md), [voice-quality.md](voice-quality.md)
+
+### Kokoro ANE (7-stage)
+
+- **Manager:** `KokoroAneManager`
+- **Same 82M weights** split across 7 CoreML stages (Albert / PostAlbert /
+  Alignment / Vocoder on ANE; Prosody / Noise / Tail on CPU+GPU).
+- **Origin:** derived (with permission) from
+  [laishere/kokoro-coreml](https://github.com/laishere/kokoro-coreml).
+- **Tradeoff:** 3–11× RTFx vs. single-graph Kokoro at the cost of single
+  voice (`af_heart`), no chunker (≤ 510 IPA phonemes), no SSML, no
+  custom lexicon.
+- **HF:** [`FluidInference/kokoro-82m-coreml/tree/main/ANE`](https://huggingface.co/FluidInference/kokoro-82m-coreml/tree/main/ANE)
+- **More:** [KokoroAne.md](KokoroAne.md)
+
+### PocketTTS
+
+- **Manager:** `PocketTtsSynthesizer` (`Sources/FluidAudio/TTS/PocketTTS/`)
+- **Architecture:** ~155M autoregressive frame-by-frame model, dynamic
+  audio chunking, no phoneme stage (works directly on text tokens).
+- **Streams:** yes — frame-by-frame.
+- **HF:** [`FluidInference/pocket-tts-coreml`](https://huggingface.co/FluidInference/pocket-tts-coreml)
+- **More:** [PocketTTS.md](PocketTTS.md)
+
+### StyleTTS2
+
+- **Manager:** `StyleTTS2Manager` (`Sources/FluidAudio/TTS/StyleTTS2/`)
+- **Pipeline (per utterance):**
+  1. `text_predictor` (fp16, ANE) → `bert_dur` features + duration
+     logits.
+  2. `diffusion_step_512` (fp16, CPU+GPU) — ADPM2 sampler with Karras-rho
+     schedule, 5 steps + classifier-free guidance.
+  3. `f0n_energy` (fp16, ANE) → F0 + energy regression.
+  4. `decoder` (fp32, CPU+GPU) — HiFi-GAN waveform synthesis at 24 kHz.
+- **Phonemizer:** `StyleTTS2Phonemizer` — in-tree Kokoro BART G2P for
+  English (misaki → espeak-ng remap: `A→eɪ I→aɪ O→oʊ W→aʊ Y→ɔɪ ᵊ→ə`).
+  Non-English falls back to `MultilingualG2PModel` (CharsiuG2P ByT5),
+  unvalidated against the LibriTTS checkpoint.
+- **Vocab:** 178-token espeak-ng IPA / stress / length set
+  (`text_cleaner_vocab.json`); encode iterates Unicode scalars (not
+  grapheme clusters) so combining marks like syllabic-`◌̩` and tie-bar
+  `◌͡` are not silently dropped.
+- **Voices:** ship offline as `ref_s.bin` blobs (256 fp32 LE, 1024 bytes)
+  produced via `mobius-styletts2/scripts/06_dump_ref_s.py`. The
+  on-device style encoder export is a follow-up.
+- **CLI:**
+  ```bash
+  swift run fluidaudiocli styletts2 "Hello, world." \
+    --voice ref_s.bin --output out.wav
+  ```
+- **Status notes:**
+  - Beta. English-only on the shipped LibriTTS checkpoint.
+  - End-to-end ASR roundtrip recognizable but not yet pristine.
+  - First-call cold start triggers ANE compilation
+    (`anecompilerservice`) for the four CoreML graphs.
+  - `initialize()` pre-fetches Kokoro G2P assets so a first-time user
+    who has never run Kokoro doesn't hit a cryptic
+    `G2PModelError.vocabLoadFailed` deep inside `synthesize`.
+- **HF:** [`FluidInference/StyleTTS-2-coreml`](https://huggingface.co/FluidInference/StyleTTS-2-coreml)
+- **Conversion repo:** `mobius/models/tts/styletts2/`
+
+### Magpie TTS Multilingual
+
+- **Status:** shipped but **not production-ready** — RTFx ≈ 0.04 on
+  M-series; ~30 s cold / ~96 s warm for an 8-word English sentence.
+- **Languages:** en, es, de, fr, it, vi, zh, hi.
+- **HF:** [`FluidInference/magpie-tts-multilingual-357m-coreml`](https://huggingface.co/FluidInference/magpie-tts-multilingual-357m-coreml)
+- **Pending work:** throughput investigation, MLX-backed Local
+  Transformer, CFG perf, Japanese support (OpenJTalk + MeCab).
+- **More:** [Magpie.md](Magpie.md)
+
+### CosyVoice3 (Mandarin)
+
+- **Status:** beta, slow. End-to-end RTFx < 1.0 typical.
+- **Bottlenecks:** Flow stays fp32 / `cpuAndGPU`-only because fp16 + ANE
+  NaNs through fused `layer_norm` (CoreMLTools limitation, tracked
+  upstream); HiFT sinegen / windowing falls back to CPU.
+- **Voice prompts:** precomputed offline via
+  `mobius/.../bootstrap_aishell3_voices.py` (speech IDs / mel /
+  192-d spk-emb).
+- **HF:** [`FluidInference/CosyVoice3-0.5B-coreml`](https://huggingface.co/FluidInference/CosyVoice3-0.5B-coreml)
+- **More:** [CosyVoice3.md](CosyVoice3.md)
+
+## Evaluated, Not Supported
+
+Backends we converted and tested but chose not to ship:
+
+| Model | Why not |
+|-------|---------|
+| **KittenTTS** ([#409](https://github.com/FluidInference/FluidAudio/pull/409)) | Inefficient espeak alternatives. Nano (15M) and Mini (82M) variants exist but don't justify the integration cost. |
+| **Qwen3-TTS** ([#290](https://github.com/FluidInference/FluidAudio/pull/290), [mobius#20](https://github.com/FluidInference/mobius/pull/20)) | Now 1.1 GB but too slow on-device. |
+| **Qwen3-ForcedAligner-0.6B** ([#315](https://github.com/FluidInference/FluidAudio/pull/315), [mobius#21](https://github.com/FluidInference/mobius/pull/21)) | 5-model CoreML pipeline, large footprint, low upstream adoption. |
+
+## Adding a New TTS Backend
+
+The high-level checklist for landing another backend:
+
+1. **Conversion** — sit it in `mobius/models/tts/<backend>/` with a
+   reproducible script, a `PRECISION.md`, and a numerical-parity test
+   against the PyTorch reference.
+2. **CoreML assets** — publish the compiled `.mlmodelc` plus any vocab
+   / config under `FluidInference/<backend>-coreml` on HuggingFace.
+3. **Swift integration** — add `Sources/FluidAudio/TTS/<Backend>/` with
+   a manager actor, an asset downloader (`Repo.<backend>` enum case
+   in `ModelNames.swift`), a `TtsBackend` case in
+   `Sources/FluidAudio/TTS/TtsBackend.swift`, and a CLI entry under
+   `Sources/FluidAudioCLI/Commands/`.
+4. **Frontend** — phonemizer / tokenizer; reuse `G2PModel` (English BART)
+   or `MultilingualG2PModel` (CharsiuG2P ByT5) where possible.
+5. **Tests** — at minimum a smoke test that downloads, synthesizes, and
+   asserts the WAV header. Quality tests via ASR roundtrip if feasible.
+6. **Docs** — add a deep-dive page in this directory and a row in this
+   README's status matrix plus `../Models.md`.
+
+## See Also
+
+- [`../Models.md`](../Models.md) — full model registry across ASR / VAD /
+  diarization / TTS.
+- [`SSML.md`](SSML.md) — SSML support (Kokoro path).
+- [`voice-quality.md`](voice-quality.md) — perceptual quality notes.


### PR DESCRIPTION
## Summary

- Adds `Documentation/TTS/README.md` — a single-page TTS index that complements the per-model deep dives already in `Documentation/TTS/`. Covers Kokoro, Kokoro ANE, PocketTTS, StyleTTS2, Magpie, CosyVoice3 with a use-case TL;DR, status matrix (status / languages / voices / RTFx / memory / highlights / caveats / link), and per-backend briefs.
- Gives StyleTTS2 a full pipeline write-up since it had no per-model doc: 4-stage diffusion (text_predictor → diffusion_step_512 → f0n_energy → decoder), 178-token espeak-ng IPA vocab, in-tree Kokoro BART G2P with misaki→espeak remap, offline `ref_s.bin` voice blobs.
- Adds the missing **StyleTTS2** row to `Documentation/Models.md` (TTS Models table + Model Sources table) so the global registry matches what ships post-#554.

## Test plan

- [ ] `Documentation/TTS/README.md` renders on GitHub
- [ ] Cross-links to sibling docs (`Kokoro.md`, `KokoroAne.md`, `PocketTTS.md`, `Magpie.md`, `CosyVoice3.md`, `SSML.md`, `voice-quality.md`) resolve
- [ ] StyleTTS2 row appears in `Documentation/Models.md` TTS table and Model Sources table
- [ ] HF repo links resolve (`FluidInference/StyleTTS-2-coreml` etc.)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
