### PR TITLE
feat(tts/kokoro-ane/zh): consolidated Mandarin G2P (erhua + jieba HMM + g2pW) (#572 items 1, 3, 4)

### DIFF
--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -1006,6 +1006,17 @@ public enum ModelNames {
         /// `<repoDir>/voices/zf_001.bin`.
         public static let defaultVoiceFileZh = "voices/zf_001.bin"
 
+        /// Mandarin g2pW polyphone-disambiguator CoreML bundle. Lives under
+        /// `<repoDir>/g2pw/` — included in `requiredModelsZh` so the bulk
+        /// `ensureModels(.mandarin)` grab pulls it without an extra round
+        /// trip. The two auxiliary text files (`vocab.txt`,
+        /// `POLYPHONIC_CHARS.txt`) ship via the lazy
+        /// `KokoroAneResourceDownloader.ensureMandarinG2pw` helper because
+        /// `DownloadUtils.downloadRepo` does not whitelist `.txt` for
+        /// subPath repos and a manual fetch keeps the bulk-grab matcher
+        /// idempotent.
+        public static let g2pwModelZh = "g2pw/g2pw.mlmodelc"
+
         /// All seven .mlmodelc bundles.
         public static let requiredCoreMLModels: Set<String> = [
             albert, postAlbert, alignment, prosody, noise, vocoder, tail,
@@ -1017,9 +1028,11 @@ public enum ModelNames {
         }
 
         /// CoreML bundles + the vocab JSON + the Mandarin default voice .bin
-        /// (which lives under `voices/`).
+        /// (under `voices/`) + the g2pW CoreML bundle (under `g2pw/`).
         public static var requiredModelsZh: Set<String> {
-            requiredCoreMLModels.union([vocab, defaultVoiceFileZh])
+            requiredCoreMLModels.union([
+                vocab, defaultVoiceFileZh, g2pwModelZh,
+            ])
         }
     }
 

--- a/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
@@ -100,6 +100,73 @@ public enum KokoroAneResourceDownloader {
         return g2pDir
     }
 
+    /// Best-effort fetch of the jieba HMM tables (start / trans / emit)
+    /// into the same `<repoDir>/g2p/` cache.
+    ///
+    /// Returns the cache directory when all three artefacts are
+    /// resident locally (either pre-cached or freshly downloaded).
+    /// Returns `nil` when any artefact is missing both locally and
+    /// remotely — the caller is expected to fall back to the
+    /// FMM/single-char-only segmentation path. The Mandarin variant
+    /// stays usable in that case; HMM is a quality booster, not a
+    /// hard dependency.
+    public static func ensureMandarinJiebaHmm(
+        repoDirectory: URL
+    ) async -> URL? {
+        let g2pDir = repoDirectory.appendingPathComponent(KokoroAneConstants.g2pSubdir)
+        if !FileManager.default.fileExists(atPath: g2pDir.path) {
+            do {
+                try FileManager.default.createDirectory(
+                    at: g2pDir, withIntermediateDirectories: true)
+            } catch {
+                logger.warning(
+                    "Could not create jieba HMM cache dir: \(error.localizedDescription)")
+                return nil
+            }
+        }
+
+        let needed = [
+            (
+                local: KokoroAneConstants.jiebaHmmStartFile,
+                remote: KokoroAneConstants.jiebaHmmStartRemoteFile
+            ),
+            (
+                local: KokoroAneConstants.jiebaHmmTransFile,
+                remote: KokoroAneConstants.jiebaHmmTransRemoteFile
+            ),
+            (
+                local: KokoroAneConstants.jiebaHmmEmitFile,
+                remote: KokoroAneConstants.jiebaHmmEmitRemoteFile
+            ),
+        ]
+
+        for entry in needed {
+            let localURL = g2pDir.appendingPathComponent(entry.local)
+            if FileManager.default.fileExists(atPath: localURL.path) { continue }
+            do {
+                logger.info(
+                    "Downloading jieba HMM asset '\(entry.remote)' from "
+                        + "\(KokoroAneConstants.g2pRemoteRepo)/\(KokoroAneConstants.g2pRemoteSubdir)/...")
+                let remotePath = "\(KokoroAneConstants.g2pRemoteSubdir)/\(entry.remote)"
+                let remoteURL = try ModelRegistry.resolveModel(
+                    KokoroAneConstants.g2pRemoteRepo, remotePath)
+                let data = try await AssetDownloader.fetchData(
+                    from: remoteURL,
+                    description: "jieba HMM asset \(entry.remote)",
+                    logger: logger
+                )
+                try data.write(to: localURL, options: [.atomic])
+                logger.info("Cached \(entry.local) (\(data.count / 1024) KB)")
+            } catch {
+                logger.warning(
+                    "Jieba HMM asset '\(entry.remote)' unavailable "
+                        + "(\(error.localizedDescription)); HMM segmentation disabled.")
+                return nil
+            }
+        }
+        return g2pDir
+    }
+
     /// Ensure the shared G2P CoreML assets (encoder + decoder + vocab) exist
     /// in the kokoro cache directory. KokoroAne reuses `G2PModel` for text →
     /// IPA conversion, and `G2PModel.loadIfNeeded` only reads from cache —

--- a/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
@@ -100,6 +100,85 @@ public enum KokoroAneResourceDownloader {
         return g2pDir
     }
 
+    /// Ensure the Mandarin g2pW polyphone disambiguator assets are
+    /// resident under `<repoDir>/g2pw/`. Returns the directory URL on
+    /// success, or `nil` if any required artefact is unavailable
+    /// (network failure, asset not yet published, …) so callers can
+    /// fall back to the dict-only Mandarin pipeline without throwing.
+    ///
+    /// The CoreML bundle (`g2pw.mlmodelc/`) is a directory and not
+    /// downloaded by this helper — it is expected to land via the
+    /// bulk `ensureModels` repo grab once the asset is added to the
+    /// `requiredModelsZh` set. This helper only fetches the two
+    /// auxiliary text files (`vocab.txt`, `POLYPHONIC_CHARS.txt`)
+    /// that ship alongside the model.
+    @discardableResult
+    public static func ensureMandarinG2pw(
+        repoDirectory: URL
+    ) async -> URL? {
+        let g2pwDir = repoDirectory.appendingPathComponent(KokoroAneConstants.g2pwSubdir)
+        if !FileManager.default.fileExists(atPath: g2pwDir.path) {
+            do {
+                try FileManager.default.createDirectory(
+                    at: g2pwDir, withIntermediateDirectories: true)
+            } catch {
+                logger.info(
+                    "g2pW assets unavailable (could not create cache dir: \(error.localizedDescription))"
+                )
+                return nil
+            }
+        }
+
+        let needed = [
+            (
+                local: KokoroAneConstants.g2pwVocabFile,
+                remote: KokoroAneConstants.g2pwVocabRemoteFile
+            ),
+            (
+                local: KokoroAneConstants.g2pwPolyphonicCharsFile,
+                remote: KokoroAneConstants.g2pwPolyphonicCharsRemoteFile
+            ),
+        ]
+
+        for entry in needed {
+            let localURL = g2pwDir.appendingPathComponent(entry.local)
+            if FileManager.default.fileExists(atPath: localURL.path) { continue }
+
+            do {
+                let remotePath = "\(KokoroAneConstants.g2pwRemoteSubdir)/\(entry.remote)"
+                let remoteURL = try ModelRegistry.resolveModel(
+                    KokoroAneConstants.g2pRemoteRepo, remotePath)
+                let data = try await AssetDownloader.fetchData(
+                    from: remoteURL,
+                    description: "Mandarin g2pW asset \(entry.remote)",
+                    logger: logger
+                )
+                try data.write(to: localURL, options: [.atomic])
+                logger.info("Cached \(entry.local) (\(data.count / 1024) KB)")
+            } catch {
+                logger.info(
+                    "g2pW asset '\(entry.local)' unavailable (\(error.localizedDescription))"
+                        + " — Mandarin G2P will run dict-only"
+                )
+                return nil
+            }
+        }
+
+        // The CoreML bundle is required for the model to actually run.
+        // Without it, return nil and let the caller skip g2pW entirely.
+        let modelURL =
+            repoDirectory
+            .appendingPathComponent(KokoroAneConstants.g2pwSubdir)
+            .appendingPathComponent(KokoroAneConstants.g2pwModelBundle)
+        if !FileManager.default.fileExists(atPath: modelURL.path) {
+            logger.info(
+                "g2pW CoreML bundle missing at \(modelURL.path) — Mandarin G2P will run dict-only"
+            )
+            return nil
+        }
+        return g2pwDir
+    }
+
     /// Ensure the shared G2P CoreML assets (encoder + decoder + vocab) exist
     /// in the kokoro cache directory. KokoroAne reuses `G2PModel` for text →
     /// IPA conversion, and `G2PModel.loadIfNeeded` only reads from cache —

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinBertTokenizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinBertTokenizer.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Minimal BERT WordPiece tokenizer for the g2pW polyphone disambiguator.
+///
+/// g2pW operates exclusively on Hanzi targets, so the tokenizer only
+/// needs the char-level path from `bert-base-chinese`: each Hanzi maps
+/// to a single token (no subword merges), unmapped characters fall
+/// through to `[UNK]`, and the sequence is wrapped in `[CLS]` / `[SEP]`
+/// padded to the model's input length. This keeps the implementation
+/// well under 200 LOC versus a full WordPiece port.
+///
+/// Vocabulary file format: one token per line, line number = token id.
+/// This matches `vocab.txt` from
+/// https://huggingface.co/bert-base-chinese — the file the upstream
+/// g2pW Python project uses verbatim.
+public struct MandarinBertTokenizer: Sendable {
+
+    /// Token → id lookup. Loaded from `vocab.txt` line-by-line.
+    public let vocab: [String: Int32]
+
+    /// Special-token ids resolved from `vocab` at load time.
+    public let clsId: Int32
+    public let sepId: Int32
+    public let padId: Int32
+    public let unkId: Int32
+
+    /// Maximum total sequence length the downstream model accepts.
+    /// `bert-base-chinese` defaults to 512.
+    public static let defaultMaxLength = 512
+
+    public enum LoadError: Swift.Error, LocalizedError {
+        case missingSpecialToken(String)
+        case emptyVocab(URL)
+
+        public var errorDescription: String? {
+            switch self {
+            case .missingSpecialToken(let name):
+                return "BERT vocab is missing required special token '\(name)'"
+            case .emptyVocab(let url):
+                return "BERT vocab at \(url.path) is empty"
+            }
+        }
+    }
+
+    /// Load `vocab.txt` from disk. Tokens are read in line order; the
+    /// id of a token equals its zero-indexed line number, matching the
+    /// `bert-base-chinese` convention.
+    public static func load(vocabURL: URL) throws -> MandarinBertTokenizer {
+        let raw = try String(contentsOf: vocabURL, encoding: .utf8)
+        let lines = raw.split(omittingEmptySubsequences: false, whereSeparator: { $0 == "\n" })
+        guard !lines.isEmpty else { throw LoadError.emptyVocab(vocabURL) }
+        var vocab: [String: Int32] = [:]
+        vocab.reserveCapacity(lines.count)
+        for (idx, line) in lines.enumerated() {
+            // Strip trailing CR (Windows line-endings) and the optional
+            // trailing newline left by the splitter; everything else is
+            // significant (BERT tokens may include leading `##` etc.).
+            var token = String(line)
+            if token.hasSuffix("\r") { token.removeLast() }
+            if token.isEmpty && idx == lines.count - 1 {
+                // Final blank line from a trailing newline — drop.
+                continue
+            }
+            vocab[token] = Int32(idx)
+        }
+        return try MandarinBertTokenizer(vocab: vocab)
+    }
+
+    public init(vocab: [String: Int32]) throws {
+        self.vocab = vocab
+        guard let cls = vocab["[CLS]"] else {
+            throw LoadError.missingSpecialToken("[CLS]")
+        }
+        guard let sep = vocab["[SEP]"] else {
+            throw LoadError.missingSpecialToken("[SEP]")
+        }
+        guard let pad = vocab["[PAD]"] else {
+            throw LoadError.missingSpecialToken("[PAD]")
+        }
+        guard let unk = vocab["[UNK]"] else {
+            throw LoadError.missingSpecialToken("[UNK]")
+        }
+        self.clsId = cls
+        self.sepId = sep
+        self.padId = pad
+        self.unkId = unk
+    }
+
+    /// Tokenization output: padded `inputIds` + `attentionMask` plus
+    /// the (post-CLS) position of each input character so g2pW can
+    /// pick its target index without re-deriving offsets.
+    public struct Encoded: Equatable, Sendable {
+        public let inputIds: [Int32]
+        public let attentionMask: [Int32]
+        public let tokenTypeIds: [Int32]
+        /// `tokenPositionForChar[i]` = id-array index where `chars[i]`
+        /// landed (always `i + 1` in the char-level path due to `[CLS]`,
+        /// but exposed explicitly so callers don't bake the offset in).
+        public let tokenPositionForChar: [Int]
+    }
+
+    /// Char-level encode of a Hanzi sentence. Truncates from the right
+    /// if the sentence + `[CLS]` + `[SEP]` would exceed `maxLength`.
+    /// Pads with `[PAD]` (`attentionMask = 0`) up to `maxLength`.
+    ///
+    /// Whitespace and ASCII punctuation in `text` are dropped — g2pW
+    /// only sees Hanzi context. If callers need to preserve those in a
+    /// downstream pipeline, they should do so outside this tokenizer.
+    public func encode(
+        chars: [Character],
+        maxLength: Int = defaultMaxLength
+    ) -> Encoded {
+        precondition(maxLength >= 2, "maxLength must hold at least [CLS] + [SEP]")
+        let usable = max(0, maxLength - 2)
+        let truncated = chars.count > usable ? Array(chars.prefix(usable)) : chars
+
+        var inputIds: [Int32] = []
+        inputIds.reserveCapacity(maxLength)
+        var positions: [Int] = []
+        positions.reserveCapacity(truncated.count)
+
+        inputIds.append(clsId)
+        for ch in truncated {
+            let token = String(ch)
+            positions.append(inputIds.count)
+            inputIds.append(vocab[token] ?? unkId)
+        }
+        inputIds.append(sepId)
+
+        var attentionMask = Array(repeating: Int32(1), count: inputIds.count)
+        if inputIds.count < maxLength {
+            let padCount = maxLength - inputIds.count
+            inputIds.append(contentsOf: Array(repeating: padId, count: padCount))
+            attentionMask.append(contentsOf: Array(repeating: Int32(0), count: padCount))
+        }
+        let tokenTypeIds = Array(repeating: Int32(0), count: maxLength)
+        return Encoded(
+            inputIds: inputIds,
+            attentionMask: attentionMask,
+            tokenTypeIds: tokenTypeIds,
+            tokenPositionForChar: positions
+        )
+    }
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinBopomofoMap.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinBopomofoMap.swift
@@ -131,7 +131,12 @@ public enum MandarinBopomofoMap {
     /// + digit string the v1.1-zh vocab expects (`"ㄏㄠ3"`). Returns
     /// `nil` when the syllable cannot be parsed (the caller logs and
     /// drops it — kokoro's own behaviour for OOV tokens is identical).
-    public static func encode(syllable base: String, tone: Int) -> String? {
+    ///
+    /// Pass `erhua: true` to append a trailing `ㄦ` between the final
+    /// and the tone digit (`小孩儿` → `ㄒㄧㄠ3ㄏㄞㄦ2`). Only the
+    /// `儿` suffix is encoded — phonetic compaction (`-n`/`-ng` drop)
+    /// is left to the acoustic model, matching misaki's style.
+    public static func encode(syllable base: String, tone: Int, erhua: Bool = false) -> String? {
         guard !base.isEmpty else { return nil }
         let normalized = normalizePinyinForLookup(base)
         guard let (initial, finalRaw) = splitInitialFinal(normalized) else {
@@ -171,6 +176,12 @@ public enum MandarinBopomofoMap {
         }
         if !final.isEmpty {
             guard let bo = finalMap[final] else { return nil }
+            out.append(bo)
+        }
+        // Erhua suffix sits between the final and the tone digit so the
+        // model sees `ㄒㄧㄠㄦ3` (a single toned r-coloured syllable)
+        // rather than `ㄒㄧㄠ3ㄦ` (two tokens).
+        if erhua, let bo = finalMap["er"] {
             out.append(bo)
         }
         // Tone digit — the v1.1-zh vocab carries 1…5 verbatim.

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinErhua.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinErhua.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Merge `儿` (er) suffixes into the preceding syllable so that
+/// `这儿`, `小孩儿`, `一会儿` emit a single r-coloured token instead
+/// of trailing `er` as a separate audible syllable.
+///
+/// Mirrors `misaki/zh_frontend.py:_merge_erhua` with one simplification:
+/// we don't drop the preceding final's `-n` / `-ng` consonant (e.g.
+/// `wan + r` stays `wanr` rather than collapsing to `war`). The Kokoro
+/// v1.1-zh acoustic model was trained on misaki-style input where the
+/// erhua marker is a standalone `ㄦ` appended to the toned final, so
+/// the simpler form preserves intelligibility without per-final tables.
+///
+/// Boundary rules:
+///
+///   * `儿` at index 0 of the sandhi buffer is *never* merged — keeps
+///     standalone words (`儿子 érzi`, `儿童 értóng`) intact.
+///   * The preceding syllable must itself not be `er` — back-to-back
+///     `er er` is left as two syllables.
+///   * Any non-`er` base is mergeable. The whitelist is intentionally
+///     loose; cases that misaki blocks (e.g. `儿` at the start of a
+///     polysyllabic word) are already filtered out by the
+///     `dict.phrases` / single-char lookup happening upstream.
+///
+/// Operates in place on the same `pendingSyllables` buffer that
+/// `MandarinToneSandhi.apply` will see — invoke this *before* sandhi
+/// so 3+3 promotion considers the (now shorter) buffer.
+public enum MandarinErhua {
+
+    /// Fold trailing `er` syllables into their predecessors. Mutates
+    /// `syllables` in place; the merged-into syllable gains
+    /// `erhua = true`, the trailing `er` is removed.
+    public static func merge(_ syllables: inout [MandarinPinyinNormalizer.Syllable]) {
+        guard syllables.count >= 2 else { return }
+
+        // Walk back-to-front so removals don't shift unprocessed indices,
+        // and skip past the merged-into slot once a merge fires (chained
+        // `er er` patterns shouldn't double-merge).
+        var i = syllables.count - 1
+        while i >= 1 {
+            let cur = syllables[i]
+            let prev = syllables[i - 1]
+            if cur.base == "er" && shouldMergeInto(prev: prev) {
+                syllables[i - 1].erhua = true
+                syllables.remove(at: i)
+                // Advance past the now-merged anchor so an immediately
+                // preceding `er` (rare but possible across word seams)
+                // isn't itself folded into something further back.
+                i -= 2
+            } else {
+                i -= 1
+            }
+        }
+    }
+
+    /// Whitelist for the merge predicate. Conservative on purpose —
+    /// any non-empty, non-`er` base is allowed.
+    private static func shouldMergeInto(
+        prev: MandarinPinyinNormalizer.Syllable
+    ) -> Bool {
+        !prev.base.isEmpty && prev.base != "er"
+    }
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
@@ -10,8 +10,11 @@ import Foundation
 ///      `。` → `.`, …).
 ///   2. **Segmentation** — forward maximum-matching against
 ///      `MandarinPinyinDict.phrases`, falling back to single-char
-///      lookups in `singles`. Matches `MagpieMandarinTokenizer`'s
-///      strategy — full jieba HMM is not ported.
+///      lookups in `singles`. When a `MandarinJiebaHmm` is wired in,
+///      runs of consecutive single-char fallbacks are first re-segmented
+///      via the jieba B/M/E/S Viterbi to recover OOV proper-noun
+///      boundaries (`特朗普`, `比特币`), and each recovered word is
+///      retried against the phrase dict before falling back to per-char.
 ///   3. **Diacritic → digit** — each pinyin syllable is normalized to
 ///      `(base, tone)` via `MandarinPinyinNormalizer`.
 ///   4. **Tone sandhi** — 3+3 → 2+3, 不 / 一 contextual rules
@@ -32,10 +35,12 @@ import Foundation
 public struct MandarinG2P: Sendable {
 
     private let dict: MandarinPinyinDict
+    private let jiebaHmm: MandarinJiebaHmm?
     private static let logger = AppLogger(category: "MandarinG2P")
 
-    public init(dict: MandarinPinyinDict) {
+    public init(dict: MandarinPinyinDict, jiebaHmm: MandarinJiebaHmm? = nil) {
         self.dict = dict
+        self.jiebaHmm = jiebaHmm
     }
 
     /// Convert text to a Bopomofo + tone-digit string ready for
@@ -123,11 +128,51 @@ public struct MandarinG2P: Sendable {
         var i = 0
         let upperBound = max(2, dict.maxPhraseCharCount)
         var literalBuffer = ""
+        var hanziFallbackRun: [Character] = []
 
         func flushLiteral() {
             if !literalBuffer.isEmpty {
                 segments.append(.literal(literalBuffer))
                 literalBuffer.removeAll(keepingCapacity: true)
+            }
+        }
+
+        // Drain a buffered run of consecutive single-char hanzi (chars
+        // the FMM phrase loop missed). When the jieba HMM is available
+        // we ask it to re-segment the run first; each resulting word is
+        // tried against the phrase dict before falling back to a
+        // per-char lookup. This recovers boundaries on OOV proper nouns
+        // like `特朗普` / `比特币` whose constituent chars individually
+        // exist in the singles dict but whose compound only resolves as
+        // a phrase.
+        func flushHanziRun() {
+            if hanziFallbackRun.isEmpty { return }
+            defer { hanziFallbackRun.removeAll(keepingCapacity: true) }
+            flushLiteral()
+            let words =
+                jiebaHmm?.segment(String(hanziFallbackRun))
+                ?? hanziFallbackRun.map { String($0) }
+            for word in words {
+                if word.count >= 2, let pinyin = dict.phrases[word] {
+                    segments.append(.pinyin(pinyin))
+                    continue
+                }
+                // Per-char fallback for either truly OOV words or single
+                // chars from a `S` state. Mirrors the original loop's
+                // single-char branch.
+                for ch in word {
+                    if let scalar = ch.unicodeScalars.first,
+                        let pinyin = dict.singles[scalar.value],
+                        !pinyin.isEmpty
+                    {
+                        segments.append(.pinyin([pinyin[0]]))
+                    } else {
+                        // Unknown char — fall through as literal so
+                        // KokoroAneVocab can have a shot at it.
+                        literalBuffer.append(ch)
+                        flushLiteral()
+                    }
+                }
             }
         }
 
@@ -137,6 +182,7 @@ public struct MandarinG2P: Sendable {
             if let scalar = ch.unicodeScalars.first,
                 MandarinBopomofoMap.allowedPunctuation.contains(ch) || scalar.value < 0x80
             {
+                flushHanziRun()
                 if MandarinBopomofoMap.allowedPunctuation.contains(ch) {
                     flushLiteral()
                     segments.append(.punctuation(String(ch)))
@@ -159,6 +205,7 @@ public struct MandarinG2P: Sendable {
                     for len in stride(from: maxLen, through: 2, by: -1) {
                         let candidate = String(chars[i..<(i + len)])
                         if let pinyin = dict.phrases[candidate] {
+                            flushHanziRun()
                             flushLiteral()
                             segments.append(.pinyin(pinyin))
                             i += len
@@ -170,19 +217,14 @@ public struct MandarinG2P: Sendable {
             }
             if matched { continue }
 
-            // Single-char lookup.
-            let scalar = ch.unicodeScalars.first
-            if let scalar, let pinyin = dict.singles[scalar.value], !pinyin.isEmpty {
-                flushLiteral()
-                segments.append(.pinyin([pinyin[0]]))
-            } else {
-                // Unknown char (likely Bopomofo, fullwidth latin, an
-                // emoji, etc.). Pass through verbatim — KokoroAneVocab
-                // will tokenise what it recognises.
-                literalBuffer.append(ch)
-            }
+            // Buffer the char into the hanzi-fallback run. Whether the
+            // singles dict knows it or not, we let `flushHanziRun`
+            // decide — that keeps the HMM input contiguous, which is
+            // what jieba expects (a "run" of unsegmented characters).
+            hanziFallbackRun.append(ch)
             i += 1
         }
+        flushHanziRun()
         flushLiteral()
         return segments
     }

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
@@ -12,13 +12,20 @@ import Foundation
 ///      `MandarinPinyinDict.phrases`, falling back to single-char
 ///      lookups in `singles`. Matches `MagpieMandarinTokenizer`'s
 ///      strategy — full jieba HMM is not ported.
-///   3. **Diacritic → digit** — each pinyin syllable is normalized to
+///   3. **Polyphone disambiguation (optional)** — when a g2pW model is
+///      wired, every single-char Hanzi whose dict entry has multiple
+///      candidate readings (or that the polyphone catalog flags) is
+///      handed to the BERT classifier with the full sentence as
+///      context. The picked bopomofo overrides the dict's first-listed
+///      reading and bypasses the rest of the pipeline (sandhi
+///      included) since the classifier output already encodes tone.
+///   4. **Diacritic → digit** — each pinyin syllable is normalized to
 ///      `(base, tone)` via `MandarinPinyinNormalizer`.
-///   4. **Tone sandhi** — 3+3 → 2+3, 不 / 一 contextual rules
+///   5. **Tone sandhi** — 3+3 → 2+3, 不 / 一 contextual rules
 ///      (`MandarinToneSandhi`).
-///   5. **Pinyin → Bopomofo** — `MandarinBopomofoMap.encode` produces
+///   6. **Pinyin → Bopomofo** — `MandarinBopomofoMap.encode` produces
 ///      the final `<initial><final><digit>` string per syllable.
-///   6. **Concatenation** — syllables joined with no separator,
+///   7. **Concatenation** — syllables joined with no separator,
 ///      punctuation interleaved verbatim. The output is fed straight
 ///      into `KokoroAneVocab.encode`.
 ///
@@ -32,21 +39,48 @@ import Foundation
 public struct MandarinG2P: Sendable {
 
     private let dict: MandarinPinyinDict
+    private let g2pw: MandarinG2pwModel?
     private static let logger = AppLogger(category: "MandarinG2P")
 
-    public init(dict: MandarinPinyinDict) {
+    public init(dict: MandarinPinyinDict, g2pw: MandarinG2pwModel? = nil) {
         self.dict = dict
+        self.g2pw = g2pw
     }
 
     /// Convert text to a Bopomofo + tone-digit string ready for
     /// `KokoroAneVocab.encode`. Empty input is rejected with `throws`
     /// to match the existing English path's behaviour.
-    public func phonemize(_ text: String) throws -> String {
+    public func phonemize(_ text: String) async throws -> String {
         let normalized = Self.normalizeText(text)
         guard !normalized.isEmpty else {
             throw KokoroAneError.inputProcessingFailed("(empty input)")
         }
-        let segments = segment(normalized)
+        let normalizedChars = Array(normalized)
+        let result = segment(chars: normalizedChars)
+        var segments = result.segments
+
+        // Polyphone disambiguation: when a g2pW model is wired and the
+        // segmenter flagged candidate Hanzi, run the classifier and
+        // splice in `.bopomofoOverride` cases. The classifier sees the
+        // full normalized sentence so it can pick by context.
+        if let g2pw, !result.polyphoneTargets.isEmpty {
+            do {
+                let picks = try await g2pw.disambiguate(
+                    chars: normalizedChars,
+                    targets: result.polyphoneTargets.map { $0.charPos }
+                )
+                for target in result.polyphoneTargets {
+                    guard let bopomofo = picks[target.charPos] else { continue }
+                    let digit = MandarinPolyphoneCatalog.toneDigitForm(bopomofo)
+                    segments[target.segmentIdx] = .bopomofoOverride(digit)
+                }
+            } catch {
+                Self.logger.warning(
+                    "g2pW disambiguation failed (\(error.localizedDescription)) — "
+                        + "falling back to dict pick")
+            }
+        }
+
         var output = ""
         var pendingSyllables: [MandarinPinyinNormalizer.Syllable] = []
 
@@ -66,7 +100,7 @@ public struct MandarinG2P: Sendable {
 
         for seg in segments {
             switch seg {
-            case .pinyin(let list):
+            case .pinyin(let list, _):
                 for py in list {
                     pendingSyllables.append(MandarinPinyinNormalizer.normalize(py))
                 }
@@ -79,6 +113,13 @@ public struct MandarinG2P: Sendable {
                 // ASCII letters / digits / unmapped Bopomofo: pass
                 // through. KokoroAneVocab will encode what it can and
                 // silently drop the rest.
+                flushPending()
+                output.append(s)
+            case .bopomofoOverride(let s):
+                // g2pW already encoded the bopomofo + tone — emit
+                // verbatim and break the sandhi window so the next
+                // syllable starts fresh. (Cross-syllable sandhi
+                // through a g2pW pick is a documented limitation.)
                 flushPending()
                 output.append(s)
             }
@@ -111,15 +152,37 @@ public struct MandarinG2P: Sendable {
     // MARK: - Segmentation
 
     enum Segment {
-        case pinyin([String])  // Diacritic-form pinyin syllables.
+        /// Diacritic-form pinyin syllables. `hanziCount` is the number
+        /// of Hanzi consumed from the input — needed by the polyphone
+        /// pass to know whether a segment is a single-char fallback
+        /// (eligible for g2pW override) or a phrase match (which the
+        /// dict already context-disambiguated).
+        case pinyin([String], hanziCount: Int)
         case punctuation(String)  // ASCII punctuation passthrough.
         case literal(String)  // Anything else (ASCII letters, digits,
         // already-phonemised bopomofo, etc.)
+        /// Pre-encoded bopomofo + tone digit from a polyphone
+        /// disambiguator. Bypasses normalization and sandhi.
+        case bopomofoOverride(String)
     }
 
-    func segment(_ text: String) -> [Segment] {
+    /// Segmentation result: the segment list plus a side-channel of
+    /// polyphone candidates. Each candidate is a single-char `.pinyin`
+    /// segment whose underlying char has > 1 reading in the dict — the
+    /// g2pW pass can override `segments[segmentIdx]` by char position.
+    struct SegmentResult {
+        let segments: [Segment]
+        let polyphoneTargets: [PolyphoneTarget]
+    }
+
+    struct PolyphoneTarget {
+        let segmentIdx: Int
+        let charPos: Int
+    }
+
+    func segment(chars: [Character]) -> SegmentResult {
         var segments: [Segment] = []
-        let chars = Array(text)
+        var polyphoneTargets: [PolyphoneTarget] = []
         var i = 0
         let upperBound = max(2, dict.maxPhraseCharCount)
         var literalBuffer = ""
@@ -160,7 +223,7 @@ public struct MandarinG2P: Sendable {
                         let candidate = String(chars[i..<(i + len)])
                         if let pinyin = dict.phrases[candidate] {
                             flushLiteral()
-                            segments.append(.pinyin(pinyin))
+                            segments.append(.pinyin(pinyin, hanziCount: len))
                             i += len
                             matched = true
                             break
@@ -174,7 +237,11 @@ public struct MandarinG2P: Sendable {
             let scalar = ch.unicodeScalars.first
             if let scalar, let pinyin = dict.singles[scalar.value], !pinyin.isEmpty {
                 flushLiteral()
-                segments.append(.pinyin([pinyin[0]]))
+                if pinyin.count > 1 {
+                    polyphoneTargets.append(
+                        PolyphoneTarget(segmentIdx: segments.count, charPos: i))
+                }
+                segments.append(.pinyin([pinyin[0]], hanziCount: 1))
             } else {
                 // Unknown char (likely Bopomofo, fullwidth latin, an
                 // emoji, etc.). Pass through verbatim — KokoroAneVocab
@@ -184,7 +251,7 @@ public struct MandarinG2P: Sendable {
             i += 1
         }
         flushLiteral()
-        return segments
+        return SegmentResult(segments: segments, polyphoneTargets: polyphoneTargets)
     }
 
     // MARK: - Text normalization

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2P.swift
@@ -14,18 +14,20 @@ import Foundation
 ///      strategy — full jieba HMM is not ported.
 ///   3. **Diacritic → digit** — each pinyin syllable is normalized to
 ///      `(base, tone)` via `MandarinPinyinNormalizer`.
-///   4. **Tone sandhi** — 3+3 → 2+3, 不 / 一 contextual rules
+///   4. **Erhua merge** — `MandarinErhua.merge` folds trailing `儿`
+///      into the previous syllable so `小孩儿` emits a single
+///      r-coloured token (`ㄒㄧㄠ3ㄏㄞㄦ2`).
+///   5. **Tone sandhi** — 3+3 → 2+3, 不 / 一 contextual rules
 ///      (`MandarinToneSandhi`).
-///   5. **Pinyin → Bopomofo** — `MandarinBopomofoMap.encode` produces
+///   6. **Pinyin → Bopomofo** — `MandarinBopomofoMap.encode` produces
 ///      the final `<initial><final><digit>` string per syllable.
-///   6. **Concatenation** — syllables joined with no separator,
+///   7. **Concatenation** — syllables joined with no separator,
 ///      punctuation interleaved verbatim. The output is fed straight
 ///      into `KokoroAneVocab.encode`.
 ///
 /// Out of scope (deferred — a future PR can extend this without
 /// breaking callers):
 ///
-///   * Erhua merging (`儿` suffix collapse).
 ///   * POS-conditioned sandhi from `tone_sandhi.py`.
 ///   * Number / datetime / English-letter normalization
 ///     (`misaki.zh_normalization`).
@@ -52,9 +54,15 @@ public struct MandarinG2P: Sendable {
 
         func flushPending() {
             guard !pendingSyllables.isEmpty else { return }
+            // Order: erhua first (it shrinks the buffer), then sandhi
+            // operates on the merged result so 3+3 promotion sees the
+            // r-coloured syllable as a single tonal unit.
+            MandarinErhua.merge(&pendingSyllables)
             MandarinToneSandhi.apply(&pendingSyllables)
             for syl in pendingSyllables {
-                if let bo = MandarinBopomofoMap.encode(syllable: syl.base, tone: syl.tone) {
+                if let bo = MandarinBopomofoMap.encode(
+                    syllable: syl.base, tone: syl.tone, erhua: syl.erhua)
+                {
                     output.append(bo)
                 } else {
                     Self.logger.warning(

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2pwModel.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinG2pwModel.swift
@@ -1,0 +1,182 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Async wrapper around the int8 g2pW CoreML model that fixes
+/// polyphone pronunciations using sentence context.
+///
+/// The model is a BERT-base classifier that, given a tokenized sentence
+/// + the position of a single target Hanzi, outputs softmax logits over
+/// the global polyphone label set (~700 classes). The runtime applies
+/// the per-target phoneme mask from `MandarinPolyphoneCatalog` so the
+/// argmax can only land on a pronunciation valid for that character.
+///
+/// Inference is invoked one target at a time — batching is left for a
+/// future iteration once the round-trip CER benchmark shows a
+/// throughput-shaped bottleneck. For typical sentence lengths (≤ 60
+/// chars, ≤ 4 polyphones) this is comfortably below the speech budget.
+///
+/// Construction is deliberately tolerant of a missing model: callers
+/// can wire the pipeline with `g2pw == nil` and the segmenter falls
+/// back to the pinyin-dict path, exactly as it does today.
+public actor MandarinG2pwModel {
+
+    private let model: MLModel
+    private let tokenizer: MandarinBertTokenizer
+    private let catalog: MandarinPolyphoneCatalog
+    private let maxLength: Int
+    private static let logger = AppLogger(category: "MandarinG2pwModel")
+
+    /// Names of the model's input/output features. These match the
+    /// converted CoreML signature shipped at
+    /// `kokoro-82m-coreml/ANE-zh/g2pw/g2pw.mlmodelc`.
+    private enum Feature: String {
+        case inputIds = "input_ids"
+        case attentionMask = "attention_mask"
+        case tokenTypeIds = "token_type_ids"
+        case targetPosition = "target_position"
+        case logits
+    }
+
+    public enum InferenceError: Swift.Error, LocalizedError {
+        case missingOutput(String)
+        case shapeMismatch(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .missingOutput(let name):
+                return "g2pW model output '\(name)' is missing"
+            case .shapeMismatch(let what):
+                return "g2pW shape mismatch: \(what)"
+            }
+        }
+    }
+
+    public init(
+        model: MLModel,
+        tokenizer: MandarinBertTokenizer,
+        catalog: MandarinPolyphoneCatalog,
+        maxLength: Int = MandarinBertTokenizer.defaultMaxLength
+    ) {
+        self.model = model
+        self.tokenizer = tokenizer
+        self.catalog = catalog
+        self.maxLength = maxLength
+    }
+
+    /// Disambiguate `targets` (positions inside `chars`) using the
+    /// supplied sentence context. Returns a sparse map from target
+    /// position to the predicted bopomofo string.
+    ///
+    /// Targets that aren't polyphonic (per the catalog) are silently
+    /// dropped — the caller should already have filtered them, but a
+    /// belt-and-braces check keeps the contract honest.
+    public func disambiguate(
+        chars: [Character],
+        targets: [Int]
+    ) async throws -> [Int: String] {
+        guard !targets.isEmpty else { return [:] }
+
+        let encoded = tokenizer.encode(chars: chars, maxLength: maxLength)
+        var output: [Int: String] = [:]
+        for charIdx in targets {
+            guard charIdx >= 0, charIdx < chars.count else { continue }
+            guard charIdx < encoded.tokenPositionForChar.count else {
+                // Truncated past this target — fall back silently.
+                continue
+            }
+            let ch = chars[charIdx]
+            guard let candidates = catalog.candidates(for: ch),
+                !candidates.isEmpty
+            else { continue }
+
+            let tokenPos = encoded.tokenPositionForChar[charIdx]
+            let logits = try await runOne(
+                inputIds: encoded.inputIds,
+                attentionMask: encoded.attentionMask,
+                tokenTypeIds: encoded.tokenTypeIds,
+                targetPosition: tokenPos
+            )
+            // Pick the argmax over the candidate subset only — the rest
+            // of the softmax is masked out as if `-inf`.
+            var bestIdx = candidates[0]
+            var bestProb = -Float.infinity
+            for cand in candidates {
+                guard cand >= 0, cand < logits.count else { continue }
+                if logits[cand] > bestProb {
+                    bestProb = logits[cand]
+                    bestIdx = cand
+                }
+            }
+            if let bopo = catalog.bopomofo(forLabel: bestIdx) {
+                output[charIdx] = bopo
+            }
+        }
+        return output
+    }
+
+    /// Pack the inputs into MLMultiArrays, run the model, and pull the
+    /// (target_position-row of the) logits out as a `[Float]`.
+    private func runOne(
+        inputIds: [Int32],
+        attentionMask: [Int32],
+        tokenTypeIds: [Int32],
+        targetPosition: Int
+    ) async throws -> [Float] {
+        let length = inputIds.count
+        let inputIdsArr = try makeInt32Array(inputIds, shape: [1, length])
+        let attentionArr = try makeInt32Array(attentionMask, shape: [1, length])
+        let tokenTypeArr = try makeInt32Array(tokenTypeIds, shape: [1, length])
+        let positionArr = try makeInt32Array([Int32(targetPosition)], shape: [1])
+
+        let provider = try MLDictionaryFeatureProvider(dictionary: [
+            Feature.inputIds.rawValue: inputIdsArr,
+            Feature.attentionMask.rawValue: attentionArr,
+            Feature.tokenTypeIds.rawValue: tokenTypeArr,
+            Feature.targetPosition.rawValue: positionArr,
+        ])
+        let result = try await model.prediction(from: provider)
+        guard let logitsArr = result.featureValue(for: Feature.logits.rawValue)?.multiArrayValue
+        else {
+            throw InferenceError.missingOutput(Feature.logits.rawValue)
+        }
+        return Self.flatten(logitsArr)
+    }
+
+    private func makeInt32Array(_ values: [Int32], shape: [Int]) throws -> MLMultiArray {
+        let arr = try MLMultiArray(
+            shape: shape.map { NSNumber(value: $0) }, dataType: .int32)
+        let count = shape.reduce(1, *)
+        guard values.count == count else {
+            throw InferenceError.shapeMismatch(
+                "expected \(count) elements for shape \(shape), got \(values.count)")
+        }
+        // Direct memcpy via the typed pointer; faster than per-index
+        // assignment for the 512-element common case.
+        let ptr = arr.dataPointer.bindMemory(to: Int32.self, capacity: count)
+        values.withUnsafeBufferPointer { src in
+            ptr.update(from: src.baseAddress!, count: count)
+        }
+        return arr
+    }
+
+    private static func flatten(_ array: MLMultiArray) -> [Float] {
+        let count = array.count
+        var out = Array(repeating: Float(0), count: count)
+        switch array.dataType {
+        case .float32:
+            let ptr = array.dataPointer.bindMemory(to: Float.self, capacity: count)
+            for i in 0..<count { out[i] = ptr[i] }
+        case .float16:
+            // Fallback: walk indexes via subscripting. This keeps the
+            // wrapper independent of the float16 SIMD path that varies
+            // by deployment target.
+            for i in 0..<count { out[i] = array[i].floatValue }
+        case .double:
+            let ptr = array.dataPointer.bindMemory(to: Double.self, capacity: count)
+            for i in 0..<count { out[i] = Float(ptr[i]) }
+        default:
+            for i in 0..<count { out[i] = array[i].floatValue }
+        }
+        return out
+    }
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinJiebaHmm.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinJiebaHmm.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+/// Jieba's character-position HMM, ported as a standalone Viterbi
+/// decoder over the four B/M/E/S states.
+///
+/// Used by `MandarinG2P.segment(_:)` as a *post-pass* over runs of
+/// consecutive single-character lookups (i.e. characters the
+/// forward-maximum-match phrase dictionary did not cover). For modern
+/// proper nouns the FMM frequently misses — `特朗普`, `比亚迪`, `比特币`
+/// — and falls back to per-char lookups, breaking word boundaries and
+/// pushing polyphones onto their isolated-char readings instead of the
+/// (correct) compound reading. The HMM recovers those boundaries by
+/// scoring `argmax_path P(states | chars)` and reading off contiguous
+/// `B…E` / `S` spans.
+///
+/// The decoder is deterministic and stateless — a single instance is
+/// safe to share across threads/actors. Construction is cheap (no
+/// model weights beyond the `MandarinJiebaHmmTables` reference).
+public struct MandarinJiebaHmm: Sendable {
+
+    private let tables: MandarinJiebaHmmTables
+
+    /// Pre-computed list of valid predecessor states for each next
+    /// state, mirroring `PrevStatus` in `jieba.finalseg`. Encoding the
+    /// constraint that:
+    ///   * `B` and `S` can only follow `E` or `S` (a word must end
+    ///     before another word starts);
+    ///   * `M` and `E` can only follow `B` or `M` (must be inside a
+    ///     word that has already begun).
+    /// Without these constraints the decoder happily emits `B B` /
+    /// `E S` paths that produce nonsense splits.
+    private static let allowedPredecessors: [JiebaHmmState: [JiebaHmmState]] = [
+        .begin: [.end, .single],
+        .middle: [.middle, .begin],
+        .single: [.single, .end],
+        .end: [.begin, .middle],
+    ]
+
+    public init(tables: MandarinJiebaHmmTables) {
+        self.tables = tables
+    }
+
+    /// Run Viterbi on `text` and return the resulting word boundaries
+    /// as substrings (preserving `Character` granularity).
+    ///
+    /// Behaviour notes:
+    ///   * Empty input → empty output.
+    ///   * Single-char input → one one-char word (HMM bypassed).
+    ///   * The output concatenates back to the input verbatim — useful
+    ///     invariant to assert in tests.
+    public func segment(_ text: String) -> [String] {
+        let chars = Array(text)
+        switch chars.count {
+        case 0: return []
+        case 1: return [String(chars[0])]
+        default: break
+        }
+
+        let states = JiebaHmmState.allCases
+        let stateCount = states.count
+
+        // Viterbi tables: viterbi[t][s] = best log-prob to reach state
+        // s at position t; path[t][s] = the predecessor state on that
+        // path.
+        var viterbi = Array(
+            repeating: Array(repeating: -Double.infinity, count: stateCount),
+            count: chars.count)
+        var path = Array(
+            repeating: Array(repeating: 0, count: stateCount),
+            count: chars.count)
+
+        // t = 0: only `begin` and `single` can start a sentence
+        // (`middle` / `end` require a predecessor inside a word). Match
+        // jieba's `start` matrix semantics directly — start[middle] /
+        // start[end] are -inf upstream anyway, but the explicit
+        // short-circuit keeps the path tables honest.
+        let firstEmit = emission(for: chars[0])
+        for (idx, state) in states.enumerated() {
+            switch state {
+            case .begin, .single:
+                viterbi[0][idx] = tables.start[idx] + firstEmit[idx]
+            case .middle, .end:
+                viterbi[0][idx] = -Double.infinity
+            }
+            path[0][idx] = idx
+        }
+
+        // t > 0: standard Viterbi, restricted to the allowed
+        // predecessors per next state.
+        for t in 1..<chars.count {
+            let emit = emission(for: chars[t])
+            for (toIdx, toState) in states.enumerated() {
+                let predecessors = Self.allowedPredecessors[toState] ?? states
+                var bestProb = -Double.infinity
+                var bestFrom = predecessors.first?.rawValue ?? 0
+                for from in predecessors {
+                    let prevProb = viterbi[t - 1][from.rawValue]
+                    let candidate =
+                        prevProb + tables.trans[from.rawValue][toIdx] + emit[toIdx]
+                    if candidate > bestProb {
+                        bestProb = candidate
+                        bestFrom = from.rawValue
+                    }
+                }
+                viterbi[t][toIdx] = bestProb
+                path[t][toIdx] = bestFrom
+            }
+        }
+
+        // Backtrack from the more probable terminal state. Only `end`
+        // and `single` are valid sentence-final states; picking the
+        // better one mirrors `jieba.finalseg.viterbi`.
+        let lastIdx = chars.count - 1
+        let endProb = viterbi[lastIdx][JiebaHmmState.end.rawValue]
+        let singleProb = viterbi[lastIdx][JiebaHmmState.single.rawValue]
+        var current =
+            endProb >= singleProb
+            ? JiebaHmmState.end.rawValue : JiebaHmmState.single.rawValue
+
+        var assignments = Array(repeating: 0, count: chars.count)
+        assignments[lastIdx] = current
+        var t = lastIdx
+        while t > 0 {
+            current = path[t][current]
+            assignments[t - 1] = current
+            t -= 1
+        }
+
+        // Read off contiguous begin…end and single spans into word
+        // slices. Anything unexpected (e.g. middle without a preceding
+        // begin due to a degenerate transition matrix in tests) is
+        // conservatively closed.
+        var words: [String] = []
+        var wordStart = 0
+        for i in 0..<chars.count {
+            let state = JiebaHmmState(rawValue: assignments[i]) ?? .single
+            switch state {
+            case .single:
+                words.append(String(chars[i]))
+                wordStart = i + 1
+            case .end:
+                words.append(String(chars[wordStart...i]))
+                wordStart = i + 1
+            case .begin, .middle:
+                continue
+            }
+        }
+        // Tail flush: if the path ended mid-word (begin or middle
+        // without a following end), emit the remainder as a single
+        // word so the output still concatenates back to the input.
+        if wordStart < chars.count {
+            words.append(String(chars[wordStart..<chars.count]))
+        }
+        return words
+    }
+
+    /// Look up the emission row for `ch`, falling back to the uniform
+    /// "unknown character" log-prob row when the char isn't in the
+    /// trained vocabulary.
+    @inline(__always)
+    private func emission(for ch: Character) -> [Double] {
+        if let row = tables.emit[ch] { return row }
+        return Array(
+            repeating: MandarinJiebaHmmTables.unknownCharLogProb,
+            count: JiebaHmmState.allCases.count)
+    }
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinJiebaTables.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinJiebaTables.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+/// Binary loader for the jieba HMM tables shipped at
+/// `FluidInference/kokoro-82m-coreml/ANE-zh/assets/`.
+///
+/// The Python jieba project distributes its character HMM as three text
+/// files (`prob_start.py`, `prob_trans.py`, `prob_emit.py`). Those are
+/// pre-converted to compact little-endian binary by a one-shot mobius
+/// script so the runtime cost is a `Data(contentsOf:)` plus a linear
+/// parse — no Python interpreter at startup.
+///
+/// Wire format for the three artefacts:
+///
+///   * `jieba_hmm_start.bin` — 4 × `Float32_LE`. The fixed B/M/E/S state
+///     order matches `jieba.finalseg.prob_start.P`.
+///
+///   * `jieba_hmm_trans.bin` — 16 × `Float32_LE`. Row-major 4×4 with the
+///     same B/M/E/S order on both axes (`trans[from*4 + to]`).
+///
+///   * `jieba_hmm_emit.bin` — repeat:
+///     ```
+///     u32_le  unicode codepoint of the emitting character
+///     4×f32_le  log-prob for B / M / E / S
+///     ```
+///     Codepoints are written in arbitrary order; the loader builds a
+///     dictionary keyed by `Character` for O(1) lookups.
+///
+/// Log-probs are natural log; the Viterbi decoder sums them additively.
+/// Codepoints absent from `emit` are treated as having a uniform
+/// log-prob of `MandarinJiebaHmmTables.unknownCharLogProb` (≈ -3.14e+38),
+/// preventing the decoder from getting stuck on OOV characters while
+/// still strongly preferring the trained vocabulary.
+public struct MandarinJiebaHmmTables: Sendable {
+
+    /// Start log-probabilities, indexed by `JiebaHmmState.rawValue`.
+    public let start: [Double]
+    /// Transition log-probabilities, `trans[from][to]`. Always 4×4.
+    public let trans: [[Double]]
+    /// Emission log-probabilities, keyed by character. Each value is a
+    /// length-4 array indexed by `JiebaHmmState.rawValue`.
+    public let emit: [Character: [Double]]
+
+    /// Sentinel log-prob for characters not present in `emit`. Picked to
+    /// be effectively negative infinity without overflowing addition.
+    public static let unknownCharLogProb: Double = -3.14e38
+
+    public init(
+        start: [Double],
+        trans: [[Double]],
+        emit: [Character: [Double]]
+    ) {
+        precondition(
+            start.count == JiebaHmmState.allCases.count,
+            "start must have one log-prob per HMM state")
+        precondition(
+            trans.count == JiebaHmmState.allCases.count
+                && trans.allSatisfy { $0.count == JiebaHmmState.allCases.count },
+            "trans must be a 4×4 matrix indexed by JiebaHmmState")
+        self.start = start
+        self.trans = trans
+        self.emit = emit
+    }
+
+    public enum LoadError: Swift.Error, LocalizedError {
+        case truncated(String)
+        case wrongSize(String, expected: Int, actual: Int)
+
+        public var errorDescription: String? {
+            switch self {
+            case .truncated(let what):
+                return "Jieba HMM table \(what) is truncated"
+            case .wrongSize(let what, let expected, let actual):
+                return "Jieba HMM table \(what) has size \(actual) bytes, expected \(expected)"
+            }
+        }
+    }
+
+    /// Load all three tables from the directory that holds them.
+    /// Convenience wrapper for the typical KokoroAneModelStore call site.
+    public static func load(directory: URL) throws -> MandarinJiebaHmmTables {
+        let startURL = directory.appendingPathComponent(
+            KokoroAneConstants.jiebaHmmStartFile)
+        let transURL = directory.appendingPathComponent(
+            KokoroAneConstants.jiebaHmmTransFile)
+        let emitURL = directory.appendingPathComponent(
+            KokoroAneConstants.jiebaHmmEmitFile)
+        let startData = try Data(contentsOf: startURL)
+        let transData = try Data(contentsOf: transURL)
+        let emitData = try Data(contentsOf: emitURL)
+        return try MandarinJiebaHmmTables(
+            startData: startData,
+            transData: transData,
+            emitData: emitData
+        )
+    }
+
+    /// Construct from raw `Data` payloads — split out from `load(directory:)`
+    /// so tests can synthesise tables in-memory without touching the disk.
+    public init(startData: Data, transData: Data, emitData: Data) throws {
+        let stateCount = JiebaHmmState.allCases.count
+
+        // start: 4 floats
+        let startBytes = stateCount * MemoryLayout<Float32>.size
+        guard startData.count == startBytes else {
+            throw LoadError.wrongSize(
+                "start", expected: startBytes, actual: startData.count)
+        }
+        var start: [Double] = []
+        start.reserveCapacity(stateCount)
+        for i in 0..<stateCount {
+            start.append(Double(Self.readFloatLE(startData, at: i * 4)))
+        }
+
+        // trans: 16 floats, row-major
+        let transBytes = stateCount * stateCount * MemoryLayout<Float32>.size
+        guard transData.count == transBytes else {
+            throw LoadError.wrongSize(
+                "trans", expected: transBytes, actual: transData.count)
+        }
+        var trans: [[Double]] = Array(
+            repeating: Array(repeating: 0.0, count: stateCount), count: stateCount)
+        for from in 0..<stateCount {
+            for to in 0..<stateCount {
+                let offset = (from * stateCount + to) * 4
+                trans[from][to] = Double(Self.readFloatLE(transData, at: offset))
+            }
+        }
+
+        // emit: stream of (u32 codepoint, 4×f32 logprobs)
+        let recordSize = 4 + stateCount * MemoryLayout<Float32>.size
+        guard emitData.count % recordSize == 0 else {
+            throw LoadError.truncated("emit (size not a multiple of \(recordSize))")
+        }
+        var emit: [Character: [Double]] = [:]
+        emit.reserveCapacity(emitData.count / recordSize)
+        var pos = 0
+        while pos < emitData.count {
+            let cp = Self.readUInt32LE(emitData, at: pos)
+            pos += 4
+            guard let scalar = Unicode.Scalar(cp) else {
+                throw LoadError.truncated("emit codepoint U+\(String(cp, radix: 16))")
+            }
+            var logProbs: [Double] = []
+            logProbs.reserveCapacity(stateCount)
+            for _ in 0..<stateCount {
+                logProbs.append(Double(Self.readFloatLE(emitData, at: pos)))
+                pos += 4
+            }
+            emit[Character(scalar)] = logProbs
+        }
+
+        self.init(start: start, trans: trans, emit: emit)
+    }
+
+    @inline(__always)
+    private static func readUInt32LE(_ data: Data, at offset: Int) -> UInt32 {
+        UInt32(data[data.startIndex + offset])
+            | (UInt32(data[data.startIndex + offset + 1]) << 8)
+            | (UInt32(data[data.startIndex + offset + 2]) << 16)
+            | (UInt32(data[data.startIndex + offset + 3]) << 24)
+    }
+
+    @inline(__always)
+    private static func readFloatLE(_ data: Data, at offset: Int) -> Float32 {
+        let bits = readUInt32LE(data, at: offset)
+        return Float32(bitPattern: bits)
+    }
+
+    /// Encode the in-memory tables back to the binary wire format. Used
+    /// by tests to round-trip a synthetic fixture through the loader.
+    public func encoded() -> (start: Data, trans: Data, emit: Data) {
+        let stateCount = JiebaHmmState.allCases.count
+
+        var startData = Data(capacity: stateCount * 4)
+        for v in start {
+            var bits = Float32(v).bitPattern
+            withUnsafeBytes(of: &bits) { startData.append(contentsOf: $0) }
+        }
+
+        var transData = Data(capacity: stateCount * stateCount * 4)
+        for row in trans {
+            for v in row {
+                var bits = Float32(v).bitPattern
+                withUnsafeBytes(of: &bits) { transData.append(contentsOf: $0) }
+            }
+        }
+
+        var emitData = Data(capacity: emit.count * (4 + stateCount * 4))
+        // Iterate in deterministic order (codepoint ascending) so two
+        // encoders produce byte-identical output for the same logical
+        // table. Important for snapshot tests.
+        let sorted = emit.sorted { lhs, rhs in
+            (lhs.key.unicodeScalars.first?.value ?? 0)
+                < (rhs.key.unicodeScalars.first?.value ?? 0)
+        }
+        for (ch, logProbs) in sorted {
+            guard let scalar = ch.unicodeScalars.first else { continue }
+            var cp = scalar.value
+            withUnsafeBytes(of: &cp) { emitData.append(contentsOf: $0) }
+            for v in logProbs {
+                var bits = Float32(v).bitPattern
+                withUnsafeBytes(of: &bits) { emitData.append(contentsOf: $0) }
+            }
+        }
+        return (startData, transData, emitData)
+    }
+}
+
+/// HMM hidden states for jieba's character-position tagger.
+///
+/// State semantics (per `jieba.finalseg`):
+///
+///   * `begin`  — first character of a multi-char word.
+///   * `middle` — interior character of a 3+ char word.
+///   * `end`    — final character of a multi-char word.
+///   * `single` — a one-character word.
+///
+/// `rawValue` doubles as the stable index used by every table in this
+/// file, so reordering this enum would re-interpret the binary tables
+/// (the index order matches the original jieba `B/M/E/S` enumeration).
+public enum JiebaHmmState: Int, CaseIterable, Sendable {
+    case begin = 0
+    case middle = 1
+    case end = 2
+    case single = 3
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinPinyinNormalizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinPinyinNormalizer.swift
@@ -18,10 +18,15 @@ public enum MandarinPinyinNormalizer {
     public struct Syllable: Equatable, Sendable {
         public var base: String  // ASCII letters only, with `ü` → `v`.
         public var tone: Int  // 1…4 = explicit, 5 = neutral / unmarked.
+        /// Whether this syllable has absorbed a trailing `儿` (erhua).
+        /// Set by `MandarinErhua.merge`; consumed by
+        /// `MandarinBopomofoMap.encode` to append the `ㄦ` suffix.
+        public var erhua: Bool
 
-        public init(base: String, tone: Int) {
+        public init(base: String, tone: Int, erhua: Bool = false) {
             self.base = base
             self.tone = tone
+            self.erhua = erhua
         }
     }
 

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinPolyphoneCatalog.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/Mandarin/MandarinPolyphoneCatalog.swift
@@ -1,0 +1,179 @@
+import Foundation
+
+/// Loader / lookup for `POLYPHONIC_CHARS.txt`, the pronunciation
+/// inventory the g2pW model is conditioned on.
+///
+/// File format (matches `g2pw/data/POLYPHONIC_CHARS.txt` upstream):
+///
+/// ```
+/// <hanzi>\t<bopomofo_with_tone>
+/// ```
+///
+/// One row per (char, valid-pronunciation) pair. Multiple rows for the
+/// same char enumerate its allowed phonemes:
+///
+/// ```
+/// 行    ㄒㄧㄥˊ
+/// 行    ㄏㄤˊ
+/// 行    ㄒㄧㄥˋ
+/// ```
+///
+/// The model emits a softmax over the global label set; only the
+/// indices in `candidates(for:)` are valid for a given target char,
+/// so the runtime applies that subset as a phoneme mask before
+/// argmax-ing.
+public struct MandarinPolyphoneCatalog: Sendable {
+
+    /// All characters that have ≥ 2 pronunciations, in the order they
+    /// first appear in the file. Used by the model as the target-char
+    /// vocabulary (a char index maps to the row index here).
+    public let chars: [Character]
+    /// Sorted-unique list of every bopomofo label that appears in the
+    /// file. The model's output dimension equals `labels.count`.
+    public let labels: [String]
+    /// Per-char index into `labels` for each valid pronunciation.
+    /// Empty array means the char is not polyphonic and should not be
+    /// routed through g2pW.
+    public let candidatesByChar: [Character: [Int]]
+    /// Convenience reverse map for chars → catalog index.
+    public let charIndex: [Character: Int]
+
+    public enum LoadError: Swift.Error, LocalizedError {
+        case malformed(String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .malformed(let what):
+                return "POLYPHONIC_CHARS.txt parse error: \(what)"
+            }
+        }
+    }
+
+    public static func load(fileURL: URL) throws -> MandarinPolyphoneCatalog {
+        let raw = try String(contentsOf: fileURL, encoding: .utf8)
+        return try MandarinPolyphoneCatalog(text: raw)
+    }
+
+    /// Parse from an in-memory string. Empty / blank / `#`-comment lines
+    /// are skipped to keep the file format permissive.
+    public init(text: String) throws {
+        var seenChars: [Character] = []
+        var seenCharSet: Set<Character> = []
+        var labelSet: Set<String> = []
+        var candidatesRaw: [Character: [String]] = [:]
+
+        // Split on unicode scalars rather than `Character`s — Swift
+        // merges `\r\n` into a single grapheme cluster, which would
+        // hide the line break from a `Character`-level splitter and
+        // cause the entire CRLF file to be treated as one row.
+        for rawLine in text.unicodeScalars.split(
+            omittingEmptySubsequences: true,
+            whereSeparator: { $0 == "\n" || $0 == "\r" })
+        {
+            let line = String(String.UnicodeScalarView(rawLine))
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
+
+            // Tolerate one or more whitespace characters as separator
+            // (the upstream file uses TAB, but a sanitised copy may use
+            // spaces — both are unambiguous because Hanzi never contain
+            // ASCII whitespace).
+            let parts = trimmed.split(
+                maxSplits: 1, omittingEmptySubsequences: true,
+                whereSeparator: { $0 == "\t" || $0 == " " })
+            guard parts.count == 2 else {
+                throw LoadError.malformed(
+                    "expected '<hanzi><sep><bopomofo>', got '\(trimmed)'")
+            }
+            let charStr = String(parts[0])
+            guard charStr.count == 1, let ch = charStr.first else {
+                throw LoadError.malformed(
+                    "expected single hanzi in column 1, got '\(charStr)'")
+            }
+            let label = String(parts[1]).trimmingCharacters(in: .whitespaces)
+            if label.isEmpty {
+                throw LoadError.malformed("empty bopomofo for '\(charStr)'")
+            }
+
+            if !seenCharSet.contains(ch) {
+                seenChars.append(ch)
+                seenCharSet.insert(ch)
+            }
+            labelSet.insert(label)
+            candidatesRaw[ch, default: []].append(label)
+        }
+
+        let labels = labelSet.sorted()
+        let labelToIndex: [String: Int] = Dictionary(
+            uniqueKeysWithValues: labels.enumerated().map { ($1, $0) })
+
+        var candidatesByChar: [Character: [Int]] = [:]
+        candidatesByChar.reserveCapacity(candidatesRaw.count)
+        for (ch, list) in candidatesRaw {
+            // Preserve input order, dedupe (some upstream rows are
+            // duplicated — a parse-time dedup keeps the mask compact).
+            var seen: Set<Int> = []
+            var indices: [Int] = []
+            for label in list {
+                guard let idx = labelToIndex[label] else { continue }
+                if seen.insert(idx).inserted { indices.append(idx) }
+            }
+            candidatesByChar[ch] = indices
+        }
+
+        self.chars = seenChars
+        self.labels = labels
+        self.candidatesByChar = candidatesByChar
+        self.charIndex = Dictionary(
+            uniqueKeysWithValues: seenChars.enumerated().map { ($1, $0) })
+    }
+
+    /// Allowed label indices for `char`, or `nil` when the char isn't
+    /// in the polyphone vocabulary (the caller should fall back to the
+    /// pinyin dict in that case).
+    public func candidates(for char: Character) -> [Int]? {
+        candidatesByChar[char]
+    }
+
+    /// Reverse lookup: bopomofo string for a given label index.
+    public func bopomofo(forLabel idx: Int) -> String? {
+        guard idx >= 0, idx < labels.count else { return nil }
+        return labels[idx]
+    }
+
+    /// Reverse lookup as the digit-suffixed form used by the v1.1-zh
+    /// vocab (`MandarinBopomofoMap.encode` output style).
+    ///
+    /// Converts the trailing tone diacritic (`ˊ` / `ˇ` / `ˋ` / `˙`) to
+    /// the numeric tone digit (`2` / `3` / `4` / `5`); a missing
+    /// diacritic implies tone `1`. The model's labels are stored in
+    /// the upstream diacritic form so the table matches the source
+    /// data verbatim — the conversion happens at emission so callers
+    /// see a string they can append straight into the phoneme buffer.
+    public func bopomofoDigitForm(forLabel idx: Int) -> String? {
+        guard let raw = bopomofo(forLabel: idx) else { return nil }
+        return Self.toneDigitForm(raw)
+    }
+
+    /// Convert `<bopomofo><diacritic?>` → `<bopomofo><digit>`. Public
+    /// so callers (and tests) can run the conversion without holding a
+    /// catalog instance.
+    public static func toneDigitForm(_ bopomofo: String) -> String {
+        guard let last = bopomofo.last else { return bopomofo }
+        switch last {
+        case "ˊ":
+            return String(bopomofo.dropLast()) + "2"
+        case "ˇ":
+            return String(bopomofo.dropLast()) + "3"
+        case "ˋ":
+            return String(bopomofo.dropLast()) + "4"
+        case "˙":
+            return String(bopomofo.dropLast()) + "5"
+        default:
+            // No diacritic — implicit tone 1. The upstream catalog
+            // never emits a literal `ˉ` so this branch is the common
+            // case for first-tone polyphones.
+            return bopomofo + "1"
+        }
+    }
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
@@ -65,6 +65,28 @@ public enum KokoroAneConstants {
     /// 7 mlmodelc bundles already in this repo).
     public static let g2pPinyinSingleRemoteFile = "pinyin_single.bin"
     public static let g2pPinyinPhrasesRemoteFile = "pinyin_phrases.bin"
+
+    // MARK: - Mandarin g2pW polyphone disambiguator
+
+    /// Local subdirectory (relative to the cached `ANE-zh/` repo dir) for
+    /// the g2pW BERT classifier + its tokenizer / catalog assets.
+    public static let g2pwSubdir = "g2pw"
+
+    /// Compiled CoreML bundle name. Matches the upstream HF folder.
+    public static let g2pwModelBundle = "g2pw.mlmodelc"
+
+    /// `bert-base-chinese` vocab co-located with the model.
+    public static let g2pwVocabFile = "vocab.txt"
+
+    /// Per-character allowed-phoneme map shipped alongside the model.
+    public static let g2pwPolyphonicCharsFile = "POLYPHONIC_CHARS.txt"
+
+    /// Subdirectory inside `g2pRemoteRepo` containing the g2pW assets.
+    public static let g2pwRemoteSubdir = "ANE-zh/g2pw"
+
+    /// Remote artefact filenames (mirrors the local names — no rename).
+    public static let g2pwVocabRemoteFile = "vocab.txt"
+    public static let g2pwPolyphonicCharsRemoteFile = "POLYPHONIC_CHARS.txt"
 }
 
 /// Language variant of the laishere/kokoro 7-stage CoreML chain.

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
@@ -65,6 +65,23 @@ public enum KokoroAneConstants {
     /// 7 mlmodelc bundles already in this repo).
     public static let g2pPinyinSingleRemoteFile = "pinyin_single.bin"
     public static let g2pPinyinPhrasesRemoteFile = "pinyin_phrases.bin"
+
+    // MARK: - Jieba HMM tables
+
+    /// Local filenames for the three jieba HMM tables (start /
+    /// transition / emission), cached alongside the pinyin dicts under
+    /// `<repoDir>/g2p/`. Format documented on
+    /// `MandarinJiebaHmmTables`.
+    public static let jiebaHmmStartFile = "jieba_hmm_start.bin"
+    public static let jiebaHmmTransFile = "jieba_hmm_trans.bin"
+    public static let jiebaHmmEmitFile = "jieba_hmm_emit.bin"
+
+    /// Remote artefact names — uploaded to the same `ANE-zh/assets/`
+    /// folder as the pinyin dicts. Combined size is ≈ 3 MB (emit table
+    /// dominates; ~7 800 codepoints × 16 bytes plus headers).
+    public static let jiebaHmmStartRemoteFile = "jieba_hmm_start.bin"
+    public static let jiebaHmmTransRemoteFile = "jieba_hmm_trans.bin"
+    public static let jiebaHmmEmitRemoteFile = "jieba_hmm_emit.bin"
 }
 
 /// Language variant of the laishere/kokoro 7-stage CoreML chain.

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -136,7 +136,7 @@ public actor KokoroAneManager {
             try await store.loadIfNeeded()
             if MandarinG2P.looksLikeHanzi(text) {
                 let g2p = try await store.mandarinG2PPipeline()
-                phonemes = try g2p.phonemize(text)
+                phonemes = try await g2p.phonemize(text)
             } else {
                 // No Hanzi present → caller already supplied bopomofo /
                 // ASCII punctuation. Pass through so power users can

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
@@ -198,9 +198,17 @@ public actor KokoroAneModelStore {
     }
 
     /// Lazy-load and cache the Mandarin G2P pipeline (binary dicts +
-    /// bopomofo mapper). Only used by ``KokoroAneVariant/mandarin``.
-    /// Idempotent within a single store lifetime; the dict is held by
-    /// value so cleanup() drops it cleanly.
+    /// bopomofo mapper, optional jieba HMM). Only used by
+    /// ``KokoroAneVariant/mandarin``. Idempotent within a single store
+    /// lifetime; cached values are held by value so cleanup() drops
+    /// them cleanly.
+    ///
+    /// The jieba HMM tables are best-effort: if their HuggingFace
+    /// artefacts are unavailable (404 / network error) the pipeline
+    /// silently falls back to the FMM + per-char-singles path. The
+    /// Mandarin variant stays fully functional in that mode — HMM is
+    /// a quality booster for OOV proper-noun boundaries, not a hard
+    /// dependency.
     public func mandarinG2PPipeline() async throws -> MandarinG2P {
         if let g2p = mandarinG2P { return g2p }
         guard variant == .mandarin else {
@@ -218,10 +226,32 @@ public actor KokoroAneModelStore {
             KokoroAneConstants.g2pPinyinSingleFile)
         let dict = try MandarinPinyinDict.load(
             singlesURL: singlesURL, phrasesURL: phrasesURL)
-        let pipeline = MandarinG2P(dict: dict)
+
+        // Best-effort jieba HMM. ensureMandarinJiebaHmm returns nil
+        // when any artefact is missing (no throw); table-loader
+        // failures are also caught here so a corrupt cache doesn't
+        // break the pipeline outright.
+        var jiebaHmm: MandarinJiebaHmm? = nil
+        if let hmmDir = await KokoroAneResourceDownloader.ensureMandarinJiebaHmm(
+            repoDirectory: repoDir)
+        {
+            do {
+                let tables = try MandarinJiebaHmmTables.load(directory: hmmDir)
+                jiebaHmm = MandarinJiebaHmm(tables: tables)
+                logger.info(
+                    "Loaded jieba HMM tables (emit chars=\(tables.emit.count))")
+            } catch {
+                logger.warning(
+                    "Jieba HMM tables failed to parse "
+                        + "(\(error.localizedDescription)); HMM segmentation disabled.")
+            }
+        }
+
+        let pipeline = MandarinG2P(dict: dict, jiebaHmm: jiebaHmm)
         mandarinG2P = pipeline
         logger.info(
-            "Loaded Mandarin G2P (phrases=\(dict.phrases.count), singles=\(dict.singles.count))"
+            "Loaded Mandarin G2P (phrases=\(dict.phrases.count), "
+                + "singles=\(dict.singles.count), jieba=\(jiebaHmm != nil))"
         )
         return pipeline
     }

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
@@ -218,12 +218,45 @@ public actor KokoroAneModelStore {
             KokoroAneConstants.g2pPinyinSingleFile)
         let dict = try MandarinPinyinDict.load(
             singlesURL: singlesURL, phrasesURL: phrasesURL)
-        let pipeline = MandarinG2P(dict: dict)
+        let g2pw = await loadG2pwIfAvailable(repoDirectory: repoDir)
+        let pipeline = MandarinG2P(dict: dict, g2pw: g2pw)
         mandarinG2P = pipeline
         logger.info(
-            "Loaded Mandarin G2P (phrases=\(dict.phrases.count), singles=\(dict.singles.count))"
+            "Loaded Mandarin G2P (phrases=\(dict.phrases.count), "
+                + "singles=\(dict.singles.count), g2pw=\(g2pw == nil ? "off" : "on"))"
         )
         return pipeline
+    }
+
+    /// Best-effort load of the g2pW polyphone disambiguator. Returns
+    /// `nil` (and logs) when the assets are missing or fail to load,
+    /// so the Mandarin G2P pipeline can keep running on the dict
+    /// alone.
+    private func loadG2pwIfAvailable(repoDirectory: URL) async -> MandarinG2pwModel? {
+        guard
+            let g2pwDir = await KokoroAneResourceDownloader.ensureMandarinG2pw(
+                repoDirectory: repoDirectory)
+        else { return nil }
+
+        let vocabURL = g2pwDir.appendingPathComponent(KokoroAneConstants.g2pwVocabFile)
+        let polyURL = g2pwDir.appendingPathComponent(
+            KokoroAneConstants.g2pwPolyphonicCharsFile)
+        let modelURL = g2pwDir.appendingPathComponent(KokoroAneConstants.g2pwModelBundle)
+
+        do {
+            let tokenizer = try MandarinBertTokenizer.load(vocabURL: vocabURL)
+            let catalog = try MandarinPolyphoneCatalog.load(fileURL: polyURL)
+            let config = MLModelConfiguration()
+            config.computeUnits = .cpuAndNeuralEngine
+            let model = try MLModel(contentsOf: modelURL, configuration: config)
+            return MandarinG2pwModel(
+                model: model, tokenizer: tokenizer, catalog: catalog)
+        } catch {
+            logger.info(
+                "g2pW load failed (\(error.localizedDescription)) — "
+                    + "Mandarin G2P will run dict-only")
+            return nil
+        }
     }
 
     public func cleanup() {

--- a/Tests/FluidAudioTests/TTS/KokoroAne/MandarinBertTokenizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/MandarinBertTokenizerTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Network-free tests for the char-level WordPiece tokenizer used by
+/// the g2pW polyphone disambiguator. The tokenizer only needs to feed
+/// Hanzi targets through `bert-base-chinese`'s vocab, so the
+/// implementation skips subword merges and these tests validate the
+/// thin char-level path.
+final class MandarinBertTokenizerTests: XCTestCase {
+
+    /// Build a minimal vocab matching the BERT layout: special tokens
+    /// at fixed ids matching `bert-base-chinese`, then a handful of
+    /// real Hanzi for the encode tests.
+    private static func smallVocab() -> [String: Int32] {
+        var v: [String: Int32] = [:]
+        v["[PAD]"] = 0
+        v["[UNK]"] = 100
+        v["[CLS]"] = 101
+        v["[SEP]"] = 102
+        v["[MASK]"] = 103
+        v["你"] = 200
+        v["好"] = 201
+        v["行"] = 202
+        v["人"] = 203
+        return v
+    }
+
+    func testInitRejectsMissingSpecialTokens() {
+        var v = Self.smallVocab()
+        v.removeValue(forKey: "[CLS]")
+        XCTAssertThrowsError(try MandarinBertTokenizer(vocab: v)) { err in
+            guard let e = err as? MandarinBertTokenizer.LoadError,
+                case .missingSpecialToken(let name) = e
+            else {
+                XCTFail("Expected missingSpecialToken, got \(err)")
+                return
+            }
+            XCTAssertEqual(name, "[CLS]")
+        }
+    }
+
+    func testEncodesCharSequenceAndPositions() throws {
+        let tok = try MandarinBertTokenizer(vocab: Self.smallVocab())
+        let encoded = tok.encode(chars: ["你", "好"], maxLength: 8)
+        XCTAssertEqual(
+            encoded.inputIds,
+            [101, 200, 201, 102, 0, 0, 0, 0])
+        XCTAssertEqual(
+            encoded.attentionMask,
+            [1, 1, 1, 1, 0, 0, 0, 0])
+        XCTAssertEqual(
+            encoded.tokenTypeIds,
+            [0, 0, 0, 0, 0, 0, 0, 0])
+        // Char[0] lands at index 1 (right after [CLS]); Char[1] at 2.
+        XCTAssertEqual(encoded.tokenPositionForChar, [1, 2])
+    }
+
+    func testUnknownCharFallsBackToUnk() throws {
+        let tok = try MandarinBertTokenizer(vocab: Self.smallVocab())
+        // 鵝 isn't in our miniature vocab — should encode as [UNK].
+        let encoded = tok.encode(chars: ["鵝"], maxLength: 4)
+        XCTAssertEqual(encoded.inputIds, [101, 100, 102, 0])
+        XCTAssertEqual(encoded.attentionMask, [1, 1, 1, 0])
+    }
+
+    func testTruncationFromTheRight() throws {
+        let tok = try MandarinBertTokenizer(vocab: Self.smallVocab())
+        // maxLength=4 leaves room for 2 chars between [CLS] and [SEP].
+        let encoded = tok.encode(
+            chars: ["你", "好", "行", "人"], maxLength: 4)
+        XCTAssertEqual(encoded.inputIds, [101, 200, 201, 102])
+        XCTAssertEqual(encoded.attentionMask, [1, 1, 1, 1])
+        // Only the first two chars get a tracked position; the
+        // remainder are dropped, so the position list is shorter than
+        // the original input.
+        XCTAssertEqual(encoded.tokenPositionForChar, [1, 2])
+    }
+
+    func testMaxLengthPreconditionEnforced() throws {
+        // maxLength == 1 leaves no room for [CLS] + [SEP]; the encode
+        // helper requires at least 2.
+        // (This is checked by precondition, not throw, so we only
+        // exercise the boundary value of 2 here.)
+        let tok = try MandarinBertTokenizer(vocab: Self.smallVocab())
+        let encoded = tok.encode(chars: [], maxLength: 2)
+        XCTAssertEqual(encoded.inputIds, [101, 102])
+        XCTAssertEqual(encoded.attentionMask, [1, 1])
+        XCTAssertEqual(encoded.tokenPositionForChar, [])
+    }
+
+    func testLoadFromTextFile() throws {
+        // `vocab.txt` semantics: line index = token id. Synthesise a
+        // tiny file in a temp dir and round-trip through `load`.
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MandarinBertTokenizerTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let url = tmpDir.appendingPathComponent("vocab.txt")
+        // Pad with placeholder tokens so [CLS]/[SEP]/[PAD]/[UNK] land
+        // at the canonical bert-base-chinese ids (0/100/101/102) — the
+        // test only needs the special tokens to resolve, not match
+        // upstream id-to-id.
+        var lines: [String] = ["[PAD]"]
+        for i in 1...99 { lines.append("[reserved_\(i)]") }
+        lines.append("[UNK]")
+        lines.append("[CLS]")
+        lines.append("[SEP]")
+        lines.append("你")
+        lines.append("好")
+        try lines.joined(separator: "\n").write(
+            to: url, atomically: true, encoding: .utf8)
+
+        let tok = try MandarinBertTokenizer.load(vocabURL: url)
+        XCTAssertEqual(tok.padId, 0)
+        XCTAssertEqual(tok.unkId, 100)
+        XCTAssertEqual(tok.clsId, 101)
+        XCTAssertEqual(tok.sepId, 102)
+        let encoded = tok.encode(chars: ["你", "好"], maxLength: 4)
+        XCTAssertEqual(encoded.inputIds, [101, 103, 104, 102])
+    }
+
+    func testTrailingNewlineDoesNotAddBlankToken() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MandarinBertTokenizerTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let url = tmpDir.appendingPathComponent("vocab.txt")
+        var lines: [String] = ["[PAD]"]
+        for i in 1...99 { lines.append("x_\(i)") }
+        lines.append("[UNK]")
+        lines.append("[CLS]")
+        lines.append("[SEP]")
+        // Leave a trailing newline — the loader should drop the empty
+        // final token rather than seed `vocab[""]`.
+        let content = lines.joined(separator: "\n") + "\n"
+        try content.write(to: url, atomically: true, encoding: .utf8)
+
+        let tok = try MandarinBertTokenizer.load(vocabURL: url)
+        XCTAssertNil(tok.vocab[""])
+        XCTAssertEqual(tok.sepId, 102)
+    }
+}

--- a/Tests/FluidAudioTests/TTS/KokoroAne/MandarinErhuaTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/MandarinErhuaTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Network-free unit tests for `MandarinErhua` — both the in-place
+/// merge primitive and the end-to-end behaviour through
+/// `MandarinG2P.phonemize`.
+final class MandarinErhuaTests: XCTestCase {
+
+    // MARK: - merge() primitives
+
+    func testMergeBasic() {
+        // 这儿 (zhe4 + er5) → single zhe-erhua syllable.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "zhe", tone: 4),
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 5),
+        ]
+        MandarinErhua.merge(&s)
+        XCTAssertEqual(s.count, 1)
+        XCTAssertEqual(s[0].base, "zhe")
+        XCTAssertEqual(s[0].tone, 4)
+        XCTAssertTrue(s[0].erhua)
+    }
+
+    func testMergeMultiSyllable() {
+        // 小孩儿 (xiao3 + hai2 + er5) → 2 syllables, last erhua.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "xiao", tone: 3),
+            MandarinPinyinNormalizer.Syllable(base: "hai", tone: 2),
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 5),
+        ]
+        MandarinErhua.merge(&s)
+        XCTAssertEqual(s.count, 2)
+        XCTAssertEqual(s[0].base, "xiao")
+        XCTAssertFalse(s[0].erhua)
+        XCTAssertEqual(s[1].base, "hai")
+        XCTAssertEqual(s[1].tone, 2)
+        XCTAssertTrue(s[1].erhua)
+    }
+
+    func testMergeAttachesToImmediatePredecessor() {
+        // 一会儿 (yi1 + hui4 + er5): er attaches to hui, not yi.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "yi", tone: 1),
+            MandarinPinyinNormalizer.Syllable(base: "hui", tone: 4),
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 5),
+        ]
+        MandarinErhua.merge(&s)
+        XCTAssertEqual(s.count, 2)
+        XCTAssertEqual(s[0].base, "yi")
+        XCTAssertFalse(s[0].erhua)
+        XCTAssertEqual(s[1].base, "hui")
+        XCTAssertTrue(s[1].erhua)
+    }
+
+    func testStandaloneErAtStartIsKept() {
+        // 儿子 (er2 + zi5): er is at index 0 → must NOT merge.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 2),
+            MandarinPinyinNormalizer.Syllable(base: "zi", tone: 5),
+        ]
+        let original = s
+        MandarinErhua.merge(&s)
+        XCTAssertEqual(s, original, "Leading er must not be merged")
+    }
+
+    func testStandaloneErChildrenWord() {
+        // 儿童 (er2 + tong2): the er is leading, and even if it weren't,
+        // it doesn't appear as a tail so no merge condition fires.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 2),
+            MandarinPinyinNormalizer.Syllable(base: "tong", tone: 2),
+        ]
+        let original = s
+        MandarinErhua.merge(&s)
+        XCTAssertEqual(s, original)
+    }
+
+    func testEmptyAndSingleNoOp() {
+        var empty: [MandarinPinyinNormalizer.Syllable] = []
+        MandarinErhua.merge(&empty)
+        XCTAssertTrue(empty.isEmpty)
+
+        var single = [MandarinPinyinNormalizer.Syllable(base: "ma", tone: 1)]
+        MandarinErhua.merge(&single)
+        XCTAssertEqual(single.count, 1)
+        XCTAssertFalse(single[0].erhua)
+    }
+
+    func testBackToBackErErLeftAlone() {
+        // Pathological back-to-back er: no second-pass into the first er.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 2),
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 5),
+        ]
+        MandarinErhua.merge(&s)
+        // The trailing er has prev.base == "er" → does NOT merge.
+        XCTAssertEqual(s.count, 2)
+        XCTAssertFalse(s[0].erhua)
+        XCTAssertFalse(s[1].erhua)
+    }
+
+    func testMergeRunsBeforeSandhiFor3Plus3() {
+        // hao3 + er5 + mei3 → erhua merges first → hao3-erhua + mei3
+        // → 3+3 promotes to 2+3 → hao2-erhua + mei3.
+        var s = [
+            MandarinPinyinNormalizer.Syllable(base: "hao", tone: 3),
+            MandarinPinyinNormalizer.Syllable(base: "er", tone: 5),
+            MandarinPinyinNormalizer.Syllable(base: "mei", tone: 3),
+        ]
+        MandarinErhua.merge(&s)
+        MandarinToneSandhi.apply(&s)
+        XCTAssertEqual(s.count, 2)
+        XCTAssertEqual(s[0].base, "hao")
+        XCTAssertEqual(s[0].tone, 2)
+        XCTAssertTrue(s[0].erhua)
+        XCTAssertEqual(s[1].base, "mei")
+        XCTAssertEqual(s[1].tone, 3)
+    }
+
+    // MARK: - Bopomofo encoding
+
+    func testEncodeAppendsErhuaSuffix() {
+        // The erhua suffix sits between the final and the tone digit.
+        let nonErhua = MandarinBopomofoMap.encode(syllable: "xiao", tone: 3)
+        let erhua = MandarinBopomofoMap.encode(syllable: "xiao", tone: 3, erhua: true)
+        XCTAssertNotNil(nonErhua)
+        XCTAssertNotNil(erhua)
+        // Erhua form contains an extra ㄦ before the tone digit.
+        XCTAssertEqual(erhua, (nonErhua ?? "").replacingOccurrences(of: "3", with: "ㄦ3"))
+    }
+
+    func testEncodeErhuaOnSimpleFinal() {
+        // hai2 + erhua → ㄏㄞㄦ2.
+        XCTAssertEqual(
+            MandarinBopomofoMap.encode(syllable: "hai", tone: 2, erhua: true),
+            "ㄏㄞㄦ2")
+    }
+
+    // MARK: - End-to-end through MandarinG2P
+
+    func testG2PEndToEndZher() throws {
+        // 这儿 in single-char dict → zhe + er → erhua-merged.
+        let dict = Self.miniDict()
+        let g2p = MandarinG2P(dict: dict)
+        let phon = try g2p.phonemize("这儿")
+        XCTAssertTrue(
+            phon.contains("ㄦ"),
+            "expected erhua suffix in '\(phon)'")
+        // Should NOT have a separate er-tone token after the main syllable.
+        XCTAssertFalse(
+            phon.contains("ㄦ5"),
+            "erhua should be attached, not a standalone er5; got '\(phon)'")
+    }
+
+    func testG2PEndToEndStandaloneErzi() throws {
+        // 儿子 → er + zi → leading er, must NOT merge.
+        let dict = Self.miniDict()
+        let g2p = MandarinG2P(dict: dict)
+        let phon = try g2p.phonemize("儿子")
+        // Both syllables are emitted independently. We confirm by
+        // checking the leading er token survives with its own tone.
+        XCTAssertTrue(
+            phon.hasPrefix("ㄦ2") || phon.hasPrefix("ㄦ"),
+            "leading 儿 should keep its own ㄦ token; got '\(phon)'")
+    }
+
+    // MARK: - Test fixtures
+
+    private static func miniDict() -> MandarinPinyinDict {
+        let singles: [UInt32: [String]] = [
+            0x8FD9: ["zhè"],  // 这
+            0x513F: ["ér"],  // 儿 (default tone 2)
+            0x5B50: ["zi"],  // 子 (neutral tone)
+            0x5C0F: ["xiǎo"],  // 小
+            0x5B69: ["hái"],  // 孩
+            0x4E00: ["yī"],  // 一
+            0x4F1A: ["huì"],  // 会
+        ]
+        // Phrase override: "儿" suffix should appear as tone-5 to match
+        // typical erhua pronunciation when it follows another syllable.
+        // The miniDict deliberately keeps it at tone 2 — the merge rule
+        // only checks `base == "er"`, not tone, so both form 2 and 5 fold.
+        return MandarinPinyinDict(phrases: [:], singles: singles)
+    }
+}

--- a/Tests/FluidAudioTests/TTS/KokoroAne/MandarinG2PTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/MandarinG2PTests.swift
@@ -224,51 +224,57 @@ final class MandarinG2PTests: XCTestCase {
         XCTAssertEqual(MandarinG2P.normalizeText("！？；："), "!?;:")
     }
 
-    func testPhonemizeRejectsEmpty() throws {
+    func testPhonemizeRejectsEmpty() async throws {
         let g2p = MandarinG2P(dict: Self.smallDict())
-        XCTAssertThrowsError(try g2p.phonemize("")) { err in
-            guard let e = err as? KokoroAneError,
-                case .inputProcessingFailed = e
-            else {
-                XCTFail("Expected inputProcessingFailed, got \(err)")
+        do {
+            _ = try await g2p.phonemize("")
+            XCTFail("Expected throw on empty input")
+        } catch let e as KokoroAneError {
+            guard case .inputProcessingFailed = e else {
+                XCTFail("Expected inputProcessingFailed, got \(e)")
                 return
             }
         }
-        XCTAssertThrowsError(try g2p.phonemize("   "))
+        do {
+            _ = try await g2p.phonemize("   ")
+            XCTFail("Expected throw on whitespace-only input")
+        } catch {
+            // expected
+        }
     }
 
-    func testPhonemizePhraseLookupBeatsSingles() throws {
+    func testPhonemizePhraseLookupBeatsSingles() async throws {
         // "你好" should resolve via the phrases dict (FMM), not by
         // single-char fallback. Both produce the same syllables here so
         // we instead assert the phrase-level sandhi runs (3+3 → 2+3 →
         // bopomofo "ㄋㄧ2ㄏㄠ3").
         let g2p = MandarinG2P(dict: Self.smallDict())
-        let out = try g2p.phonemize("你好")
+        let out = try await g2p.phonemize("你好")
         XCTAssertEqual(out, "ㄋㄧ2ㄏㄠ3")
     }
 
-    func testPhonemizeAppliesBuSandhi() throws {
+    func testPhonemizeAppliesBuSandhi() async throws {
         let g2p = MandarinG2P(dict: Self.smallDict())
-        let out = try g2p.phonemize("我不去")
+        let out = try await g2p.phonemize("我不去")
         // 我 wǒ → "uo" final tokenises as the vocab Hanzi token "我".
         // bu4-before-qu4 → bu2. qu4 → q + ü(ㄩ) + 4.
         XCTAssertEqual(out, "我3ㄅㄨ2ㄑㄩ4")
     }
 
-    func testPhonemizeKeepsPunctuation() throws {
+    func testPhonemizeKeepsPunctuation() async throws {
         let g2p = MandarinG2P(dict: Self.smallDict())
-        let out = try g2p.phonemize("你好,世界。")
+        let out = try await g2p.phonemize("你好,世界。")
         // Sandhi never crosses punctuation, so 你好 → 2+3 and 世界 →
         // 4+4 (no sandhi between them). 世 shi4 → ㄕ + 十; 界 jie4 →
         // ㄐ + ㄝ (ㄧ glide is implicit in the v1.1-zh vocab).
         XCTAssertEqual(out, "ㄋㄧ2ㄏㄠ3,ㄕ十4ㄐㄝ4.")
     }
 
-    func testPhonemizeSandhiResetsAtPunctuation() throws {
+    func testPhonemizeSandhiResetsAtPunctuation() async throws {
         // Two adjacent third tones across a comma must NOT trigger
         // 3+3 sandhi.
         let g2p = MandarinG2P(dict: Self.smallDict())
-        let out = try g2p.phonemize("你好,你好")
+        let out = try await g2p.phonemize("你好,你好")
         XCTAssertEqual(out, "ㄋㄧ2ㄏㄠ3,ㄋㄧ2ㄏㄠ3")
     }
 

--- a/Tests/FluidAudioTests/TTS/KokoroAne/MandarinG2pwIntegrationTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/MandarinG2pwIntegrationTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Network-free integration tests for the MandarinG2P + g2pW wiring.
+///
+/// The g2pW model itself is a 152 MB CoreML bundle that requires a
+/// network download, so these tests exercise the *identification* of
+/// polyphone targets and the dict-only fallback path. The actual
+/// `MandarinG2pwModel.disambiguate(...)` call is covered by a
+/// network-gated benchmark (`mandarin-cer-benchmark` CLI command).
+final class MandarinG2pwIntegrationTests: XCTestCase {
+
+    /// Build a minimal `MandarinPinyinDict` containing both
+    /// monophonic chars (one reading) and one polyphonic char
+    /// (`行` with 4 readings) so the segmenter has something to flag.
+    private static func mixedDict() -> MandarinPinyinDict {
+        var phrases: [String: [String]] = [:]
+        phrases["你好"] = ["nǐ", "hǎo"]
+        var singles: [UInt32: [String]] = [:]
+        // 我 wǒ — single reading.
+        singles[Character("我").unicodeScalars.first!.value] = ["wǒ"]
+        // 去 qù — single reading.
+        singles[Character("去").unicodeScalars.first!.value] = ["qù"]
+        // 行 — polyphonic. The dict's first reading wins by default.
+        singles[Character("行").unicodeScalars.first!.value] = [
+            "xíng", "háng", "xìng",
+        ]
+        // 银 — single reading.
+        singles[Character("银").unicodeScalars.first!.value] = ["yín"]
+        return MandarinPinyinDict(phrases: phrases, singles: singles)
+    }
+
+    func testSegmenterFlagsPolyphonicTargets() throws {
+        let g2p = MandarinG2P(dict: Self.mixedDict())
+        let chars: [Character] = Array("我去银行")
+        let result = g2p.segment(chars: chars)
+        // 我 / 去 / 银 → single reading, no flag. 行 (idx 3) →
+        // 3 readings → polyphone target.
+        XCTAssertEqual(result.polyphoneTargets.count, 1)
+        let target = try XCTUnwrap(result.polyphoneTargets.first)
+        XCTAssertEqual(target.charPos, 3)
+        // The flagged segment must still resolve via the dict in the
+        // absence of g2pW.
+        XCTAssertEqual(result.segments.count, 4)
+    }
+
+    func testPhraseSegmentsAreNotFlaggedAsTargets() throws {
+        let g2p = MandarinG2P(dict: Self.mixedDict())
+        let chars: [Character] = Array("你好")
+        let result = g2p.segment(chars: chars)
+        // FMM hits the phrase — neither char becomes a polyphone
+        // candidate (the phrase already disambiguated context).
+        XCTAssertEqual(result.polyphoneTargets.count, 0)
+        XCTAssertEqual(result.segments.count, 1)
+    }
+
+    func testDictOnlyFallbackProducesBaselineOutput() async throws {
+        // Without a g2pW model wired in, polyphonic chars fall back
+        // to the dict's first-listed reading. This is the existing
+        // pipeline behaviour and must not regress when the optional
+        // g2pW field stays nil.
+        let g2p = MandarinG2P(dict: Self.mixedDict())
+        let out = try await g2p.phonemize("我去银行")
+        // 我 wǒ (vocab Hanzi token "我"3) + 去 qù (ㄑㄩ4) +
+        // 银 yín (ㄧㄣ2) + 行 xíng (ㄒ + 一ㄥ vocab token + 2).
+        // Just assert the output is non-empty and contains the
+        // dict-derived 行 → "ㄒ" prefix; the exact bopomofo of 行
+        // depends on the v1.1-zh vocab special-token mapping.
+        XCTAssertFalse(out.isEmpty)
+        XCTAssertTrue(out.contains("ㄒ"))
+    }
+
+    func testMixedTextWithMultiplePolyphones() throws {
+        // Two polyphonic chars in one sentence → two targets. The
+        // segmenter records charPos in the *normalized* string so
+        // upstream g2pW can pick by context.
+        let g2p = MandarinG2P(dict: Self.mixedDict())
+        let chars: [Character] = Array("行行去")
+        let result = g2p.segment(chars: chars)
+        XCTAssertEqual(result.polyphoneTargets.count, 2)
+        XCTAssertEqual(
+            result.polyphoneTargets.map { $0.charPos }, [0, 1])
+    }
+}

--- a/Tests/FluidAudioTests/TTS/KokoroAne/MandarinJiebaHmmTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/MandarinJiebaHmmTests.swift
@@ -1,0 +1,270 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Network-free unit tests for the jieba HMM tail. Exercises both the
+/// pure Viterbi decoder and its integration with `MandarinG2P.segment`.
+///
+/// All HMM tables used here are synthesised in-process from a small set
+/// of hand-picked log-probabilities — no `.bin` artefacts are read from
+/// disk. The fixture deliberately makes the "join 3 chars into a word"
+/// path overwhelmingly likely on a known set of characters so the
+/// Viterbi output is deterministic and easy to assert against.
+final class MandarinJiebaHmmTests: XCTestCase {
+
+    // MARK: - Fixture builder
+
+    /// Build a 4-state HMM that:
+    ///   * Strongly prefers `B M E` for the chars in `groupChars`
+    ///     (joins them into one word when contiguous).
+    ///   * Emits `S` for any other character.
+    /// The resulting table is small (≤ ~10 chars) but enough to exercise
+    /// every branch of the Viterbi backtrace.
+    private static func buildToyTables(
+        groupChars: Set<Character>,
+        singletonChars: Set<Character>
+    ) -> MandarinJiebaHmmTables {
+        let highProb = 0.0  // log(1)
+        let lowProb = -100.0  // effectively never
+        let mediumProb = -1.0
+
+        // start[B]=high, start[S]=high, start[M]=start[E]=low
+        let start: [Double] = [
+            highProb,  // B
+            lowProb,  // M
+            lowProb,  // E
+            highProb,  // S
+        ]
+
+        // trans[from][to] (rows: B/M/E/S):
+        //   B → M (continue word) very likely; B → E (2-char word) possible
+        //   M → M (long words) possible; M → E (close word) likely
+        //   E → B (start next word) likely; E → S (start next single)
+        //   S → B (start next word) likely; S → S (next single) likely
+        // Disallowed transitions get lowProb so the
+        // `allowedPredecessors` constraint isn't the only safeguard.
+        let trans: [[Double]] = [
+            // from B
+            [lowProb, highProb, mediumProb, lowProb],
+            // from M
+            [lowProb, mediumProb, highProb, lowProb],
+            // from E
+            [highProb, lowProb, lowProb, mediumProb],
+            // from S
+            [highProb, lowProb, lowProb, highProb],
+        ]
+
+        // Emission table: chars in groupChars are happy in B/M/E,
+        // chars in singletonChars are happy in S, everything else is
+        // mildly unhappy everywhere (tested via the unknown-char path).
+        var emit: [Character: [Double]] = [:]
+        for ch in groupChars {
+            emit[ch] = [highProb, highProb, highProb, lowProb]
+        }
+        for ch in singletonChars {
+            emit[ch] = [lowProb, lowProb, lowProb, highProb]
+        }
+        return MandarinJiebaHmmTables(start: start, trans: trans, emit: emit)
+    }
+
+    // MARK: - Viterbi correctness
+
+    func testEmptyInputProducesEmptyOutput() {
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特", "朗", "普"], singletonChars: ["他"]))
+        XCTAssertEqual(hmm.segment(""), [])
+    }
+
+    func testSingleCharBypassesViterbi() {
+        // Single char input must short-circuit (no backtrack possible).
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特"], singletonChars: []))
+        XCTAssertEqual(hmm.segment("特"), ["特"])
+    }
+
+    func testGroupCharsCollapseIntoWord() {
+        // 特朗普 should collapse to a single B-M-E run.
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特", "朗", "普"], singletonChars: []))
+        XCTAssertEqual(hmm.segment("特朗普"), ["特朗普"])
+    }
+
+    func testSingletonCharsStaySeparate() {
+        // 他 / 们 / 去 are tagged as `S` — each emerges as its own word.
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: [], singletonChars: ["他", "们", "去"]))
+        XCTAssertEqual(hmm.segment("他们去"), ["他", "们", "去"])
+    }
+
+    func testMixedRunPreservesBoundaries() {
+        // 他 + 特朗普 → ["他", "特朗普"]. The boundary between an `S`
+        // and the start of a new word (`B`) is the meat of the
+        // segmenter — if the trans/emit interaction is wrong this is
+        // where it breaks.
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特", "朗", "普"], singletonChars: ["他"]))
+        XCTAssertEqual(hmm.segment("他特朗普"), ["他", "特朗普"])
+    }
+
+    func testOutputAlwaysConcatenatesToInput() {
+        // Invariant: the segments must concatenate back to the input
+        // verbatim. Worth asserting on every test path because the
+        // backtrace is easy to get off-by-one.
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["比", "特", "币"], singletonChars: ["他", "用"]))
+        let input = "他用比特币"
+        let words = hmm.segment(input)
+        XCTAssertEqual(words.joined(), input)
+    }
+
+    func testUnknownCharsStillProduceSomething() {
+        // Chars absent from `emit` use the unknownCharLogProb sentinel;
+        // the decoder must still produce a (non-empty) segmentation.
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特"], singletonChars: ["他"]))
+        let words = hmm.segment("乙丙丁")  // none in emit
+        XCTAssertEqual(words.joined(), "乙丙丁")
+        XCTAssertFalse(words.isEmpty)
+    }
+
+    // MARK: - Binary loader round-trip
+
+    func testTablesRoundTripThroughBinaryEncoder() throws {
+        // Build a fixture, encode to bytes, decode back, compare.
+        let original = Self.buildToyTables(
+            groupChars: ["特", "朗", "普", "比", "币"],
+            singletonChars: ["他", "用"])
+        let encoded = original.encoded()
+        let decoded = try MandarinJiebaHmmTables(
+            startData: encoded.start,
+            transData: encoded.trans,
+            emitData: encoded.emit)
+
+        // start / trans should round-trip exactly (Float32 representable).
+        for i in 0..<original.start.count {
+            XCTAssertEqual(decoded.start[i], original.start[i], accuracy: 1e-6)
+        }
+        for i in 0..<original.trans.count {
+            for j in 0..<original.trans[i].count {
+                XCTAssertEqual(
+                    decoded.trans[i][j], original.trans[i][j], accuracy: 1e-6)
+            }
+        }
+        XCTAssertEqual(Set(decoded.emit.keys), Set(original.emit.keys))
+        for key in original.emit.keys {
+            for s in 0..<JiebaHmmState.allCases.count {
+                XCTAssertEqual(
+                    decoded.emit[key]![s], original.emit[key]![s], accuracy: 1e-6)
+            }
+        }
+    }
+
+    func testWrongStartSizeIsRejected() {
+        let badStart = Data(count: 8)  // expected 16
+        let goodTrans = Data(count: 64)
+        let goodEmit = Data()
+        XCTAssertThrowsError(
+            try MandarinJiebaHmmTables(
+                startData: badStart, transData: goodTrans, emitData: goodEmit)
+        ) { error in
+            guard case MandarinJiebaHmmTables.LoadError.wrongSize(let what, _, _) = error
+            else { return XCTFail("Expected wrongSize, got \(error)") }
+            XCTAssertEqual(what, "start")
+        }
+    }
+
+    func testTruncatedEmitIsRejected() {
+        let goodStart = Data(count: 16)
+        let goodTrans = Data(count: 64)
+        let badEmit = Data(count: 5)  // not a multiple of recordSize (20)
+        XCTAssertThrowsError(
+            try MandarinJiebaHmmTables(
+                startData: goodStart, transData: goodTrans, emitData: badEmit)
+        ) { error in
+            guard case MandarinJiebaHmmTables.LoadError.truncated = error else {
+                return XCTFail("Expected truncated, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Integration with MandarinG2P.segment
+
+    func testMandarinG2PWithoutHmmKeepsPerCharFallback() throws {
+        // No HMM: 特朗普 (not in the toy phrase dict) should each char
+        // get a per-singles lookup. Sanity check that wiring HMM as
+        // optional preserves the baseline behaviour.
+        let dict = Self.miniDict()
+        let g2p = MandarinG2P(dict: dict)
+        let phon = try g2p.phonemize("特朗普")
+        XCTAssertFalse(phon.isEmpty)
+        // Each char emits at least an initial+final+tone fragment.
+        XCTAssertGreaterThanOrEqual(phon.count, 3)
+    }
+
+    func testMandarinG2PWithHmmRetriesPhraseDict() throws {
+        // With HMM + a phrase entry for 特朗普, the per-char fallback
+        // should be replaced by the phrase pinyin.
+        var phrases: [String: [String]] = [:]
+        phrases["特朗普"] = ["tè", "lǎng", "pǔ"]
+        let singles: [UInt32: [String]] = [
+            0x7279: ["tè"],  // 特
+            0x6717: ["lǎng"],  // 朗
+            0x666E: ["pǔ"],  // 普
+        ]
+        let dict = MandarinPinyinDict(phrases: phrases, singles: singles)
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特", "朗", "普"], singletonChars: []))
+        let g2p = MandarinG2P(dict: dict, jiebaHmm: hmm)
+
+        // The HMM-recovered word `特朗普` hits the phrase dict; the
+        // result should equal what a pure-phrase lookup would produce.
+        let g2pPhraseOnly = MandarinG2P(dict: dict)
+        let withHmm = try g2p.phonemize("特朗普")
+        let withoutHmmButCached = try g2pPhraseOnly.phonemize("特朗普")
+        XCTAssertEqual(withHmm, withoutHmmButCached)
+    }
+
+    func testIntegrationFlushesHanziRunOnPunctuation() throws {
+        // 他特朗普,你好 — punctuation between hanzi-runs must split the
+        // HMM input, otherwise the comma would end up inside the
+        // segmenter's character buffer.
+        var phrases: [String: [String]] = [:]
+        phrases["特朗普"] = ["tè", "lǎng", "pǔ"]
+        phrases["你好"] = ["nǐ", "hǎo"]
+        let singles: [UInt32: [String]] = [
+            0x4ED6: ["tā"],  // 他
+            0x7279: ["tè"], 0x6717: ["lǎng"], 0x666E: ["pǔ"],
+            0x4F60: ["nǐ"], 0x597D: ["hǎo"],
+        ]
+        let dict = MandarinPinyinDict(phrases: phrases, singles: singles)
+        let hmm = MandarinJiebaHmm(
+            tables: Self.buildToyTables(
+                groupChars: ["特", "朗", "普"], singletonChars: ["他"]))
+        let g2p = MandarinG2P(dict: dict, jiebaHmm: hmm)
+        let phon = try g2p.phonemize("他特朗普,你好")
+        // The comma should appear in the bopomofo string (passthrough).
+        XCTAssertTrue(phon.contains(","), "expected ',' in '\(phon)'")
+    }
+
+    // MARK: - Test fixtures
+
+    private static func miniDict() -> MandarinPinyinDict {
+        let singles: [UInt32: [String]] = [
+            0x7279: ["tè"],  // 特
+            0x6717: ["lǎng"],  // 朗
+            0x666E: ["pǔ"],  // 普
+            0x4F60: ["nǐ"],  // 你
+            0x597D: ["hǎo"],  // 好
+        ]
+        return MandarinPinyinDict(phrases: [:], singles: singles)
+    }
+}

--- a/Tests/FluidAudioTests/TTS/KokoroAne/MandarinPolyphoneCatalogTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/MandarinPolyphoneCatalogTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Network-free tests for `MandarinPolyphoneCatalog` — the parser for
+/// `POLYPHONIC_CHARS.txt` and the diacritic → digit conversion that
+/// adapts upstream g2pW labels to the v1.1-zh vocab style.
+final class MandarinPolyphoneCatalogTests: XCTestCase {
+
+    private static let sample = """
+        # comment lines and blanks are skipped
+        行\tㄒㄧㄥˊ
+        行\tㄏㄤˊ
+        行\tㄒㄧㄥˋ
+        长\tㄔㄤˊ
+        长\tㄓㄤˇ
+        都\tㄉㄡ
+        都\tㄉㄨ
+        """
+
+    func testParsesCharsInOrder() throws {
+        let cat = try MandarinPolyphoneCatalog(text: Self.sample)
+        XCTAssertEqual(cat.chars, ["行", "长", "都"])
+        // Reverse map matches the order.
+        XCTAssertEqual(cat.charIndex["行"], 0)
+        XCTAssertEqual(cat.charIndex["长"], 1)
+        XCTAssertEqual(cat.charIndex["都"], 2)
+    }
+
+    func testLabelsAreSortedUnique() throws {
+        let cat = try MandarinPolyphoneCatalog(text: Self.sample)
+        // 7 entries, but two of them (`ㄉㄡ` `ㄉㄨ`) and the two
+        // `行` rows that share `ㄒㄧㄥ` differ — distinct. So total
+        // unique label count is 7.
+        XCTAssertEqual(cat.labels.count, 7)
+        XCTAssertEqual(cat.labels, cat.labels.sorted())
+    }
+
+    func testCandidatesPerChar() throws {
+        let cat = try MandarinPolyphoneCatalog(text: Self.sample)
+        let xing = cat.candidates(for: "行")
+        XCTAssertNotNil(xing)
+        XCTAssertEqual(xing?.count, 3)
+        let zhang = cat.candidates(for: "长")
+        XCTAssertEqual(zhang?.count, 2)
+        // Non-polyphonic char lookup returns nil.
+        XCTAssertNil(cat.candidates(for: "好"))
+    }
+
+    func testBopomofoReverseLookup() throws {
+        let cat = try MandarinPolyphoneCatalog(text: Self.sample)
+        let labels = Set(cat.labels)
+        XCTAssertTrue(labels.contains("ㄒㄧㄥˊ"))
+        XCTAssertTrue(labels.contains("ㄏㄤˊ"))
+        // Round-trip via the digit form.
+        let xingCandidates = try XCTUnwrap(cat.candidates(for: "行"))
+        let digitForms = xingCandidates.compactMap { cat.bopomofoDigitForm(forLabel: $0) }
+        XCTAssertEqual(Set(digitForms), Set(["ㄒㄧㄥ2", "ㄏㄤ2", "ㄒㄧㄥ4"]))
+    }
+
+    func testToneDigitConversion() {
+        // Each diacritic maps to its tone digit.
+        XCTAssertEqual(MandarinPolyphoneCatalog.toneDigitForm("ㄒㄧㄥˊ"), "ㄒㄧㄥ2")
+        XCTAssertEqual(MandarinPolyphoneCatalog.toneDigitForm("ㄏㄠˇ"), "ㄏㄠ3")
+        XCTAssertEqual(MandarinPolyphoneCatalog.toneDigitForm("ㄕˋ"), "ㄕ4")
+        XCTAssertEqual(MandarinPolyphoneCatalog.toneDigitForm("ㄉㄜ˙"), "ㄉㄜ5")
+        // Missing diacritic ⇒ implicit tone 1.
+        XCTAssertEqual(MandarinPolyphoneCatalog.toneDigitForm("ㄉㄡ"), "ㄉㄡ1")
+        // Empty input returns empty.
+        XCTAssertEqual(MandarinPolyphoneCatalog.toneDigitForm(""), "")
+    }
+
+    func testRejectsMalformedRow() {
+        let bad = "行\n长\tㄔㄤˊ\n"
+        XCTAssertThrowsError(try MandarinPolyphoneCatalog(text: bad)) { err in
+            guard let e = err as? MandarinPolyphoneCatalog.LoadError,
+                case .malformed = e
+            else {
+                XCTFail("Expected malformed error, got \(err)")
+                return
+            }
+        }
+    }
+
+    func testRejectsMultiHanziKey() {
+        let bad = "行人\tㄒㄧㄥˊ\n"
+        XCTAssertThrowsError(try MandarinPolyphoneCatalog(text: bad))
+    }
+
+    func testHandlesCRLFAndBlanks() throws {
+        let crlf = "行\tㄒㄧㄥˊ\r\n\r\n# comment\r\n长\tㄓㄤˇ\r\n"
+        let cat = try MandarinPolyphoneCatalog(text: crlf)
+        XCTAssertEqual(cat.chars, ["行", "长"])
+    }
+
+    func testDeduplicatesRepeatedRows() throws {
+        let dup = "行\tㄒㄧㄥˊ\n行\tㄒㄧㄥˊ\n行\tㄏㄤˊ\n"
+        let cat = try MandarinPolyphoneCatalog(text: dup)
+        // Only two distinct labels for 行.
+        XCTAssertEqual(cat.candidates(for: "行")?.count, 2)
+    }
+
+    func testInvalidLabelIndexReturnsNil() throws {
+        let cat = try MandarinPolyphoneCatalog(text: Self.sample)
+        XCTAssertNil(cat.bopomofo(forLabel: -1))
+        XCTAssertNil(cat.bopomofo(forLabel: cat.labels.count + 100))
+    }
+}


### PR DESCRIPTION
## Summary

Consolidates PRs #574, #575, and #576 into a single landing for Mandarin G2P enhancements per [issue #572](https://github.com/FluidInference/FluidAudio/issues/572). All three features are non-overlapping and stack cleanly inside `MandarinG2P.phonemize`:

- **Item 3 — Erhua merging** (was #574): folds trailing `儿` into the previous syllable so `小孩儿` emits a single r-coloured token instead of a stray `er` tail.
- **Item 4 — Jieba HMM tail** (was #575): re-segments OOV runs of single-char fallbacks via a 4-state B/M/E/S Viterbi to recover proper-noun boundaries (`特朗普`, `比特币`); recovered words are then retried against the phrase dict before per-char fallback.
- **Item 1 — g2pW polyphone disambiguation** (was #576): int8 BERT-base classifier (152 MB CoreML) picks the right reading for polyphonic Hanzi (`行`/`长`/`重`/`朝`/…) using the full sentence as context. Best-effort: falls back to dict-only when assets are missing.

Item 2 (number normalization) already merged via #573. Items 5 (POS sandhi, #577) and 6 (custom lexicon, #578) remain as separate PRs.

## Pipeline order

```
text
  → MandarinNumberNormalizer.normalize        (already on main)
  → normalizeText (punctuation)
  → segment(): FMM phrases + jieba HMM tail   (NEW: item 4)
  → polyphone disambiguation via g2pW         (NEW: item 1)
  → diacritic → digit (MandarinPinyinNormalizer)
  → MandarinErhua.merge                       (NEW: item 3)
  → MandarinToneSandhi.apply
  → MandarinBopomofoMap.encode
```

## API changes

- `MandarinG2P.phonemize` is now `async throws` (g2pW disambiguation requires async). Backwards-compatible callers must add `try await`.
- `MandarinG2P.init(dict:, jiebaHmm:, g2pw:)` — both new parameters are optional, default `nil` keeps baseline behaviour.
- New `Segment.bopomofoOverride(String)` case carries g2pW's pre-encoded bopomofo + tone digit; bypasses sandhi.

## Asset requirements

Pulled from `huggingface.co/FluidInference/kokoro-82m-coreml`:

- `ANE-zh/g2pw/g2pw.mlmodelc/` — bulk `ensureModels` (added to `requiredModelsZh`)
- `ANE-zh/g2pw/vocab.txt` + `POLYPHONIC_CHARS.txt` — `ensureMandarinG2pw` lazy fetch
- `ANE-zh/assets/jieba_hmm_{start,trans,emit}.bin` — `ensureMandarinJiebaHmm` lazy fetch

All three optional asset groups degrade gracefully: missing g2pW falls back to dict-first reading, missing jieba HMM falls back to per-char singles.

## Test plan

- [x] `swift build` clean
- [x] 102 tests pass across `MandarinG2PTests`, `MandarinErhuaTests`, `MandarinJiebaHmmTests`, `MandarinPolyphoneCatalogTests`, `MandarinBertTokenizerTests`, `MandarinNumberNormalizerTests`
- [x] Polyphone target tracking through jieba HMM resegmentation: `flushHanziRun` carries absolute char positions so g2pW sees the right context window
- [x] Backward-compat: `MandarinG2P(dict:)` (no jieba, no g2pW) still passes baseline tests

## Closes

- #574 (erhua)
- #575 (jieba HMM)
- #576 (g2pW)

Refs #572.