### PR TITLE
feat(tts/kokoro-ane/zh): erhua merging (#572 item 3)

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinBopomofoMap.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinBopomofoMap.swift
@@ -131,7 +131,12 @@ public enum MandarinBopomofoMap {
     /// + digit string the v1.1-zh vocab expects (`"ㄏㄠ3"`). Returns
     /// `nil` when the syllable cannot be parsed (the caller logs and
     /// drops it — kokoro's own behaviour for OOV tokens is identical).
-    public static func encode(syllable base: String, tone: Int) -> String? {
+    ///
+    /// Pass `erhua: true` to append a trailing `ㄦ` between the final
+    /// and the tone digit (`小孩儿` → `ㄒㄧㄠ3ㄏㄞㄦ2`). Only the
+    /// `儿` suffix is encoded — phonetic compaction (`-n`/`-ng` drop)
+    /// is left to the acoustic model, matching misaki's style.
+    public static func encode(syllable base: String, tone: Int, erhua: Bool = false) -> String? {
         guard !base.isEmpty else { return nil }
         let normalized = normalizePinyinForLookup(base)
         guard let (initial, finalRaw) = splitInitialFinal(normalized) else {
@@ -171,6 +176,12 @@ public enum MandarinBopomofoMap {
         }
         if !final.isEmpty {
             guard let bo = finalMap[final] else { return nil }
+            out.append(bo)
+        }
+        // Erhua suffix sits between the final and the tone digit so the
+        // model sees `ㄒㄧㄠㄦ3` (a single toned r-coloured syllable)
+        // rather than `ㄒㄧㄠ3ㄦ` (two tokens).
+        if erhua, let bo = finalMap["er"] {
             out.append(bo)
         }
         // Tone digit — the v1.1-zh vocab carries 1…5 verbatim.

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinErhua.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinErhua.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Merge `儿` (er) suffixes into the preceding syllable so that
+/// `这儿`, `小孩儿`, `一会儿` emit a single r-coloured token instead
+/// of trailing `er` as a separate audible syllable.
+///
+/// Mirrors `misaki/zh_frontend.py:_merge_erhua` with one simplification:
+/// we don't drop the preceding final's `-n` / `-ng` consonant (e.g.
+/// `wan + r` stays `wanr` rather than collapsing to `war`). The Kokoro
+/// v1.1-zh acoustic model was trained on misaki-style input where the
+/// erhua marker is a standalone `ㄦ` appended to the toned final, so
+/// the simpler form preserves intelligibility without per-final tables.
+///
+/// Boundary rules:
+///
+///   * `儿` at index 0 of the sandhi buffer is *never* merged — keeps
+///     standalone words (`儿子 érzi`, `儿童 értóng`) intact.
+///   * The preceding syllable must itself not be `er` — back-to-back
+///     `er er` is left as two syllables.
+///   * Any non-`er` base is mergeable. The whitelist is intentionally
+///     loose; cases that misaki blocks (e.g. `儿` at the start of a
+///     polysyllabic word) are already filtered out by the
+///     `dict.phrases` / single-char lookup happening upstream.
+///
+/// Operates in place on the same `pendingSyllables` buffer that
+/// `MandarinToneSandhi.apply` will see — invoke this *before* sandhi
+/// so 3+3 promotion considers the (now shorter) buffer.
+public enum MandarinErhua {
+
+    /// Fold trailing `er` syllables into their predecessors. Mutates
+    /// `syllables` in place; the merged-into syllable gains
+    /// `erhua = true`, the trailing `er` is removed.
+    public static func merge(_ syllables: inout [MandarinPinyinNormalizer.Syllable]) {
+        guard syllables.count >= 2 else { return }
+
+        // Walk back-to-front so removals don't shift unprocessed indices,
+        // and skip past the merged-into slot once a merge fires (chained
+        // `er er` patterns shouldn't double-merge).
+        var i = syllables.count - 1
+        while i >= 1 {
+            let cur = syllables[i]
+            let prev = syllables[i - 1]
+            if cur.base == "er" && shouldMergeInto(prev: prev) {
+                syllables[i - 1].erhua = true
+                syllables.remove(at: i)
+                // Advance past the now-merged anchor so an immediately
+                // preceding `er` (rare but possible across word seams)
+                // isn't itself folded into something further back.
+                i -= 2
+            } else {
+                i -= 1
+            }
+        }
+    }
+
+    /// Whitelist for the merge predicate. Conservative on purpose —
+    /// any non-empty, non-`er` base is allowed.
+    private static func shouldMergeInto(
+        prev: MandarinPinyinNormalizer.Syllable
+    ) -> Bool {
+        !prev.base.isEmpty && prev.base != "er"
+    }
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
@@ -14,18 +14,20 @@ import Foundation
 ///      strategy — full jieba HMM is not ported.
 ///   3. **Diacritic → digit** — each pinyin syllable is normalized to
 ///      `(base, tone)` via `MandarinPinyinNormalizer`.
-///   4. **Tone sandhi** — 3+3 → 2+3, 不 / 一 contextual rules
+///   4. **Erhua merge** — `MandarinErhua.merge` folds trailing `儿`
+///      into the previous syllable so `小孩儿` emits a single
+///      r-coloured token (`ㄒㄧㄠ3ㄏㄞㄦ2`).
+///   5. **Tone sandhi** — 3+3 → 2+3, 不 / 一 contextual rules
 ///      (`MandarinToneSandhi`).
-///   5. **Pinyin → Bopomofo** — `MandarinBopomofoMap.encode` produces
+///   6. **Pinyin → Bopomofo** — `MandarinBopomofoMap.encode` produces
 ///      the final `<initial><final><digit>` string per syllable.
-///   6. **Concatenation** — syllables joined with no separator,
+///   7. **Concatenation** — syllables joined with no separator,
 ///      punctuation interleaved verbatim. The output is fed straight
 ///      into `KokoroAneVocab.encode`.
 ///
 /// Out of scope (deferred — a future PR can extend this without
 /// breaking callers):
 ///
-///   * Erhua merging (`儿` suffix collapse).
 ///   * POS-conditioned sandhi from `tone_sandhi.py`.
 ///   * Number / datetime / English-letter normalization
 ///     (`misaki.zh_normalization`).
@@ -52,9 +54,15 @@ public struct MandarinG2P: Sendable {
 
         func flushPending() {
             guard !pendingSyllables.isEmpty else { return }
+            // Order: erhua first (it shrinks the buffer), then sandhi
+            // operates on the merged result so 3+3 promotion sees the
+            // r-coloured syllable as a single tonal unit.
+            MandarinErhua.merge(&pendingSyllables)
             MandarinToneSandhi.apply(&pendingSyllables)
             for syl in pendingSyllables {
-                if let bo = MandarinBopomofoMap.encode(syllable: syl.base, tone: syl.tone) {
+                if let bo = MandarinBopomofoMap.encode(
+                    syllable: syl.base, tone: syl.tone, erhua: syl.erhua)
+                {
                     output.append(bo)
                 } else {
                     Self.logger.warning(

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinPinyinNormalizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinPinyinNormalizer.swift
@@ -18,10 +18,15 @@ public enum MandarinPinyinNormalizer {
     public struct Syllable: Equatable, Sendable {
         public var base: String  // ASCII letters only, with `ü` → `v`.
         public var tone: Int  // 1…4 = explicit, 5 = neutral / unmarked.
+        /// Whether this syllable has absorbed a trailing `儿` (erhua).
+        /// Set by `MandarinErhua.merge`; consumed by
+        /// `MandarinBopomofoMap.encode` to append the `ㄦ` suffix.
+        public var erhua: Bool
 
-        public init(base: String, tone: Int) {
+        public init(base: String, tone: Int, erhua: Bool = false) {
             self.base = base
             self.tone = tone
+            self.erhua = erhua
         }
     }
 

--- a/Tests/FluidAudioTests/TTS/KokoroAne/MandarinErhuaTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/MandarinErhuaTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Network-free unit tests for `MandarinErhua` — both the in-place
+/// merge primitive and the end-to-end behaviour through
+/// `MandarinG2P.phonemize`.
+final class MandarinErhuaTests: XCTestCase {
+
+    // MARK: - merge() primitives
+
+    func testMergeBasic() {
+        // 这儿 (zhe4 + er5) → single zhe-erhua syllable.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "zhe", tone: 4),
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 5),
+        ]
+        MandarinErhua.merge(&s)
+        XCTAssertEqual(s.count, 1)
+        XCTAssertEqual(s[0].base, "zhe")
+        XCTAssertEqual(s[0].tone, 4)
+        XCTAssertTrue(s[0].erhua)
+    }
+
+    func testMergeMultiSyllable() {
+        // 小孩儿 (xiao3 + hai2 + er5) → 2 syllables, last erhua.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "xiao", tone: 3),
+            MandarinPinyinNormalizer.Syllable(base: "hai", tone: 2),
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 5),
+        ]
+        MandarinErhua.merge(&s)
+        XCTAssertEqual(s.count, 2)
+        XCTAssertEqual(s[0].base, "xiao")
+        XCTAssertFalse(s[0].erhua)
+        XCTAssertEqual(s[1].base, "hai")
+        XCTAssertEqual(s[1].tone, 2)
+        XCTAssertTrue(s[1].erhua)
+    }
+
+    func testMergeAttachesToImmediatePredecessor() {
+        // 一会儿 (yi1 + hui4 + er5): er attaches to hui, not yi.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "yi", tone: 1),
+            MandarinPinyinNormalizer.Syllable(base: "hui", tone: 4),
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 5),
+        ]
+        MandarinErhua.merge(&s)
+        XCTAssertEqual(s.count, 2)
+        XCTAssertEqual(s[0].base, "yi")
+        XCTAssertFalse(s[0].erhua)
+        XCTAssertEqual(s[1].base, "hui")
+        XCTAssertTrue(s[1].erhua)
+    }
+
+    func testStandaloneErAtStartIsKept() {
+        // 儿子 (er2 + zi5): er is at index 0 → must NOT merge.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 2),
+            MandarinPinyinNormalizer.Syllable(base: "zi", tone: 5),
+        ]
+        let original = s
+        MandarinErhua.merge(&s)
+        XCTAssertEqual(s, original, "Leading er must not be merged")
+    }
+
+    func testStandaloneErChildrenWord() {
+        // 儿童 (er2 + tong2): the er is leading, and even if it weren't,
+        // it doesn't appear as a tail so no merge condition fires.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 2),
+            MandarinPinyinNormalizer.Syllable(base: "tong", tone: 2),
+        ]
+        let original = s
+        MandarinErhua.merge(&s)
+        XCTAssertEqual(s, original)
+    }
+
+    func testEmptyAndSingleNoOp() {
+        var empty: [MandarinPinyinNormalizer.Syllable] = []
+        MandarinErhua.merge(&empty)
+        XCTAssertTrue(empty.isEmpty)
+
+        var single = [MandarinPinyinNormalizer.Syllable(base: "ma", tone: 1)]
+        MandarinErhua.merge(&single)
+        XCTAssertEqual(single.count, 1)
+        XCTAssertFalse(single[0].erhua)
+    }
+
+    func testBackToBackErErLeftAlone() {
+        // Pathological back-to-back er: no second-pass into the first er.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 2),
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 5),
+        ]
+        MandarinErhua.merge(&s)
+        // The trailing er has prev.base == "er" → does NOT merge.
+        XCTAssertEqual(s.count, 2)
+        XCTAssertFalse(s[0].erhua)
+        XCTAssertFalse(s[1].erhua)
+    }
+
+    func testMergeRunsBeforeSandhiFor3Plus3() {
+        // hao3 + er5 + mei3 → erhua merges first → hao3-erhua + mei3
+        // → 3+3 promotes to 2+3 → hao2-erhua + mei3.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "hao", tone: 3),
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 5),
+            MandarinPinyinNormalizer.Syllable(base: "mei", tone: 3),
+        ]
+        MandarinErhua.merge(&s)
+        MandarinToneSandhi.apply(&s)
+        XCTAssertEqual(s.count, 2)
+        XCTAssertEqual(s[0].base, "hao")
+        XCTAssertEqual(s[0].tone, 2)
+        XCTAssertTrue(s[0].erhua)
+        XCTAssertEqual(s[1].base, "mei")
+        XCTAssertEqual(s[1].tone, 3)
+    }
+
+    // MARK: - Bopomofo encoding
+
+    func testEncodeAppendsErhuaSuffix() {
+        // The erhua suffix sits between the final and the tone digit.
+        let nonErhua = MandarinBopomofoMap.encode(syllable: "xiao", tone: 3)
+        let erhua = MandarinBopomofoMap.encode(syllable: "xiao", tone: 3, erhua: true)
+        XCTAssertNotNil(nonErhua)
+        XCTAssertNotNil(erhua)
+        // Erhua form contains an extra ㄦ before the tone digit.
+        XCTAssertEqual(erhua, (nonErhua ?? "").replacingOccurrences(of: "3", with: "ㄦ3"))
+    }
+
+    func testEncodeErhuaOnSimpleFinal() {
+        // hai2 + erhua → ㄏㄞㄦ2.
+        XCTAssertEqual(
+            MandarinBopomofoMap.encode(syllable: "hai", tone: 2, erhua: true),
+            "ㄏㄞㄦ2")
+    }
+
+    // MARK: - End-to-end through MandarinG2P
+
+    func testG2PEndToEndZher() throws {
+        // 这儿 in single-char dict → zhe + er → erhua-merged.
+        let dict = Self.miniDict()
+        let g2p = MandarinG2P(dict: dict)
+        let phon = try g2p.phonemize("这儿")
+        XCTAssertTrue(
+            phon.contains("ㄦ"),
+            "expected erhua suffix in '\(phon)'")
+        // Should NOT have a separate er-tone token after the main syllable.
+        XCTAssertFalse(
+            phon.contains("ㄦ5"),
+            "erhua should be attached, not a standalone er5; got '\(phon)'")
+    }
+
+    func testG2PEndToEndStandaloneErzi() throws {
+        // 儿子 → er + zi → leading er, must NOT merge.
+        let dict = Self.miniDict()
+        let g2p = MandarinG2P(dict: dict)
+        let phon = try g2p.phonemize("儿子")
+        // Both syllables are emitted independently. We confirm by
+        // checking the leading er token survives with its own tone.
+        XCTAssertTrue(
+            phon.hasPrefix("ㄦ2") || phon.hasPrefix("ㄦ"),
+            "leading 儿 should keep its own ㄦ token; got '\(phon)'")
+    }
+
+    // MARK: - Test fixtures
+
+    private static func miniDict() -> MandarinPinyinDict {
+        let singles: [UInt32: [String]] = [
+            0x8FD9: ["zhè"],  // 这
+            0x513F: ["ér"],  // 儿 (default tone 2)
+            0x5B50: ["zi"],  // 子 (neutral tone)
+            0x5C0F: ["xiǎo"],  // 小
+            0x5B69: ["hái"],  // 孩
+            0x4E00: ["yī"],  // 一
+            0x4F1A: ["huì"],  // 会
+        ]
+        // Phrase override: "儿" suffix should appear as tone-5 to match
+        // typical erhua pronunciation when it follows another syllable.
+        // The miniDict deliberately keeps it at tone 2 — the merge rule
+        // only checks `base == "er"`, not tone, so both form 2 and 5 fold.
+        return MandarinPinyinDict(phrases: [:], singles: singles)
+    }
+}


### PR DESCRIPTION
## Summary

Issue #572 item 3. Native speakers fold the \`er\` of trailing 儿
into the previous syllable's final (\`这儿 zhèr\`, not \`zhè-er\`).
Without the merge the model emits an audible \`er\` tail.

- New \`MandarinErhua.merge\` pass on the pending syllable buffer
- Adds \`erhua: Bool\` flag to \`MandarinPinyinNormalizer.Syllable\`
- \`MandarinBopomofoMap.encode\` consults the flag and emits the
  \`ㄦ\`-suffixed bopomofo
- Standalone 儿 (e.g. 儿子 first char) is left alone
- Runs before sandhi so the merged syllable participates in 3+3 with
  its neighbours

## Test plan

- [x] \`MandarinErhuaTests\`: 这儿, 小孩儿, 一会儿, 儿子, 好儿+sandhi
- [x] \`MandarinG2PTests\` baseline regression
- [x] \`swift build\` + \`swift format lint\` clean