### PR TITLE
feat(asr/cohere): long-form transcribeLong + cold/warm docs

### DIFF
--- a/Documentation/ASR/Cohere.md
+++ b/Documentation/ASR/Cohere.md
@@ -198,6 +198,45 @@ Two sources of the ~1-3% gap on most languages:
 2. **Quantization**: FluidAudio ships INT8 encoder + FP16 cache-external
    decoder; Cohere's reported numbers are full FP16 PyTorch inference.
 
+### Cold-start vs warm inference (isolated, single process)
+
+The headline RTFx numbers above assume the encoder/decoder are loaded **once**
+and reused across many transcribes. Spawning a fresh process per WAV pays the
+ANE compile cost on every call and looks dramatically slower.
+
+Isolated single-process bench, M2 (2022) Tahoe 26.0, INT8 encoder + FP16
+cache-external decoder, `cohere-transcribe` invoked once with five WAVs sharing
+one model load:
+
+| # | Duration | Encoder | Decoder | Total | RTFx | Notes |
+|--:|---:|---:|---:|---:|---:|---|
+| 0 |  3.32 s | 186.33 s | 1.46 s | 187.81 s | 0.02× | **cold ANE compile** |
+| 1 |  6.87 s |   2.47 s | 0.90 s |   3.41 s | 2.02× | warm |
+| 2 |  8.94 s |   3.31 s | 1.21 s |   4.57 s | 1.96× | warm |
+| 3 | 37.15 s |   1.51 s | 2.54 s |   4.26 s | 8.73× | warm, full 35 s window |
+
+Takeaways:
+
+- **Cold compile is one-time per process**, not per call. `anecompilerservice`
+  re-emits the encoder MIL graph for ANE the first time a fresh process loads
+  the model. ~3 min on M2 Tahoe; longer on first-ever compiles for some
+  language splits (the cmn_hans_cn FLEURS run logged a ~6 min cold-start).
+  Wiping `~/Library/Caches/.../com.apple.e5rt.e5bundlecache/` does not avoid
+  it; a clean process always pays it.
+- **Warm encoder is shape-bound, not duration-bound.** Every call processes a
+  fixed 3,500-frame mel (35 s @ 10 ms hop). Short audio does not finish the
+  encoder faster — warm encoder cost stays in a 1.5–3.3 s band regardless of
+  input length.
+- **Audio > 35 s is silently truncated** to the first 35 s by
+  `padOrTruncate(... fixedFrames: 3_500)` in
+  `Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift:250`. Split long audio
+  at clause boundaries upstream if you need full coverage.
+- **Process reuse is what unlocks the documented RTFx.** The LibriSpeech
+  test-clean run above (5h 24m audio, RTFx 1.72× total) absorbs the cold
+  compile across 2,620 utterances; per-call warm path is closer to RTFx
+  2–9× depending on how much of the 35 s window is filled. Re-spawning per
+  WAV would push effective RTFx well below 0.1×.
+
 ## Notes and Caveats
 
 - **INT8 encoder quality parity**: encoder hidden states match FP16 within

--- a/Documentation/ASR/Cohere.md
+++ b/Documentation/ASR/Cohere.md
@@ -227,10 +227,13 @@ Takeaways:
   fixed 3,500-frame mel (35 s @ 10 ms hop). Short audio does not finish the
   encoder faster — warm encoder cost stays in a 1.5–3.3 s band regardless of
   input length.
-- **Audio > 35 s is silently truncated** to the first 35 s by
-  `padOrTruncate(... fixedFrames: 3_500)` in
-  `Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift:250`. Split long audio
-  at clause boundaries upstream if you need full coverage.
+- **Audio > 35 s is auto-chunked** by `transcribeLong` with a 30 s hop and 5 s
+  overlap (matches upstream `overlap_chunk_second: 5`); adjacent chunk token
+  streams are stitched via token-level longest-common-substring merge. The
+  raw `transcribe` call still uses the strict 35 s window with
+  `padOrTruncate(... fixedFrames: 3_500)` at
+  `Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift:250`, so picking
+  `transcribeLong` is the right default for unknown-length audio.
 - **Process reuse is what unlocks the documented RTFx.** The LibriSpeech
   test-clean run above (5h 24m audio, RTFx 1.72× total) absorbs the cold
   compile across 2,620 utterances; per-call warm path is closer to RTFx
@@ -244,11 +247,14 @@ Takeaways:
   are within ±0.5%, so the INT8 hybrid is the recommended default.
 - **Cache-external decoder stays FP16**: INT8 decoder quantization regresses
   quality significantly in testing and is not shipped.
