### PR TITLE
feat(tts/kokoro-ane/zh): number/date/currency verbalization (#572 item 2)

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
@@ -5,20 +5,24 @@ import Foundation
 ///
 /// Pipeline (mirrors `misaki/zh_frontend.py`):
 ///
-///   1. **Punctuation normalization** — fullwidth → ASCII for the
+///   1. **Number normalization** — `MandarinNumberNormalizer` verbalizes
+///      Arabic numerals, dates, times, percentages, fractions, and
+///      currency expressions into Hanzi the rest of the pipeline can
+///      speak directly (`2025年5月3日` → `二零二五年五月三日`).
+///   2. **Punctuation normalization** — fullwidth → ASCII for the
 ///      characters the v1.1-zh vocab actually carries (`，` → `,`,
 ///      `。` → `.`, …).
-///   2. **Segmentation** — forward maximum-matching against
+///   3. **Segmentation** — forward maximum-matching against
 ///      `MandarinPinyinDict.phrases`, falling back to single-char
 ///      lookups in `singles`. Matches `MagpieMandarinTokenizer`'s
 ///      strategy — full jieba HMM is not ported.
-///   3. **Diacritic → digit** — each pinyin syllable is normalized to
+///   4. **Diacritic → digit** — each pinyin syllable is normalized to
 ///      `(base, tone)` via `MandarinPinyinNormalizer`.
-///   4. **Tone sandhi** — 3+3 → 2+3, 不 / 一 contextual rules
+///   5. **Tone sandhi** — 3+3 → 2+3, 不 / 一 contextual rules
 ///      (`MandarinToneSandhi`).
-///   5. **Pinyin → Bopomofo** — `MandarinBopomofoMap.encode` produces
+///   6. **Pinyin → Bopomofo** — `MandarinBopomofoMap.encode` produces
 ///      the final `<initial><final><digit>` string per syllable.
-///   6. **Concatenation** — syllables joined with no separator,
+///   7. **Concatenation** — syllables joined with no separator,
 ///      punctuation interleaved verbatim. The output is fed straight
 ///      into `KokoroAneVocab.encode`.
 ///
@@ -27,8 +31,7 @@ import Foundation
 ///
 ///   * Erhua merging (`儿` suffix collapse).
 ///   * POS-conditioned sandhi from `tone_sandhi.py`.
-///   * Number / datetime / English-letter normalization
-///     (`misaki.zh_normalization`).
+///   * English-letter normalization (`misaki.zh_normalization`).
 public struct MandarinG2P: Sendable {
 
     private let dict: MandarinPinyinDict
@@ -42,7 +45,8 @@ public struct MandarinG2P: Sendable {
     /// `KokoroAneVocab.encode`. Empty input is rejected with `throws`
     /// to match the existing English path's behaviour.
     public func phonemize(_ text: String) throws -> String {
-        let normalized = Self.normalizeText(text)
+        let verbalized = MandarinNumberNormalizer.normalize(text)
+        let normalized = Self.normalizeText(verbalized)
         guard !normalized.isEmpty else {
             throw KokoroAneError.inputProcessingFailed("(empty input)")
         }

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinNumberNormalizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinNumberNormalizer.swift
@@ -1,0 +1,266 @@
+import Foundation
+
+/// Mandarin number / date / time / currency verbalization pre-pass.
+///
+/// Runs *before* `MandarinG2P.normalizeText` so Arabic numerals, dates,
+/// times, percentages, fractions, and currency expressions are converted
+/// into Hanzi the existing G2P pipeline can speak directly. The
+/// transformation is text-in / text-out — pure function, no state.
+///
+/// Mirrors the most common cases from `misaki/zh/num.py`. Out of scope
+/// (deferred — extending later won't break callers):
+///
+///   * Scientific notation (`1e6`).
+///   * English-style ordinals (`1st`, `2nd`).
+///   * Unit abbreviations (`kg`, `°C`, `km/h`).
+///   * Phone-number / ID grouping (`138-0013-8000`).
+///
+/// Rule ordering is significant — date / time / currency patterns run
+/// before the generic decimal / integer fallthrough so that
+/// `2025年5月3日` becomes one cohesive Hanzi span instead of leaving
+/// `年` / `月` / `日` glued to digit fragments.
+public enum MandarinNumberNormalizer {
+
+    private static let digits: [Character] = [
+        "零", "一", "二", "三", "四", "五", "六", "七", "八", "九",
+    ]
+    private static let groupUnits: [String] = ["", "万", "亿", "兆"]
+
+    /// Convert all numeric expressions in `text` to their Hanzi
+    /// verbalization. Non-numeric content passes through unchanged.
+    ///
+    /// Regexes are compiled per call rather than cached at file scope —
+    /// keeps the type Sendable-clean without `@unchecked` annotations.
+    /// Compilation cost is microseconds and dominated by the surrounding
+    /// G2P pipeline.
+    public static func normalize(_ text: String) -> String {
+        var s = text
+        for (pattern, transform) in pipeline {
+            s = apply(pattern: pattern, transform: transform, to: s)
+        }
+        return s
+    }
+
+    // MARK: - Cardinal
+
+    /// Verbalize a non-negative integer up to ~10¹⁶ (`9999_9999_9999_9999`).
+    /// Larger inputs degrade gracefully by emitting digit-by-digit.
+    static func cardinal(_ n: Int64) -> String {
+        if n == 0 { return "零" }
+        if n < 0 { return "负" + cardinal(-n) }
+
+        var groups: [Int] = []
+        var x = n
+        while x > 0 {
+            groups.append(Int(x % 10000))
+            x /= 10000
+        }
+        if groups.count > groupUnits.count {
+            return digitString(String(n))
+        }
+
+        var result = ""
+        var emitted = false
+        for i in (0..<groups.count).reversed() {
+            let g = groups[i]
+            if g == 0 { continue }
+            if emitted && g < 1000 {
+                result += "零"
+            }
+            result += fourDigitChunk(g, isHighest: !emitted)
+            result += groupUnits[i]
+            emitted = true
+        }
+        return result
+    }
+
+    /// Render a 4-digit value (0..<10000). `isHighest` collapses the
+    /// 1x range to `十` (e.g. `12` → `十二`) when no higher group
+    /// precedes it; intra-number tens always render as `一十X`.
+    private static func fourDigitChunk(_ n: Int, isHighest: Bool) -> String {
+        if n == 0 { return "" }
+        var result = ""
+        let q = n / 1000
+        let h = (n / 100) % 10
+        let t = (n / 10) % 10
+        let u = n % 10
+        var pendingZero = false
+
+        if q > 0 {
+            result.append(digits[q])
+            result += "千"
+        }
+        if h > 0 {
+            if pendingZero {
+                result += "零"
+                pendingZero = false
+            }
+            result.append(digits[h])
+            result += "百"
+        } else if q > 0 && (t > 0 || u > 0) {
+            pendingZero = true
+        }
+        if t > 0 {
+            if pendingZero {
+                result += "零"
+                pendingZero = false
+            }
+            if t == 1 && q == 0 && h == 0 && isHighest {
+                result += "十"
+            } else {
+                result.append(digits[t])
+                result += "十"
+            }
+        } else if (q > 0 || h > 0) && u > 0 {
+            pendingZero = true
+        }
+        if u > 0 {
+            if pendingZero {
+                result += "零"
+                pendingZero = false
+            }
+            result.append(digits[u])
+        }
+        return result
+    }
+
+    /// Spell each digit individually (e.g. `"2025"` → `"二零二五"`).
+    /// Used for years and as a fallback for out-of-range integers.
+    static func digitString(_ s: String) -> String {
+        var out = ""
+        for ch in s {
+            if let v = ch.wholeNumberValue, (0..<10).contains(v) {
+                out.append(digits[v])
+            } else if ch == "-" {
+                out += "负"
+            } else if ch == "." {
+                out += "点"
+            }
+        }
+        return out
+    }
+
+    /// `"3.14"` → `"三点一四"`. Integer part as cardinal, fractional
+    /// part digit-by-digit. Trailing zeros in the fractional part are
+    /// stripped to match colloquial Mandarin (`5.50` → `五点五`).
+    static func decimal(_ s: String) -> String {
+        let parts = s.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+        let intPart = String(parts[0])
+        if parts.count == 1 {
+            return Int64(intPart).map(cardinal) ?? digitString(intPart)
+        }
+        var fracPart = String(parts[1])
+        while fracPart.count > 1 && fracPart.last == "0" {
+            fracPart.removeLast()
+        }
+        let intStr = Int64(intPart).map(cardinal) ?? digitString(intPart)
+        if fracPart.isEmpty || fracPart == "0" {
+            return intStr
+        }
+        return intStr + "点" + digitString(fracPart)
+    }
+
+    // MARK: - Rule plumbing
+
+    private typealias Transform = ([String]) -> String
+
+    private static func apply(
+        pattern: String,
+        transform: Transform,
+        to text: String
+    ) -> String {
+        // Patterns are compile-time literals — a failure here is a
+        // programmer bug, surface it loudly instead of silently dropping.
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            fatalError("MandarinNumberNormalizer: invalid regex \(pattern)")
+        }
+        let ns = text as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        let matches = regex.matches(in: text, options: [], range: range)
+        guard !matches.isEmpty else { return text }
+        var out = ""
+        var cursor = 0
+        for m in matches {
+            let mr = m.range
+            if mr.location > cursor {
+                out += ns.substring(
+                    with: NSRange(location: cursor, length: mr.location - cursor))
+            }
+            var groups: [String] = []
+            groups.reserveCapacity(m.numberOfRanges)
+            for i in 0..<m.numberOfRanges {
+                let r = m.range(at: i)
+                groups.append(r.location == NSNotFound ? "" : ns.substring(with: r))
+            }
+            out += transform(groups)
+            cursor = mr.location + mr.length
+        }
+        if cursor < ns.length {
+            out += ns.substring(
+                with: NSRange(location: cursor, length: ns.length - cursor))
+        }
+        return out
+    }
+
+    private static func intToHanzi(_ s: String) -> String {
+        Int64(s).map(cardinal) ?? s
+    }
+
+    /// Ordered list of (regex, transform) pairs applied left-to-right.
+    /// Order is significant — date / time / currency patterns must run
+    /// before generic decimal / integer fallthrough.
+    private static var pipeline: [(String, Transform)] {
+        [
+            // Date: 2025年5月3日 / 2025年5月3号
+            (
+                #"(\d{4})年(\d{1,2})月(\d{1,2})[日号]"#,
+                { g in
+                    digitString(g[1]) + "年" + intToHanzi(g[2]) + "月" + intToHanzi(g[3]) + "日"
+                }
+            ),
+            // Date: 2025年5月
+            (
+                #"(\d{4})年(\d{1,2})月"#,
+                { g in
+                    digitString(g[1]) + "年" + intToHanzi(g[2]) + "月"
+                }
+            ),
+            // Date: 2025-05-03 / 2025/05/03
+            (
+                #"(\d{4})[-/](\d{1,2})[-/](\d{1,2})\b"#,
+                { g in
+                    digitString(g[1]) + "年" + intToHanzi(g[2]) + "月" + intToHanzi(g[3]) + "日"
+                }
+            ),
+            // Date: 2025年 (year-only)
+            (#"(\d{4})年"#, { g in digitString(g[1]) + "年" }),
+            // Time: HH:MM:SS
+            (
+                #"(\d{1,2}):(\d{2}):(\d{2})"#,
+                { g in
+                    intToHanzi(g[1]) + "点" + intToHanzi(g[2]) + "分" + intToHanzi(g[3]) + "秒"
+                }
+            ),
+            // Time: HH:MM
+            (
+                #"(\d{1,2}):(\d{2})"#,
+                { g in
+                    intToHanzi(g[1]) + "点" + intToHanzi(g[2]) + "分"
+                }
+            ),
+            // Currency: prefix symbol + amount.
+            (#"[¥￥](\d+(?:\.\d+)?)"#, { g in decimal(g[1]) + "元" }),
+            (#"\$(\d+(?:\.\d+)?)"#, { g in decimal(g[1]) + "美元" }),
+            (#"€(\d+(?:\.\d+)?)"#, { g in decimal(g[1]) + "欧元" }),
+            (#"£(\d+(?:\.\d+)?)"#, { g in decimal(g[1]) + "英镑" }),
+            // Percentage: 99% / 0.5%
+            (#"(\d+(?:\.\d+)?)%"#, { g in "百分之" + decimal(g[1]) }),
+            // Fraction: a/b — denominator first in Chinese (`二分之一` for `1/2`).
+            (#"(\d+)/(\d+)"#, { g in intToHanzi(g[2]) + "分之" + intToHanzi(g[1]) }),
+            // Plain decimal (catches what currency / percentage didn't).
+            (#"\d+\.\d+"#, { g in decimal(g[0]) }),
+            // Plain integer fallthrough.
+            (#"\d+"#, { g in intToHanzi(g[0]) }),
+        ]
+    }
+}

--- a/Tests/FluidAudioTests/TTS/KokoroAne/MandarinNumberNormalizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/MandarinNumberNormalizerTests.swift
@@ -1,0 +1,231 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Network-free unit tests for `MandarinNumberNormalizer`. The
+/// transformation is a pure function with no model dependency, so the
+/// suite is exhaustive across the cardinal / decimal / percentage /
+/// fraction / currency / date / time rules.
+final class MandarinNumberNormalizerTests: XCTestCase {
+
+    // MARK: - Cardinal
+
+    func testCardinalZero() {
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(0), "零")
+    }
+
+    func testCardinalSingleDigit() {
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(1), "一")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(9), "九")
+    }
+
+    func testCardinalTen() {
+        // Standalone 10 collapses to 十 (vs intra-number 一十).
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(10), "十")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(12), "十二")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(19), "十九")
+    }
+
+    func testCardinalTens() {
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(20), "二十")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(45), "四十五")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(99), "九十九")
+    }
+
+    func testCardinalHundred() {
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(100), "一百")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(101), "一百零一")
+        // Intra-number tens use 一十, not the standalone 十 form.
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(110), "一百一十")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(123), "一百二十三")
+    }
+
+    func testCardinalThousand() {
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(1000), "一千")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(1001), "一千零一")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(1010), "一千零一十")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(2345), "二千三百四十五")
+    }
+
+    func testCardinalWan() {
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(10000), "一万")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(12345), "一万二千三百四十五")
+        // Higher group's "10" surfaces as 十 because no group precedes it.
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(100_000), "十万")
+        // Cross-group zero gap fills with 零 once.
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(100_001), "十万零一")
+    }
+
+    func testCardinalYi() {
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(100_000_000), "一亿")
+        XCTAssertEqual(
+            MandarinNumberNormalizer.cardinal(123_456_789),
+            "一亿二千三百四十五万六千七百八十九")
+    }
+
+    func testCardinalNegative() {
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(-5), "负五")
+        XCTAssertEqual(MandarinNumberNormalizer.cardinal(-1234), "负一千二百三十四")
+    }
+
+    // MARK: - Decimal
+
+    func testDecimalSimple() {
+        XCTAssertEqual(MandarinNumberNormalizer.decimal("3.14"), "三点一四")
+    }
+
+    func testDecimalIntegerOnly() {
+        XCTAssertEqual(MandarinNumberNormalizer.decimal("42"), "四十二")
+    }
+
+    func testDecimalStripsTrailingZeros() {
+        // Colloquial Mandarin drops trailing zeros from the fractional part.
+        XCTAssertEqual(MandarinNumberNormalizer.decimal("5.50"), "五点五")
+        XCTAssertEqual(MandarinNumberNormalizer.decimal("1.00"), "一")
+    }
+
+    func testDecimalPreservesInteriorZero() {
+        XCTAssertEqual(MandarinNumberNormalizer.decimal("3.05"), "三点零五")
+    }
+
+    // MARK: - Digit-by-digit
+
+    func testDigitString() {
+        XCTAssertEqual(MandarinNumberNormalizer.digitString("2025"), "二零二五")
+        XCTAssertEqual(MandarinNumberNormalizer.digitString("007"), "零零七")
+    }
+
+    // MARK: - normalize() — top-level
+
+    func testNormalizeIntegerInline() {
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("我有3只猫"), "我有三只猫")
+    }
+
+    func testNormalizeMultipleIntegers() {
+        XCTAssertEqual(
+            MandarinNumberNormalizer.normalize("买了10个苹果和5个梨"),
+            "买了十个苹果和五个梨")
+    }
+
+    func testNormalizeDecimal() {
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("圆周率是3.14"), "圆周率是三点一四")
+    }
+
+    // MARK: - Percentage
+
+    func testNormalizePercentage() {
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("99%"), "百分之九十九")
+    }
+
+    func testNormalizeDecimalPercentage() {
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("0.5%"), "百分之零点五")
+    }
+
+    // MARK: - Fraction
+
+    func testNormalizeFraction() {
+        // Denominator first in Chinese: 1/2 → 二分之一.
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("1/2"), "二分之一")
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("3/4"), "四分之三")
+    }
+
+    // MARK: - Money
+
+    func testNormalizeRMB() {
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("¥120"), "一百二十元")
+        // Fullwidth ￥ also matches.
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("￥120"), "一百二十元")
+    }
+
+    func testNormalizeUSD() {
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("$5.50"), "五点五美元")
+    }
+
+    func testNormalizeEUR() {
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("€100"), "一百欧元")
+    }
+
+    func testNormalizeGBP() {
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("£25"), "二十五英镑")
+    }
+
+    // MARK: - Date
+
+    func testNormalizeChineseDate() {
+        XCTAssertEqual(
+            MandarinNumberNormalizer.normalize("2025年5月3日"),
+            "二零二五年五月三日")
+    }
+
+    func testNormalizeChineseDateHao() {
+        XCTAssertEqual(
+            MandarinNumberNormalizer.normalize("2025年5月3号"),
+            "二零二五年五月三日")
+    }
+
+    func testNormalizeChineseYearMonth() {
+        XCTAssertEqual(
+            MandarinNumberNormalizer.normalize("2025年5月"),
+            "二零二五年五月")
+    }
+
+    func testNormalizeIsoDate() {
+        XCTAssertEqual(
+            MandarinNumberNormalizer.normalize("2025-05-03"),
+            "二零二五年五月三日")
+        XCTAssertEqual(
+            MandarinNumberNormalizer.normalize("2025/05/03"),
+            "二零二五年五月三日")
+    }
+
+    func testNormalizeYearOnly() {
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("2025年"), "二零二五年")
+    }
+
+    // MARK: - Time
+
+    func testNormalizeHourMinute() {
+        XCTAssertEqual(MandarinNumberNormalizer.normalize("8:30"), "八点三十分")
+    }
+
+    func testNormalizeHourMinuteSecond() {
+        XCTAssertEqual(
+            MandarinNumberNormalizer.normalize("23:59:59"),
+            "二十三点五十九分五十九秒")
+    }
+
+    // MARK: - Round-trip via MandarinG2P (regression check)
+
+    func testBaselineHanziStillWorks() throws {
+        // Sanity: number normalization MUST NOT corrupt pure-Hanzi input
+        // that has no numerals.
+        let dict = Self.miniDict()
+        let g2p = MandarinG2P(dict: dict)
+        XCTAssertNoThrow(try g2p.phonemize("你好"))
+    }
+
+    func testInlineNumberFlowsThroughG2P() throws {
+        // 5 normalises to 五 → already in dict → emits a syllable.
+        let dict = Self.miniDict()
+        let g2p = MandarinG2P(dict: dict)
+        let phon = try g2p.phonemize("有5个")
+        XCTAssertFalse(phon.isEmpty)
+    }
+
+    // MARK: - Test fixtures
+
+    private static func miniDict() -> MandarinPinyinDict {
+        // Cover the few hanzi used by the round-trip tests above. Real
+        // dictionary lives in HF assets; this fixture is intentionally
+        // minimal to keep tests offline.
+        let singles: [UInt32: [String]] = [
+            0x4F60: ["nǐ"],  // 你
+            0x597D: ["hǎo"],  // 好
+            0x6709: ["yǒu"],  // 有
+            0x4E94: ["wǔ"],  // 五
+            0x4E2A: ["gè"],  // 个
+        ]
+        return MandarinPinyinDict(phrases: [:], singles: singles)
+    }
+}


### PR DESCRIPTION
## Summary

Issue #572 item 2. Pre-pass that verbalizes numerics, dates, times,
percentages, fractions, and currencies into Hanzi *before*
`MandarinG2P` segments the text. Without it, conversational input
like \`¥120\`, \`2025年5月3日\`, \`8:30\`, \`99%\` either fragments
into per-digit literals or gets dropped entirely by the segmenter.

- Port misaki/zh/num.py rules: cardinals up to 兆 (10¹²), decimal
  point form, percentages with 百分之, fractions (二分之一), money
  (¥/$/€/￥), dates (YYYY年MM月DD日, YYYY/MM/DD), times (HH:MM[:SS])
- Hook in `MandarinG2P.phonemize` before punctuation normalization
- Pure function, no new public API surface on `KokoroAneManager`

## Test plan

- [x] `MandarinNumberNormalizerTests` covers cardinals, decimals,
      percentages, fractions, money, dates, times
- [x] `MandarinG2PTests` baseline regression (no behavior change on
      pure-Hanzi input)
- [x] `swift build` + `swift format lint` clean