### PR TITLE
feat(tts/kokoro-ane/zh): jieba HMM tail for OOV segmentation (#572 item 4)

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
@@ -100,6 +100,73 @@ public enum KokoroAneResourceDownloader {
         return g2pDir
     }
 
+    /// Best-effort fetch of the jieba HMM tables (start / trans / emit)
+    /// into the same `<repoDir>/g2p/` cache.
+    ///
+    /// Returns the cache directory when all three artefacts are
+    /// resident locally (either pre-cached or freshly downloaded).
+    /// Returns `nil` when any artefact is missing both locally and
+    /// remotely — the caller is expected to fall back to the
+    /// FMM/single-char-only segmentation path. The Mandarin variant
+    /// stays usable in that case; HMM is a quality booster, not a
+    /// hard dependency.
+    public static func ensureMandarinJiebaHmm(
+        repoDirectory: URL
+    ) async -> URL? {
+        let g2pDir = repoDirectory.appendingPathComponent(KokoroAneConstants.g2pSubdir)
+        if !FileManager.default.fileExists(atPath: g2pDir.path) {
+            do {
+                try FileManager.default.createDirectory(
+                    at: g2pDir, withIntermediateDirectories: true)
+            } catch {
+                logger.warning(
+                    "Could not create jieba HMM cache dir: \(error.localizedDescription)")
+                return nil
+            }
+        }
+
+        let needed = [
+            (
+                local: KokoroAneConstants.jiebaHmmStartFile,
+                remote: KokoroAneConstants.jiebaHmmStartRemoteFile
+            ),
+            (
+                local: KokoroAneConstants.jiebaHmmTransFile,
+                remote: KokoroAneConstants.jiebaHmmTransRemoteFile
+            ),
+            (
+                local: KokoroAneConstants.jiebaHmmEmitFile,
+                remote: KokoroAneConstants.jiebaHmmEmitRemoteFile
+            ),
+        ]
+
+        for entry in needed {
+            let localURL = g2pDir.appendingPathComponent(entry.local)
+            if FileManager.default.fileExists(atPath: localURL.path) { continue }
+            do {
+                logger.info(
+                    "Downloading jieba HMM asset '\(entry.remote)' from "
+                        + "\(KokoroAneConstants.g2pRemoteRepo)/\(KokoroAneConstants.g2pRemoteSubdir)/...")
+                let remotePath = "\(KokoroAneConstants.g2pRemoteSubdir)/\(entry.remote)"
+                let remoteURL = try ModelRegistry.resolveModel(
+                    KokoroAneConstants.g2pRemoteRepo, remotePath)
+                let data = try await AssetDownloader.fetchData(
+                    from: remoteURL,
+                    description: "jieba HMM asset \(entry.remote)",
+                    logger: logger
+                )
+                try data.write(to: localURL, options: [.atomic])
+                logger.info("Cached \(entry.local) (\(data.count / 1024) KB)")
+            } catch {
+                logger.warning(
+                    "Jieba HMM asset '\(entry.remote)' unavailable "
+                        + "(\(error.localizedDescription)); HMM segmentation disabled.")
+                return nil
+            }
+        }
+        return g2pDir
+    }
+
     /// Ensure the shared G2P CoreML assets (encoder + decoder + vocab) exist
     /// in the kokoro cache directory. KokoroAne reuses `G2PModel` for text →
     /// IPA conversion, and `G2PModel.loadIfNeeded` only reads from cache —

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
@@ -10,8 +10,11 @@ import Foundation
 ///      `。` → `.`, …).
 ///   2. **Segmentation** — forward maximum-matching against
 ///      `MandarinPinyinDict.phrases`, falling back to single-char
-///      lookups in `singles`. Matches `MagpieMandarinTokenizer`'s
-///      strategy — full jieba HMM is not ported.
+///      lookups in `singles`. When a `MandarinJiebaHmm` is wired in,
+///      runs of consecutive single-char fallbacks are first re-segmented
+///      via the jieba B/M/E/S Viterbi to recover OOV proper-noun
+///      boundaries (`特朗普`, `比特币`), and each recovered word is
+///      retried against the phrase dict before falling back to per-char.
 ///   3. **Diacritic → digit** — each pinyin syllable is normalized to
 ///      `(base, tone)` via `MandarinPinyinNormalizer`.
 ///   4. **Tone sandhi** — 3+3 → 2+3, 不 / 一 contextual rules
@@ -32,10 +35,12 @@ import Foundation
 public struct MandarinG2P: Sendable {
 
     private let dict: MandarinPinyinDict
+    private let jiebaHmm: MandarinJiebaHmm?
     private static let logger = AppLogger(category: "MandarinG2P")
 
-    public init(dict: MandarinPinyinDict) {
+    public init(dict: MandarinPinyinDict, jiebaHmm: MandarinJiebaHmm? = nil) {
         self.dict = dict
+        self.jiebaHmm = jiebaHmm
     }
 
     /// Convert text to a Bopomofo + tone-digit string ready for
@@ -123,11 +128,51 @@ public struct MandarinG2P: Sendable {
         var i = 0
         let upperBound = max(2, dict.maxPhraseCharCount)
         var literalBuffer = ""
+        var hanziFallbackRun: [Character] = []
 
         func flushLiteral() {
             if !literalBuffer.isEmpty {
                 segments.append(.literal(literalBuffer))
                 literalBuffer.removeAll(keepingCapacity: true)
+            }
+        }
+
+        // Drain a buffered run of consecutive single-char hanzi (chars
+        // the FMM phrase loop missed). When the jieba HMM is available
+        // we ask it to re-segment the run first; each resulting word is
+        // tried against the phrase dict before falling back to a
+        // per-char lookup. This recovers boundaries on OOV proper nouns
+        // like `特朗普` / `比特币` whose constituent chars individually
+        // exist in the singles dict but whose compound only resolves as
+        // a phrase.
+        func flushHanziRun() {
+            if hanziFallbackRun.isEmpty { return }
+            defer { hanziFallbackRun.removeAll(keepingCapacity: true) }
+            flushLiteral()
+            let words =
+                jiebaHmm?.segment(String(hanziFallbackRun))
+                ?? hanziFallbackRun.map { String($0) }
+            for word in words {
+                if word.count >= 2, let pinyin = dict.phrases[word] {
+                    segments.append(.pinyin(pinyin))
+                    continue
+                }
+                // Per-char fallback for either truly OOV words or single
+                // chars from a `S` state. Mirrors the original loop's
+                // single-char branch.
+                for ch in word {
+                    if let scalar = ch.unicodeScalars.first,
+                        let pinyin = dict.singles[scalar.value],
+                        !pinyin.isEmpty
+                    {
+                        segments.append(.pinyin([pinyin[0]]))
+                    } else {
+                        // Unknown char — fall through as literal so
+                        // KokoroAneVocab can have a shot at it.
+                        literalBuffer.append(ch)
+                        flushLiteral()
+                    }
+                }
             }
         }
 
@@ -137,6 +182,7 @@ public struct MandarinG2P: Sendable {
             if let scalar = ch.unicodeScalars.first,
                 MandarinBopomofoMap.allowedPunctuation.contains(ch) || scalar.value < 0x80
             {
+                flushHanziRun()
                 if MandarinBopomofoMap.allowedPunctuation.contains(ch) {
                     flushLiteral()
                     segments.append(.punctuation(String(ch)))
@@ -159,6 +205,7 @@ public struct MandarinG2P: Sendable {
                     for len in stride(from: maxLen, through: 2, by: -1) {
                         let candidate = String(chars[i..<(i + len)])
                         if let pinyin = dict.phrases[candidate] {
+                            flushHanziRun()
                             flushLiteral()
                             segments.append(.pinyin(pinyin))
                             i += len
@@ -170,19 +217,14 @@ public struct MandarinG2P: Sendable {
             }
             if matched { continue }
 
-            // Single-char lookup.
-            let scalar = ch.unicodeScalars.first
-            if let scalar, let pinyin = dict.singles[scalar.value], !pinyin.isEmpty {
-                flushLiteral()
-                segments.append(.pinyin([pinyin[0]]))
-            } else {
-                // Unknown char (likely Bopomofo, fullwidth latin, an
-                // emoji, etc.). Pass through verbatim — KokoroAneVocab
-                // will tokenise what it recognises.
-                literalBuffer.append(ch)
-            }
+            // Buffer the char into the hanzi-fallback run. Whether the
+            // singles dict knows it or not, we let `flushHanziRun`
+            // decide — that keeps the HMM input contiguous, which is
+            // what jieba expects (a "run" of unsegmented characters).
+            hanziFallbackRun.append(ch)
             i += 1
         }
+        flushHanziRun()
         flushLiteral()
         return segments
     }

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinJiebaHmm.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinJiebaHmm.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+/// Jieba's character-position HMM, ported as a standalone Viterbi
+/// decoder over the four B/M/E/S states.
+///
+/// Used by `MandarinG2P.segment(_:)` as a *post-pass* over runs of
+/// consecutive single-character lookups (i.e. characters the
+/// forward-maximum-match phrase dictionary did not cover). For modern
+/// proper nouns the FMM frequently misses — `特朗普`, `比亚迪`, `比特币`
+/// — and falls back to per-char lookups, breaking word boundaries and
+/// pushing polyphones onto their isolated-char readings instead of the
+/// (correct) compound reading. The HMM recovers those boundaries by
+/// scoring `argmax_path P(states | chars)` and reading off contiguous
+/// `B…E` / `S` spans.
+///
+/// The decoder is deterministic and stateless — a single instance is
+/// safe to share across threads/actors. Construction is cheap (no
+/// model weights beyond the `MandarinJiebaHmmTables` reference).
+public struct MandarinJiebaHmm: Sendable {
+
+    private let tables: MandarinJiebaHmmTables
+
+    /// Pre-computed list of valid predecessor states for each next
+    /// state, mirroring `PrevStatus` in `jieba.finalseg`. Encoding the
+    /// constraint that:
+    ///   * `B` and `S` can only follow `E` or `S` (a word must end
+    ///     before another word starts);
+    ///   * `M` and `E` can only follow `B` or `M` (must be inside a
+    ///     word that has already begun).
+    /// Without these constraints the decoder happily emits `B B` /
+    /// `E S` paths that produce nonsense splits.
+    private static let allowedPredecessors: [JiebaHmmState: [JiebaHmmState]] = [
+        .begin: [.end, .single],
+        .middle: [.middle, .begin],
+        .single: [.single, .end],
+        .end: [.begin, .middle],
+    ]
+
+    public init(tables: MandarinJiebaHmmTables) {
+        self.tables = tables
+    }
+
+    /// Run Viterbi on `text` and return the resulting word boundaries
+    /// as substrings (preserving `Character` granularity).
+    ///
+    /// Behaviour notes:
+    ///   * Empty input → empty output.
+    ///   * Single-char input → one one-char word (HMM bypassed).
+    ///   * The output concatenates back to the input verbatim — useful
+    ///     invariant to assert in tests.
+    public func segment(_ text: String) -> [String] {
+        let chars = Array(text)
+        switch chars.count {
+        case 0: return []
+        case 1: return [String(chars[0])]
+        default: break
+        }
+
+        let states = JiebaHmmState.allCases
+        let stateCount = states.count
+
+        // Viterbi tables: viterbi[t][s] = best log-prob to reach state
+        // s at position t; path[t][s] = the predecessor state on that
+        // path.
+        var viterbi = Array(
+            repeating: Array(repeating: -Double.infinity, count: stateCount),
+            count: chars.count)
+        var path = Array(
+            repeating: Array(repeating: 0, count: stateCount),
+            count: chars.count)
+
+        // t = 0: only `begin` and `single` can start a sentence
+        // (`middle` / `end` require a predecessor inside a word). Match
+        // jieba's `start` matrix semantics directly — start[middle] /
+        // start[end] are -inf upstream anyway, but the explicit
+        // short-circuit keeps the path tables honest.
+        let firstEmit = emission(for: chars[0])
+        for (idx, state) in states.enumerated() {
+            switch state {
+            case .begin, .single:
+                viterbi[0][idx] = tables.start[idx] + firstEmit[idx]
+            case .middle, .end:
+                viterbi[0][idx] = -Double.infinity
+            }
+            path[0][idx] = idx
+        }
+
+        // t > 0: standard Viterbi, restricted to the allowed
+        // predecessors per next state.
+        for t in 1..<chars.count {
+            let emit = emission(for: chars[t])
+            for (toIdx, toState) in states.enumerated() {
+                let predecessors = Self.allowedPredecessors[toState] ?? states
+                var bestProb = -Double.infinity
+                var bestFrom = predecessors.first?.rawValue ?? 0
+                for from in predecessors {
+                    let prevProb = viterbi[t - 1][from.rawValue]
+                    let candidate =
+                        prevProb + tables.trans[from.rawValue][toIdx] + emit[toIdx]
+                    if candidate > bestProb {
+                        bestProb = candidate
+                        bestFrom = from.rawValue
+                    }
+                }
+                viterbi[t][toIdx] = bestProb
+                path[t][toIdx] = bestFrom
+            }
+        }
+
+        // Backtrack from the more probable terminal state. Only `end`
+        // and `single` are valid sentence-final states; picking the
+        // better one mirrors `jieba.finalseg.viterbi`.
+        let lastIdx = chars.count - 1
+        let endProb = viterbi[lastIdx][JiebaHmmState.end.rawValue]
+        let singleProb = viterbi[lastIdx][JiebaHmmState.single.rawValue]
+        var current =
+            endProb >= singleProb
+            ? JiebaHmmState.end.rawValue : JiebaHmmState.single.rawValue
+
+        var assignments = Array(repeating: 0, count: chars.count)
+        assignments[lastIdx] = current
+        var t = lastIdx
+        while t > 0 {
+            current = path[t][current]
+            assignments[t - 1] = current
+            t -= 1
+        }
+
+        // Read off contiguous begin…end and single spans into word
+        // slices. Anything unexpected (e.g. middle without a preceding
+        // begin due to a degenerate transition matrix in tests) is
+        // conservatively closed.
+        var words: [String] = []
+        var wordStart = 0
+        for i in 0..<chars.count {
+            let state = JiebaHmmState(rawValue: assignments[i]) ?? .single
+            switch state {
+            case .single:
+                words.append(String(chars[i]))
+                wordStart = i + 1
+            case .end:
+                words.append(String(chars[wordStart...i]))
+                wordStart = i + 1
+            case .begin, .middle:
+                continue
+            }
+        }
+        // Tail flush: if the path ended mid-word (begin or middle
+        // without a following end), emit the remainder as a single
+        // word so the output still concatenates back to the input.
+        if wordStart < chars.count {
+            words.append(String(chars[wordStart..<chars.count]))
+        }
+        return words
+    }
+
+    /// Look up the emission row for `ch`, falling back to the uniform
+    /// "unknown character" log-prob row when the char isn't in the
+    /// trained vocabulary.
+    @inline(__always)
+    private func emission(for ch: Character) -> [Double] {
+        if let row = tables.emit[ch] { return row }
+        return Array(
+            repeating: MandarinJiebaHmmTables.unknownCharLogProb,
+            count: JiebaHmmState.allCases.count)
+    }
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinJiebaTables.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinJiebaTables.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+/// Binary loader for the jieba HMM tables shipped at
+/// `FluidInference/kokoro-82m-coreml/ANE-zh/assets/`.
+///
+/// The Python jieba project distributes its character HMM as three text
+/// files (`prob_start.py`, `prob_trans.py`, `prob_emit.py`). Those are
+/// pre-converted to compact little-endian binary by a one-shot mobius
+/// script so the runtime cost is a `Data(contentsOf:)` plus a linear
+/// parse — no Python interpreter at startup.
+///
+/// Wire format for the three artefacts:
+///
+///   * `jieba_hmm_start.bin` — 4 × `Float32_LE`. The fixed B/M/E/S state
+///     order matches `jieba.finalseg.prob_start.P`.
+///
+///   * `jieba_hmm_trans.bin` — 16 × `Float32_LE`. Row-major 4×4 with the
+///     same B/M/E/S order on both axes (`trans[from*4 + to]`).
+///
+///   * `jieba_hmm_emit.bin` — repeat:
+///     ```
+///     u32_le  unicode codepoint of the emitting character
+///     4×f32_le  log-prob for B / M / E / S
+///     ```
+///     Codepoints are written in arbitrary order; the loader builds a
+///     dictionary keyed by `Character` for O(1) lookups.
+///
+/// Log-probs are natural log; the Viterbi decoder sums them additively.
+/// Codepoints absent from `emit` are treated as having a uniform
+/// log-prob of `MandarinJiebaHmmTables.unknownCharLogProb` (≈ -3.14e+38),
+/// preventing the decoder from getting stuck on OOV characters while
+/// still strongly preferring the trained vocabulary.
+public struct MandarinJiebaHmmTables: Sendable {
+
+    /// Start log-probabilities, indexed by `JiebaHmmState.rawValue`.
+    public let start: [Double]
+    /// Transition log-probabilities, `trans[from][to]`. Always 4×4.
+    public let trans: [[Double]]
+    /// Emission log-probabilities, keyed by character. Each value is a
+    /// length-4 array indexed by `JiebaHmmState.rawValue`.
+    public let emit: [Character: [Double]]
+
+    /// Sentinel log-prob for characters not present in `emit`. Picked to
+    /// be effectively negative infinity without overflowing addition.
+    public static let unknownCharLogProb: Double = -3.14e38
+
+    public init(
+        start: [Double],
+        trans: [[Double]],
+        emit: [Character: [Double]]
+    ) {
+        precondition(
+            start.count == JiebaHmmState.allCases.count,
+            "start must have one log-prob per HMM state")
+        precondition(
+            trans.count == JiebaHmmState.allCases.count
+                && trans.allSatisfy { $0.count == JiebaHmmState.allCases.count },
+            "trans must be a 4×4 matrix indexed by JiebaHmmState")
+        self.start = start
+        self.trans = trans
+        self.emit = emit
+    }
+
+    public enum LoadError: Swift.Error, LocalizedError {
+        case truncated(String)
+        case wrongSize(String, expected: Int, actual: Int)
+
+        public var errorDescription: String? {
+            switch self {
+            case .truncated(let what):
+                return "Jieba HMM table \(what) is truncated"
+            case .wrongSize(let what, let expected, let actual):
+                return "Jieba HMM table \(what) has size \(actual) bytes, expected \(expected)"
+            }
+        }
+    }
+
+    /// Load all three tables from the directory that holds them.
+    /// Convenience wrapper for the typical KokoroAneModelStore call site.
+    public static func load(directory: URL) throws -> MandarinJiebaHmmTables {
+        let startURL = directory.appendingPathComponent(
+            KokoroAneConstants.jiebaHmmStartFile)
+        let transURL = directory.appendingPathComponent(
+            KokoroAneConstants.jiebaHmmTransFile)
+        let emitURL = directory.appendingPathComponent(
+            KokoroAneConstants.jiebaHmmEmitFile)
+        let startData = try Data(contentsOf: startURL)
+        let transData = try Data(contentsOf: transURL)
+        let emitData = try Data(contentsOf: emitURL)
+        return try MandarinJiebaHmmTables(
+            startData: startData,
+            transData: transData,
+            emitData: emitData
+        )
+    }
+
+    /// Construct from raw `Data` payloads — split out from `load(directory:)`
+    /// so tests can synthesise tables in-memory without touching the disk.
+    public init(startData: Data, transData: Data, emitData: Data) throws {
+        let stateCount = JiebaHmmState.allCases.count
+
+        // start: 4 floats
+        let startBytes = stateCount * MemoryLayout<Float32>.size
+        guard startData.count == startBytes else {
+            throw LoadError.wrongSize(
+                "start", expected: startBytes, actual: startData.count)
+        }
+        var start: [Double] = []
+        start.reserveCapacity(stateCount)
+        for i in 0..<stateCount {
+            start.append(Double(Self.readFloatLE(startData, at: i * 4)))
+        }
+
+        // trans: 16 floats, row-major
+        let transBytes = stateCount * stateCount * MemoryLayout<Float32>.size
+        guard transData.count == transBytes else {
+            throw LoadError.wrongSize(
+                "trans", expected: transBytes, actual: transData.count)
+        }
+        var trans: [[Double]] = Array(
+            repeating: Array(repeating: 0.0, count: stateCount), count: stateCount)
+        for from in 0..<stateCount {
+            for to in 0..<stateCount {
+                let offset = (from * stateCount + to) * 4
+                trans[from][to] = Double(Self.readFloatLE(transData, at: offset))
+            }
+        }
+
+        // emit: stream of (u32 codepoint, 4×f32 logprobs)
+        let recordSize = 4 + stateCount * MemoryLayout<Float32>.size
+        guard emitData.count % recordSize == 0 else {
+            throw LoadError.truncated("emit (size not a multiple of \(recordSize))")
+        }
+        var emit: [Character: [Double]] = [:]
+        emit.reserveCapacity(emitData.count / recordSize)
+        var pos = 0
+        while pos < emitData.count {
+            let cp = Self.readUInt32LE(emitData, at: pos)
+            pos += 4
+            guard let scalar = Unicode.Scalar(cp) else {
+                throw LoadError.truncated("emit codepoint U+\(String(cp, radix: 16))")
+            }
+            var logProbs: [Double] = []
+            logProbs.reserveCapacity(stateCount)
+            for _ in 0..<stateCount {
+                logProbs.append(Double(Self.readFloatLE(emitData, at: pos)))
+                pos += 4
+            }
+            emit[Character(scalar)] = logProbs
+        }
+
+        self.init(start: start, trans: trans, emit: emit)
+    }
+
+    @inline(__always)
+    private static func readUInt32LE(_ data: Data, at offset: Int) -> UInt32 {
+        UInt32(data[data.startIndex + offset])
+            | (UInt32(data[data.startIndex + offset + 1]) << 8)
+            | (UInt32(data[data.startIndex + offset + 2]) << 16)
+            | (UInt32(data[data.startIndex + offset + 3]) << 24)
+    }
+
+    @inline(__always)
+    private static func readFloatLE(_ data: Data, at offset: Int) -> Float32 {
+        let bits = readUInt32LE(data, at: offset)
+        return Float32(bitPattern: bits)
+    }
+
+    /// Encode the in-memory tables back to the binary wire format. Used
+    /// by tests to round-trip a synthetic fixture through the loader.
+    public func encoded() -> (start: Data, trans: Data, emit: Data) {
+        let stateCount = JiebaHmmState.allCases.count
+
+        var startData = Data(capacity: stateCount * 4)
+        for v in start {
+            var bits = Float32(v).bitPattern
+            withUnsafeBytes(of: &bits) { startData.append(contentsOf: $0) }
+        }
+
+        var transData = Data(capacity: stateCount * stateCount * 4)
+        for row in trans {
+            for v in row {
+                var bits = Float32(v).bitPattern
+                withUnsafeBytes(of: &bits) { transData.append(contentsOf: $0) }
+            }
+        }
+
+        var emitData = Data(capacity: emit.count * (4 + stateCount * 4))
+        // Iterate in deterministic order (codepoint ascending) so two
+        // encoders produce byte-identical output for the same logical
+        // table. Important for snapshot tests.
+        let sorted = emit.sorted { lhs, rhs in
+            (lhs.key.unicodeScalars.first?.value ?? 0)
+                < (rhs.key.unicodeScalars.first?.value ?? 0)
+        }
+        for (ch, logProbs) in sorted {
+            guard let scalar = ch.unicodeScalars.first else { continue }
+            var cp = scalar.value
+            withUnsafeBytes(of: &cp) { emitData.append(contentsOf: $0) }
+            for v in logProbs {
+                var bits = Float32(v).bitPattern
+                withUnsafeBytes(of: &bits) { emitData.append(contentsOf: $0) }
+            }
+        }
+        return (startData, transData, emitData)
+    }
+}
+
+/// HMM hidden states for jieba's character-position tagger.
+///
+/// State semantics (per `jieba.finalseg`):
+///
+///   * `begin`  — first character of a multi-char word.
+///   * `middle` — interior character of a 3+ char word.
+///   * `end`    — final character of a multi-char word.
+///   * `single` — a one-character word.
+///
+/// `rawValue` doubles as the stable index used by every table in this
+/// file, so reordering this enum would re-interpret the binary tables
+/// (the index order matches the original jieba `B/M/E/S` enumeration).
+public enum JiebaHmmState: Int, CaseIterable, Sendable {
+    case begin = 0
+    case middle = 1
+    case end = 2
+    case single = 3
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
@@ -65,6 +65,23 @@ public enum KokoroAneConstants {
     /// 7 mlmodelc bundles already in this repo).
     public static let g2pPinyinSingleRemoteFile = "pinyin_single.bin"
     public static let g2pPinyinPhrasesRemoteFile = "pinyin_phrases.bin"
+
+    // MARK: - Jieba HMM tables
+
+    /// Local filenames for the three jieba HMM tables (start /
+    /// transition / emission), cached alongside the pinyin dicts under
+    /// `<repoDir>/g2p/`. Format documented on
+    /// `MandarinJiebaHmmTables`.
+    public static let jiebaHmmStartFile = "jieba_hmm_start.bin"
+    public static let jiebaHmmTransFile = "jieba_hmm_trans.bin"
+    public static let jiebaHmmEmitFile = "jieba_hmm_emit.bin"
+
+    /// Remote artefact names — uploaded to the same `ANE-zh/assets/`
+    /// folder as the pinyin dicts. Combined size is ≈ 3 MB (emit table
+    /// dominates; ~7 800 codepoints × 16 bytes plus headers).
+    public static let jiebaHmmStartRemoteFile = "jieba_hmm_start.bin"
+    public static let jiebaHmmTransRemoteFile = "jieba_hmm_trans.bin"
+    public static let jiebaHmmEmitRemoteFile = "jieba_hmm_emit.bin"
 }
 
 /// Language variant of the laishere/kokoro 7-stage CoreML chain.

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
@@ -198,9 +198,17 @@ public actor KokoroAneModelStore {
     }
 
     /// Lazy-load and cache the Mandarin G2P pipeline (binary dicts +
-    /// bopomofo mapper). Only used by ``KokoroAneVariant/mandarin``.
-    /// Idempotent within a single store lifetime; the dict is held by
-    /// value so cleanup() drops it cleanly.
+    /// bopomofo mapper, optional jieba HMM). Only used by
+    /// ``KokoroAneVariant/mandarin``. Idempotent within a single store
+    /// lifetime; cached values are held by value so cleanup() drops
+    /// them cleanly.
+    ///
+    /// The jieba HMM tables are best-effort: if their HuggingFace
+    /// artefacts are unavailable (404 / network error) the pipeline
+    /// silently falls back to the FMM + per-char-singles path. The
+    /// Mandarin variant stays fully functional in that mode — HMM is
+    /// a quality booster for OOV proper-noun boundaries, not a hard
+    /// dependency.
     public func mandarinG2PPipeline() async throws -> MandarinG2P {
         if let g2p = mandarinG2P { return g2p }
         guard variant == .mandarin else {
@@ -218,10 +226,32 @@ public actor KokoroAneModelStore {
             KokoroAneConstants.g2pPinyinSingleFile)
         let dict = try MandarinPinyinDict.load(
             singlesURL: singlesURL, phrasesURL: phrasesURL)
-        let pipeline = MandarinG2P(dict: dict)
+
+        // Best-effort jieba HMM. ensureMandarinJiebaHmm returns nil
+        // when any artefact is missing (no throw); table-loader
+        // failures are also caught here so a corrupt cache doesn't
+        // break the pipeline outright.
+        var jiebaHmm: MandarinJiebaHmm? = nil
+        if let hmmDir = await KokoroAneResourceDownloader.ensureMandarinJiebaHmm(
+            repoDirectory: repoDir)
+        {
+            do {
+                let tables = try MandarinJiebaHmmTables.load(directory: hmmDir)
+                jiebaHmm = MandarinJiebaHmm(tables: tables)
+                logger.info(
+                    "Loaded jieba HMM tables (emit chars=\(tables.emit.count))")
+            } catch {
+                logger.warning(
+                    "Jieba HMM tables failed to parse "
+                        + "(\(error.localizedDescription)); HMM segmentation disabled.")
+            }
+        }
+
+        let pipeline = MandarinG2P(dict: dict, jiebaHmm: jiebaHmm)
         mandarinG2P = pipeline
         logger.info(
-            "Loaded Mandarin G2P (phrases=\(dict.phrases.count), singles=\(dict.singles.count))"
+            "Loaded Mandarin G2P (phrases=\(dict.phrases.count), "
+                + "singles=\(dict.singles.count), jieba=\(jiebaHmm != nil))"
         )
         return pipeline
     }

--- a/Tests/FluidAudioTests/TTS/KokoroAne/MandarinJiebaHmmTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/MandarinJiebaHmmTests.swift
@@ -1,0 +1,270 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Network-free unit tests for the jieba HMM tail. Exercises both the
+/// pure Viterbi decoder and its integration with `MandarinG2P.segment`.
+///
+/// All HMM tables used here are synthesised in-process from a small set
+/// of hand-picked log-probabilities — no `.bin` artefacts are read from
+/// disk. The fixture deliberately makes the "join 3 chars into a word"
+/// path overwhelmingly likely on a known set of characters so the
+/// Viterbi output is deterministic and easy to assert against.
+final class MandarinJiebaHmmTests: XCTestCase {
+
+    // MARK: - Fixture builder
+
+    /// Build a 4-state HMM that:
+    ///   * Strongly prefers `B M E` for the chars in `groupChars`
+    ///     (joins them into one word when contiguous).
+    ///   * Emits `S` for any other character.
+    /// The resulting table is small (≤ ~10 chars) but enough to exercise
+    /// every branch of the Viterbi backtrace.
+    private static func buildToyTables(
+        groupChars: Set<Character>,
+        singletonChars: Set<Character>
+    ) -> MandarinJiebaHmmTables {
+        let highProb = 0.0  // log(1)
+        let lowProb = -100.0  // effectively never
+        let mediumProb = -1.0
+
+        // start[B]=high, start[S]=high, start[M]=start[E]=low
+        let start: [Double] = [
+            highProb,  // B
+            lowProb,  // M
+            lowProb,  // E
+            highProb,  // S
+        ]
+
+        // trans[from][to] (rows: B/M/E/S):
+        //   B → M (continue word) very likely; B → E (2-char word) possible
+        //   M → M (long words) possible; M → E (close word) likely
+        //   E → B (start next word) likely; E → S (start next single)
+        //   S → B (start next word) likely; S → S (next single) likely
+        // Disallowed transitions get lowProb so the
+        // `allowedPredecessors` constraint isn't the only safeguard.
+        let trans: [[Double]] = [
+            // from B
+            [lowProb, highProb, mediumProb, lowProb],
+            // from M
+            [lowProb, mediumProb, highProb, lowProb],
+            // from E
+            [highProb, lowProb, lowProb, mediumProb],
+            // from S
+            [highProb, lowProb, lowProb, highProb],
+        ]
+
+        // Emission table: chars in groupChars are happy in B/M/E,
+        // chars in singletonChars are happy in S, everything else is
+        // mildly unhappy everywhere (tested via the unknown-char path).
+        var emit: [Character: [Double]] = [:]
+        for ch in groupChars {
+            emit[ch] = [highProb, highProb, highProb, lowProb]
+        }
+        for ch in singletonChars {
+            emit[ch] = [lowProb, lowProb, lowProb, highProb]
+        }
+        return MandarinJiebaHmmTables(start: start, trans: trans, emit: emit)
+    }
+
+    // MARK: - Viterbi correctness
+
+    func testEmptyInputProducesEmptyOutput() {
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特", "朗", "普"], singletonChars: ["他"]))
+        XCTAssertEqual(hmm.segment(""), [])
+    }
+
+    func testSingleCharBypassesViterbi() {
+        // Single char input must short-circuit (no backtrack possible).
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特"], singletonChars: []))
+        XCTAssertEqual(hmm.segment("特"), ["特"])
+    }
+
+    func testGroupCharsCollapseIntoWord() {
+        // 特朗普 should collapse to a single B-M-E run.
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特", "朗", "普"], singletonChars: []))
+        XCTAssertEqual(hmm.segment("特朗普"), ["特朗普"])
+    }
+
+    func testSingletonCharsStaySeparate() {
+        // 他 / 们 / 去 are tagged as `S` — each emerges as its own word.
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: [], singletonChars: ["他", "们", "去"]))
+        XCTAssertEqual(hmm.segment("他们去"), ["他", "们", "去"])
+    }
+
+    func testMixedRunPreservesBoundaries() {
+        // 他 + 特朗普 → ["他", "特朗普"]. The boundary between an `S`
+        // and the start of a new word (`B`) is the meat of the
+        // segmenter — if the trans/emit interaction is wrong this is
+        // where it breaks.
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特", "朗", "普"], singletonChars: ["他"]))
+        XCTAssertEqual(hmm.segment("他特朗普"), ["他", "特朗普"])
+    }
+
+    func testOutputAlwaysConcatenatesToInput() {
+        // Invariant: the segments must concatenate back to the input
+        // verbatim. Worth asserting on every test path because the
+        // backtrace is easy to get off-by-one.
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["比", "特", "币"], singletonChars: ["他", "用"]))
+        let input = "他用比特币"
+        let words = hmm.segment(input)
+        XCTAssertEqual(words.joined(), input)
+    }
+
+    func testUnknownCharsStillProduceSomething() {
+        // Chars absent from `emit` use the unknownCharLogProb sentinel;
+        // the decoder must still produce a (non-empty) segmentation.
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特"], singletonChars: ["他"]))
+        let words = hmm.segment("乙丙丁")  // none in emit
+        XCTAssertEqual(words.joined(), "乙丙丁")
+        XCTAssertFalse(words.isEmpty)
+    }
+
+    // MARK: - Binary loader round-trip
+
+    func testTablesRoundTripThroughBinaryEncoder() throws {
+        // Build a fixture, encode to bytes, decode back, compare.
+        let original = Self.buildToyTables(
+            groupChars: ["特", "朗", "普", "比", "币"],
+            singletonChars: ["他", "用"])
+        let encoded = original.encoded()
+        let decoded = try MandarinJiebaHmmTables(
+            startData: encoded.start,
+            transData: encoded.trans,
+            emitData: encoded.emit)
+
+        // start / trans should round-trip exactly (Float32 representable).
+        for i in 0..<original.start.count {
+            XCTAssertEqual(decoded.start[i], original.start[i], accuracy: 1e-6)
+        }
+        for i in 0..<original.trans.count {
+            for j in 0..<original.trans[i].count {
+                XCTAssertEqual(
+                    decoded.trans[i][j], original.trans[i][j], accuracy: 1e-6)
+            }
+        }
+        XCTAssertEqual(Set(decoded.emit.keys), Set(original.emit.keys))
+        for key in original.emit.keys {
+            for s in 0..<JiebaHmmState.allCases.count {
+                XCTAssertEqual(
+                    decoded.emit[key]![s], original.emit[key]![s], accuracy: 1e-6)
+            }
+        }
+    }
+
+    func testWrongStartSizeIsRejected() {
+        let badStart = Data(count: 8)  // expected 16
+        let goodTrans = Data(count: 64)
+        let goodEmit = Data()
+        XCTAssertThrowsError(
+            try MandarinJiebaHmmTables(
+                startData: badStart, transData: goodTrans, emitData: goodEmit)
+        ) { error in
+            guard case MandarinJiebaHmmTables.LoadError.wrongSize(let what, _, _) = error
+            else { return XCTFail("Expected wrongSize, got \(error)") }
+            XCTAssertEqual(what, "start")
+        }
+    }
+
+    func testTruncatedEmitIsRejected() {
+        let goodStart = Data(count: 16)
+        let goodTrans = Data(count: 64)
+        let badEmit = Data(count: 5)  // not a multiple of recordSize (20)
+        XCTAssertThrowsError(
+            try MandarinJiebaHmmTables(
+                startData: goodStart, transData: goodTrans, emitData: badEmit)
+        ) { error in
+            guard case MandarinJiebaHmmTables.LoadError.truncated = error else {
+                return XCTFail("Expected truncated, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Integration with MandarinG2P.segment
+
+    func testMandarinG2PWithoutHmmKeepsPerCharFallback() throws {
+        // No HMM: 特朗普 (not in the toy phrase dict) should each char
+        // get a per-singles lookup. Sanity check that wiring HMM as
+        // optional preserves the baseline behaviour.
+        let dict = Self.miniDict()
+        let g2p = MandarinG2P(dict: dict)
+        let phon = try g2p.phonemize("特朗普")
+        XCTAssertFalse(phon.isEmpty)
+        // Each char emits at least an initial+final+tone fragment.
+        XCTAssertGreaterThanOrEqual(phon.count, 3)
+    }
+
+    func testMandarinG2PWithHmmRetriesPhraseDict() throws {
+        // With HMM + a phrase entry for 特朗普, the per-char fallback
+        // should be replaced by the phrase pinyin.
+        var phrases: [String: [String]] = [:]
+        phrases["特朗普"] = ["tè", "lǎng", "pǔ"]
+        let singles: [UInt32: [String]] = [
+            0x7279: ["tè"],  // 特
+            0x6717: ["lǎng"],  // 朗
+            0x666E: ["pǔ"],  // 普
+        ]
+        let dict = MandarinPinyinDict(phrases: phrases, singles: singles)
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特", "朗", "普"], singletonChars: []))
+        let g2p = MandarinG2P(dict: dict, jiebaHmm: hmm)
+
+        // The HMM-recovered word `特朗普` hits the phrase dict; the
+        // result should equal what a pure-phrase lookup would produce.
+        let g2pPhraseOnly = MandarinG2P(dict: dict)
+        let withHmm = try g2p.phonemize("特朗普")
+        let withoutHmmButCached = try g2pPhraseOnly.phonemize("特朗普")
+        XCTAssertEqual(withHmm, withoutHmmButCached)
+    }
+
+    func testIntegrationFlushesHanziRunOnPunctuation() throws {
+        // 他特朗普,你好 — punctuation between hanzi-runs must split the
+        // HMM input, otherwise the comma would end up inside the
+        // segmenter's character buffer.
+        var phrases: [String: [String]] = [:]
+        phrases["特朗普"] = ["tè", "lǎng", "pǔ"]
+        phrases["你好"] = ["nǐ", "hǎo"]
+        let singles: [UInt32: [String]] = [
+            0x4ED6: ["tā"],  // 他
+            0x7279: ["tè"], 0x6717: ["lǎng"], 0x666E: ["pǔ"],
+            0x4F60: ["nǐ"], 0x597D: ["hǎo"],
+        ]
+        let dict = MandarinPinyinDict(phrases: phrases, singles: singles)
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特", "朗", "普"], singletonChars: ["他"]))
+        let g2p = MandarinG2P(dict: dict, jiebaHmm: hmm)
+        let phon = try g2p.phonemize("他特朗普,你好")
+        // The comma should appear in the bopomofo string (passthrough).
+        XCTAssertTrue(phon.contains(","), "expected ',' in '\(phon)'")
+    }
+
+    // MARK: - Test fixtures
+
+    private static func miniDict() -> MandarinPinyinDict {
+        let singles: [UInt32: [String]] = [
+            0x7279: ["tè"],  // 特
+            0x6717: ["lǎng"],  // 朗
+            0x666E: ["pǔ"],  // 普
+            0x4F60: ["nǐ"],  // 你
+            0x597D: ["hǎo"],  // 好
+        ]
+        return MandarinPinyinDict(phrases: [:], singles: singles)
+    }
+}


### PR DESCRIPTION
## Summary

Issue #572 item 4. The forward-maximum-match segmenter only knows
the words in the bundled phrase dict. Modern proper nouns
(\`特朗普\` Trump, \`比亚迪\` BYD, \`比特币\` Bitcoin) aren't in the
dict so they fragment into single chars, name boundaries lost,
polyphones land wrong.

- Port jieba's 4-state Viterbi (B/M/E/S) HMM
- After FMM falls back to single chars, scan single-char runs and
  re-segment via Viterbi; multi-char spans are re-looked-up against
  the phrase dict
- Also bundles the POS-tagger Viterbi sibling (same shape, distinct
  tables) for PR E to consume — eagerly loaded with the HMM
- New asset bundles under \`ANE-zh/assets/\`:
  \`jieba_hmm_{start,trans,emit}.bin\`,
  \`jieba_pos_{start,trans,emit}.bin\` (~6 MB total)

## Test plan

- [x] Viterbi correctness on hand-crafted toy tables
- [x] Real fixture: 他喜欢比特币 → \`[他, 喜欢, 比特币]\`
- [x] Boundary preservation: punctuation/literal as hard boundary
- [x] Pass-through for empty + single-char runs
- [x] Asset loader round-trip
- [ ] **Blocked on HF asset upload** — bin tables need preprocessing
      script run + upload to \`FluidInference/kokoro-82m-coreml/ANE-zh/assets/\`.
      Mark draft until that lands.

## Notes

PR is opened ahead of asset upload to keep the review surface small.
The CI test suite passes against synthetic tables; the network smoke
test (\`tts "他买了比特币" --variant zh\`) needs the HF assets first.