-- **Single-chunk only**: the CoreML pipeline processes one 35 s window per
-  call (matches upstream `max_audio_clip_s: 35`). The reference Python
-  pipeline supports >35 s audio via sliding-window chunking with 5 s overlap
-  (`overlap_chunk_second: 5`); FluidAudio does not implement that wrapper
-  yet — files exceeding 35 s are skipped by the benchmark CLI with a warning.
+- **Long-form audio**: the encoder always sees a fixed 35 s window
+  (`max_audio_clip_s: 35`). Use `CoherePipeline.transcribeLong` for audio of
+  unknown / arbitrary length — it slides a 35 s window with 5 s overlap
+  (matching upstream `overlap_chunk_second: 5`) and stitches adjacent chunks
+  via token-level longest-common-substring merge. The raw `transcribe` API is
+  the single-chunk path and silently truncates input > 35 s. The CLI commands
+  (`cohere-transcribe`, `cohere-benchmark`, `tts-benchmark`) all use
+  `transcribeLong` and no longer skip > 35 s files.
 - **Language must be specified**: no automatic language ID. Pass
   `CohereAsrConfig.Language` on every call; the wrong language produces
   degenerate output.

--- a/Sources/FluidAudio/ASR/Cohere/CohereAsrConfig.swift
+++ b/Sources/FluidAudio/ASR/Cohere/CohereAsrConfig.swift
@@ -14,6 +14,14 @@ public enum CohereAsrConfig {
     /// Maximum number of audio samples (560,000 at 16kHz = 35 seconds).
     public static let maxSamples: Int = 560_000
 
+    /// Sliding-window overlap (seconds) when chunking audio > `maxAudioSeconds`.
+    ///
+    /// Matches upstream `cohere-pytorch/config.json` `overlap_chunk_second: 5`.
+    public static let chunkOverlapSeconds: Float = 5.0
+
+    /// Sliding-window hop (seconds) for long-form audio: 35 − 5 = 30 s.
+    public static var chunkHopSeconds: Float { maxAudioSeconds - chunkOverlapSeconds }
+
     /// Vocabulary size.
     public static let vocabSize: Int = 16_384
 

--- a/Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift
+++ b/Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift
@@ -497,6 +497,142 @@ public actor CoherePipeline {
             totalSeconds: CFAbsoluteTimeGetCurrent() - total0)
     }
 
