### PR TITLE
feat(asr/parakeet-v3): default to int4-per-channel encoder

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -176,6 +176,11 @@ extension AsrModels {
                 vocabulary: ModelNames.TDTJa.vocabularyFile
             )
         case .v3:
+            // v3 uses JointDecisionv3 exclusively. Top-K outputs (`top_k_ids`,
+            // `top_k_logits`) are always computed by the joint graph, but
+            // Swift-side extraction is gated by `needsTopK` in
+            // `TdtModelInference.runJointPrepared` so callers that don't pass
+            // `language:` pay no extra allocations per step.
             return (
                 encoder: encoderPrecision.encoderFileName,
                 decoder: Names.decoderFile,

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -188,8 +188,9 @@ extension AsrModels {
             //
             // The int4-per-channel encoder is the v3 default (~285 MB on disk
             // vs ~426 MB for the prior 6-bit palettized encoder, ~49× RTFx
-            // steady-state). LibriSpeech test-clean WER regresses from ~2.6%
-            // to ~5.2%; opt out by overriding `encoderInt4File` upstream.
+            // steady-state). LibriSpeech test-clean Avg WER regresses from
+            // ~2.64% to ~3.76%; opt out by overriding `encoderInt4File`
+            // upstream.
             return (
                 encoder: Names.encoderInt4File,
                 decoder: Names.decoderFile,

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -126,12 +126,13 @@ extension AsrModels {
                 ModelSpec(fileName: Names.preprocessorFile, computeUnits: config.computeUnits)
             ]
         }
+        let fileNames = getModelFileNames(version: version)
         return [
             // Preprocessor ops map to CPU-only across all platforms. XCode profiling shows
             // that 100% of the the operations map to the CPU anyways.
             ModelSpec(fileName: Names.preprocessorFile, computeUnits: .cpuOnly),
 
-            ModelSpec(fileName: Names.encoderFile, computeUnits: config.computeUnits),
+            ModelSpec(fileName: fileNames.encoder, computeUnits: config.computeUnits),
         ]
     }
 
@@ -160,13 +161,20 @@ extension AsrModels {
     // Use centralized model names
     private typealias Names = ModelNames.ASR
 
-    /// Get version-specific file names for decoder and joint models
+    /// Get version-specific file names for encoder, decoder and joint models.
+    ///
+    /// `encoder` is the on-disk filename for the conformer encoder. v3 ships
+    /// the int4-per-channel encoder (`Names.encoderInt4File`) by default; v2
+    /// and tdtJa keep their original `Encoder.mlmodelc`. For fused-frontend
+    /// versions (110m hybrid) the encoder lives inside the preprocessor and
+    /// the value of `encoder` is unused by `createModelSpecs`.
     private static func getModelFileNames(
         version: AsrModelVersion
-    ) -> (decoder: String, joint: String, vocabulary: String) {
+    ) -> (encoder: String, decoder: String, joint: String, vocabulary: String) {
         switch version {
         case .tdtJa:
             return (
+                encoder: ModelNames.TDTJa.encoderFile,
                 decoder: ModelNames.TDTJa.decoderFile,
                 joint: ModelNames.TDTJa.jointFile,
                 vocabulary: ModelNames.TDTJa.vocabularyFile
@@ -177,13 +185,20 @@ extension AsrModels {
             // Swift-side extraction is gated by `needsTopK` in
             // `TdtModelInference.runJointPrepared` so callers that don't pass
             // `language:` pay no extra allocations per step.
+            //
+            // The int4-per-channel encoder is the v3 default (~285 MB on disk
+            // vs ~426 MB for the prior 6-bit palettized encoder, ~49× RTFx
+            // steady-state). LibriSpeech test-clean WER regresses from ~2.6%
+            // to ~5.2%; opt out by overriding `encoderInt4File` upstream.
             return (
+                encoder: Names.encoderInt4File,
                 decoder: Names.decoderFile,
                 joint: Names.jointV3File,
                 vocabulary: Names.vocabularyFile
             )
         default:
             return (
+                encoder: Names.encoderFile,
                 decoder: Names.decoderFile,
                 joint: Names.jointFile,
                 vocabulary: Names.vocabularyFile
@@ -259,14 +274,15 @@ extension AsrModels {
         guard let preprocessorModel = loadedModels[Names.preprocessorFile] else {
             throw AsrModelsError.loadingFailed("Failed to load preprocessor model")
         }
-        let encoderModel = loadedModels[Names.encoderFile]  // nil for fused models
+
+        // Get version-specific file names (encoder filename varies by version:
+        // v3 uses the int4-per-channel encoder, v2/tdtJa keep `Encoder.mlmodelc`).
+        let fileNames = getModelFileNames(version: version)
+        let encoderModel = loadedModels[fileNames.encoder]  // nil for fused models
 
         if !version.hasFusedEncoder && encoderModel == nil {
             throw AsrModelsError.loadingFailed("Failed to load encoder model (required for split frontend)")
         }
-
-        // Get version-specific file names
-        let fileNames = getModelFileNames(version: version)
 
         // Load decoder first
         let decoderModels = try await DownloadUtils.loadModels(
@@ -517,7 +533,7 @@ extension AsrModels {
             specs = [
                 // Preprocessor ops map to CPU-only across all platforms.
                 DownloadSpec(fileName: Names.preprocessorFile, computeUnits: .cpuOnly),
-                DownloadSpec(fileName: Names.encoderFile, computeUnits: defaultUnits),
+                DownloadSpec(fileName: fileNames.encoder, computeUnits: defaultUnits),
                 DownloadSpec(fileName: fileNames.decoder, computeUnits: defaultUnits),
                 DownloadSpec(fileName: fileNames.joint, computeUnits: defaultUnits),
             ]
@@ -596,7 +612,7 @@ extension AsrModels {
             ("Joint", fileNames.joint),
         ]
         if !version.hasFusedEncoder {
-            modelsToValidate.insert(("Encoder", ModelNames.ASR.encoderFile), at: 1)
+            modelsToValidate.insert(("Encoder", fileNames.encoder), at: 1)
         }
 
         for (name, fileName) in modelsToValidate {

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -163,17 +163,6 @@ extension AsrModels {
     // Use centralized model names
     private typealias Names = ModelNames.ASR
 
-    /// Get version-specific file names for encoder, decoder and joint models.
-    ///
-    /// `encoder` is the on-disk filename for the conformer encoder.
-    /// - v3 honours `encoderPrecision` and selects between the 8-bit
-    ///   palettized `Encoder.mlmodelc` (`.int8`, default) and the
-    ///   int4-per-channel `EncoderInt4.mlmodelc` (`.int4`).
-    /// - v2 and tdtJa ship a single encoder file each and ignore
-    ///   `encoderPrecision`.
-    /// - For fused-frontend versions (110m hybrid) the encoder lives inside
-    ///   the preprocessor and the value of `encoder` is unused by
-    ///   `createModelSpecs`.
     private static func getModelFileNames(
         version: AsrModelVersion,
         encoderPrecision: ParakeetEncoderPrecision
@@ -187,17 +176,6 @@ extension AsrModels {
                 vocabulary: ModelNames.TDTJa.vocabularyFile
             )
         case .v3:
-            // v3 uses JointDecisionv3 exclusively. Top-K outputs (`top_k_ids`,
-            // `top_k_logits`) are always computed by the joint graph, but
-            // Swift-side extraction is gated by `needsTopK` in
-            // `TdtModelInference.runJointPrepared` so callers that don't pass
-            // `language:` pay no extra allocations per step.
-            //
-            // Encoder file selection follows `encoderPrecision`:
-            //   - .int8 (default): 8-bit palettized `Encoder.mlmodelc`
-            //     (~426 MB, ~2.64% WER on LibriSpeech test-clean)
-            //   - .int4: int4-per-channel `EncoderInt4.mlmodelc`
-            //     (~285 MB, ~3.76% WER, ~33% disk reduction)
             return (
                 encoder: encoderPrecision.encoderFileName,
                 decoder: Names.decoderFile,
@@ -214,7 +192,6 @@ extension AsrModels {
         }
     }
 
-    /// Get version-specific required models set
     private static func getRequiredModels(
         version: AsrModelVersion,
         encoderPrecision: ParakeetEncoderPrecision
@@ -237,11 +214,6 @@ extension AsrModels {
     ///                   computeUnits will be respected. When nil, platform-optimized defaults
     ///                   are used (per-model optimization based on model type).
     ///   - version: ASR model version to load (defaults to v3)
-    ///   - encoderPrecision: For v3, selects the on-disk encoder variant.
-    ///                   `.int8` (default) loads the 8-bit palettized
-    ///                   `Encoder.mlmodelc`; `.int4` loads
-    ///                   `EncoderInt4.mlmodelc` (smaller, slightly worse WER).
-    ///                   Ignored for non-v3 versions.
     ///
     /// - Returns: Loaded ASR models
     ///
@@ -267,11 +239,7 @@ extension AsrModels {
         let config = configuration ?? defaultConfiguration()
 
         let parentDirectory = directory.deletingLastPathComponent()
-        // The download/cache layer keys its required-set lookup off the
-        // `variant` string. Pass it for v3 (so the existence check picks the
-        // right encoder file) and nil otherwise.
         let downloadVariant: String? = (version == .v3) ? encoderPrecision.rawValue : nil
-        // Load preprocessor and encoder first; decoder and joint are loaded below as well.
         let specs = createModelSpecs(using: config, version: version, encoderPrecision: encoderPrecision)
 
         var loadedModels: [String: MLModel] = [:]
@@ -297,8 +265,6 @@ extension AsrModels {
             throw AsrModelsError.loadingFailed("Failed to load preprocessor model")
         }
 
-        // Get version-specific file names (encoder filename varies by version
-        // and, for v3, by `encoderPrecision`).
         let fileNames = getModelFileNames(version: version, encoderPrecision: encoderPrecision)
         let encoderModel = loadedModels[fileNames.encoder]  // nil for fused models
 
@@ -396,8 +362,6 @@ extension AsrModels {
     }
 
     private static func loadVocabulary(from directory: URL, version: AsrModelVersion) throws -> [Int: String] {
-        // Get version-specific vocabulary file name. The vocab filename is
-        // independent of `encoderPrecision`, so we pass the default here.
         let vocabularyFileName = getModelFileNames(version: version, encoderPrecision: .int8).vocabulary
         let vocabPath = repoPath(from: directory, version: version).appendingPathComponent(vocabularyFileName)
 

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -118,7 +118,9 @@ extension AsrModels {
     }
 
     private static func createModelSpecs(
-        using config: MLModelConfiguration, version: AsrModelVersion
+        using config: MLModelConfiguration,
+        version: AsrModelVersion,
+        encoderPrecision: ParakeetEncoderPrecision
     ) -> [ModelSpec] {
         if version.hasFusedEncoder {
             // Fused preprocessor+encoder runs on ANE (it contains the conformer encoder)
@@ -126,7 +128,7 @@ extension AsrModels {
                 ModelSpec(fileName: Names.preprocessorFile, computeUnits: config.computeUnits)
             ]
         }
-        let fileNames = getModelFileNames(version: version)
+        let fileNames = getModelFileNames(version: version, encoderPrecision: encoderPrecision)
         return [
             // Preprocessor ops map to CPU-only across all platforms. XCode profiling shows
             // that 100% of the the operations map to the CPU anyways.
@@ -163,13 +165,18 @@ extension AsrModels {
 
     /// Get version-specific file names for encoder, decoder and joint models.
     ///
-    /// `encoder` is the on-disk filename for the conformer encoder. v3 ships
-    /// the int4-per-channel encoder (`Names.encoderInt4File`) by default; v2
-    /// and tdtJa keep their original `Encoder.mlmodelc`. For fused-frontend
-    /// versions (110m hybrid) the encoder lives inside the preprocessor and
-    /// the value of `encoder` is unused by `createModelSpecs`.
+    /// `encoder` is the on-disk filename for the conformer encoder.
+    /// - v3 honours `encoderPrecision` and selects between the 8-bit
+    ///   palettized `Encoder.mlmodelc` (`.int8`, default) and the
+    ///   int4-per-channel `EncoderInt4.mlmodelc` (`.int4`).
+    /// - v2 and tdtJa ship a single encoder file each and ignore
+    ///   `encoderPrecision`.
+    /// - For fused-frontend versions (110m hybrid) the encoder lives inside
+    ///   the preprocessor and the value of `encoder` is unused by
+    ///   `createModelSpecs`.
     private static func getModelFileNames(
-        version: AsrModelVersion
+        version: AsrModelVersion,
+        encoderPrecision: ParakeetEncoderPrecision
     ) -> (encoder: String, decoder: String, joint: String, vocabulary: String) {
         switch version {
         case .tdtJa:
@@ -186,13 +193,13 @@ extension AsrModels {
             // `TdtModelInference.runJointPrepared` so callers that don't pass
             // `language:` pay no extra allocations per step.
             //
-            // The int4-per-channel encoder is the v3 default (~285 MB on disk
-            // vs ~426 MB for the prior 6-bit palettized encoder, ~49× RTFx
-            // steady-state). LibriSpeech test-clean Avg WER regresses from
-            // ~2.64% to ~3.76%; opt out by overriding `encoderInt4File`
-            // upstream.
+            // Encoder file selection follows `encoderPrecision`:
+            //   - .int8 (default): 8-bit palettized `Encoder.mlmodelc`
+            //     (~426 MB, ~2.64% WER on LibriSpeech test-clean)
+            //   - .int4: int4-per-channel `EncoderInt4.mlmodelc`
+            //     (~285 MB, ~3.76% WER, ~33% disk reduction)
             return (
-                encoder: Names.encoderInt4File,
+                encoder: encoderPrecision.encoderFileName,
                 decoder: Names.decoderFile,
                 joint: Names.jointV3File,
                 vocabulary: Names.vocabularyFile
@@ -208,12 +215,15 @@ extension AsrModels {
     }
 
     /// Get version-specific required models set
-    private static func getRequiredModels(version: AsrModelVersion) -> Set<String> {
+    private static func getRequiredModels(
+        version: AsrModelVersion,
+        encoderPrecision: ParakeetEncoderPrecision
+    ) -> Set<String> {
         switch version {
         case .tdtJa:
             return ModelNames.TDTJa.requiredModels
         case .v3:
-            return Names.requiredModelsV3
+            return Names.requiredModelsV3(precision: encoderPrecision)
         default:
             return version.hasFusedEncoder ? Names.requiredModelsFused : Names.requiredModels
         }
@@ -227,6 +237,11 @@ extension AsrModels {
     ///                   computeUnits will be respected. When nil, platform-optimized defaults
     ///                   are used (per-model optimization based on model type).
     ///   - version: ASR model version to load (defaults to v3)
+    ///   - encoderPrecision: For v3, selects the on-disk encoder variant.
+    ///                   `.int8` (default) loads the 8-bit palettized
+    ///                   `Encoder.mlmodelc`; `.int4` loads
+    ///                   `EncoderInt4.mlmodelc` (smaller, slightly worse WER).
+    ///                   Ignored for non-v3 versions.
     ///
     /// - Returns: Loaded ASR models
     ///
@@ -237,6 +252,7 @@ extension AsrModels {
         from directory: URL,
         configuration: MLModelConfiguration? = nil,
         version: AsrModelVersion = .v3,
+        encoderPrecision: ParakeetEncoderPrecision = .int8,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> AsrModels {
         // Validate that CTC-only models use their dedicated managers
@@ -251,8 +267,12 @@ extension AsrModels {
         let config = configuration ?? defaultConfiguration()
 
         let parentDirectory = directory.deletingLastPathComponent()
+        // The download/cache layer keys its required-set lookup off the
+        // `variant` string. Pass it for v3 (so the existence check picks the
+        // right encoder file) and nil otherwise.
+        let downloadVariant: String? = (version == .v3) ? encoderPrecision.rawValue : nil
         // Load preprocessor and encoder first; decoder and joint are loaded below as well.
-        let specs = createModelSpecs(using: config, version: version)
+        let specs = createModelSpecs(using: config, version: version, encoderPrecision: encoderPrecision)
 
         var loadedModels: [String: MLModel] = [:]
 
@@ -262,6 +282,7 @@ extension AsrModels {
                 modelNames: [spec.fileName],
                 directory: parentDirectory,
                 computeUnits: spec.computeUnits,
+                variant: downloadVariant,
                 progressHandler: progressHandler
             )
 
@@ -276,9 +297,9 @@ extension AsrModels {
             throw AsrModelsError.loadingFailed("Failed to load preprocessor model")
         }
 
-        // Get version-specific file names (encoder filename varies by version:
-        // v3 uses the int4-per-channel encoder, v2/tdtJa keep `Encoder.mlmodelc`).
-        let fileNames = getModelFileNames(version: version)
+        // Get version-specific file names (encoder filename varies by version
+        // and, for v3, by `encoderPrecision`).
+        let fileNames = getModelFileNames(version: version, encoderPrecision: encoderPrecision)
         let encoderModel = loadedModels[fileNames.encoder]  // nil for fused models
 
         if !version.hasFusedEncoder && encoderModel == nil {
@@ -291,6 +312,7 @@ extension AsrModels {
             modelNames: [fileNames.decoder],
             directory: parentDirectory,
             computeUnits: config.computeUnits,
+            variant: downloadVariant,
             progressHandler: progressHandler
         )
 
@@ -306,6 +328,7 @@ extension AsrModels {
             modelNames: [fileNames.joint],
             directory: parentDirectory,
             computeUnits: config.computeUnits,
+            variant: downloadVariant,
             progressHandler: progressHandler
         )
 
@@ -373,8 +396,9 @@ extension AsrModels {
     }
 
     private static func loadVocabulary(from directory: URL, version: AsrModelVersion) throws -> [Int: String] {
-        // Get version-specific vocabulary file name
-        let vocabularyFileName = getModelFileNames(version: version).vocabulary
+        // Get version-specific vocabulary file name. The vocab filename is
+        // independent of `encoderPrecision`, so we pass the default here.
+        let vocabularyFileName = getModelFileNames(version: version, encoderPrecision: .int8).vocabulary
         let vocabPath = repoPath(from: directory, version: version).appendingPathComponent(vocabularyFileName)
 
         if !FileManager.default.fileExists(atPath: vocabPath.path) {
@@ -489,6 +513,7 @@ extension AsrModels {
         to directory: URL? = nil,
         force: Bool = false,
         version: AsrModelVersion = .v3,
+        encoderPrecision: ParakeetEncoderPrecision = .int8,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> URL {
         // Validate that CTC-only models use their dedicated managers
@@ -501,8 +526,9 @@ extension AsrModels {
         let targetDir = directory ?? defaultCacheDirectory(for: version)
         logger.info("Downloading ASR models to: \(targetDir.path)")
         let parentDir = targetDir.deletingLastPathComponent()
+        let downloadVariant: String? = (version == .v3) ? encoderPrecision.rawValue : nil
 
-        if !force && modelsExist(at: targetDir, version: version) {
+        if !force && modelsExist(at: targetDir, version: version, encoderPrecision: encoderPrecision) {
             logger.info("ASR models already present at: \(targetDir.path)")
             return targetDir
         }
@@ -520,7 +546,7 @@ extension AsrModels {
         }
 
         let defaultUnits = defaultConfiguration().computeUnits
-        let fileNames = getModelFileNames(version: version)
+        let fileNames = getModelFileNames(version: version, encoderPrecision: encoderPrecision)
 
         let specs: [DownloadSpec]
         if version.hasFusedEncoder {
@@ -546,6 +572,7 @@ extension AsrModels {
                 modelNames: [spec.fileName],
                 directory: parentDir,
                 computeUnits: spec.computeUnits,
+                variant: downloadVariant,
                 progressHandler: progressHandler
             )
         }
@@ -558,11 +585,20 @@ extension AsrModels {
         to directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
         version: AsrModelVersion = .v3,
+        encoderPrecision: ParakeetEncoderPrecision = .int8,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> AsrModels {
-        let targetDir = try await download(to: directory, version: version, progressHandler: progressHandler)
+        let targetDir = try await download(
+            to: directory,
+            version: version,
+            encoderPrecision: encoderPrecision,
+            progressHandler: progressHandler
+        )
         return try await load(
-            from: targetDir, configuration: configuration, version: version,
+            from: targetDir,
+            configuration: configuration,
+            version: version,
+            encoderPrecision: encoderPrecision,
             progressHandler: progressHandler)
     }
 
@@ -571,9 +607,13 @@ extension AsrModels {
         return modelsExist(at: directory, version: detectedVersion)
     }
 
-    public static func modelsExist(at directory: URL, version: AsrModelVersion) -> Bool {
+    public static func modelsExist(
+        at directory: URL,
+        version: AsrModelVersion,
+        encoderPrecision: ParakeetEncoderPrecision = .int8
+    ) -> Bool {
         let fileManager = FileManager.default
-        let requiredFiles = getRequiredModels(version: version)
+        let requiredFiles = getRequiredModels(version: version, encoderPrecision: encoderPrecision)
 
         // Check in the DownloadUtils repo structure
         let repoPath = repoPath(from: directory, version: version)
@@ -584,20 +624,23 @@ extension AsrModels {
         }
 
         // Also check for vocabulary file associated with the version
-        let vocabularyFileName = getModelFileNames(version: version).vocabulary
+        let vocabularyFileName = getModelFileNames(version: version, encoderPrecision: encoderPrecision).vocabulary
         let vocabPath = repoPath.appendingPathComponent(vocabularyFileName)
         let vocabPresent = fileManager.fileExists(atPath: vocabPath.path)
 
         return modelsPresent && vocabPresent
     }
 
-    public static func isModelValid(version: AsrModelVersion = .v3) async throws -> Bool {
+    public static func isModelValid(
+        version: AsrModelVersion = .v3,
+        encoderPrecision: ParakeetEncoderPrecision = .int8
+    ) async throws -> Bool {
         guard SystemInfo.isAppleSilicon else {
             throw ASRError.unsupportedPlatform("Parakeet models require Apple Silicon")
         }
 
         let cacheDir = defaultCacheDirectory(for: version)
-        guard modelsExist(at: cacheDir, version: version) else {
+        guard modelsExist(at: cacheDir, version: version, encoderPrecision: encoderPrecision) else {
             logger.info("Model validation failed: model files not found")
             return false
         }
@@ -606,7 +649,7 @@ extension AsrModels {
         let config = MLModelConfiguration()
         config.computeUnits = .cpuOnly
 
-        let fileNames = getModelFileNames(version: version)
+        let fileNames = getModelFileNames(version: version, encoderPrecision: encoderPrecision)
         var modelsToValidate = [
             ("Preprocessor", ModelNames.ASR.preprocessorFile),
             ("Decoder", fileNames.decoder),

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -227,23 +227,10 @@ public enum Repo: String, CaseIterable, Sendable {
 }
 
 /// Encoder precision for the v3 Parakeet TDT 0.6B encoder.
-///
-/// v3 ships two on-disk variants of the conformer encoder:
-///   - `.int8`: `Encoder.mlmodelc` — 8-bit palettized (per-tensor LUT, fp16
-///     codebook). ~426 MB, ~2.64% WER on LibriSpeech test-clean, ~47× RTFx
-///     steady-state on M2 with `.cpuAndNeuralEngine`. This is the default.
-///   - `.int4`: `EncoderInt4.mlmodelc` — int4 linear-per-channel weight
-///     quantization with fp16 activations. ~285 MB (–33% disk), ~3.76% WER,
-///     ~43× RTFx. Opt in for memory/disk savings at a small accuracy cost.
-///
-/// The decoder, joint, and preprocessor are fp16 in both variants. Only the
-/// v3 loader honours this flag; other versions (v2, tdtJa, 110m hybrid) ship
-/// a single encoder file and ignore `encoderPrecision`.
 public enum ParakeetEncoderPrecision: String, Sendable, CaseIterable {
     case int8
     case int4
 
-    /// On-disk encoder filename for this precision (within the v3 repo).
     public var encoderFileName: String {
         switch self {
         case .int8:
@@ -316,12 +303,6 @@ public enum ModelNames {
         /// Joint decoder variant for v3 that exposes top-K outputs
         /// (`top_k_ids`, `top_k_logits`) used for language-aware script filtering.
         public static let jointV3File = "JointDecisionv3.mlmodelc"
-        /// Int4-per-channel quantized encoder offered as an opt-in for v3.
-        /// Trades ~2.64% -> ~3.76% LibriSpeech test-clean WER for a ~33% disk
-        /// reduction (285 MB vs 426 MB for the default 8-bit palettized
-        /// encoder) and ~49× vs ~47× RTFx steady-state on M-series. The v3
-        /// default remains the 8-bit palettized `Encoder.mlmodelc`; pass
-        /// `encoderPrecision: .int4` to opt in.
         public static let encoderInt4File = "EncoderInt4.mlmodelc"
         public static let ctcHeadFile = ctcHead + ".mlmodelc"
 
@@ -334,18 +315,6 @@ public enum ModelNames {
             jointFile,
         ]
 
-        /// Required models for v3, parameterized on encoder precision.
-        ///
-        /// v3 always ships:
-        ///   - the v3 joint (`JointDecisionv3.mlmodelc`, top-K outputs for
-        ///     language-aware script filtering)
-        ///   - the shared preprocessor and decoder
-        ///
-        /// The encoder file is selected by `precision`:
-        ///   - `.int8` (default): `Encoder.mlmodelc` — 8-bit palettized,
-        ///     ~2.64% WER, ~426 MB on disk
-        ///   - `.int4`: `EncoderInt4.mlmodelc` — int4-per-channel, ~3.76%
-        ///     WER, ~285 MB on disk
         public static func requiredModelsV3(
             precision: ParakeetEncoderPrecision = .int8
         ) -> Set<String> {
@@ -1039,10 +1008,6 @@ public enum ModelNames {
         case .vad:
             return ModelNames.VAD.requiredModels
         case .parakeetV3:
-            // `variant` carries the encoder precision ("int8"/"int4") for v3.
-            // Anything unrecognised falls back to the default (.int8) so old
-            // callers that pass `variant: nil` still resolve to the shipped
-            // 8-bit palettized encoder.
             let precision = ParakeetEncoderPrecision(rawValue: variant ?? "") ?? .int8
             return ModelNames.ASR.requiredModelsV3(precision: precision)
         case .parakeetV2:

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -226,6 +226,34 @@ public enum Repo: String, CaseIterable, Sendable {
     }
 }
 
+/// Encoder precision for the v3 Parakeet TDT 0.6B encoder.
+///
+/// v3 ships two on-disk variants of the conformer encoder:
+///   - `.int8`: `Encoder.mlmodelc` — 8-bit palettized (per-tensor LUT, fp16
+///     codebook). ~426 MB, ~2.64% WER on LibriSpeech test-clean, ~47× RTFx
+///     steady-state on M2 with `.cpuAndNeuralEngine`. This is the default.
+///   - `.int4`: `EncoderInt4.mlmodelc` — int4 linear-per-channel weight
+///     quantization with fp16 activations. ~285 MB (–33% disk), ~3.76% WER,
+///     ~43× RTFx. Opt in for memory/disk savings at a small accuracy cost.
+///
+/// The decoder, joint, and preprocessor are fp16 in both variants. Only the
+/// v3 loader honours this flag; other versions (v2, tdtJa, 110m hybrid) ship
+/// a single encoder file and ignore `encoderPrecision`.
+public enum ParakeetEncoderPrecision: String, Sendable, CaseIterable {
+    case int8
+    case int4
+
+    /// On-disk encoder filename for this precision (within the v3 repo).
+    public var encoderFileName: String {
+        switch self {
+        case .int8:
+            return ModelNames.ASR.encoderFile
+        case .int4:
+            return ModelNames.ASR.encoderInt4File
+        }
+    }
+}
+
 /// Centralized model names for all FluidAudio components
 public enum ModelNames {
 
@@ -288,16 +316,17 @@ public enum ModelNames {
         /// Joint decoder variant for v3 that exposes top-K outputs
         /// (`top_k_ids`, `top_k_logits`) used for language-aware script filtering.
         public static let jointV3File = "JointDecisionv3.mlmodelc"
-        /// Int4-per-channel quantized encoder used as the v3 default. Trades
-        /// ~2.64% -> ~3.76% LibriSpeech test-clean WER for a ~33% disk reduction
-        /// (285 MB vs 426 MB for the prior 6-bit palettized encoder) and
-        /// ~49× RTFx steady-state on M-series.
-        public static let encoderInt4 = "EncoderInt4"
-        public static let encoderInt4File = encoderInt4 + ".mlmodelc"
+        /// Int4-per-channel quantized encoder offered as an opt-in for v3.
+        /// Trades ~2.64% -> ~3.76% LibriSpeech test-clean WER for a ~33% disk
+        /// reduction (285 MB vs 426 MB for the default 8-bit palettized
+        /// encoder) and ~49× vs ~47× RTFx steady-state on M-series. The v3
+        /// default remains the 8-bit palettized `Encoder.mlmodelc`; pass
+        /// `encoderPrecision: .int4` to opt in.
+        public static let encoderInt4File = "EncoderInt4.mlmodelc"
         public static let ctcHeadFile = ctcHead + ".mlmodelc"
 
         /// Required models for v2 / legacy split-frontend loaders.
-        /// v3 uses `requiredModelsV3` (with `jointV3File`).
+        /// v3 uses `requiredModelsV3(precision:)` (with `jointV3File`).
         public static let requiredModels: Set<String> = [
             preprocessorFile,
             encoderFile,
@@ -305,16 +334,28 @@ public enum ModelNames {
             jointFile,
         ]
 
-        /// Required models for v3. v3 ships:
-        ///   - the int4-per-channel encoder (`encoderInt4File`) by default
-        ///   - `JointDecisionv3.mlmodelc` (top-K outputs for language-aware
-        ///     script filtering)
-        public static let requiredModelsV3: Set<String> = [
-            preprocessorFile,
-            encoderInt4File,
-            decoderFile,
-            jointV3File,
-        ]
+        /// Required models for v3, parameterized on encoder precision.
+        ///
+        /// v3 always ships:
+        ///   - the v3 joint (`JointDecisionv3.mlmodelc`, top-K outputs for
+        ///     language-aware script filtering)
+        ///   - the shared preprocessor and decoder
+        ///
+        /// The encoder file is selected by `precision`:
+        ///   - `.int8` (default): `Encoder.mlmodelc` — 8-bit palettized,
+        ///     ~2.64% WER, ~426 MB on disk
+        ///   - `.int4`: `EncoderInt4.mlmodelc` — int4-per-channel, ~3.76%
+        ///     WER, ~285 MB on disk
+        public static func requiredModelsV3(
+            precision: ParakeetEncoderPrecision = .int8
+        ) -> Set<String> {
+            [
+                preprocessorFile,
+                precision.encoderFileName,
+                decoderFile,
+                jointV3File,
+            ]
+        }
 
         /// Required models for fused frontend (110m hybrid: preprocessor contains encoder)
         public static let requiredModelsFused: Set<String> = [
@@ -998,7 +1039,12 @@ public enum ModelNames {
         case .vad:
             return ModelNames.VAD.requiredModels
         case .parakeetV3:
-            return ModelNames.ASR.requiredModelsV3
+            // `variant` carries the encoder precision ("int8"/"int4") for v3.
+            // Anything unrecognised falls back to the default (.int8) so old
+            // callers that pass `variant: nil` still resolve to the shipped
+            // 8-bit palettized encoder.
+            let precision = ParakeetEncoderPrecision(rawValue: variant ?? "") ?? .int8
+            return ModelNames.ASR.requiredModelsV3(precision: precision)
         case .parakeetV2:
             return ModelNames.ASR.requiredModels
         case .parakeetTdtCtc110m:

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -289,7 +289,7 @@ public enum ModelNames {
         /// (`top_k_ids`, `top_k_logits`) used for language-aware script filtering.
         public static let jointV3File = "JointDecisionv3.mlmodelc"
         /// Int4-per-channel quantized encoder used as the v3 default. Trades
-        /// ~2.6× -> ~5.2× LibriSpeech test-clean WER for a ~33% disk reduction
+        /// ~2.64% -> ~3.76% LibriSpeech test-clean WER for a ~33% disk reduction
         /// (285 MB vs 426 MB for the prior 6-bit palettized encoder) and
         /// ~49× RTFx steady-state on M-series.
         public static let encoderInt4 = "EncoderInt4"

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -288,6 +288,12 @@ public enum ModelNames {
         /// Joint decoder variant for v3 that exposes top-K outputs
         /// (`top_k_ids`, `top_k_logits`) used for language-aware script filtering.
         public static let jointV3File = "JointDecisionv3.mlmodelc"
+        /// Int4-per-channel quantized encoder used as the v3 default. Trades
+        /// ~2.6× -> ~5.2× LibriSpeech test-clean WER for a ~33% disk reduction
+        /// (285 MB vs 426 MB for the prior 6-bit palettized encoder) and
+        /// ~49× RTFx steady-state on M-series.
+        public static let encoderInt4 = "EncoderInt4"
+        public static let encoderInt4File = encoderInt4 + ".mlmodelc"
         public static let ctcHeadFile = ctcHead + ".mlmodelc"
 
         /// Required models for v2 / legacy split-frontend loaders.
@@ -299,11 +305,13 @@ public enum ModelNames {
             jointFile,
         ]
 
-        /// Required models for v3. v3 always uses `JointDecisionv3.mlmodelc`
-        /// (with top-K outputs for language-aware script filtering).
+        /// Required models for v3. v3 ships:
+        ///   - the int4-per-channel encoder (`encoderInt4File`) by default
+        ///   - `JointDecisionv3.mlmodelc` (top-K outputs for language-aware
+        ///     script filtering)
         public static let requiredModelsV3: Set<String> = [
             preprocessorFile,
-            encoderFile,
+            encoderInt4File,
             decoderFile,
             jointV3File,
         ]

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -215,6 +215,7 @@ enum TranscribeCommand {
         var modelDir: String?
         var parakeetVariant: StreamingModelVariant?
         var language: Language?
+        var encoderPrecision: ParakeetEncoderPrecision = .int8
 
         // Parse options
         var i = 1
@@ -282,6 +283,16 @@ enum TranscribeCommand {
                     language = lang
                     i += 1
                 }
+            case "--encoder-precision":
+                if i + 1 < arguments.count {
+                    guard let precision = ParakeetEncoderPrecision(rawValue: arguments[i + 1].lowercased()) else {
+                        let valid = ParakeetEncoderPrecision.allCases.map(\.rawValue).joined(separator: ", ")
+                        logger.error("Unknown encoder precision: \(arguments[i + 1]). Valid: \(valid)")
+                        exit(1)
+                    }
+                    encoderPrecision = precision
+                    i += 1
+                }
             default:
                 logger.warning("Warning: Unknown option: \(arguments[i])")
             }
@@ -306,7 +317,7 @@ enum TranscribeCommand {
             await testBatchTranscription(
                 audioFile: audioFile, showMetadata: showMetadata, wordTimestamps: wordTimestamps,
                 outputJsonPath: outputJsonPath, modelVersion: modelVersion, customVocabPath: customVocabPath,
-                modelDir: modelDir, language: language)
+                modelDir: modelDir, language: language, encoderPrecision: encoderPrecision)
         }
     }
 
@@ -314,16 +325,17 @@ enum TranscribeCommand {
     private static func testBatchTranscription(
         audioFile: String, showMetadata: Bool, wordTimestamps: Bool, outputJsonPath: String?,
         modelVersion: AsrModelVersion, customVocabPath: String?, modelDir: String? = nil,
-        language: Language? = nil
+        language: Language? = nil, encoderPrecision: ParakeetEncoderPrecision = .int8
     ) async {
         do {
             // Initialize ASR models
             let models: AsrModels
             if let modelDir = modelDir {
                 let dir = URL(fileURLWithPath: modelDir)
-                models = try await AsrModels.load(from: dir, version: modelVersion)
+                models = try await AsrModels.load(from: dir, version: modelVersion, encoderPrecision: encoderPrecision)
             } else {
-                models = try await AsrModels.downloadAndLoad(version: modelVersion)
+                models = try await AsrModels.downloadAndLoad(
+                    version: modelVersion, encoderPrecision: encoderPrecision)
             }
             let tdtConfig = TdtConfig(blankId: modelVersion.blankId)
             let asrConfig = ASRConfig(

--- a/Tests/FluidAudioTests/ASR/Parakeet/ModelNamesTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/ModelNamesTests.swift
@@ -188,4 +188,34 @@ final class ModelNamesTests: XCTestCase {
         // Should be 1 less than regular models (which has 4: Preprocessor, Encoder, Decoder, Joint)
         XCTAssertEqual(fusedModels.count, ModelNames.ASR.requiredModels.count - 1)
     }
+
+    // MARK: - v3 int4 Encoder Tests
+
+    func testV3UsesInt4EncoderAsDefault() {
+        // v3 ships the int4-per-channel encoder by default; the legacy
+        // `Encoder.mlmodelc` is still defined (used by v2 / legacy split
+        // frontends) but is NOT part of the v3 required set.
+        let v3Models = ModelNames.getRequiredModelNames(for: .parakeetV3, variant: nil)
+
+        XCTAssertTrue(v3Models.contains(ModelNames.ASR.encoderInt4File))
+        XCTAssertEqual(ModelNames.ASR.encoderInt4File, "EncoderInt4.mlmodelc")
+        XCTAssertFalse(v3Models.contains(ModelNames.ASR.encoderFile))
+
+        // v3 still uses the v3 joint and the shared preprocessor + decoder.
+        XCTAssertTrue(v3Models.contains(ModelNames.ASR.preprocessorFile))
+        XCTAssertTrue(v3Models.contains(ModelNames.ASR.decoderFile))
+        XCTAssertTrue(v3Models.contains(ModelNames.ASR.jointV3File))
+        XCTAssertEqual(v3Models.count, 4)
+    }
+
+    func testV2KeepsLegacyEncoder() {
+        // v2 must keep the original `Encoder.mlmodelc`; the int4 default is
+        // v3-only.
+        let v2Models = ModelNames.getRequiredModelNames(for: .parakeetV2, variant: nil)
+
+        XCTAssertTrue(v2Models.contains(ModelNames.ASR.encoderFile))
+        XCTAssertFalse(v2Models.contains(ModelNames.ASR.encoderInt4File))
+        XCTAssertTrue(v2Models.contains(ModelNames.ASR.jointFile))
+        XCTAssertFalse(v2Models.contains(ModelNames.ASR.jointV3File))
+    }
 }

--- a/Tests/FluidAudioTests/ASR/Parakeet/ModelNamesTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/ModelNamesTests.swift
@@ -189,17 +189,16 @@ final class ModelNamesTests: XCTestCase {
         XCTAssertEqual(fusedModels.count, ModelNames.ASR.requiredModels.count - 1)
     }
 
-    // MARK: - v3 int4 Encoder Tests
+    // MARK: - v3 Encoder Precision Tests
 
-    func testV3UsesInt4EncoderAsDefault() {
-        // v3 ships the int4-per-channel encoder by default; the legacy
-        // `Encoder.mlmodelc` is still defined (used by v2 / legacy split
-        // frontends) but is NOT part of the v3 required set.
+    func testV3DefaultsToInt8Encoder() {
+        // v3 default: 8-bit palettized `Encoder.mlmodelc`. `variant: nil`
+        // is treated the same as `variant: "int8"` for back-compat with
+        // callers that don't know about precision selection.
         let v3Models = ModelNames.getRequiredModelNames(for: .parakeetV3, variant: nil)
 
-        XCTAssertTrue(v3Models.contains(ModelNames.ASR.encoderInt4File))
-        XCTAssertEqual(ModelNames.ASR.encoderInt4File, "EncoderInt4.mlmodelc")
-        XCTAssertFalse(v3Models.contains(ModelNames.ASR.encoderFile))
+        XCTAssertTrue(v3Models.contains(ModelNames.ASR.encoderFile))
+        XCTAssertFalse(v3Models.contains(ModelNames.ASR.encoderInt4File))
 
         // v3 still uses the v3 joint and the shared preprocessor + decoder.
         XCTAssertTrue(v3Models.contains(ModelNames.ASR.preprocessorFile))
@@ -208,8 +207,62 @@ final class ModelNamesTests: XCTestCase {
         XCTAssertEqual(v3Models.count, 4)
     }
 
+    func testV3Int8VariantMatchesDefault() {
+        let nilVariant = ModelNames.getRequiredModelNames(for: .parakeetV3, variant: nil)
+        let int8Variant = ModelNames.getRequiredModelNames(for: .parakeetV3, variant: "int8")
+        XCTAssertEqual(nilVariant, int8Variant)
+    }
+
+    func testV3Int4VariantSelectsInt4Encoder() {
+        // Opt in to the int4-per-channel encoder via variant string.
+        let v3Models = ModelNames.getRequiredModelNames(for: .parakeetV3, variant: "int4")
+
+        XCTAssertTrue(v3Models.contains(ModelNames.ASR.encoderInt4File))
+        XCTAssertEqual(ModelNames.ASR.encoderInt4File, "EncoderInt4.mlmodelc")
+        XCTAssertFalse(v3Models.contains(ModelNames.ASR.encoderFile))
+
+        // Joint, preprocessor, and decoder are unchanged.
+        XCTAssertTrue(v3Models.contains(ModelNames.ASR.preprocessorFile))
+        XCTAssertTrue(v3Models.contains(ModelNames.ASR.decoderFile))
+        XCTAssertTrue(v3Models.contains(ModelNames.ASR.jointV3File))
+        XCTAssertEqual(v3Models.count, 4)
+    }
+
+    func testV3UnknownVariantFallsBackToInt8() {
+        // Defensive: anything other than "int8"/"int4" should resolve to the
+        // shipped default rather than throw or return an empty set.
+        let v3Models = ModelNames.getRequiredModelNames(for: .parakeetV3, variant: "fp32")
+        XCTAssertTrue(v3Models.contains(ModelNames.ASR.encoderFile))
+        XCTAssertFalse(v3Models.contains(ModelNames.ASR.encoderInt4File))
+    }
+
+    func testParakeetEncoderPrecisionEncoderFileNames() {
+        XCTAssertEqual(ParakeetEncoderPrecision.int8.encoderFileName, ModelNames.ASR.encoderFile)
+        XCTAssertEqual(ParakeetEncoderPrecision.int4.encoderFileName, ModelNames.ASR.encoderInt4File)
+    }
+
+    func testRequiredModelsV3ForBothPrecisions() {
+        let int8Set = ModelNames.ASR.requiredModelsV3(precision: .int8)
+        XCTAssertTrue(int8Set.contains(ModelNames.ASR.encoderFile))
+        XCTAssertFalse(int8Set.contains(ModelNames.ASR.encoderInt4File))
+
+        let int4Set = ModelNames.ASR.requiredModelsV3(precision: .int4)
+        XCTAssertTrue(int4Set.contains(ModelNames.ASR.encoderInt4File))
+        XCTAssertFalse(int4Set.contains(ModelNames.ASR.encoderFile))
+
+        // Both sets share preprocessor / decoder / joint v3.
+        for shared in [
+            ModelNames.ASR.preprocessorFile,
+            ModelNames.ASR.decoderFile,
+            ModelNames.ASR.jointV3File,
+        ] {
+            XCTAssertTrue(int8Set.contains(shared))
+            XCTAssertTrue(int4Set.contains(shared))
+        }
+    }
+
     func testV2KeepsLegacyEncoder() {
-        // v2 must keep the original `Encoder.mlmodelc`; the int4 default is
+        // v2 must keep the original `Encoder.mlmodelc`; the int4 toggle is
         // v3-only.
         let v2Models = ModelNames.getRequiredModelNames(for: .parakeetV2, variant: nil)
 

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -108,4 +108,4 @@ swift build -c release
 | 8-bit palettized  | 425 MB  | 2.64%   | 1.03%   | 47.1×        | 153 MB   |
 | int4 linear/ch    | 285 MB  | 3.76%   | 1.59%   | 43.1×        | 139 MB   |
 
-Apple M2, `.cpuAndNeuralEngine`. Decoder/joint/preprocessor fp16 in both. The "fp16" encoder we ship at `Encoder.mlmodelc` is actually 8-bit palettized (per-tensor LUT, fp16 codebook values, 294 `constexpr_lut_to_dense` ops) — a true uncompressed fp16 encoder is ~1.13 GB. Peak RAM = `maximum resident set size` from `/usr/bin/time -l` over a 100-file slice (process working set is steady-state, doesn't scale with corpus size). Models: [FluidInference/parakeet-tdt-0.6b-v3-coreml](https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml).
+Apple M2, `.cpuAndNeuralEngine`. Decoder/joint/preprocessor fp16 in both. Models: [FluidInference/parakeet-tdt-0.6b-v3-coreml](https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml).

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -96,3 +96,16 @@ swift build -c release
 - True streaming with 1.12s audio chunks and encoder state carryover
 - RNNT greedy decoding with proper decoder LSTM state management
 - Models available at: [alexwengg/nemotron-speech-streaming-en-0.6b-coreml](https://huggingface.co/alexwengg/nemotron-speech-streaming-en-0.6b-coreml)
+
+---
+
+# Parakeet TDT 0.6B v3 Benchmark Results
+
+## LibriSpeech test-clean (2,620 files, 19,452.5 s audio)
+
+| Encoder           | On-disk | Avg WER | Avg CER | Overall RTFx | Peak RAM |
+|-------------------|--------:|--------:|--------:|-------------:|---------:|
+| 8-bit palettized  | 425 MB  | 2.64%   | 1.03%   | 47.1×        | 153 MB   |
+| int4 linear/ch    | 285 MB  | 3.76%   | 1.59%   | 43.1×        | 139 MB   |
+
+Apple M2, `.cpuAndNeuralEngine`. Decoder/joint/preprocessor fp16 in both. The "fp16" encoder we ship at `Encoder.mlmodelc` is actually 8-bit palettized (per-tensor LUT, fp16 codebook values, 294 `constexpr_lut_to_dense` ops) — a true uncompressed fp16 encoder is ~1.13 GB. Peak RAM = `maximum resident set size` from `/usr/bin/time -l` over a 100-file slice (process working set is steady-state, doesn't scale with corpus size). Models: [FluidInference/parakeet-tdt-0.6b-v3-coreml](https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml).


### PR DESCRIPTION
## Summary

Switch the Parakeet TDT v3 default encoder from the 6-bit palettized `Encoder.mlmodelc` to a new int4-per-channel `EncoderInt4.mlmodelc`. v2 and TDTJa keep the legacy 6-bit encoder; v3 is the only path that changes.

## WER / size / speed (LibriSpeech test-clean, 100 files, M2)

| variant | WER | disk | RTFx | ANE residency |
|---|---|---|---|---|
| baseline (6-bit palettized, current default) | 2.64% | 426 MB | 36.8x | 99.4% |
| **int4-per-channel (new default)** | **5.24%** | **285 MB** | **49.2x** | 82.0% |
| enc-prune+int8 | 2.57% | 568 MB | 19.8x | 82.0% |
| enc-int4-linear-per-block-32 | 3.95% | 319 MB | 15.6x | 33.3% |
| enc-prune+int4-block | 3.95% | 319 MB | 15.9x | 33.3% |

The chosen variant trades roughly 2× LibriSpeech WER (still in the same single-digit-percent regime) for **33% less disk** and the **fastest RTFx** of any variant tested. Per-block quants drop off ANE entirely (33%) while per-channel stays compatible (82%).

## Implementation

- `ModelNames.ASR`
  - Add `encoderInt4 = \"EncoderInt4\"` and `encoderInt4File = \"EncoderInt4.mlmodelc\"`.
  - Swap `encoderFile` for `encoderInt4File` in `requiredModelsV3`. `encoderFile` stays defined and is still used by v2 / TDTJa / 110m.
- `AsrModels.swift`
  - Extend `getModelFileNames(version:)` return tuple from `(decoder, joint, vocabulary)` to `(encoder, decoder, joint, vocabulary)`.
  - Thread `fileNames.encoder` through `createModelSpecs`, the v3 `load` flow, the `download` spec list, and `isModelValid`. v3 returns `Names.encoderInt4File`; v2/tdtJa return their existing `Encoder.mlmodelc`; fused (110m) is unaffected.
- Tests: add `testV3UsesInt4EncoderAsDefault` and `testV2KeepsLegacyEncoder` in `ModelNamesTests`.

## Distribution

The new `EncoderInt4.mlpackage` / `EncoderInt4.mlmodelc` will be uploaded to the existing `FluidInference/parakeet-tdt-0.6b-v3-coreml` HF repo alongside the current `Encoder.mlmodelc`. Older library versions that still ask for `Encoder.mlmodelc` continue to work unchanged.

## Test plan

- [x] `swift build` clean
- [x] `swift test --filter ModelNamesTests` — 20/20 (2 new)
- [x] `swift test --filter AsrModelsTests` — 30/30
- [x] End-to-end transcription smoke test on LibriSpeech 61-70970-0001.flac via `EncoderInt4.mlmodelc`: correct text, RTFx 29.12x. ANE cold compile 21.3s (one-time).
- [x] swift-format lint clean on the modified files (only pre-existing Sortformer warnings remain in `ModelNames.swift`).
- [ ] CI: tests + asr-benchmark
- [ ] Verify HF download path on a clean cache once `EncoderInt4.mlmodelc` is uploaded to the v3 repo.

## Companion

The mobius PR adds the conversion scripts that produced these variants (`extra_encoder_variants.py`, `analyze_fallback.py`, `compute_unit_sweep.py`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fluidinference/fluidaudio/pull/560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
