### PR TITLE
feat(tts/kokoro-ane): user-supplied Mandarin custom lexicon (#572 item 6)

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinCustomLexicon.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinCustomLexicon.swift
@@ -1,0 +1,242 @@
+import Foundation
+
+/// User-supplied pronunciation overrides for the Mandarin
+/// (``KokoroAneVariant/mandarin``) Kokoro-ANE pipeline.
+///
+/// Slots in **at the front** of ``MandarinG2P``'s segmentation cascade:
+/// the orchestrator runs a longest-prefix match against the user lexicon
+/// before falling back to the bundled `pinyin_phrases.bin` /
+/// `pinyin_single.bin` dictionary. A user entry of equal length to a
+/// dict entry wins.
+///
+/// Two entry forms are accepted:
+///
+/// * **Pinyin (digit form)** — e.g. `["zi4", "jie2", "tiao4", "dong4"]`
+///   for `字节跳动`. Tokens are validated at registration time by
+///   parsing through ``MandarinPinyinNormalizer/parseDigitForm(_:)`` and
+///   re-encoding with ``MandarinBopomofoMap/encode(syllable:tone:)``;
+///   bad tokens throw at load time. These tokens **participate in tone
+///   sandhi** with surrounding context (3+3 chains, 不 / 一 rules) just
+///   like dict entries.
+///
+/// * **Bopomofo escape** — tokens prefixed with `@`, e.g. `["@ㄈㄨ4"]`.
+///   The `@` is stripped and the remainder is treated as already-encoded
+///   final-form output (bopomofo + tone digit). Useful for OOV
+///   characters that don't fit the pinyin model, or for callers porting
+///   pronunciations from another zh-TTS. These tokens **bypass tone
+///   sandhi** (already in final form).
+///
+/// Construction: `init(entries:)` (programmatic) or
+/// `load(from:)` / `parse(_:)` (file-based, line format documented on
+/// ``parse(_:)``).
+public struct MandarinCustomLexicon: Sendable, Equatable {
+
+    /// One pre-validated pronunciation token. The lexicon decomposes
+    /// each user entry into an ordered list of these.
+    public enum Token: Sendable, Equatable {
+        /// Pinyin form (`"zi4"` → `Syllable(base: "zi", tone: 4)`).
+        /// Participates in sandhi via ``MandarinG2P``'s syllable
+        /// buffer.
+        case syllable(MandarinPinyinNormalizer.Syllable)
+        /// `@`-escape: pre-encoded bopomofo + tone digit emitted
+        /// verbatim. Sandhi never sees these.
+        case bopomofo(String)
+    }
+
+    /// Hanzi word (matched against ``MandarinG2P``'s segmenter input)
+    /// → ordered token list. Equal-length matches resolve in dict order
+    /// (deterministic via Swift's hashed dict iteration not being
+    /// guaranteed — duplicates are rejected at parse time so this never
+    /// matters in practice).
+    public let entries: [String: [Token]]
+
+    /// Longest entry key in characters. Pre-computed at init so
+    /// ``longestMatch(in:from:)`` can bound its scan.
+    public let maxKeyCharCount: Int
+
+    public init(entries: [String: [Token]] = [:]) {
+        self.entries = entries
+        self.maxKeyCharCount = entries.keys.map { $0.count }.max() ?? 0
+    }
+
+    /// Validate raw user input. Each value list is parsed token-by-token;
+    /// pinyin tokens go through
+    /// ``MandarinPinyinNormalizer/parseDigitForm(_:)`` plus
+    /// ``MandarinBopomofoMap/encode(syllable:tone:)`` to confirm they
+    /// produce a valid bopomofo string. Bopomofo (`@`-prefixed) tokens
+    /// are charset-checked against the v1.1-zh vocab character set.
+    /// Throws on the first bad token.
+    public init(entries raw: [String: [String]]) throws {
+        var validated: [String: [Token]] = [:]
+        validated.reserveCapacity(raw.count)
+        for (word, tokens) in raw {
+            guard !word.isEmpty else {
+                throw KokoroAneError.inputProcessingFailed(
+                    "MandarinCustomLexicon: empty word")
+            }
+            guard !tokens.isEmpty else {
+                throw KokoroAneError.inputProcessingFailed(
+                    "MandarinCustomLexicon: '\(word)' has no tokens")
+            }
+            var parsed: [Token] = []
+            parsed.reserveCapacity(tokens.count)
+            for raw in tokens {
+                parsed.append(try Self.parseToken(raw, word: word))
+            }
+            validated[word] = parsed
+        }
+        self.entries = validated
+        self.maxKeyCharCount = validated.keys.map { $0.count }.max() ?? 0
+    }
+
+    /// Empty lexicon — the default for ``MandarinG2P``.
+    public static let empty = MandarinCustomLexicon(entries: [:] as [String: [Token]])
+
+    public var count: Int { entries.count }
+    public var isEmpty: Bool { entries.isEmpty }
+
+    // MARK: - Lookup
+
+    /// Longest-prefix match against `chars[start...]`. Returns the
+    /// matched character count and the token list, or `nil` if no
+    /// entry's key prefix-matches the substring.
+    func longestMatch(
+        in chars: [Character], from start: Int
+    ) -> (length: Int, tokens: [Token])? {
+        guard !entries.isEmpty, start < chars.count else { return nil }
+        let remaining = chars.count - start
+        let maxLen = min(maxKeyCharCount, remaining)
+        guard maxLen >= 1 else { return nil }
+        for len in stride(from: maxLen, through: 1, by: -1) {
+            let candidate = String(chars[start..<(start + len)])
+            if let tokens = entries[candidate] {
+                return (len, tokens)
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Merge
+
+    /// Combine two lexicons. Keys from `other` overwrite keys from
+    /// `self` on collision (mirrors ``TtsCustomLexicon/merged(with:)``).
+    public func merged(with other: MandarinCustomLexicon) -> MandarinCustomLexicon {
+        var combined = entries
+        for (k, v) in other.entries {
+            combined[k] = v
+        }
+        return MandarinCustomLexicon(entries: combined)
+    }
+
+    // MARK: - File I/O
+
+    /// Load a lexicon from a UTF-8 text file. See ``parse(_:)`` for the
+    /// format spec.
+    public static func load(from url: URL) throws -> MandarinCustomLexicon {
+        let data = try Data(contentsOf: url)
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw KokoroAneError.inputProcessingFailed(
+                "MandarinCustomLexicon: file is not valid UTF-8 at \(url.path)")
+        }
+        return try parse(content)
+    }
+
+    /// Line format:
+    ///
+    /// ```
+    /// # Comments start with '#'.
+    /// # Blank lines are skipped.
+    /// # First whitespace-run separates word from tokens.
+    /// 字节跳动  zi4 jie2 tiao4 dong4
+    /// 比亚迪    bi3 ya4 di2
+    /// foo       @ㄈㄨ4
+    /// ```
+    ///
+    /// Throws on duplicate words (last-wins is too easy to misread —
+    /// callers must dedupe explicitly), empty token lists, or any token
+    /// that fails validation.
+    public static func parse(_ content: String) throws -> MandarinCustomLexicon {
+        var raw: [String: [String]] = [:]
+        for (lineIndex, rawLine) in content.split(
+            separator: "\n", omittingEmptySubsequences: false
+        ).enumerated() {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            let parts = line.split(
+                whereSeparator: { $0.isWhitespace }
+            ).map(String.init)
+            guard parts.count >= 2 else {
+                throw KokoroAneError.inputProcessingFailed(
+                    "MandarinCustomLexicon: line \(lineIndex + 1) has no tokens: '\(line)'"
+                )
+            }
+            let word = parts[0]
+            let tokens = Array(parts.dropFirst())
+            if raw[word] != nil {
+                throw KokoroAneError.inputProcessingFailed(
+                    "MandarinCustomLexicon: duplicate word '\(word)' on line \(lineIndex + 1)"
+                )
+            }
+            raw[word] = tokens
+        }
+        return try MandarinCustomLexicon(entries: raw)
+    }
+
+    // MARK: - Token validation
+
+    private static func parseToken(_ raw: String, word: String) throws -> Token {
+        guard !raw.isEmpty else {
+            throw KokoroAneError.inputProcessingFailed(
+                "MandarinCustomLexicon: '\(word)' has an empty token")
+        }
+        if raw.hasPrefix("@") {
+            let bopo = String(raw.dropFirst())
+            guard !bopo.isEmpty else {
+                throw KokoroAneError.inputProcessingFailed(
+                    "MandarinCustomLexicon: '\(word)' has a bare '@' token")
+            }
+            try validateBopomofo(bopo, word: word)
+            return .bopomofo(bopo)
+        }
+        guard let syl = MandarinPinyinNormalizer.parseDigitForm(raw) else {
+            throw KokoroAneError.inputProcessingFailed(
+                "MandarinCustomLexicon: '\(word)' has invalid pinyin token "
+                    + "'\(raw)' (expected base+tone-digit, e.g. 'zi4')")
+        }
+        guard MandarinBopomofoMap.encode(syllable: syl.base, tone: syl.tone) != nil else {
+            throw KokoroAneError.inputProcessingFailed(
+                "MandarinCustomLexicon: '\(word)' token '\(raw)' parsed but "
+                    + "MandarinBopomofoMap can't encode it")
+        }
+        return .syllable(syl)
+    }
+
+    /// Verify every character in a `@`-escape token is in the v1.1-zh
+    /// vocab's emit-character set: bopomofo glyphs (initials + finals),
+    /// the special hanzi tokens kokoro was trained on, tone digits 1-5,
+    /// and the punctuation passthrough set.
+    private static func validateBopomofo(_ bopo: String, word: String) throws {
+        for ch in bopo {
+            if Self.allowedBopomofoCharSet.contains(ch) { continue }
+            throw KokoroAneError.inputProcessingFailed(
+                "MandarinCustomLexicon: '\(word)' bopomofo token contains "
+                    + "char '\(ch)' that is not in the v1.1-zh vocab")
+        }
+    }
+
+    /// Pre-computed union of every legal output character from
+    /// ``MandarinBopomofoMap`` plus tone digits 1-5 and allowed
+    /// punctuation. Built lazily on first reference.
+    private static let allowedBopomofoCharSet: Set<Character> = {
+        var set = Set<Character>()
+        for value in MandarinBopomofoMap.initialMap.values {
+            for ch in value { set.insert(ch) }
+        }
+        for value in MandarinBopomofoMap.finalMap.values {
+            for ch in value { set.insert(ch) }
+        }
+        for d in "12345" { set.insert(d) }
+        for p in MandarinBopomofoMap.allowedPunctuation { set.insert(p) }
+        return set
+    }()
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
@@ -34,8 +34,19 @@ public struct MandarinG2P: Sendable {
     private let dict: MandarinPinyinDict
     private static let logger = AppLogger(category: "MandarinG2P")
 
+    /// User-supplied pronunciation overrides. When non-empty, slots in
+    /// at the front of the segmentation cascade — longest match wins,
+    /// user beats dict at equal length. Default ``MandarinCustomLexicon/empty``
+    /// is a no-op.
+    public var customLexicon: MandarinCustomLexicon = .empty
+
     public init(dict: MandarinPinyinDict) {
         self.dict = dict
+    }
+
+    public init(dict: MandarinPinyinDict, customLexicon: MandarinCustomLexicon) {
+        self.dict = dict
+        self.customLexicon = customLexicon
     }
 
     /// Convert text to a Bopomofo + tone-digit string ready for
@@ -70,6 +81,13 @@ public struct MandarinG2P: Sendable {
                 for py in list {
                     pendingSyllables.append(MandarinPinyinNormalizer.normalize(py))
                 }
+            case .syllables(let list):
+                // User-lexicon pinyin tokens — already in
+                // (base, tone) form. They join the same syllable buffer
+                // so sandhi runs across user/dict boundaries naturally
+                // (e.g. user word ending in tone-3 followed by dict
+                // word starting with tone-3 → 3+3 promotion).
+                pendingSyllables.append(contentsOf: list)
             case .punctuation(let s):
                 // Sandhi never crosses punctuation; emit accumulated
                 // syllables first.
@@ -112,6 +130,8 @@ public struct MandarinG2P: Sendable {
 
     enum Segment {
         case pinyin([String])  // Diacritic-form pinyin syllables.
+        case syllables([MandarinPinyinNormalizer.Syllable])
+        // Pre-parsed syllables (user-lexicon source).
         case punctuation(String)  // ASCII punctuation passthrough.
         case literal(String)  // Anything else (ASCII letters, digits,
         // already-phonemised bopomofo, etc.)
@@ -149,9 +169,19 @@ public struct MandarinG2P: Sendable {
                 continue
             }
 
+            // User lexicon takes priority over dict (longest match
+            // wins, user beats dict at equal length). Allows
+            // single-char overrides too (`maxKeyCharCount` may be 1).
+            var matched = false
+            if let hit = customLexicon.longestMatch(in: chars, from: i) {
+                flushLiteral()
+                emitLexiconHit(hit.tokens, into: &segments)
+                i += hit.length
+                continue
+            }
+
             // Forward-max-match against phrases (only worth trying when
             // ≥ 2 hanzi remain).
-            var matched = false
             let remaining = chars.count - i
             if remaining > 1 {
                 let maxLen = min(upperBound, remaining)
@@ -185,6 +215,44 @@ public struct MandarinG2P: Sendable {
         }
         flushLiteral()
         return segments
+    }
+
+    /// Emit a user-lexicon hit as a single segment when possible
+    /// (consecutive run of one token kind), or as separate segments
+    /// when the hit mixes pinyin + bopomofo tokens. Preserving order
+    /// matters because sandhi accumulates across `.syllables` segments
+    /// but resets at `.literal` segments (matching the existing
+    /// punctuation/dict contract).
+    private func emitLexiconHit(
+        _ tokens: [MandarinCustomLexicon.Token],
+        into segments: inout [Segment]
+    ) {
+        var pendingSyls: [MandarinPinyinNormalizer.Syllable] = []
+        var pendingBopo = ""
+        func flushSyls() {
+            if !pendingSyls.isEmpty {
+                segments.append(.syllables(pendingSyls))
+                pendingSyls.removeAll(keepingCapacity: true)
+            }
+        }
+        func flushBopo() {
+            if !pendingBopo.isEmpty {
+                segments.append(.literal(pendingBopo))
+                pendingBopo.removeAll(keepingCapacity: true)
+            }
+        }
+        for tok in tokens {
+            switch tok {
+            case .syllable(let s):
+                flushBopo()
+                pendingSyls.append(s)
+            case .bopomofo(let s):
+                flushSyls()
+                pendingBopo.append(s)
+            }
+        }
+        flushSyls()
+        flushBopo()
     }
 
     // MARK: - Text normalization

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinPinyinNormalizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinPinyinNormalizer.swift
@@ -66,4 +66,35 @@ public enum MandarinPinyinNormalizer {
         }
         return Syllable(base: base, tone: tone)
     }
+
+    /// Parse a digit-form pinyin token (`"zi4"`, `"jie2"`, `"de5"`) into
+    /// the same `Syllable` shape ``normalize(_:)`` produces. Returns
+    /// `nil` when the input is missing the trailing tone digit, has an
+    /// empty base, or contains characters outside `[a-z]` (after
+    /// lowercasing). Used by the custom-lexicon loader so user entries
+    /// flow through the standard post-segmentation pipeline (sandhi +
+    /// bopomofo encoding) without going through the diacritic
+    /// round-trip.
+    ///
+    /// `ü` and `Ü` are also accepted in the base and collapse to `v`
+    /// (matching ``normalize(_:)``'s pypinyin TONE3 convention).
+    public static func parseDigitForm(_ token: String) -> Syllable? {
+        guard let last = token.last, let tone = Int(String(last)),
+            (1...5).contains(tone)
+        else {
+            return nil
+        }
+        let raw = token.dropLast().lowercased()
+        guard !raw.isEmpty else { return nil }
+        var base = ""
+        base.reserveCapacity(raw.count)
+        for ch in raw {
+            switch ch {
+            case "ü": base.append("v")
+            case "a"..."z": base.append(ch)
+            default: return nil
+            }
+        }
+        return Syllable(base: base, tone: tone)
+    }
 }

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -96,6 +96,22 @@ public actor KokoroAneManager {
         self.defaultVoice = voice
     }
 
+    /// Install (or clear) a user-supplied Mandarin pronunciation override.
+    ///
+    /// Slots in **at the front** of ``MandarinG2P``'s segmentation cascade:
+    /// longest-prefix match against the user lexicon runs before the
+    /// bundled `pinyin_phrases.bin` / `pinyin_single.bin` lookup. User
+    /// entries of equal length to a dict entry win. Pinyin-form tokens
+    /// (`zi4`) participate in tone sandhi with surrounding context;
+    /// `@`-bopomofo tokens (`@ㄈㄨ4`) bypass sandhi.
+    ///
+    /// Pass ``MandarinCustomLexicon/empty`` to clear. Only meaningful
+    /// for ``KokoroAneVariant/mandarin`` — calling on the English variant
+    /// stores the value but has no synthesis effect.
+    public func setMandarinCustomLexicon(_ lexicon: MandarinCustomLexicon) async {
+        await store.setMandarinCustomLexicon(lexicon)
+    }
+
     /// Drop loaded mlmodelcs + voice packs. The store reloads on next call.
     public func cleanup() async {
         await store.cleanup()

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
@@ -101,6 +101,7 @@ public actor KokoroAneModelStore {
     private var voicePacks: [String: KokoroAneVoicePack] = [:]
     private var repoDirectory: URL?
     private var mandarinG2P: MandarinG2P?
+    private var mandarinCustomLexicon: MandarinCustomLexicon = .empty
 
     private let directory: URL?
     private let computeUnits: KokoroAneComputeUnits
@@ -218,12 +219,26 @@ public actor KokoroAneModelStore {
             KokoroAneConstants.g2pPinyinSingleFile)
         let dict = try MandarinPinyinDict.load(
             singlesURL: singlesURL, phrasesURL: phrasesURL)
-        let pipeline = MandarinG2P(dict: dict)
+        var pipeline = MandarinG2P(dict: dict)
+        pipeline.customLexicon = mandarinCustomLexicon
         mandarinG2P = pipeline
         logger.info(
             "Loaded Mandarin G2P (phrases=\(dict.phrases.count), singles=\(dict.singles.count))"
         )
         return pipeline
+    }
+
+    /// Install (or clear) the user-supplied Mandarin pronunciation
+    /// override. The lexicon is cached on the store so it survives a
+    /// pipeline rebuild, and is pushed into the live ``MandarinG2P``
+    /// instance immediately if one is already loaded. Calling on a
+    /// non-mandarin store stores the value but has no synthesis effect
+    /// (the pipeline is never instantiated for English).
+    public func setMandarinCustomLexicon(_ lexicon: MandarinCustomLexicon) {
+        mandarinCustomLexicon = lexicon
+        if mandarinG2P != nil {
+            mandarinG2P?.customLexicon = lexicon
+        }
     }
 
     public func cleanup() {

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -43,17 +43,31 @@ public struct TTS {
 
     private static func loadCustomLexicon(from path: String?) throws -> TtsCustomLexicon? {
         guard let path = path else { return nil }
-        let expanded = (path as NSString).expandingTildeInPath
-        let url: URL
-        if expanded.hasPrefix("/") {
-            url = URL(fileURLWithPath: expanded)
-        } else {
-            let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-            url = cwd.appendingPathComponent(expanded)
-        }
+        let url = resolveLexiconURL(path)
         let lexicon = try TtsCustomLexicon.load(from: url)
         logger.info("Loaded custom lexicon with \(lexicon.count) entries from \(url.path)")
         return lexicon
+    }
+
+    /// Mandarin lexicon loader sibling — same path-resolution rules,
+    /// different file format. See ``MandarinCustomLexicon/parse(_:)`` for
+    /// the line spec.
+    private static func loadMandarinLexicon(from path: String?) throws -> MandarinCustomLexicon? {
+        guard let path = path else { return nil }
+        let url = resolveLexiconURL(path)
+        let lexicon = try MandarinCustomLexicon.load(from: url)
+        logger.info(
+            "Loaded Mandarin custom lexicon with \(lexicon.count) entries from \(url.path)")
+        return lexicon
+    }
+
+    private static func resolveLexiconURL(_ path: String) -> URL {
+        let expanded = (path as NSString).expandingTildeInPath
+        if expanded.hasPrefix("/") {
+            return URL(fileURLWithPath: expanded)
+        }
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+        return cwd.appendingPathComponent(expanded)
     }
 
     private static let longFormBenchmark: String = """
@@ -470,7 +484,7 @@ public struct TTS {
         if backend == .kokoroAne {
             await runKokoroAne(
                 text: text, output: output, voice: voice, metricsPath: metricsPath,
-                variant: kokoroAneVariant)
+                variant: kokoroAneVariant, lexiconPath: lexiconPath)
             return
         }
 
@@ -904,7 +918,7 @@ public struct TTS {
 
     private static func runKokoroAne(
         text: String, output: String, voice: String, metricsPath: String?,
-        variant: KokoroAneVariant
+        variant: KokoroAneVariant, lexiconPath: String?
     ) async {
         do {
             let tStart = Date()
@@ -917,6 +931,25 @@ public struct TTS {
                 ? variant.defaultVoice : voice
             let manager = KokoroAneManager(
                 variant: variant, defaultVoice: resolvedVoice)
+
+            // --lexicon is dual-format. For Mandarin, parse + install the
+            // user override before initialize() so it's live on the first
+            // synthesize() call. For English, the Mandarin format wouldn't
+            // parse anyway — log + ignore so users aren't silently
+            // surprised by a flag with no effect.
+            if let lexiconPath {
+                switch variant {
+                case .mandarin:
+                    if let lex = try loadMandarinLexicon(from: lexiconPath) {
+                        await manager.setMandarinCustomLexicon(lex)
+                    }
+                case .english:
+                    logger.warning(
+                        "--lexicon ignored: KokoroAne English variant has "
+                            + "no custom lexicon support yet (only Mandarin does). "
+                            + "Pass --backend kokoro to use the English lexicon.")
+                }
+            }
 
             let tLoad0 = Date()
             try await manager.initialize()
@@ -1067,7 +1100,14 @@ public struct TTS {
                                      cosyvoice3-tokenizer-parity  Qwen2 BPE round-trip
                                    (Production cosyvoice3 backend auto-downloads
                                     assets from HuggingFace on first synthesis.)
-              --lexicon, -l        Custom pronunciation lexicon file (word=phonemes format, Kokoro only)
+              --lexicon, -l        Custom pronunciation lexicon file. Format depends on backend:
+                                     Kokoro (default backend):
+                                       word=phon1phon2 phon3   (IPA, grapheme-split)
+                                     KokoroAne --variant zh:
+                                       word  pinyin1 pinyin2   (e.g. zi4 jie2)
+                                       word  @bopomofo1        (escape: @-prefixed,
+                                                                bypasses tone sandhi)
+                                   Ignored for KokoroAne English (no lexicon support yet).
               --benchmark          Run a predefined benchmarking suite with multiple sentences
               --variant            Force Kokoro 5s/15s model (values: 5s,15s) OR
                                pick KokoroAne language (values: en,zh).

--- a/Tests/FluidAudioTests/TTS/KokoroAne/MandarinCustomLexiconTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/MandarinCustomLexiconTests.swift
@@ -1,0 +1,275 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Unit tests for the user-supplied Mandarin pronunciation override
+/// (Issue #572 item 6). Covers:
+///   * `MandarinPinyinNormalizer.parseDigitForm` digit-token parsing
+///   * `MandarinCustomLexicon` file parser + validation throws
+///   * `MandarinCustomLexicon.longestMatch` (user beats dict at equal
+///     length, longest user entry wins)
+///   * `MandarinG2P.phonemize` end-to-end with a non-empty lexicon
+///     (sandhi runs across user/dict boundaries; `@`-bopomofo bypasses)
+///   * `merged(with:)` semantics
+///
+/// All tests are network-free — they build tiny in-memory dicts in the
+/// same style as `MandarinG2PTests`.
+final class MandarinCustomLexiconTests: XCTestCase {
+
+    // MARK: - parseDigitForm
+
+    func testParseDigitFormBasicTones() {
+        let zi4 = MandarinPinyinNormalizer.parseDigitForm("zi4")
+        XCTAssertEqual(zi4, .init(base: "zi", tone: 4))
+
+        let jie2 = MandarinPinyinNormalizer.parseDigitForm("jie2")
+        XCTAssertEqual(jie2, .init(base: "jie", tone: 2))
+
+        let de5 = MandarinPinyinNormalizer.parseDigitForm("de5")
+        XCTAssertEqual(de5, .init(base: "de", tone: 5))
+    }
+
+    func testParseDigitFormUmlautCollapsesToV() {
+        // Both diacritic ü and the ASCII v form collapse to "v".
+        XCTAssertEqual(
+            MandarinPinyinNormalizer.parseDigitForm("lü4"),
+            .init(base: "lv", tone: 4))
+        XCTAssertEqual(
+            MandarinPinyinNormalizer.parseDigitForm("lv4"),
+            .init(base: "lv", tone: 4))
+    }
+
+    func testParseDigitFormUppercaseLowercased() {
+        XCTAssertEqual(
+            MandarinPinyinNormalizer.parseDigitForm("ZI4"),
+            .init(base: "zi", tone: 4))
+    }
+
+    func testParseDigitFormRejectsBadInput() {
+        // No tone digit
+        XCTAssertNil(MandarinPinyinNormalizer.parseDigitForm("zi"))
+        // Bare digit (empty base)
+        XCTAssertNil(MandarinPinyinNormalizer.parseDigitForm("4"))
+        // Tone out of range
+        XCTAssertNil(MandarinPinyinNormalizer.parseDigitForm("zi6"))
+        XCTAssertNil(MandarinPinyinNormalizer.parseDigitForm("zi0"))
+        // Non-letter inside base
+        XCTAssertNil(MandarinPinyinNormalizer.parseDigitForm("zi-4"))
+        // Empty
+        XCTAssertNil(MandarinPinyinNormalizer.parseDigitForm(""))
+    }
+
+    // MARK: - File parser
+
+    func testParseHandlesCommentsAndBlankLines() throws {
+        let lex = try MandarinCustomLexicon.parse(
+            """
+            # This is a comment
+            # Another comment
+
+            字节跳动  zi4 jie2 tiao4 dong4
+
+            # Tail comment
+            比亚迪  bi3 ya4 di2
+            """)
+        XCTAssertEqual(lex.count, 2)
+        XCTAssertEqual(lex.maxKeyCharCount, 4)
+
+        guard let bytedance = lex.entries["字节跳动"] else {
+            XCTFail("missing 字节跳动")
+            return
+        }
+        XCTAssertEqual(bytedance.count, 4)
+        if case .syllable(let s) = bytedance[0] {
+            XCTAssertEqual(s, .init(base: "zi", tone: 4))
+        } else {
+            XCTFail("expected syllable token")
+        }
+    }
+
+    func testParseAcceptsAtBopomofoEscape() throws {
+        let lex = try MandarinCustomLexicon.parse(
+            """
+            foo  @ㄈㄨ4
+            """)
+        XCTAssertEqual(lex.count, 1)
+        if case .bopomofo(let s) = lex.entries["foo"]?.first {
+            XCTAssertEqual(s, "ㄈㄨ4")
+        } else {
+            XCTFail("expected bopomofo token")
+        }
+    }
+
+    func testParseRejectsZeroTokens() {
+        XCTAssertThrowsError(try MandarinCustomLexicon.parse("foo")) { err in
+            XCTAssertTrue(err is KokoroAneError)
+        }
+    }
+
+    func testParseRejectsDuplicateWord() {
+        XCTAssertThrowsError(
+            try MandarinCustomLexicon.parse(
+                """
+                字节  zi4 jie2
+                字节  bi3 ya4
+                """)
+        ) { err in
+            XCTAssertTrue(err is KokoroAneError)
+        }
+    }
+
+    func testParseRejectsInvalidPinyinToken() {
+        // No tone digit in token → parseDigitForm returns nil → throw.
+        XCTAssertThrowsError(
+            try MandarinCustomLexicon.parse("foo  zi"))
+    }
+
+    func testParseRejectsUnencodableSyllable() {
+        // parseDigitForm accepts "xq4" (well-formed token), but
+        // MandarinBopomofoMap can't encode it → throw.
+        XCTAssertThrowsError(
+            try MandarinCustomLexicon.parse("foo  xq4"))
+    }
+
+    func testParseRejectsBareAtToken() {
+        XCTAssertThrowsError(
+            try MandarinCustomLexicon.parse("foo  @"))
+    }
+
+    func testParseRejectsBopomofoWithUnknownChars() {
+        // Latin letters aren't in the v1.1-zh bopomofo charset.
+        XCTAssertThrowsError(
+            try MandarinCustomLexicon.parse("foo  @abc1"))
+    }
+
+    func testEmptyLexiconIsNoop() {
+        let empty = MandarinCustomLexicon.empty
+        XCTAssertTrue(empty.isEmpty)
+        XCTAssertEqual(empty.count, 0)
+        XCTAssertEqual(empty.maxKeyCharCount, 0)
+        let chars = Array("你好")
+        XCTAssertNil(empty.longestMatch(in: chars, from: 0))
+    }
+
+    // MARK: - longestMatch
+
+    func testLongestMatchPicksLongestEntry() throws {
+        let lex = try MandarinCustomLexicon(entries: [
+            "字节": ["zi4", "jie2"],
+            "字节跳动": ["zi4", "jie2", "tiao4", "dong4"],
+        ])
+        let chars = Array("字节跳动是公司")
+        let hit = lex.longestMatch(in: chars, from: 0)
+        XCTAssertEqual(hit?.length, 4, "should pick the 4-char entry over the 2-char one")
+    }
+
+    func testLongestMatchHonorsStartOffset() throws {
+        let lex = try MandarinCustomLexicon(entries: [
+            "字节": ["zi4", "jie2"]
+        ])
+        let chars = Array("公司字节")
+        XCTAssertNil(lex.longestMatch(in: chars, from: 0))
+        XCTAssertEqual(lex.longestMatch(in: chars, from: 2)?.length, 2)
+    }
+
+    // MARK: - merged
+
+    func testMergedOtherWinsOnCollision() throws {
+        let a = try MandarinCustomLexicon(entries: [
+            "字节": ["zi4", "jie2"]
+        ])
+        let b = try MandarinCustomLexicon(entries: [
+            "字节": ["zi3", "jie3"],
+            "公司": ["gong1", "si1"],
+        ])
+        let merged = a.merged(with: b)
+        XCTAssertEqual(merged.count, 2)
+        if case .syllable(let s) = merged.entries["字节"]?.first {
+            XCTAssertEqual(s.tone, 3, "b should win over a")
+        } else {
+            XCTFail("missing 字节 entry")
+        }
+    }
+
+    // MARK: - MandarinG2P integration
+
+    private static func smallDict() -> MandarinPinyinDict {
+        let phrases: [String: [String]] = [
+            "你好": ["nǐ", "hǎo"]
+        ]
+        let singles: [UInt32: [String]] = [
+            // 是 shì
+            0x662F: ["shì"],
+            // 公 gōng
+            0x516C: ["gōng"],
+            // 司 sī
+            0x53F8: ["sī"],
+        ]
+        return MandarinPinyinDict(phrases: phrases, singles: singles)
+    }
+
+    func testPhonemizeUsesUserLexiconForCustomWord() throws {
+        // 字节跳动 isn't in our tiny dict, so without a lexicon the
+        // single-char fallback would also miss and produce nothing.
+        // With the lexicon installed, the user reading wins.
+        let lex = try MandarinCustomLexicon(entries: [
+            "字节跳动": ["zi4", "jie2", "tiao4", "dong4"]
+        ])
+        var g2p = MandarinG2P(dict: Self.smallDict())
+        g2p.customLexicon = lex
+        let out = try g2p.phonemize("字节跳动")
+        // Each pinyin runs through the standard bopomofo encoder.
+        XCTAssertFalse(out.isEmpty)
+        // Spot-check that the first syllable's tone digit landed.
+        XCTAssertTrue(out.contains("4"))
+    }
+
+    func testPhonemizeUserBeatsDictAtEqualLength() throws {
+        // Dict says 你好 → ni3 hao3 (→ sandhi → ni2 hao3).
+        // Override forces ni4 hao4 (no sandhi promotion since neither
+        // is tone-3).
+        let lex = try MandarinCustomLexicon(entries: [
+            "你好": ["ni4", "hao4"]
+        ])
+        var g2p = MandarinG2P(dict: Self.smallDict())
+        g2p.customLexicon = lex
+        let out = try g2p.phonemize("你好")
+        XCTAssertEqual(out, "ㄋㄧ4ㄏㄠ4")
+    }
+
+    func testPhonemizeSandhiRunsAcrossUserDictBoundary() throws {
+        // User word ends in tone-3, dict word starts with tone-3 → 3+3
+        // sandhi must promote the user's tone-3 to tone-2 across the
+        // boundary (validates that .syllables segments append to the
+        // same pending buffer as .pinyin segments).
+        let lex = try MandarinCustomLexicon(entries: [
+            "我": ["wo3"]
+        ])
+        var g2p = MandarinG2P(dict: Self.smallDict())
+        g2p.customLexicon = lex
+        let out = try g2p.phonemize("我你好")
+        // "我" wo3 + "你" ni3 + "好" hao3 → 3+3+3 → right-to-left → 2+2+3
+        XCTAssertEqual(out, "我2ㄋㄧ2ㄏㄠ3")
+    }
+
+    func testPhonemizeAtBopomofoBypassesSandhi() throws {
+        // @-bopomofo tokens are emitted verbatim and do not enter the
+        // syllable buffer, so they don't participate in sandhi.
+        let lex = try MandarinCustomLexicon(entries: [
+            "我": ["@ㄨㄛ3"]
+        ])
+        var g2p = MandarinG2P(dict: Self.smallDict())
+        g2p.customLexicon = lex
+        let out = try g2p.phonemize("我你好")
+        // 我 → ㄨㄛ3 verbatim (no sandhi promotion). Then 你好 alone
+        // → ni3 hao3 → sandhi → ni2 hao3.
+        XCTAssertEqual(out, "ㄨㄛ3ㄋㄧ2ㄏㄠ3")
+    }
+
+    func testPhonemizeWithEmptyLexiconMatchesDictOnlyPath() throws {
+        let g2p = MandarinG2P(dict: Self.smallDict())
+        let out = try g2p.phonemize("你好")
+        XCTAssertEqual(out, "ㄋㄧ2ㄏㄠ3")
+    }
+}


### PR DESCRIPTION
## Summary

Issue #572 item 6. Lets app developers ship a project-specific
Mandarin lexicon that overrides both the bundled phrase dict and
g2pW. Useful for proper nouns the bundled dict doesn't cover
(brand names, technical jargon, regionalisms) and for cases where
the user knows the correct reading and wants to bypass any
heuristic.

## Test plan

- [x] Custom lexicon entry overrides phrase dict
- [x] Custom lexicon entry overrides single-char dict
- [x] Empty lexicon = no-op (baseline preserved)
- [x] \`swift build\` + \`swift format lint\` clean

## Independent

This PR is independent of #573–#577. Land in any order.