### PR TITLE
feat(tts/kokoro-ane/zh): POS-aware tone sandhi (#572 item 5)

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinToneSandhiPOS.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinToneSandhiPOS.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+/// POS-aware Mandarin tone sandhi.
+///
+/// The baseline `MandarinToneSandhi` ships only the POS-independent
+/// rules (3+3, 不+tone-4, 一+tone-X). It deliberately misfires on a
+/// handful of contexts that matter for natural speech:
+///
+///  * Ordinal `一` (`第一`, `一月`, `一号`) — the bare ordinal keeps
+///    tone 1 but the baseline promotes it to 2/4 unconditionally.
+///  * `不` reduplication (`好不好`, `行不行`, `要不要`) — the `不`
+///    sits between two copies of the same word and keeps tone 4
+///    rather than promoting to tone 2.
+///  * Word-grouped 3+3 — the linguistic norm is to apply 3+3 sandhi
+///    *within* a prosodic word; cross-word 3+3 promotes only the
+///    word-final tone 3. The baseline's pure-run rule overshoots on
+///    sentences like `我也想去` (3 3 3 3 → would emit 2 2 2 3,
+///    correct output is 2 2 3 3 — `想去` is its own word).
+///
+/// This module replaces `MandarinToneSandhi.apply(_:)` for callers
+/// that have a jieba POS tagger available. Inputs:
+///
+///  * `syllables` — the pending syllable buffer (in/out).
+///  * `words` — `[Range<Int>]` partitioning `syllables.indices` into
+///    prosodic words (e.g. `[0..<2, 2..<3]` = "two-syllable word
+///    then a one-syllable word"). Ranges must cover every syllable
+///    exactly once and be non-overlapping.
+///  * `tags` — POS tag per word (jieba's `paddle`/`ictclas` set:
+///    `m` = numeral, `r` = pronoun, `n*` = nouns, `v*` = verbs, …).
+///    `tags.count == words.count` is required.
+///
+/// When the caller cannot supply POS tags (no jieba POS tagger
+/// loaded), use `MandarinToneSandhi.apply(_:)` instead — that path
+/// keeps the baseline rules and stays backward-compatible.
+public enum MandarinToneSandhiPOS {
+
+    /// Apply POS-aware sandhi to `syllables` in place.
+    ///
+    /// Pass order matches the baseline:
+    ///   1. 不 / 一 contextual sandhi with POS carve-outs.
+    ///   2. 3+3 sandhi, scoped per-word, with cross-word fallback.
+    public static func apply(
+        _ syllables: inout [MandarinPinyinNormalizer.Syllable],
+        words: [Range<Int>],
+        tags: [String]
+    ) {
+        guard syllables.count >= 2 else { return }
+        precondition(
+            words.count == tags.count,
+            "MandarinToneSandhiPOS: words.count (\(words.count)) != tags.count (\(tags.count))"
+        )
+
+        // Pass 1: 不 / 一 contextual sandhi with carve-outs.
+        applyBuYiSandhi(&syllables, words: words, tags: tags)
+
+        // Pass 2: word-grouped 3+3.
+        applyThirdToneSandhi(&syllables, words: words)
+    }
+
+    // MARK: - 不 / 一
+
+    /// Walk the syllable buffer applying 不 and 一 contextual rules,
+    /// honouring the POS carve-outs from `tone_sandhi.py`.
+    private static func applyBuYiSandhi(
+        _ syllables: inout [MandarinPinyinNormalizer.Syllable],
+        words: [Range<Int>],
+        tags: [String]
+    ) {
+        // Build a quick `syllableIdx -> (wordIdx, positionWithinWord)`
+        // lookup so the rule code can ask "what tag is this 一's
+        // word?" in O(1).
+        var wordOfSyllable = [Int](repeating: -1, count: syllables.count)
+        var positionInWord = [Int](repeating: -1, count: syllables.count)
+        for (wIdx, range) in words.enumerated() {
+            var pos = 0
+            for sIdx in range {
+                guard sIdx >= 0, sIdx < syllables.count else { continue }
+                wordOfSyllable[sIdx] = wIdx
+                positionInWord[sIdx] = pos
+                pos += 1
+            }
+        }
+
+        for i in 0..<(syllables.count - 1) {
+            let cur = syllables[i]
+            let next = syllables[i + 1]
+
+            if cur.base == "bu" && cur.tone == 4 && next.tone == 4 {
+                // Reduplication carve-out: 好不好 / 行不行. Detect when
+                // the previous syllable matches the next one's base
+                // (case-insensitive on the ASCII pinyin) — that's the
+                // [X, 不, X] pattern. In that frame `不` keeps tone 4.
+                let isReduplication: Bool = {
+                    guard i >= 1 else { return false }
+                    let prev = syllables[i - 1]
+                    return prev.base == next.base
+                }()
+                if !isReduplication {
+                    syllables[i].tone = 2
+                }
+            } else if cur.base == "yi" && cur.tone == 1 {
+                // Ordinal carve-out: when 一 is its own one-syllable
+                // word AND that word is tagged as a numeral (`m`) the
+                // surrounding context is an ordinal / unit reading
+                // (`第一`, `一月`, `一号`, …). Keep tone 1.
+                //
+                // `第一` segments as `["第", "一"]` with tags
+                // `["m", "m"]` from jieba — both are `m`. The carve-out
+                // also covers bare year/month/day numerals where 一
+                // stands alone in its own word.
+                let wIdx = wordOfSyllable[i]
+                let isOrdinal: Bool = {
+                    guard wIdx >= 0, wIdx < tags.count else { return false }
+                    let tag = tags[wIdx]
+                    let wordRange = words[wIdx]
+                    let isSoloYi = wordRange.count == 1
+                    return isSoloYi && tag == "m"
+                }()
+                if isOrdinal { continue }
+
+                switch next.tone {
+                case 4:
+                    syllables[i].tone = 2
+                case 1, 2, 3:
+                    syllables[i].tone = 4
+                default:
+                    break
+                }
+            }
+        }
+    }
+
+    // MARK: - 3+3
+
+    /// Word-scoped 3+3 sandhi.
+    ///
+    /// Within each word, apply the standard rule: any consecutive
+    /// run of tone-3 syllables shifts every syllable but the last to
+    /// tone 2 (`3 3 3 → 2 2 3`).
+    ///
+    /// Across words, when a word ends in tone 3 and the next word
+    /// starts with tone 3, only the word-final syllable of the
+    /// preceding word promotes to tone 2 (the prosodic break stops
+    /// the chain from cascading further left).
+    private static func applyThirdToneSandhi(
+        _ syllables: inout [MandarinPinyinNormalizer.Syllable],
+        words: [Range<Int>]
+    ) {
+        // Step 1: in-word 3+3 within each word's range.
+        for word in words {
+            guard !word.isEmpty else { continue }
+            var i = word.lowerBound
+            while i < word.upperBound {
+                guard syllables[i].tone == 3 else {
+                    i += 1
+                    continue
+                }
+                var j = i
+                while j < word.upperBound && syllables[j].tone == 3 { j += 1 }
+                if j - i >= 2 {
+                    for k in i..<(j - 1) {
+                        syllables[k].tone = 2
+                    }
+                }
+                i = j
+            }
+        }
+
+        // Step 2: cross-word 3+3. After in-word sandhi only word
+        // boundaries remain as candidate (3, 3) pairs — the
+        // word-final syllable kept tone 3, and so might the next
+        // word's leading syllable. Promote the word-final to tone 2
+        // when the immediately following word starts with tone 3.
+        //
+        // We do not cascade further: only the boundary syllable
+        // shifts, even if both words are entirely tone 3 (the
+        // in-word pass already handled the rest).
+        for k in 0..<(words.count - 1) {
+            let lhs = words[k]
+            let rhs = words[k + 1]
+            guard !lhs.isEmpty, !rhs.isEmpty else { continue }
+            let lastIdx = lhs.upperBound - 1
+            let firstIdx = rhs.lowerBound
+            if syllables[lastIdx].tone == 3 && syllables[firstIdx].tone == 3 {
+                syllables[lastIdx].tone = 2
+            }
+        }
+    }
+}

--- a/Tests/FluidAudioTests/TTS/KokoroAne/MandarinToneSandhiPOSTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/MandarinToneSandhiPOSTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Coverage for the POS-aware tone sandhi rules. Inputs are
+/// constructed by hand from the `(base, tone)` form so the tests
+/// stay independent of the dictionary lookup path.
+final class MandarinToneSandhiPOSTests: XCTestCase {
+
+    private typealias Syllable = MandarinPinyinNormalizer.Syllable
+
+    private func syl(_ base: String, _ tone: Int) -> Syllable {
+        Syllable(base: base, tone: tone)
+    }
+
+    // MARK: - 一 carve-outs
+
+    func testYiOrdinalKeepsToneOneInSoloNumeralWord() {
+        // 第一 → `["第", "一"]` with both tagged `m`. The 一 sits in
+        // its own one-syllable numeral word, so the carve-out must
+        // suppress the yi1 + tone-4 → 2 promotion (next would be
+        // tone-4 if a measure word followed; we test the bare form).
+        var syllables = [syl("di", 4), syl("yi", 1)]
+        let words = [0..<1, 1..<2]
+        let tags = ["m", "m"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        XCTAssertEqual(syllables.map { $0.tone }, [4, 1])
+    }
+
+    func testYiInOrdinalBeforeTone1WordKeepsToneOne() {
+        // 一月 → `["一", "月"]`, tags `["m", "m"]`. Without the
+        // carve-out the baseline would promote yi1 to tone 4 in
+        // front of yue1 (tone-1 successor).
+        var syllables = [syl("yi", 1), syl("yue", 1)]
+        let words = [0..<1, 1..<2]
+        let tags = ["m", "m"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        XCTAssertEqual(syllables.map { $0.tone }, [1, 1])
+    }
+
+    func testYiContextualSandhiStillFiresInVerbContext() {
+        // 一起 (yi1 + qi3) → POS tags `["d", "v"]` in jieba (一起 is
+        // a single word in practice, but for the sandhi rule we
+        // exercise the case where 一 is *not* in a solo numeral
+        // word). yi1 + tone-3 → tone 4.
+        var syllables = [syl("yi", 1), syl("qi", 3)]
+        let words = [0..<2]
+        let tags = ["d"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        // 一起: yi promotes to 4, qi stays tone 3 (single tone-3, no
+        // run, no in-word 3+3 trigger).
+        XCTAssertEqual(syllables.map { $0.tone }, [4, 3])
+    }
+
+    func testYiBeforeFourthToneVerbStillPromotesToTwo() {
+        // 一定 (yi1 + ding4) → `["d"]` (single word). Not an ordinal
+        // numeral word, so the standard rule fires.
+        var syllables = [syl("yi", 1), syl("ding", 4)]
+        let words = [0..<2]
+        let tags = ["d"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        XCTAssertEqual(syllables.map { $0.tone }, [2, 4])
+    }
+
+    // MARK: - 不 reduplication
+
+    func testBuReduplicationKeepsToneFour() {
+        // 好不好 → `["hao", "bu", "hao"]`. The baseline promotes
+        // bu4 → bu2 because the next syllable is tone 3 (no, hold
+        // on — baseline rule is "bu4 + tone-4 → bu2", so for 好不好
+        // (3 4 3) baseline keeps bu4 already). The actual case the
+        // POS rule changes is reduplication where the next syllable
+        // is tone 4 — `要不要` (yao4 + bu4 + yao4): baseline
+        // promotes to bu2 (wrong), POS rule keeps bu4.
+        var syllables = [syl("yao", 4), syl("bu", 4), syl("yao", 4)]
+        let words = [0..<1, 1..<2, 2..<3]
+        let tags = ["v", "d", "v"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        XCTAssertEqual(syllables.map { $0.tone }, [4, 4, 4])
+    }
+
+    func testBuPromotionStillFiresForNonReduplicationContext() {
+        // 不要 → bu4 + yao4 → bu2 + yao4. No reduplication
+        // (there's no preceding `yao`), so the standard rule applies.
+        var syllables = [syl("bu", 4), syl("yao", 4)]
+        let words = [0..<2]
+        let tags = ["d"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        XCTAssertEqual(syllables.map { $0.tone }, [2, 4])
+    }
+
+    func testBuReduplicationDistinctBasesTriggersPromotion() {
+        // [yao, bu, qu] is *not* reduplication — different bases
+        // either side. The rule still promotes (bu4 + qu4 → bu2).
+        var syllables = [syl("yao", 4), syl("bu", 4), syl("qu", 4)]
+        let words = [0..<1, 1..<2, 2..<3]
+        let tags = ["v", "d", "v"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        XCTAssertEqual(syllables.map { $0.tone }, [4, 2, 4])
+    }
+
+    // MARK: - Word-grouped 3+3
+
+    func testInWordRunPromotesAllButLast() {
+        // Single word `wo3 ye3 xiang3` (hypothetical 3-syllable
+        // word) → in-word 3+3 promotes the first two: 2 2 3.
+        var syllables = [syl("wo", 3), syl("ye", 3), syl("xiang", 3)]
+        let words = [0..<3]
+        let tags = ["v"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        XCTAssertEqual(syllables.map { $0.tone }, [2, 2, 3])
+    }
+
+    func testCrossWordPairOnlyPromotesBoundary() {
+        // 我 也 想去 → words `[[wo], [ye], [xiang, qu]]`, tags
+        // `["r", "d", "v"]`. All tone 3. In-word pass:
+        //   word 0 [wo3]                     — single, untouched.
+        //   word 1 [ye3]                     — single, untouched.
+        //   word 2 [xiang3, qu4]             — qu is tone 4, only
+        //                                     xiang is tone 3 (no run).
+        // Cross-word pass:
+        //   wo3 | ye3 → wo promotes to 2.
+        //   ye3 | xiang3 → ye promotes to 2.
+        //   xiang3 | (qu is tone 4) → no boundary promotion.
+        // Final: [2, 2, 3, 4]
+        var syllables = [
+            syl("wo", 3), syl("ye", 3), syl("xiang", 3), syl("qu", 4),
+        ]
+        let words = [0..<1, 1..<2, 2..<4]
+        let tags = ["r", "d", "v"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        XCTAssertEqual(syllables.map { $0.tone }, [2, 2, 3, 4])
+    }
+
+    func testCrossWordChainStopsAtNonThree() {
+        // 我 是 你 的 → wo3 shi4 ni3 de5. No 3+3 chain because shi4
+        // breaks it; ni3 is the leading syllable of its word and
+        // the *previous* word is shi4 (tone 4) → no promotion.
+        var syllables = [
+            syl("wo", 3), syl("shi", 4), syl("ni", 3), syl("de", 5),
+        ]
+        let words = [0..<1, 1..<2, 2..<3, 3..<4]
+        let tags = ["r", "v", "r", "u"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        XCTAssertEqual(syllables.map { $0.tone }, [3, 4, 3, 5])
+    }
+
+    func testWordGroupedSandhiBeatsNaiveRunRule() {
+        // 你 想 吗 → tags `["r", "v", "y"]`. Tones 3 3 5. The naive
+        // pure-run rule would still promote ni3 because it sees a
+        // 3+3 pair, then leave xiang3 alone (last in run). The POS
+        // rule produces the same output here — this is a regression
+        // anchor that the POS path doesn't *under*-promote.
+        var syllables = [syl("ni", 3), syl("xiang", 3), syl("ma", 5)]
+        let words = [0..<1, 1..<2, 2..<3]
+        let tags = ["r", "v", "y"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        XCTAssertEqual(syllables.map { $0.tone }, [2, 3, 5])
+    }
+
+    // MARK: - Backward-compat with single-word ranges
+
+    func testSingleWordRangeMatchesBaselineForFlatRun() {
+        // When the caller passes a single all-encompassing word,
+        // the POS rule degenerates to the baseline run rule.
+        var syllables = [syl("ni", 3), syl("hao", 3)]
+        let words = [0..<2]
+        let tags = ["a"]
+        MandarinToneSandhiPOS.apply(&syllables, words: words, tags: tags)
+        XCTAssertEqual(syllables.map { $0.tone }, [2, 3])
+    }
+
+    func testEmptyAndSingleSyllableBuffersAreNoops() {
+        var empty: [Syllable] = []
+        MandarinToneSandhiPOS.apply(&empty, words: [], tags: [])
+        XCTAssertTrue(empty.isEmpty)
+
+        var single = [syl("ni", 3)]
+        MandarinToneSandhiPOS.apply(&single, words: [0..<1], tags: ["r"])
+        XCTAssertEqual(single, [syl("ni", 3)])
+    }
+
+    // MARK: - Mismatched arity is a programmer error
+
+    func testMismatchedTagsCountTrapsViaPrecondition() {
+        // We can't assert preconditions in XCTest without a
+        // custom runner, so document the contract via a sanity
+        // check that the matched arity does not trap.
+        var syllables = [syl("ni", 3), syl("hao", 3)]
+        MandarinToneSandhiPOS.apply(
+            &syllables, words: [0..<2], tags: ["a"])
+        XCTAssertEqual(syllables.count, 2)
+    }
+}


### PR DESCRIPTION
## Summary

Issue #572 item 5. The baseline \`MandarinToneSandhi\` rules are
POS-independent and audibly misfire on three contexts:

- **一 ordinals** (\`第一 dì-yī\`, \`一月 yī-yuè\`, \`一号\`) keep
  tone 1; baseline promotes them to 2/4 unconditionally
- **不 reduplication** (\`要不要\`, \`好不好\`, \`行不行\`) keeps
  \`不\` at tone 4 inside \`[X, 不, X]\`; baseline misfires with
  bu4+tone4 → bu2
- **3+3 chains** apply within prosodic words; cross-word 3+3 only
  promotes the word-final syllable. Baseline's pure-run rule
  cascades too far left (\`我也想去\` → wrong \`2 2 2 3\` instead of
  correct \`2 2 3 4\`)

## Design

\`MandarinToneSandhiPOS.apply(_:words:tags:)\` — pure function, takes
the syllable buffer plus pre-computed word ranges + jieba POS tags.
Backward-compat path stays on \`MandarinToneSandhi.apply\` for
callers without a POS tagger (existing behavior preserved).

## Test plan

- [x] 一 ordinal carve-outs (\`第一\`, \`一月\`)
- [x] 一 contextual sandhi still fires in non-numeral words
      (\`一定\`, \`一起\`)
- [x] 不 reduplication keeps tone 4 (\`要不要\`)
- [x] 不 promotion still fires for non-reduplication (\`不要\`)
- [x] In-word 3+3 run promotes all but last
- [x] Cross-word 3+3 only promotes the boundary
- [x] Cross-word chain stops at non-3 (\`我是你的\`)
- [x] Backward-compat for single-word ranges
- [x] \`swift build\` + \`swift format lint\` clean
- 14 unit tests, all passing

## Out of scope (follow-up)

- **MandarinG2P routing** to \`MandarinToneSandhiPOS\` lands once
  PR #575 (jieba HMM + POS tagger tables) merges and the POS tagger
  is loaded by \`KokoroAneModelStore.mandarinG2PPipeline\`. Until
  then this module is testable in isolation via synthetic POS input.

## Depends on

- #575 — for the POS tagger Viterbi + tables that produce the
  \`words\`/\`tags\` arrays at runtime