### PR TITLE
Feat/pocket tts int8 precision swap

### DIFF
--- a/Documentation/TTS/PocketTTS.md
+++ b/Documentation/TTS/PocketTTS.md
@@ -17,6 +17,53 @@ How the Swift code generates speech from text.
 | `PocketTtsConstantsLoader.swift` | Loads binary constants (embeddings, tokenizer, quantizer weights) |
 | `PocketTtsConstants.swift` | All numeric constants (dimensions, thresholds, etc.) |
 
+## Model Files & Precision
+
+The four CoreML submodels (plus the optional Mimi encoder) and their
+auxiliary asset directories. All paths are relative to
+[`FluidInference/pocket-tts-coreml`](https://huggingface.co/FluidInference/pocket-tts-coreml)
+on HuggingFace; sizes are for the English language pack.
+
+| File | Precision | Size | HF path | Role |
+|------|-----------|------|---------|------|
+| `cond_step.mlmodelc` | fp16 | 254.3 MB | `v2/<lang>/cond_step.mlmodelc` | KV-cache prefill — runs once per chunk over voice + text tokens (~141 calls); writes the 6-layer KV cache that FlowLM consumes during generation |
+| `flowlm_step.mlmodelc` | fp16 | 290.5 MB | `v2/<lang>/flowlm_step.mlmodelc` | Autoregressive transformer — runs **once per audio frame** during generation; outputs a `[1, 1024]` hidden state + EOS logit per step. Loaded when `precision: .fp16` (default) |
+| `flowlm_stepv2.mlmodelc` | int8 attn + FFN linears, fp16 elsewhere | 73.5 MB | `v2/<lang>/flowlm_stepv2.mlmodelc` | Drop-in replacement for `flowlm_step` when `precision: .int8` — same I/O signature, ~4× smaller. Quantization recipe per [kyutai-labs/pocket-tts#147](https://github.com/kyutai-labs/pocket-tts/pull/147) |
+| `flow_decoder.mlmodelc` | fp16 | 37.3 MB | `v2/<lang>/flow_decoder.mlmodelc` | LSD flow-matching decoder — runs an 8-step Euler loop per audio frame (`latent += velocity · dt`); turns transformer output into a 32-dim audio latent |
+| `mimi_decoder.mlmodelc` | fp16 (outputs explicitly fp16) | 40.0 MB | `v2/<lang>/mimi_decoder.mlmodelc` | Mimi VAE audio decoder — runs once per audio frame, takes a 512-dim quantized vector and produces 1920 PCM samples (24 kHz). Maintains 23 streaming-state tensors fed back as next-frame input |
+| `mimi_encoder.mlmodelc` | fp16 | optional | `mimi_encoder.mlmodelc` *(repo root)* | **Voice cloning only.** Language-agnostic; lives at the repo root, not under `v2/<lang>/`. Downloaded separately on first `cloneVoice(...)` call |
+| `constants_bin/` | binary tensors | 144.2 MB | `v2/<lang>/constants_bin/` | Token embedding table, SentencePiece tokenizer, denormalize/quantize mean+std, per-voice prompts (`alba.safetensors`, etc.) |
+| `constants/` | metadata sidecar | 16.7 MB | `v2/<lang>/constants/` | Auxiliary constants referenced by `PocketTtsConstantsLoader` |
+
+`<lang>` is one of: `english`, `french_24l`, `german`, `german_24l`,
+`italian`, `italian_24l`, `portuguese`, `portuguese_24l`, `spanish`,
+`spanish_24l`.
+
+### Totals (English, on disk)
+
+| Configuration | Total |
+|---------------|-------|
+| `precision: .fp16` (default) | 766.3 MB |
+| `precision: .int8` | 549.3 MB |
+| **int8 savings vs fp16** | **−217 MB (28%)** |
+
+The `v2/<lang>/` HF directory ships **both** flowlm variants, so a fresh
+download pulls the unused one too. `PocketTtsResourceDownloader` deletes
+the unused FlowLM `.mlmodelc` and `.mlpackage` directories after download
+completes so only the requested precision occupies disk long-term.
+
+### Why only `flowlm_step` is quantized
+
+The four submodels have different sensitivity to quantization. Only the
+FlowLM transformer is published in an int8 variant upstream:
+
+| Submodel | Quantized? | Why |
+|----------|------------|-----|
+| `cond_step` | No | One-shot prefill; conditioning errors propagate through the entire utterance |
+| `flowlm_step` | **Yes** | Per-frame transformer with causal attention; quantization error stays bounded per frame, doesn't compound. Largest file — best size-to-risk trade |
+| `flow_decoder` | No | 8-step Euler loop where each step's error feeds the next; small file (37 MB) makes savings marginal anyway |
+| `mimi_decoder` | No | Autoregressive feedback loop where 23 streaming-state tensors carry across frames; errors compound frame-over-frame |
+
 ## Call Flow
 
 ```

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -588,12 +588,17 @@ public enum ModelNames {
     public enum PocketTTS {
         public static let condStep = "cond_step"
         public static let flowlmStep = "flowlm_step"
+        /// int8 variant of the FlowLM transformer published upstream alongside
+        /// the default `flowlm_step`. Lives in the same `v2/<lang>/` directory
+        /// and gets selected when the caller asks for `.int8` precision.
+        public static let flowlmStepV2 = "flowlm_stepv2"
         public static let flowDecoder = "flow_decoder"
         public static let mimiDecoder = "mimi_decoder"
         public static let mimiEncoder = "mimi_encoder"
 
         public static let condStepFile = condStep + ".mlmodelc"
         public static let flowlmStepFile = flowlmStep + ".mlmodelc"
+        public static let flowlmStepV2File = flowlmStepV2 + ".mlmodelc"
         public static let flowDecoderFile = flowDecoder + ".mlmodelc"
         public static let mimiDecoderFile = mimiDecoder + ".mlmodelc"
         public static let mimiEncoderFile = mimiEncoder + ".mlmodelc"
@@ -601,7 +606,31 @@ public enum ModelNames {
         /// Directory containing binary constants, tokenizer, and voice data.
         public static let constantsBinDir = "constants_bin"
 
-        /// Required files inside any language's `v2/<lang>/` pack.
+        /// FlowLM filename for a given precision. Both variants ship in the
+        /// same `v2/<lang>/` directory upstream; only the FlowLM transformer
+        /// has an int8 variant — `cond_step`, `flow_decoder`, and
+        /// `mimi_decoder` always load the default file.
+        public static func flowlmStepFile(precision: PocketTtsPrecision) -> String {
+            switch precision {
+            case .fp16: return flowlmStepFile
+            case .int8: return flowlmStepV2File
+            }
+        }
+
+        /// Required files inside any language's `v2/<lang>/` pack for the
+        /// given precision. The set differs only in the FlowLM filename.
+        public static func requiredModels(precision: PocketTtsPrecision) -> Set<String> {
+            [
+                condStepFile,
+                flowlmStepFile(precision: precision),
+                flowDecoderFile,
+                mimiDecoderFile,
+                constantsBinDir,
+            ]
+        }
+
+        /// Required files for the default precision. Kept for callers that
+        /// haven't been updated to pass a precision argument.
         public static let requiredModels: Set<String> = [
             condStepFile,
             flowlmStepFile,

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -12,12 +12,26 @@ public enum PocketTtsResourceDownloader {
     ///   - language: Which upstream language pack to fetch.
     ///   - directory: Optional override for the base cache directory.
     ///     When `nil`, uses the default platform cache location.
+    ///   - precision: Which precision variant to load (default: `.fp16`,
+    ///     matching upstream's on-disk weight format).
+    ///     `.int8` reuses the same upstream `v2/<lang>/` directory but loads
+    ///     `flowlm_stepv2.mlmodelc` (int8 weight quantization on the FlowLM
+    ///     transformer's attention + FFN linears, per kyutai-labs/pocket-tts#147)
+    ///     instead of `flowlm_step.mlmodelc`. The other three models stay
+    ///     at the default fp16 precision.
     ///   - progressHandler: Optional callback for download progress updates.
-    /// - Returns: The directory that contains the four `.mlmodelc` packages
-    ///   plus `constants_bin/` for the requested language.
+    /// - Returns: The directory that contains the requested `.mlmodelc`
+    ///   packages plus `constants_bin/` for the requested language.
+    ///
+    /// Note: the upstream `v2/<lang>/` directory ships both flowlm variants,
+    /// so a fresh download pulls the unused variant too. After download
+    /// completes, the unused FlowLM `.mlmodelc` and `.mlpackage` directories
+    /// are deleted so only the requested precision occupies disk
+    /// (~217 MB savings for `.int8`, ~75 MB savings for `.fp16`).
     public static func ensureModels(
         language: PocketTtsLanguage,
         directory: URL? = nil,
+        precision: PocketTtsPrecision = .fp16,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> URL {
         let targetDir = try directory ?? cacheDirectory()
@@ -28,19 +42,20 @@ public enum PocketTtsResourceDownloader {
         let subdir = language.repoSubdirectory
         let languageRoot = repoDir.appendingPathComponent(subdir)
 
-        let allPresent = ModelNames.PocketTTS.requiredModels.allSatisfy { model in
+        let required = ModelNames.PocketTTS.requiredModels(precision: precision)
+        let allPresent = required.allSatisfy { model in
             FileManager.default.fileExists(
                 atPath: languageRoot.appendingPathComponent(model).path)
         }
 
         guard !allPresent else {
             logger.info(
-                "PocketTTS \(language.rawValue) models found in cache")
+                "PocketTTS \(language.rawValue) (\(precision)) models found in cache")
             return languageRoot
         }
 
         logger.info(
-            "Downloading PocketTTS \(language.rawValue) language pack from HuggingFace (\(subdir))..."
+            "Downloading PocketTTS \(language.rawValue) (\(precision)) language pack from HuggingFace (\(subdir))..."
         )
         try await DownloadUtils.downloadSubdirectory(
             .pocketTts,
@@ -49,7 +64,47 @@ public enum PocketTtsResourceDownloader {
             progressHandler: progressHandler
         )
 
+        // The HF subdir contains both FlowLM precisions; delete the one we
+        // don't need so disk usage matches the loaded models.
+        removeUnusedFlowlmVariant(at: languageRoot, keeping: precision)
+
         return languageRoot
+    }
+
+    /// Delete the FlowLM `.mlmodelc` and `.mlpackage` directories that don't
+    /// match the requested precision. Idempotent — silently skips paths that
+    /// don't exist.
+    private static func removeUnusedFlowlmVariant(
+        at languageRoot: URL,
+        keeping precision: PocketTtsPrecision
+    ) {
+        let unusedNames: [String]
+        switch precision {
+        case .fp16:
+            // Loading flowlm_step.mlmodelc; drop the int8 variant.
+            unusedNames = [
+                ModelNames.PocketTTS.flowlmStepV2 + ".mlmodelc",
+                ModelNames.PocketTTS.flowlmStepV2 + ".mlpackage",
+            ]
+        case .int8:
+            // Loading flowlm_stepv2.mlmodelc; drop the default variant.
+            unusedNames = [
+                ModelNames.PocketTTS.flowlmStep + ".mlmodelc",
+                ModelNames.PocketTTS.flowlmStep + ".mlpackage",
+            ]
+        }
+        for name in unusedNames {
+            let url = languageRoot.appendingPathComponent(name)
+            guard FileManager.default.fileExists(atPath: url.path) else { continue }
+            do {
+                try FileManager.default.removeItem(at: url)
+                logger.info("Removed unused PocketTTS variant on disk: \(name)")
+            } catch {
+                logger.warning(
+                    "Failed to remove unused PocketTTS variant \(name): \(error.localizedDescription)"
+                )
+            }
+        }
     }
 
     /// Ensure the Mimi encoder model is downloaded for voice cloning.

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -26,15 +26,26 @@ public actor PocketTtsModelStore {
     private var mimiDecoderKeysCache: PocketTtsMimiKeys?
     private let directory: URL?
     public let language: PocketTtsLanguage
+    public let precision: PocketTtsPrecision
 
     /// - Parameters:
     ///   - language: Which upstream language pack to load. Defaults to
     ///     `.english`.
     ///   - directory: Optional override for the base cache directory. When
     ///     `nil`, uses the default platform cache location.
-    public init(language: PocketTtsLanguage = .english, directory: URL? = nil) {
+    ///   - precision: Which FlowLM precision to load (default: `.fp16`,
+    ///     matching upstream's on-disk weight format). `.int8` swaps
+    ///     `flowlm_step.mlmodelc` for `flowlm_stepv2.mlmodelc` from the
+    ///     same upstream `v2/<lang>/` directory; the other three submodels
+    ///     stay at fp16.
+    public init(
+        language: PocketTtsLanguage = .english,
+        directory: URL? = nil,
+        precision: PocketTtsPrecision = .fp16
+    ) {
         self.language = language
         self.directory = directory
+        self.precision = precision
     }
 
     /// Load all four CoreML models and the constants bundle.
@@ -43,12 +54,13 @@ public actor PocketTtsModelStore {
 
         let languageRoot = try await PocketTtsResourceDownloader.ensureModels(
             language: language,
-            directory: directory
+            directory: directory,
+            precision: precision
         )
         self.languageRootDirectory = languageRoot
 
         logger.info(
-            "Loading PocketTTS CoreML models (language=\(self.language.rawValue))..."
+            "Loading PocketTTS CoreML models (language=\(self.language.rawValue), precision=\(self.precision))..."
         )
 
         // Use CPU+GPU for all models to avoid ANE float16 precision loss.
@@ -63,7 +75,7 @@ public actor PocketTtsModelStore {
 
         let modelFiles: [String] = [
             ModelNames.PocketTTS.condStepFile,
-            ModelNames.PocketTTS.flowlmStepFile,
+            ModelNames.PocketTTS.flowlmStepFile(precision: precision),
             ModelNames.PocketTTS.flowDecoderFile,
             ModelNames.PocketTTS.mimiDecoderFile,
         ]

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
@@ -82,3 +82,56 @@ public enum PocketTtsLanguage: String, Sendable, CaseIterable {
         "v2/\(rawValue)"
     }
 }
+
+/// Precision variant of the PocketTTS CoreML models.
+///
+/// Both variants live in the upstream `FluidInference/pocket-tts-coreml` repo
+/// under `v2/<lang>/`. They share `cond_step`, `flow_decoder`, `mimi_decoder`,
+/// and `constants_bin/`; only the FlowLM transformer differs — `flowlm_step`
+/// (default) vs `flowlm_stepv2` (int8 weight quantization on the FlowLM
+/// transformer's attention + FFN linear layers, following the recipe from
+/// kyutai-labs/pocket-tts#147).
+///
+/// `fp16` is the upstream default — fp16 weights on disk, ~290 MB for the
+/// FlowLM transformer alone (~767 MB total for the language pack). The
+/// `PocketTtsModelStore` uses `.cpuAndGPU` compute units so CoreML upcasts
+/// activations to fp32 at runtime, matching the Python reference
+/// implementation's numerical fidelity.
+///
+/// `int8` replaces only `flowlm_step`'s attention + FFN linear weights with
+/// int8 (per-channel scale tensors stay fp16); `cond_step`, `flow_decoder`,
+/// and `mimi_decoder` keep the default fp16 weights to preserve the
+/// autoregressive feedback loop's numerical fidelity. Saves ~217 MB on
+/// disk for English (~767 MB → ~550 MB), no measurable WER regression in
+/// upstream's evaluation.
+///
+/// ## Why per-submodel quantization isn't exposed yet
+///
+/// Upstream's `experiment/pocket-tts-int8` branch prototyped a richer API
+/// (`PocketTtsQuantization` with per-submodel `PocketTtsModelPrecision`),
+/// alongside this internal A/B quality data on int8 quantization
+/// (English 6L, prompt-relative):
+///
+/// | Submodel        | speaker_sim | Pearson | Notes                                       |
+/// |-----------------|-------------|---------|---------------------------------------------|
+/// | cond_step       | 0.984       | 0.94    | safe                                        |
+/// | flowlm_step     | 0.989       | 0.94    | safe (this is what we ship)                 |
+/// | flow_decoder    | 0.981       | 0.78    | risky — LSD 8-step loop compounds error     |
+/// | mimi_decoder    | 0.998       | 1.00    | transparent (per upstream's measurements)   |
+///
+/// Their measurements disagree with the Kyutai recipe on `mimi_decoder`:
+/// Kyutai keeps it at the default precision because of the autoregressive
+/// feedback loop, while upstream's A/B reports it transparent. The
+/// conservative reading is to trust both — keep mimi at the default
+/// precision until either source revises.
+///
+/// We don't expose the richer API here because the per-submodel int8 files
+/// (`cond_step_int8.mlmodelc`, etc.) are **not published on HuggingFace**
+/// today. Only `flowlm_stepv2.mlmodelc` is published. Adding a per-submodel
+/// API would let callers request configurations that 404 at download time.
+/// If upstream publishes per-submodel int8 artifacts, this enum can grow
+/// into the experiment branch's `PocketTtsQuantization` shape mechanically.
+public enum PocketTtsPrecision: Sendable, Hashable {
+    case fp16
+    case int8
+}

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsManager.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsManager.swift
@@ -32,12 +32,21 @@ public actor PocketTtsManager {
     ///     `.english` for backward compatibility.
     ///   - directory: Optional override for the base cache directory.
     ///     When `nil`, uses the default platform cache location.
+    ///   - precision: Which FlowLM precision to load (default: `.fp16`,
+    ///     matching upstream's on-disk weight format). `.int8` swaps
+    ///     `flowlm_step` for the upstream `flowlm_stepv2` int8-quantized
+    ///     variant per kyutai-labs/pocket-tts#147.
     public init(
         defaultVoice: String = PocketTtsConstants.defaultVoice,
         language: PocketTtsLanguage = .english,
-        directory: URL? = nil
+        directory: URL? = nil,
+        precision: PocketTtsPrecision = .fp16
     ) {
-        self.modelStore = PocketTtsModelStore(language: language, directory: directory)
+        self.modelStore = PocketTtsModelStore(
+            language: language,
+            directory: directory,
+            precision: precision
+        )
         self.defaultVoice = defaultVoice
         self.language = language
     }


### PR DESCRIPTION
### Why is this change needed?
<!-- Explain the motivation for this change. What problem does it solve? -->

Wires up the published `flowlm_stepv2.mlmodelc` int8 variant via a
`PocketTtsPrecision { .fp16, .int8 }` parameter on `PocketTtsManager`,
threaded through to `PocketTtsModelStore` and `PocketTtsResourceDownloader`.

Closes the loop on the `flowlm_stepv2.mlmodelc` artifact that's been
published under `v2/<lang>/` for a while but didn't have a Swift loader
hook. Default stays `.fp16`, no behavior change for existing callers.

## What's in this PR

**Code (5 files, +171/-12):**
- `PocketTtsPrecision.swift` — new enum `{ .fp16, .int8 }`, with
  docstring documenting the kyutai-labs/pocket-tts#147 recipe and
  preserving the per-submodel A/B data from `experiment/pocket-tts-int8`
  (cond_step / flowlm_step / flow_decoder / mimi_decoder safety summary)
- `ModelNames.swift` — `flowlmStepV2` constant +
  `flowlmStepFile(precision:)` and `requiredModels(precision:)` helpers
- `PocketTtsResourceDownloader.swift` — `precision:` param,
  precision-aware cache check, and `removeUnusedFlowlmVariant()` post-
  download cleanup so callers' disk usage matches the loaded models
- `PocketTtsModelStore.swift` — `precision:` init param plumbed to the
  precision-aware filename helper
- `PocketTtsManager.swift` — `precision:` init param threaded to the
  store

**Docs (1 file, +47):**
- `Documentation/TTS/PocketTTS.md` — new "Model Files & Precision"
  section: per-submodel precision/size/HF-path table, fp16-vs-int8
  totals, rationale for why only `flowlm_step` is quantized

## Why default is `.fp16`

I asked about the on-disk weight format before committing the rename
and verified by inspecting `model.mlmodel` for both flowlm variants:
the int8 variant has explicit `cast_fp16_to_fp32` op scaffolding
throughout, while the default has none — indicating uniform fp16
weights. Combined with the 304→77 MB size ratio (~4×, consistent with
fp16→int8 plus quantization scale tensors) the default file's weights
are fp16 on disk. The existing `PocketTtsModelStore.swift:65-67`
comment about "CPU/GPU compute in float32 matches the Python reference"
is correct about runtime compute precision (CoreML upcasts fp16
weights to fp32 on `.cpuAndGPU`); it just doesn't describe disk format
and reads as accurate as-is.

## Why per-submodel quantization isn't exposed

The `experiment/pocket-tts-int8` branch's `PocketTtsQuantization`
struct (per-submodel `PocketTtsModelPrecision`) is a richer API, but
the per-submodel int8 artifacts (`cond_step_int8.mlmodelc`, etc.)
aren't published on HuggingFace today. Adding the API would let
callers request configurations that 404 at download time. Only
`flowlm_stepv2.mlmodelc` is published, and that's what this PR wires
up. The `PocketTtsPrecision` enum can grow into the experiment
branch's `PocketTtsQuantization` shape mechanically if/when the
per-submodel artifacts ship.

## Disk footprint (English language pack)

| | fp16 (default) | int8 |
|---|---|---|
| Total active files on disk | 766.3 MB | 549.3 MB |
| **int8 savings vs fp16** | — | **−217 MB (28%)** |

The `v2/<lang>/` HF directory ships both flowlm variants, so first
download briefly holds ~857 MB before the cleanup pass deletes the
unused `.mlmodelc` and `.mlpackage`.

## Backward compatibility

- `PocketTtsManager()` / `PocketTtsModelStore()` / `ensureModels()`
  defaults all stay `.fp16`, which loads `flowlm_step.mlmodelc` exactly
  as before
- Existing `requiredModels` constant retained alongside new
  `requiredModels(precision:)` so non-precision-aware callers keep
  compiling

## Verification done

- All 11 published language packs have both `flowlm_step.mlmodelc`
  and `flowlm_stepv2.mlmodelc` under `v2/<lang>/` — verified via HF
  tree API
- Branch is exactly +2 commits on top of `main`
  (`00ea906 fix: remove module_map from MachTaskSelfWrapper subspec`)
- Diff content is identical to `Gaozhongpai/FluidAudio:main`, just
  squashed from 5 iterative commits into 2 clean ones (one feat, one
  docs)

I haven't run `swift test` locally — Bash on Windows here, no Swift
toolchain. Happy to fix anything CI flags.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/558" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