+    // MARK: Long-form (sliding-window over the 35 s single-chunk encoder)
+
+    /// Transcribe arbitrary-length audio by sliding the existing 35 s encoder
+    /// window with a 5 s overlap and merging adjacent chunks via token-level
+    /// longest-common-substring.
+    ///
+    /// Audio ≤ `CohereAsrConfig.maxAudioSeconds` short-circuits to the
+    /// single-chunk `transcribe()` path and is byte-identical to it. Longer
+    /// audio is split at `chunkHopSeconds = maxAudioSeconds − chunkOverlapSeconds`
+    /// hops; chunk windows of `maxAudioSeconds` are decoded independently and
+    /// stitched. Encoder/decoder/total seconds are summed across chunks.
+    ///
+    /// Mirrors the upstream Python pipeline's `overlap_chunk_second: 5`. No
+    /// model changes — the encoder still sees a fixed `[1, 128, 3500]` mel and
+    /// the decoder cache is reset per chunk.
+    public func transcribeLong(
+        audio: [Float],
+        models: LoadedModels,
+        language: CohereAsrConfig.Language = .english,
+        maxNewTokens: Int = 108,
+        repetitionPenalty: Float = 1.1,
+        noRepeatNgram: Int = 3
+    ) async throws -> TranscriptionResult {
+        let total0 = CFAbsoluteTimeGetCurrent()
+
+        let sr = CohereAsrConfig.sampleRate
+        let chunkSamples = Int(CohereAsrConfig.maxAudioSeconds) * sr
+        let hopSamples = Int(CohereAsrConfig.chunkHopSeconds) * sr
+
+        // Short audio: pass through unchanged.
+        if audio.count <= chunkSamples {
+            return try await transcribe(
+                audio: audio,
+                models: models,
+                language: language,
+                maxNewTokens: maxNewTokens,
+                repetitionPenalty: repetitionPenalty,
+                noRepeatNgram: noRepeatNgram)
+        }
+
+        var mergedTokens: [Int] = []
+        var encoderSecs: Double = 0
+        var decoderSecs: Double = 0
+        var start = 0
+        var chunkIndex = 0
+
+        while start < audio.count {
+            let end = min(start + chunkSamples, audio.count)
+            let chunk = Array(audio[start..<end])
+
+            // Don't bother decoding a final tail of pure overlap — the previous
+            // chunk already covered it.
+            if chunkIndex > 0, (end - start) <= (chunkSamples - hopSamples) {
+                break
+            }
+
+            let result = try await transcribe(
+                audio: chunk,
+                models: models,
+                language: language,
+                maxNewTokens: maxNewTokens,
+                repetitionPenalty: repetitionPenalty,
+                noRepeatNgram: noRepeatNgram)
+
+            encoderSecs += result.encoderSeconds
+            decoderSecs += result.decoderSeconds
+
+            mergedTokens = Self.mergeTokenStreams(prefix: mergedTokens, suffix: result.tokenIds)
+
+            chunkIndex += 1
+            if end >= audio.count { break }
+            start += hopSamples
+        }
+
+        let text = Self.convertTokensToText(mergedTokens, vocabulary: models.vocabulary)
+        return TranscriptionResult(
+            text: text,
+            tokenIds: mergedTokens,
+            encoderSeconds: encoderSecs,
+            decoderSeconds: decoderSecs,
+            totalSeconds: CFAbsoluteTimeGetCurrent() - total0)
+    }
+
+    /// Merge two adjacent chunk token streams using longest-common-substring.
+    ///
+    /// Both chunks transcribe ~5 s of identical audio at their seam, so their
+    /// token IDs share a common subsequence near the prefix's tail / the
+    /// suffix's head. We search a bounded window (`windowTokens` tokens at the
+    /// boundary) for the longest common substring of length ≥ `minMatch`. On a
+    /// hit we drop the prefix's matched suffix and concatenate the suffix
+    /// verbatim. On a miss we concatenate plainly — better to duplicate a few
+    /// tokens than to lose content.
+    static func mergeTokenStreams(
+        prefix: [Int],
+        suffix: [Int],
+        windowTokens: Int = 32,
+        minMatch: Int = 4
+    ) -> [Int] {
+        if prefix.isEmpty { return suffix }
+        if suffix.isEmpty { return prefix }
+
+        let pTail = Array(prefix.suffix(windowTokens))
+        let sHead = Array(suffix.prefix(windowTokens))
+        let m = pTail.count
+        let n = sHead.count
+        if m == 0 || n == 0 { return prefix + suffix }
+
+        // Classic LCS-substring DP (O(m·n), m,n ≤ windowTokens).
+        var dp = [Int](repeating: 0, count: n + 1)
+        var bestLen = 0
+        var bestSEnd = 0  // index in sHead (exclusive) where the match ends
+        for i in 1...m {
+            var prev = 0
+            for j in 1...n {
+                let temp = dp[j]
+                if pTail[i - 1] == sHead[j - 1] {
+                    dp[j] = prev + 1
+                    if dp[j] > bestLen {
+                        bestLen = dp[j]
+                        bestSEnd = j
+                    }
+                } else {
+                    dp[j] = 0
+                }
+                prev = temp
+            }
+        }
+
+        guard bestLen >= minMatch else { return prefix + suffix }
+
+        // Keep the prefix as-is (it already contains one copy of the overlap
+        // tokens) and drop the suffix's matched head so the seam is not
+        // duplicated.
+        return prefix + Array(suffix.dropFirst(bestSEnd))
+    }
+
     // MARK: Encoder
 
     private func runEncoder(

--- a/Sources/FluidAudioCLI/Commands/ASR/Cohere/CohereBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Cohere/CohereBenchmark.swift
@@ -443,15 +443,8 @@ enum CohereBenchmark {
             do {
                 let samples = try AudioConverter().resampleAudioFile(path: file.audioPath.path)
                 let duration = Double(samples.count) / Double(CohereAsrConfig.sampleRate)
-                if duration > Double(CohereAsrConfig.maxAudioSeconds) {
-                    logger.warning(
-                        "  Skipping \(file.fileName) (\(String(format: "%.1f", duration))s > "
-                            + "\(CohereAsrConfig.maxAudioSeconds)s single-chunk limit)"
-                    )
-                    continue
-                }
 
-                let result = try await pipeline.transcribe(
+                let result = try await pipeline.transcribeLong(
                     audio: samples,
                     models: models,
                     language: language,
@@ -729,8 +722,10 @@ enum CohereBenchmark {
                 el_gr, ar_eg, ja_jp, cmn_hans_cn, ko_kr, vi_vn
 
             Note:
-                Cohere Transcribe is single-chunk with a 35s audio limit. Files
-                exceeding that are skipped with a warning.
+                The Cohere encoder accepts a 35s window. Audio longer than 35s is
+                automatically chunked with 5s overlap (matching upstream
+                `overlap_chunk_second: 5`) and adjacent chunks are stitched via
+                token-level longest-common-substring merge.
 
             Examples:
                 # LibriSpeech test-clean, English, 100 utterances

--- a/Sources/FluidAudioCLI/Commands/ASR/Cohere/CohereTranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Cohere/CohereTranscribeCommand.swift
@@ -168,7 +168,7 @@ enum CohereTranscribeCommand {
             logger.info("Models loaded in \(String(format: "%.2f", loadSecs))s")
 
             let pipeline = CoherePipeline()
-            let result = try await pipeline.transcribe(
+            let result = try await pipeline.transcribeLong(
                 audio: samples,
                 models: models,
                 language: language,

--- a/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
@@ -1272,7 +1272,7 @@ public enum TtsBenchmarkCommand {
                 label: "cohere-transcribe-\(language.rawValue)",
                 transcribeOne: { url in
                     let samples = try converter.resampleAudioFile(path: url.path)
-                    let r = try await pipeline.transcribe(
+                    let r = try await pipeline.transcribeLong(
                         audio: samples,
                         models: models,
                         language: language,

--- a/Tests/FluidAudioTests/ASR/Cohere/CohereLongFormTests.swift
+++ b/Tests/FluidAudioTests/ASR/Cohere/CohereLongFormTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+@available(macOS 14, iOS 17, *)
+final class CohereLongFormTests: XCTestCase {
+
+    // MARK: - Config
+
+    func testChunkOverlapMatchesUpstream() {
+        // Matches `overlap_chunk_second: 5` in upstream cohere-pytorch config.
+        XCTAssertEqual(CohereAsrConfig.chunkOverlapSeconds, 5.0)
+    }
+
+    func testChunkHopIsMaxMinusOverlap() {
+        XCTAssertEqual(
+            CohereAsrConfig.chunkHopSeconds,
+            CohereAsrConfig.maxAudioSeconds - CohereAsrConfig.chunkOverlapSeconds)
+        XCTAssertEqual(CohereAsrConfig.chunkHopSeconds, 30.0)
+    }
+
+    // MARK: - mergeTokenStreams
+
+    func testMergePrefixEmpty() {
+        let merged = CoherePipeline.mergeTokenStreams(prefix: [], suffix: [1, 2, 3])
+        XCTAssertEqual(merged, [1, 2, 3])
+    }
+
+    func testMergeSuffixEmpty() {
+        let merged = CoherePipeline.mergeTokenStreams(prefix: [1, 2, 3], suffix: [])
+        XCTAssertEqual(merged, [1, 2, 3])
+    }
+
+    func testMergeNoCommonRunFallsBackToConcat() {
+        let merged = CoherePipeline.mergeTokenStreams(
+            prefix: [10, 11, 12, 13],
+            suffix: [20, 21, 22, 23])
+        XCTAssertEqual(merged, [10, 11, 12, 13, 20, 21, 22, 23])
+    }
+
+    func testMergeShortMatchBelowThresholdFallsBackToConcat() {
+        // A common run of 3 tokens is below the default minMatch=4 threshold.
+        let merged = CoherePipeline.mergeTokenStreams(
+            prefix: [1, 2, 3, 7, 8, 9],
+            suffix: [7, 8, 9, 100, 200])
+        XCTAssertEqual(merged, [1, 2, 3, 7, 8, 9, 7, 8, 9, 100, 200])
+    }
+
+    func testMergeOverlapAtBoundary() {
+        // Prefix tail and suffix head share a 5-token run. Merge drops the
+        // overlap from prefix's tail and the overlap from suffix's head.
+        let prefix = [1, 2, 3, 4, 50, 51, 52, 53, 54]
+        let suffix = [50, 51, 52, 53, 54, 60, 61, 62]
+        let merged = CoherePipeline.mergeTokenStreams(prefix: prefix, suffix: suffix)
+        XCTAssertEqual(merged, [1, 2, 3, 4, 50, 51, 52, 53, 54, 60, 61, 62])
+    }
+
+    func testMergeOverlapOffsetWithinWindow() {
+        // The overlap doesn't have to align with the absolute boundary — the
+        // merge uses an LCS over a bounded window, so a shifted match still
+        // works.
+        let prefix = [1, 2, 3, 90, 91, 92, 93, 94, 95]
+        let suffix = [91, 92, 93, 94, 95, 200, 201]
+        let merged = CoherePipeline.mergeTokenStreams(prefix: prefix, suffix: suffix)
+        XCTAssertEqual(merged, [1, 2, 3, 90, 91, 92, 93, 94, 95, 200, 201])
+    }
+
+    func testMergePrefersLongestRun() {
+        // Two candidate matches: a 4-token run earlier and a 5-token run later.
+        // The longer run wins.
+        let prefix = [1, 2, 3, 4, 7, 8, 9, 10, 11]
+        let suffix = [1, 2, 3, 4, 7, 8, 9, 10, 11, 99]
+        let merged = CoherePipeline.mergeTokenStreams(prefix: prefix, suffix: suffix)
+        // The 9-token tail of prefix matches the 9-token head of suffix → the
+        // suffix tail '99' is the only thing kept after the prefix.
+        XCTAssertEqual(merged, [1, 2, 3, 4, 7, 8, 9, 10, 11, 99])
+    }
+
+    func testMergeWindowBoundsLcsCost() {
+        // 4-token threshold; the run lives entirely inside the merge window
+        // (default 32 tokens). Verifies behavior when prefix is much longer
+        // than the window.
+        let leadIn = Array(0..<200)
+        let prefix = leadIn + [500, 501, 502, 503, 504]
+        let suffix = [500, 501, 502, 503, 504, 700, 701]
+        let merged = CoherePipeline.mergeTokenStreams(prefix: prefix, suffix: suffix)
+        XCTAssertEqual(merged, leadIn + [500, 501, 502, 503, 504, 700, 701])
+    }
+}


### PR DESCRIPTION
## Summary

Two related changes that grew out of the cohere isolated-bench investigation:

### 1. Long-form Cohere ASR — `CoherePipeline.transcribeLong`

The encoder is fixed at a 35 s window, so the prior `transcribe()` silently truncated longer audio via `padOrTruncate(... fixedFrames: 3_500)` in `Sources/FluidAudio/ASR/Cohere/CoherePipeline.swift:250`.

`transcribeLong` slices audio into 35 s chunks with **5 s overlap** (matches upstream `cohere-pytorch/config.json` `overlap_chunk_second: 5`) and stitches adjacent chunks via **token-level longest-common-substring merge**. No model changes — encoder shape stays `[1, 128, 3500]`, decoder cache shape unchanged.

- Audio ≤ 35 s short-circuits to the existing single-chunk `transcribe()` path → byte-identical short-form behavior, zero perf delta on FLEURS / LibriSpeech (which are all ≤ 35 s)
- Audio > 35 s: hop = 30 s, decode each chunk independently, merge token streams (drop the suffix's matched head, keep prefix as-is)
- LCS window bounded to 32 tokens per seam → O(K²) merge is negligible vs. decode
- Per-chunk encoder/decoder/total seconds are summed into one `TranscriptionResult`

CLI rewiring:
- `cohere-transcribe`, `cohere-benchmark`, `tts-benchmark` now route through `transcribeLong`
- `cohere-benchmark` no longer skips files exceeding 35 s

Smoke-tested on a Mandarin 81 s WAV: full 80 s now transcribes (previously cut at 35 s). 10 unit tests cover `mergeTokenStreams` correctness (empty-input, no-overlap, threshold fallback, boundary overlap, offset overlap, longest-run preference, window bounds) and chunk-config constants.

### 2. Cold-start vs warm inference docs

Adds a section to `Documentation/ASR/Cohere.md` capturing the isolated single-process bench (cold ANE compile ~186 s on M2 Tahoe; warm calls 3.4–4.6 s, RTFx 1.96×–8.73×). Clarifies process reuse is what unlocks the headline FLEURS/LibriSpeech RTFx.

## Test plan

- [x] `swift test --filter CohereLongFormTests` (10 / 10 pass)
- [x] `swift test --filter CohereAsrConfigTests` and `CoherePipelineMaskTests` (no regressions)
- [x] `swift build` (debug) clean; `swift build -c release` clean
- [x] Smoke: `cohere-transcribe /tmp/cohere_test_80s.wav --language zh` transcribes full 80 s of audio (3 chunks merged, no duplicated overlap content)
- [x] `swift format lint` — no new warnings in changed files