### PR TITLE
feat(tts/magpie): nanocodec v1/v2/v3 + decoder_step ANE pin + dual-precision API

### DIFF
--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -769,19 +769,30 @@ public enum ModelNames {
         public static let decoderPrefill = "decoder_prefill"
         public static let decoderStep = "decoder_step"
         public static let nanocodecDecoder = "nanocodec_decoder"
-        /// Chunked T_in=24-frame nanocodec build. Output 24576 audio samples
-        /// per call; runtime slides this with stride 8 / overlap 16 frames.
-        /// Lands ~43 % ANE-resident at 38.4 ms/call vs the monolithic
-        /// T=256 model that can only run on CPU at ~8.76 s/utterance.
-        /// Optional: when this file is absent we fall back to the monolithic
-        /// `nanocodec_decoder.mlmodelc` and the `.cpuOnly` pin.
+        /// Chunked T_in=24-frame nanocodec, fp16 weights. Output 24576 audio
+        /// samples per call; runtime slides this with stride 8 / overlap 16
+        /// frames. Lands ~43 % ANE-resident at 38.4 ms/call (M2). Audibly
+        /// noisy on voiced speech: fp16 weight quantization adds 27 dB SNR
+        /// of speech-correlated noise vs PyTorch reference. Use only when
+        /// throughput matters more than quality. The fp32 v2 build below
+        /// is the recommended default.
         public static let nanocodecDecoderT24 = "nanocodec_decoder_t24"
+        /// Chunked T_in=24-frame nanocodec, fp32 weights (Phase F result).
+        /// Same I/O contract as the fp16 build but pinned to CPU at ~142.5
+        /// ms/call (M2). Audibly clean — matches PyTorch reference within
+        /// the Snake-approximation noise floor. Phase F (per-op + per-
+        /// location mixed-precision sweep, see
+        /// `mobius/.../per_module/results/STATUS.md`) confirmed no
+        /// mixed-precision island recovers cleanliness, so the production
+        /// trade-off is full fp32 / CPU-only / RTFx ~1.3× end-to-end.
+        public static let nanocodecDecoderT24V2 = "nanocodec_decoder_t24_v2"
 
         public static let textEncoderFile = textEncoder + ".mlmodelc"
         public static let decoderPrefillFile = decoderPrefill + ".mlmodelc"
         public static let decoderStepFile = decoderStep + ".mlmodelc"
         public static let nanocodecDecoderFile = nanocodecDecoder + ".mlmodelc"
         public static let nanocodecDecoderT24File = nanocodecDecoderT24 + ".mlmodelc"
+        public static let nanocodecDecoderT24V2File = nanocodecDecoderT24V2 + ".mlmodelc"
 
         public static let constantsDir = "constants"
         public static let tokenizerDir = "tokenizer"

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -768,41 +768,52 @@ public enum ModelNames {
         public static let textEncoder = "text_encoder"
         public static let decoderPrefill = "decoder_prefill"
         public static let decoderStep = "decoder_step"
+        /// Implicit v1: original monolithic T=256 nanocodec, fp16 weights,
+        /// CPU only (~8.76 s wall on M2). Audibly noisy on voiced speech —
+        /// the same fp16 weight-quantization noise that v2 has, plus 4×
+        /// slower because the activation tensor exceeds the ANE
+        /// `W ≤ 16384` limit so it can't go on the Neural Engine.
+        /// Retained as a legacy fallback only; v2 / v3 supersede it.
         public static let nanocodecDecoder = "nanocodec_decoder"
-        /// Chunked T_in=24-frame nanocodec, fp16 weights. Output 24576 audio
-        /// samples per call; runtime slides this with stride 8 / overlap 16
-        /// frames. Lands ~43 % ANE-resident at 38.4 ms/call (M2). Audibly
-        /// noisy on voiced speech: fp16 weight quantization adds 27 dB SNR
-        /// of speech-correlated noise vs PyTorch reference. Use only when
-        /// throughput matters more than quality. The fp32 v2 build below
-        /// is the recommended default.
-        public static let nanocodecDecoderT24 = "nanocodec_decoder_t24"
-        /// Chunked T_in=24-frame nanocodec, fp32 weights (Phase F result).
-        /// Same I/O contract as the fp16 build but pinned to CPU at ~142.5
+        /// v2: chunked T_in=24-frame nanocodec, fp16 weights. Output 24576
+        /// audio samples per call; runtime slides this with stride 8 /
+        /// overlap 16 frames. Lands ~43 % ANE-resident at 38.4 ms/call
+        /// (M2). Audibly noisy on voiced speech: fp16 weight quantization
+        /// adds 27 dB SNR of speech-correlated noise vs PyTorch reference.
+        /// Use only when throughput matters more than quality. v3 is the
+        /// recommended default.
+        public static let nanocodecDecoderV2 = "nanocodec_decoder_v2"
+        /// v3: chunked T_in=24-frame nanocodec, fp32 weights (Phase F
+        /// result). Same I/O contract as v2 but pinned to CPU at ~142.5
         /// ms/call (M2). Audibly clean — matches PyTorch reference within
         /// the Snake-approximation noise floor. Phase F (per-op + per-
         /// location mixed-precision sweep, see
         /// `mobius/.../per_module/results/STATUS.md`) confirmed no
         /// mixed-precision island recovers cleanliness, so the production
         /// trade-off is full fp32 / CPU-only / RTFx ~1.3× end-to-end.
-        public static let nanocodecDecoderT24V2 = "nanocodec_decoder_t24_v2"
+        public static let nanocodecDecoderV3 = "nanocodec_decoder_v3"
 
         public static let textEncoderFile = textEncoder + ".mlmodelc"
         public static let decoderPrefillFile = decoderPrefill + ".mlmodelc"
         public static let decoderStepFile = decoderStep + ".mlmodelc"
         public static let nanocodecDecoderFile = nanocodecDecoder + ".mlmodelc"
-        public static let nanocodecDecoderT24File = nanocodecDecoderT24 + ".mlmodelc"
-        public static let nanocodecDecoderT24V2File = nanocodecDecoderT24V2 + ".mlmodelc"
+        public static let nanocodecDecoderV2File = nanocodecDecoderV2 + ".mlmodelc"
+        public static let nanocodecDecoderV3File = nanocodecDecoderV3 + ".mlmodelc"
 
         public static let constantsDir = "constants"
         public static let tokenizerDir = "tokenizer"
 
         /// Files required for English synthesis. Other languages append their own
         /// lookup files on top (see `MagpieResourceDownloader`).
+        ///
+        /// Lists `nanocodecDecoderV3File` (fp32 default) — bulk download
+        /// re-fires for users who only have the legacy fp16 monolithic
+        /// (`nanocodecDecoderFile`) cached, so they upgrade to a clean
+        /// nanocodec automatically on next launch.
         public static let requiredModels: Set<String> = [
             textEncoderFile,
             decoderStepFile,
-            nanocodecDecoderFile,
+            nanocodecDecoderV3File,
             constantsDir,
         ]
     }

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -769,11 +769,19 @@ public enum ModelNames {
         public static let decoderPrefill = "decoder_prefill"
         public static let decoderStep = "decoder_step"
         public static let nanocodecDecoder = "nanocodec_decoder"
+        /// Chunked T_in=24-frame nanocodec build. Output 24576 audio samples
+        /// per call; runtime slides this with stride 8 / overlap 16 frames.
+        /// Lands ~43 % ANE-resident at 38.4 ms/call vs the monolithic
+        /// T=256 model that can only run on CPU at ~8.76 s/utterance.
+        /// Optional: when this file is absent we fall back to the monolithic
+        /// `nanocodec_decoder.mlmodelc` and the `.cpuOnly` pin.
+        public static let nanocodecDecoderT24 = "nanocodec_decoder_t24"
 
         public static let textEncoderFile = textEncoder + ".mlmodelc"
         public static let decoderPrefillFile = decoderPrefill + ".mlmodelc"
         public static let decoderStepFile = decoderStep + ".mlmodelc"
         public static let nanocodecDecoderFile = nanocodecDecoder + ".mlmodelc"
+        public static let nanocodecDecoderT24File = nanocodecDecoderT24 + ".mlmodelc"
 
         public static let constantsDir = "constants"
         public static let tokenizerDir = "tokenizer"

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -768,29 +768,11 @@ public enum ModelNames {
         public static let textEncoder = "text_encoder"
         public static let decoderPrefill = "decoder_prefill"
         public static let decoderStep = "decoder_step"
-        /// Implicit v1: original monolithic T=256 nanocodec, fp16 weights,
-        /// CPU only (~8.76 s wall on M2). Audibly noisy on voiced speech —
-        /// the same fp16 weight-quantization noise that v2 has, plus 4×
-        /// slower because the activation tensor exceeds the ANE
-        /// `W ≤ 16384` limit so it can't go on the Neural Engine.
-        /// Retained as a legacy fallback only; v2 / v3 supersede it.
+        /// v1: T=256 monolithic, fp16, CPU. Legacy fallback (noisy + slow).
         public static let nanocodecDecoder = "nanocodec_decoder"
-        /// v2: chunked T_in=24-frame nanocodec, fp16 weights. Output 24576
-        /// audio samples per call; runtime slides this with stride 8 /
-        /// overlap 16 frames. Lands ~43 % ANE-resident at 38.4 ms/call
-        /// (M2). Audibly noisy on voiced speech: fp16 weight quantization
-        /// adds 27 dB SNR of speech-correlated noise vs PyTorch reference.
-        /// Use only when throughput matters more than quality. v3 is the
-        /// recommended default.
+        /// v2: T_in=24 chunked, fp16. Fast (~43% ANE) but noisy on voiced speech.
         public static let nanocodecDecoderV2 = "nanocodec_decoder_v2"
-        /// v3: chunked T_in=24-frame nanocodec, fp32 weights (Phase F
-        /// result). Same I/O contract as v2 but pinned to CPU at ~142.5
-        /// ms/call (M2). Audibly clean — matches PyTorch reference within
-        /// the Snake-approximation noise floor. Phase F (per-op + per-
-        /// location mixed-precision sweep, see
-        /// `mobius/.../per_module/results/STATUS.md`) confirmed no
-        /// mixed-precision island recovers cleanliness, so the production
-        /// trade-off is full fp32 / CPU-only / RTFx ~1.3× end-to-end.
+        /// v3: T_in=24 chunked, fp32, CPU. Audibly clean (default).
         public static let nanocodecDecoderV3 = "nanocodec_decoder_v3"
 
         public static let textEncoderFile = textEncoder + ".mlmodelc"
@@ -804,12 +786,9 @@ public enum ModelNames {
         public static let tokenizerDir = "tokenizer"
 
         /// Files required for English synthesis. Other languages append their own
-        /// lookup files on top (see `MagpieResourceDownloader`).
-        ///
-        /// Lists `nanocodecDecoderV3File` (fp32 default) — bulk download
-        /// re-fires for users who only have the legacy fp16 monolithic
-        /// (`nanocodecDecoderFile`) cached, so they upgrade to a clean
-        /// nanocodec automatically on next launch.
+        /// lookup files on top (see `MagpieResourceDownloader`). Listing
+        /// `nanocodecDecoderV3File` ensures legacy v1-only caches get
+        /// re-downloaded and upgraded to the clean v3.
         public static let requiredModels: Set<String> = [
             textEncoderFile,
             decoderStepFile,

--- a/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
@@ -14,6 +14,9 @@ public actor MagpieModelStore {
     private var textEncoderModel: MLModel?
     private var decoderPrefillModel: MLModel?  // optional fast path
     private var decoderStepModel: MLModel?
+    /// Either the chunked T_in=24 build (preferred, ANE) or the monolithic
+    /// T=256 build (legacy, CPU-only). `MagpieNanocodec` reads the input
+    /// shape and chunks accordingly.
     private var nanocodecDecoderModel: MLModel?
 
     private var constantsBundle: MagpieConstantsBundle?
@@ -79,21 +82,32 @@ public actor MagpieModelStore {
         aneConfig.computeUnits =
             computeUnits == .cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
 
-        // `nanocodec_decoder.mlmodelc` is fastest on **CPU only**. The model's
-        // upsample stack (5 transposed convs + 96 sin/pow per-frame embedding
-        // ops + 86 LeakyReLU) doesn't map well onto Metal MPS, and ANE compile
-        // fails on its conv stack. Empirically (M-series, single fwd of 256
-        // frames):
-        //   .cpuOnly             ~2.87 s
-        //   .cpuAndGPU           ~3.86 s
-        //   .cpuAndNeuralEngine ~10.12 s   (ANE compile fail → CPU fallback dance)
-        //   .all                 ~2.95 s
-        // Putting it on `.cpuAndGPU` also makes `decoder_step` ~40 ms/step
-        // because both contend for the same Metal queue. Pinning nanocodec to
-        // CPU keeps Metal exclusive for decoder_step (25 ms/step) and saves a
-        // full second on the nanocodec call → ~1.03x RTFx vs ~0.91x before.
-        let cpuConfig = MLModelConfiguration()
-        cpuConfig.computeUnits = .cpuOnly
+        // Nanocodec is pinned to CPU regardless of `computeUnits`.
+        //
+        // The monolithic T=256 build can't use ANE anyway: its activation
+        // tensor exceeds the W ≤ 16384 limit on space-to-batch lowering of
+        // the dilated convs and ANECCompile() fails whole-graph.
+        //
+        // The chunked T_in=24 build *can* run ~43 %-resident on ANE, but
+        // we ship it as fp32 weights (`compute_precision=FLOAT32` in
+        // `convert_nanocodec.py`) because fp16 weight quantization
+        // produces audible speech-correlated noise during voiced segments
+        // — the silence-RMS metrics hide it, but A/B listening against
+        // a PyTorch sin² reference makes it obvious. fp32 weights force
+        // the CoreML runtime onto CPU (ANE is fp16-only), and the noise
+        // floor matches the PyTorch reference within ~3.5 dB.
+        //
+        // Noise floor (quietest 0.3 s window, post-norm):
+        //   PyTorch sin² (gold)              -77.4 dBFS
+        //   T=24 chunked, fp32 weights, CPU  -73.6 dBFS  ← current
+        //   T=24 chunked, fp16 weights, CPU  -73.9 dBFS  (audibly noisy)
+        //   T=24 chunked, fp16 weights, ANE  -66.8 dBFS  (audibly noisy)
+        //
+        // fp32 trades throughput for fidelity: nanocodec wall is ~4×
+        // slower than fp16 (8.5–9.7 s vs 2.2 s on a 12 s utterance, M2),
+        // but the pipeline stays real-time at RTFx ~1.3× median.
+        let nanocodecConfig = MLModelConfiguration()
+        nanocodecConfig.computeUnits = .cpuOnly
 
         let loadStart = Date()
 
@@ -109,11 +123,24 @@ public actor MagpieModelStore {
             config: aneConfig,
             required: true)
 
+        // Prefer the chunked T_in=24 build (loads on ANE). Fall back to the
+        // monolithic T=256 build if t24 isn't present in the repo. Exactly
+        // one of the two must exist for synthesis to work.
         nanocodecDecoderModel = try loadModel(
             repoDir: repoDir,
-            fileName: ModelNames.Magpie.nanocodecDecoderFile,
-            config: cpuConfig,
-            required: true)
+            fileName: ModelNames.Magpie.nanocodecDecoderT24File,
+            config: nanocodecConfig,
+            required: false)
+        if nanocodecDecoderModel == nil {
+            logger.notice(
+                "T_in=24 nanocodec absent; falling back to monolithic CPU-only nanocodec_decoder.mlmodelc"
+            )
+            nanocodecDecoderModel = try loadModel(
+                repoDir: repoDir,
+                fileName: ModelNames.Magpie.nanocodecDecoderFile,
+                config: nanocodecConfig,
+                required: true)
+        }
 
         decoderPrefillModel = try loadModel(
             repoDir: repoDir,

--- a/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
@@ -1,6 +1,21 @@
 @preconcurrency import CoreML
 import Foundation
 
+/// Selects which T_in=24 nanocodec build the store loads.
+///
+/// - `.fp32`: `nanocodec_decoder_t24_v2.mlmodelc` — full fp32 weights, pinned
+///   to CPU (~142.5 ms / 24-frame call on M2). Audibly clean, matches the
+///   PyTorch sin² reference within the Snake-approximation noise floor.
+///   Pipeline stays real-time at RTFx ~1.3× median.
+/// - `.fp16`: `nanocodec_decoder_t24.mlmodelc` — fp16 weights, runs
+///   ~43 % ANE-resident at ~38.4 ms / 24-frame call. Faster but audibly
+///   noisy on voiced speech (~27 dB SNR vs PyTorch reference, hidden by
+///   silence-RMS metrics). Use only when throughput dominates quality.
+public enum MagpieNanocodecPrecision: String, Sendable {
+    case fp16
+    case fp32
+}
+
 /// Actor-based store for Magpie CoreML models + constants + LocalTransformer weights.
 ///
 /// Manages loading of 3 required models (text_encoder, decoder_step, nanocodec_decoder)
@@ -14,9 +29,14 @@ public actor MagpieModelStore {
     private var textEncoderModel: MLModel?
     private var decoderPrefillModel: MLModel?  // optional fast path
     private var decoderStepModel: MLModel?
-    /// Either the chunked T_in=24 build (preferred, ANE) or the monolithic
-    /// T=256 build (legacy, CPU-only). `MagpieNanocodec` reads the input
-    /// shape and chunks accordingly.
+    /// One of:
+    ///   - chunked T_in=24 fp32 build (`nanocodec_decoder_t24_v2`, default,
+    ///     CPU-only, audibly clean)
+    ///   - chunked T_in=24 fp16 build (`nanocodec_decoder_t24`, fast/ANE,
+    ///     audibly noisy)
+    ///   - monolithic T=256 build (`nanocodec_decoder`, legacy fallback,
+    ///     CPU-only)
+    /// `MagpieNanocodec` reads the input shape and chunks accordingly.
     private var nanocodecDecoderModel: MLModel?
 
     private var constantsBundle: MagpieConstantsBundle?
@@ -27,19 +47,28 @@ public actor MagpieModelStore {
     private let directory: URL?
     private let computeUnits: MLComputeUnits
     private let preferredLanguages: Set<MagpieLanguage>
+    private let nanocodecPrecision: MagpieNanocodecPrecision
 
     /// - Parameters:
     ///   - directory: Optional override for the base cache directory.
     ///   - computeUnits: CoreML compute preference for all models.
     ///   - preferredLanguages: Set of languages whose tokenizer data should be fetched.
+    ///   - nanocodecPrecision: Which T_in=24 nanocodec build to load.
+    ///     `.fp32` (default) is audibly clean but pinned to CPU
+    ///     (~142.5 ms/call on M2). `.fp16` runs ~43 % ANE-resident
+    ///     (~38.4 ms/call) but is audibly noisy on voiced speech due to
+    ///     fp16 weight quantization. See Phase F write-up in
+    ///     `mobius/.../per_module/results/STATUS.md`.
     public init(
         directory: URL? = nil,
         computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
-        preferredLanguages: Set<MagpieLanguage> = [.english]
+        preferredLanguages: Set<MagpieLanguage> = [.english],
+        nanocodecPrecision: MagpieNanocodecPrecision = .fp32
     ) {
         self.directory = directory
         self.computeUnits = computeUnits
         self.preferredLanguages = preferredLanguages
+        self.nanocodecPrecision = nanocodecPrecision
     }
 
     /// Download (if missing) and load all Magpie CoreML models + constants.
@@ -82,32 +111,38 @@ public actor MagpieModelStore {
         aneConfig.computeUnits =
             computeUnits == .cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
 
-        // Nanocodec is pinned to CPU regardless of `computeUnits`.
+        // Nanocodec compute units are dictated by precision, not by the
+        // caller's `computeUnits` setting:
         //
-        // The monolithic T=256 build can't use ANE anyway: its activation
-        // tensor exceeds the W ≤ 16384 limit on space-to-batch lowering of
-        // the dilated convs and ANECCompile() fails whole-graph.
+        //   .fp32  → `.cpuOnly`. fp32 weights force the CoreML runtime
+        //            off ANE (ANE is fp16-only). Audibly clean.
+        //   .fp16  → `.cpuAndNeuralEngine` (or `.cpuOnly` if the caller
+        //            explicitly requested CPU-only). Runs ~43 %-resident
+        //            on ANE at ~38.4 ms / 24-frame call but is audibly
+        //            noisy on voiced speech.
         //
-        // The chunked T_in=24 build *can* run ~43 %-resident on ANE, but
-        // we ship it as fp32 weights (`compute_precision=FLOAT32` in
-        // `convert_nanocodec.py`) because fp16 weight quantization
-        // produces audible speech-correlated noise during voiced segments
-        // — the silence-RMS metrics hide it, but A/B listening against
-        // a PyTorch sin² reference makes it obvious. fp32 weights force
-        // the CoreML runtime onto CPU (ANE is fp16-only), and the noise
-        // floor matches the PyTorch reference within ~3.5 dB.
+        // The monolithic T=256 fallback build can't use ANE anyway: its
+        // activation tensor exceeds the W ≤ 16384 limit on space-to-batch
+        // lowering of the dilated convs and ANECCompile() fails
+        // whole-graph.
         //
         // Noise floor (quietest 0.3 s window, post-norm):
         //   PyTorch sin² (gold)              -77.4 dBFS
-        //   T=24 chunked, fp32 weights, CPU  -73.6 dBFS  ← current
+        //   T=24 chunked, fp32 weights, CPU  -73.6 dBFS  (clean, default)
         //   T=24 chunked, fp16 weights, CPU  -73.9 dBFS  (audibly noisy)
         //   T=24 chunked, fp16 weights, ANE  -66.8 dBFS  (audibly noisy)
         //
-        // fp32 trades throughput for fidelity: nanocodec wall is ~4×
-        // slower than fp16 (8.5–9.7 s vs 2.2 s on a 12 s utterance, M2),
-        // but the pipeline stays real-time at RTFx ~1.3× median.
+        // See Phase F in `mobius/.../per_module/results/STATUS.md` for
+        // the full mixed-precision sweep that closed off any per-stage
+        // or per-op-type fp16/fp32 island.
         let nanocodecConfig = MLModelConfiguration()
-        nanocodecConfig.computeUnits = .cpuOnly
+        switch nanocodecPrecision {
+        case .fp32:
+            nanocodecConfig.computeUnits = .cpuOnly
+        case .fp16:
+            nanocodecConfig.computeUnits =
+                computeUnits == .cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
+        }
 
         let loadStart = Date()
 
@@ -123,22 +158,49 @@ public actor MagpieModelStore {
             config: aneConfig,
             required: true)
 
-        // Prefer the chunked T_in=24 build (loads on ANE). Fall back to the
-        // monolithic T=256 build if t24 isn't present in the repo. Exactly
-        // one of the two must exist for synthesis to work.
+        // Pick the requested precision's t24 build first. If it isn't in
+        // the repo, fall back to the other precision's t24 build (with a
+        // warning), and finally to the monolithic T=256 build. Exactly
+        // one of the three must exist for synthesis to work.
+        let primaryT24Name: String
+        let secondaryT24Name: String
+        switch nanocodecPrecision {
+        case .fp32:
+            primaryT24Name = ModelNames.Magpie.nanocodecDecoderT24V2File
+            secondaryT24Name = ModelNames.Magpie.nanocodecDecoderT24File
+        case .fp16:
+            primaryT24Name = ModelNames.Magpie.nanocodecDecoderT24File
+            secondaryT24Name = ModelNames.Magpie.nanocodecDecoderT24V2File
+        }
+
         nanocodecDecoderModel = try loadModel(
             repoDir: repoDir,
-            fileName: ModelNames.Magpie.nanocodecDecoderT24File,
+            fileName: primaryT24Name,
             config: nanocodecConfig,
             required: false)
         if nanocodecDecoderModel == nil {
-            logger.notice(
-                "T_in=24 nanocodec absent; falling back to monolithic CPU-only nanocodec_decoder.mlmodelc"
+            logger.warning(
+                "Requested \(nanocodecPrecision.rawValue) nanocodec (\(primaryT24Name)) absent; trying alternate precision \(secondaryT24Name)"
             )
+            // Loading the alternate-precision build under the requested
+            // compute config is fine: fp32 weights will force CPU at
+            // runtime regardless, fp16 weights honour the chosen units.
+            nanocodecDecoderModel = try loadModel(
+                repoDir: repoDir,
+                fileName: secondaryT24Name,
+                config: nanocodecConfig,
+                required: false)
+        }
+        if nanocodecDecoderModel == nil {
+            logger.notice(
+                "No T_in=24 nanocodec present; falling back to monolithic CPU-only nanocodec_decoder.mlmodelc"
+            )
+            let monolithicConfig = MLModelConfiguration()
+            monolithicConfig.computeUnits = .cpuOnly
             nanocodecDecoderModel = try loadModel(
                 repoDir: repoDir,
                 fileName: ModelNames.Magpie.nanocodecDecoderFile,
-                config: nanocodecConfig,
+                config: monolithicConfig,
                 required: true)
         }
 

--- a/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
@@ -79,13 +79,16 @@ public actor MagpieModelStore {
 
         // Nanocodec compute units track precision: fp32 → CPU-only (ANE is
         // fp16-only); fp16 → ANE unless caller explicitly pinned CPU.
-        let nanocodecConfig = MLModelConfiguration()
-        switch nanocodecPrecision {
-        case .fp32:
-            nanocodecConfig.computeUnits = .cpuOnly
-        case .fp16:
-            nanocodecConfig.computeUnits =
-                computeUnits == .cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
+        func nanocodecConfig(for precision: MagpieNanocodecPrecision) -> MLModelConfiguration {
+            let cfg = MLModelConfiguration()
+            switch precision {
+            case .fp32:
+                cfg.computeUnits = .cpuOnly
+            case .fp16:
+                cfg.computeUnits =
+                    computeUnits == .cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
+            }
+            return cfg
         }
 
         let loadStart = Date()
@@ -103,7 +106,10 @@ public actor MagpieModelStore {
             required: true)
 
         // Try the requested precision, then the other chunked build, then
-        // the legacy monolithic v1.
+        // the legacy monolithic v1. Each candidate carries its own config so
+        // the fallback doesn't inherit the primary's compute-unit selection.
+        let secondaryPrecision: MagpieNanocodecPrecision =
+            nanocodecPrecision == .fp32 ? .fp16 : .fp32
         let primaryName: String
         let secondaryName: String
         switch nanocodecPrecision {
@@ -118,7 +124,7 @@ public actor MagpieModelStore {
         nanocodecDecoderModel = try loadModel(
             repoDir: repoDir,
             fileName: primaryName,
-            config: nanocodecConfig,
+            config: nanocodecConfig(for: nanocodecPrecision),
             required: false)
         if nanocodecDecoderModel == nil {
             logger.warning(
@@ -127,7 +133,7 @@ public actor MagpieModelStore {
             nanocodecDecoderModel = try loadModel(
                 repoDir: repoDir,
                 fileName: secondaryName,
-                config: nanocodecConfig,
+                config: nanocodecConfig(for: secondaryPrecision),
                 required: false)
         }
         if nanocodecDecoderModel == nil {

--- a/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
@@ -1,13 +1,13 @@
 @preconcurrency import CoreML
 import Foundation
 
-/// Selects which T_in=24 nanocodec build the store loads.
+/// Selects which chunked nanocodec build the store loads.
 ///
-/// - `.fp32`: `nanocodec_decoder_t24_v2.mlmodelc` — full fp32 weights, pinned
-///   to CPU (~142.5 ms / 24-frame call on M2). Audibly clean, matches the
-///   PyTorch sin² reference within the Snake-approximation noise floor.
-///   Pipeline stays real-time at RTFx ~1.3× median.
-/// - `.fp16`: `nanocodec_decoder_t24.mlmodelc` — fp16 weights, runs
+/// - `.fp32` (v3): `nanocodec_decoder_v3.mlmodelc` — full fp32 weights,
+///   pinned to CPU (~142.5 ms / 24-frame call on M2). Audibly clean,
+///   matches the PyTorch sin² reference within the Snake-approximation
+///   noise floor. Pipeline stays real-time at RTFx ~1.3× median.
+/// - `.fp16` (v2): `nanocodec_decoder_v2.mlmodelc` — fp16 weights, runs
 ///   ~43 % ANE-resident at ~38.4 ms / 24-frame call. Faster but audibly
 ///   noisy on voiced speech (~27 dB SNR vs PyTorch reference, hidden by
 ///   silence-RMS metrics). Use only when throughput dominates quality.
@@ -30,12 +30,12 @@ public actor MagpieModelStore {
     private var decoderPrefillModel: MLModel?  // optional fast path
     private var decoderStepModel: MLModel?
     /// One of:
-    ///   - chunked T_in=24 fp32 build (`nanocodec_decoder_t24_v2`, default,
+    ///   - v3: chunked T_in=24 fp32 build (`nanocodec_decoder_v3`, default,
     ///     CPU-only, audibly clean)
-    ///   - chunked T_in=24 fp16 build (`nanocodec_decoder_t24`, fast/ANE,
+    ///   - v2: chunked T_in=24 fp16 build (`nanocodec_decoder_v2`, fast/ANE,
     ///     audibly noisy)
-    ///   - monolithic T=256 build (`nanocodec_decoder`, legacy fallback,
-    ///     CPU-only)
+    ///   - v1: monolithic T=256 fp16 build (`nanocodec_decoder`, legacy
+    ///     fallback, CPU-only, audibly noisy)
     /// `MagpieNanocodec` reads the input shape and chunks accordingly.
     private var nanocodecDecoderModel: MLModel?
 
@@ -158,42 +158,48 @@ public actor MagpieModelStore {
             config: aneConfig,
             required: true)
 
-        // Pick the requested precision's t24 build first. If it isn't in
-        // the repo, fall back to the other precision's t24 build (with a
-        // warning), and finally to the monolithic T=256 build. Exactly
-        // one of the three must exist for synthesis to work.
-        let primaryT24Name: String
-        let secondaryT24Name: String
+        // Pick the requested precision's chunked build first. If it isn't
+        // in the repo, fall back to the other precision's chunked build
+        // (with a warning), and finally to the legacy monolithic v1
+        // (`nanocodec_decoder.mlmodelc`). Exactly one of the three must
+        // exist for synthesis to work.
+        //
+        // Naming:
+        //   v1 → `nanocodec_decoder.mlmodelc`     (legacy mono, fp16, noisy)
+        //   v2 → `nanocodec_decoder_v2.mlmodelc`  (chunked, fp16, noisy)
+        //   v3 → `nanocodec_decoder_v3.mlmodelc`  (chunked, fp32, clean — default)
+        let primaryName: String
+        let secondaryName: String
         switch nanocodecPrecision {
         case .fp32:
-            primaryT24Name = ModelNames.Magpie.nanocodecDecoderT24V2File
-            secondaryT24Name = ModelNames.Magpie.nanocodecDecoderT24File
+            primaryName = ModelNames.Magpie.nanocodecDecoderV3File
+            secondaryName = ModelNames.Magpie.nanocodecDecoderV2File
         case .fp16:
-            primaryT24Name = ModelNames.Magpie.nanocodecDecoderT24File
-            secondaryT24Name = ModelNames.Magpie.nanocodecDecoderT24V2File
+            primaryName = ModelNames.Magpie.nanocodecDecoderV2File
+            secondaryName = ModelNames.Magpie.nanocodecDecoderV3File
         }
 
         nanocodecDecoderModel = try loadModel(
             repoDir: repoDir,
-            fileName: primaryT24Name,
+            fileName: primaryName,
             config: nanocodecConfig,
             required: false)
         if nanocodecDecoderModel == nil {
             logger.warning(
-                "Requested \(nanocodecPrecision.rawValue) nanocodec (\(primaryT24Name)) absent; trying alternate precision \(secondaryT24Name)"
+                "Requested \(nanocodecPrecision.rawValue) nanocodec (\(primaryName)) absent; trying alternate precision \(secondaryName)"
             )
             // Loading the alternate-precision build under the requested
             // compute config is fine: fp32 weights will force CPU at
             // runtime regardless, fp16 weights honour the chosen units.
             nanocodecDecoderModel = try loadModel(
                 repoDir: repoDir,
-                fileName: secondaryT24Name,
+                fileName: secondaryName,
                 config: nanocodecConfig,
                 required: false)
         }
         if nanocodecDecoderModel == nil {
             logger.notice(
-                "No T_in=24 nanocodec present; falling back to monolithic CPU-only nanocodec_decoder.mlmodelc"
+                "No chunked nanocodec (v2/v3) present; falling back to legacy monolithic CPU-only nanocodec_decoder.mlmodelc (audibly noisy)"
             )
             let monolithicConfig = MLModelConfiguration()
             monolithicConfig.computeUnits = .cpuOnly

--- a/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
@@ -57,16 +57,27 @@ public actor MagpieModelStore {
         let config = MLModelConfiguration()
         config.computeUnits = computeUnits
 
-        // `decoder_step.mlmodelc` reliably fails ANE compilation
-        // (`MILCompilerForANE error: ANECCompile() FAILED`) due to its rank-4
-        // split-K/V scatter layout, then falls back to CPU at the cost of one
-        // failed ANE compile attempt per call (~hundreds of ms each). Pin it
-        // to `.cpuAndGPU` so CoreML skips the ANE attempt entirely and runs
-        // on Metal MPS — verified end-to-end as the fastest path
-        // (96s warm vs 103s warm on `.cpuAndNeuralEngine`).
-        let gpuConfig = MLModelConfiguration()
-        gpuConfig.computeUnits =
-            computeUnits == .cpuOnly ? .cpuOnly : .cpuAndGPU
+        // `decoder_step.mlmodelc` runs cleanly on ANE: coreml-cli static
+        // analysis reports 97.3 % ANE residency (765 / 773 ops; the 8 CPU
+        // ops are trivial int32 casts / a `select` with ~0.14 ms total cost).
+        // Single-call median predict is 15.2 ms on `.cpuAndNeuralEngine`
+        // vs 22.5 ms on `.cpuAndGPU` (Apple M2). End-to-end on the ~110-char
+        // bench sentence (seed=42, John, en):
+        //   .cpuAndGPU             36.1 ms/step, 30.98 s synth, RTFx 0.62×,
+        //                          and the AR loop never reaches EOS
+        //                          (`EOS: false`, hits maxSteps with tail
+        //                          garbage) — 651 codes / 19.23 s audio.
+        //   .cpuAndNeuralEngine    23.9 ms/step bench / 14.3 ms/step
+        //                          standalone, 9.25 s synth, RTFx 1.21×,
+        //                          terminates correctly (`EOS: true`,
+        //                          234 codes / 11.20 s audio).
+        // ANE is both ~2× faster and produces correctly-terminated audio,
+        // so pin to `.cpuAndNeuralEngine`. (Older comment claiming
+        // `MILCompilerForANE error: ANECCompile() FAILED` no longer holds —
+        // the rank-4 split-K/V scatter compiles cleanly.)
+        let aneConfig = MLModelConfiguration()
+        aneConfig.computeUnits =
+            computeUnits == .cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
 
         // `nanocodec_decoder.mlmodelc` is fastest on **CPU only**. The model's
         // upsample stack (5 transposed convs + 96 sin/pow per-frame embedding
@@ -95,7 +106,7 @@ public actor MagpieModelStore {
         decoderStepModel = try loadModel(
             repoDir: repoDir,
             fileName: ModelNames.Magpie.decoderStepFile,
-            config: gpuConfig,
+            config: aneConfig,
             required: true)
 
         nanocodecDecoderModel = try loadModel(

--- a/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
@@ -1,16 +1,9 @@
 @preconcurrency import CoreML
 import Foundation
 
-/// Selects which chunked nanocodec build the store loads.
-///
-/// - `.fp32` (v3): `nanocodec_decoder_v3.mlmodelc` — full fp32 weights,
-///   pinned to CPU (~142.5 ms / 24-frame call on M2). Audibly clean,
-///   matches the PyTorch sin² reference within the Snake-approximation
-///   noise floor. Pipeline stays real-time at RTFx ~1.3× median.
-/// - `.fp16` (v2): `nanocodec_decoder_v2.mlmodelc` — fp16 weights, runs
-///   ~43 % ANE-resident at ~38.4 ms / 24-frame call. Faster but audibly
-///   noisy on voiced speech (~27 dB SNR vs PyTorch reference, hidden by
-///   silence-RMS metrics). Use only when throughput dominates quality.
+/// Which chunked nanocodec build to load.
+/// `.fp32` (v3) is the audibly-clean default; `.fp16` (v2) is faster
+/// (~4×, partial ANE) but noisy on voiced speech.
 public enum MagpieNanocodecPrecision: String, Sendable {
     case fp16
     case fp32
@@ -29,14 +22,8 @@ public actor MagpieModelStore {
     private var textEncoderModel: MLModel?
     private var decoderPrefillModel: MLModel?  // optional fast path
     private var decoderStepModel: MLModel?
-    /// One of:
-    ///   - v3: chunked T_in=24 fp32 build (`nanocodec_decoder_v3`, default,
-    ///     CPU-only, audibly clean)
-    ///   - v2: chunked T_in=24 fp16 build (`nanocodec_decoder_v2`, fast/ANE,
-    ///     audibly noisy)
-    ///   - v1: monolithic T=256 fp16 build (`nanocodec_decoder`, legacy
-    ///     fallback, CPU-only, audibly noisy)
-    /// `MagpieNanocodec` reads the input shape and chunks accordingly.
+    /// v3 / v2 / v1 nanocodec — `MagpieNanocodec` chunks based on the
+    /// model's input shape.
     private var nanocodecDecoderModel: MLModel?
 
     private var constantsBundle: MagpieConstantsBundle?
@@ -52,13 +39,8 @@ public actor MagpieModelStore {
     /// - Parameters:
     ///   - directory: Optional override for the base cache directory.
     ///   - computeUnits: CoreML compute preference for all models.
-    ///   - preferredLanguages: Set of languages whose tokenizer data should be fetched.
-    ///   - nanocodecPrecision: Which T_in=24 nanocodec build to load.
-    ///     `.fp32` (default) is audibly clean but pinned to CPU
-    ///     (~142.5 ms/call on M2). `.fp16` runs ~43 % ANE-resident
-    ///     (~38.4 ms/call) but is audibly noisy on voiced speech due to
-    ///     fp16 weight quantization. See Phase F write-up in
-    ///     `mobius/.../per_module/results/STATUS.md`.
+    ///   - preferredLanguages: Languages whose tokenizer data is fetched.
+    ///   - nanocodecPrecision: Chunked nanocodec build (default `.fp32`).
     public init(
         directory: URL? = nil,
         computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
@@ -89,52 +71,14 @@ public actor MagpieModelStore {
         let config = MLModelConfiguration()
         config.computeUnits = computeUnits
 
-        // `decoder_step.mlmodelc` runs cleanly on ANE: coreml-cli static
-        // analysis reports 97.3 % ANE residency (765 / 773 ops; the 8 CPU
-        // ops are trivial int32 casts / a `select` with ~0.14 ms total cost).
-        // Single-call median predict is 15.2 ms on `.cpuAndNeuralEngine`
-        // vs 22.5 ms on `.cpuAndGPU` (Apple M2). End-to-end on the ~110-char
-        // bench sentence (seed=42, John, en):
-        //   .cpuAndGPU             36.1 ms/step, 30.98 s synth, RTFx 0.62×,
-        //                          and the AR loop never reaches EOS
-        //                          (`EOS: false`, hits maxSteps with tail
-        //                          garbage) — 651 codes / 19.23 s audio.
-        //   .cpuAndNeuralEngine    23.9 ms/step bench / 14.3 ms/step
-        //                          standalone, 9.25 s synth, RTFx 1.21×,
-        //                          terminates correctly (`EOS: true`,
-        //                          234 codes / 11.20 s audio).
-        // ANE is both ~2× faster and produces correctly-terminated audio,
-        // so pin to `.cpuAndNeuralEngine`. (Older comment claiming
-        // `MILCompilerForANE error: ANECCompile() FAILED` no longer holds —
-        // the rank-4 split-K/V scatter compiles cleanly.)
+        // `decoder_step` is 97 % ANE-resident; pinning to ANE is ~2× faster
+        // than CPU+GPU and the only path that terminates correctly via EOS.
         let aneConfig = MLModelConfiguration()
         aneConfig.computeUnits =
             computeUnits == .cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
 
-        // Nanocodec compute units are dictated by precision, not by the
-        // caller's `computeUnits` setting:
-        //
-        //   .fp32  → `.cpuOnly`. fp32 weights force the CoreML runtime
-        //            off ANE (ANE is fp16-only). Audibly clean.
-        //   .fp16  → `.cpuAndNeuralEngine` (or `.cpuOnly` if the caller
-        //            explicitly requested CPU-only). Runs ~43 %-resident
-        //            on ANE at ~38.4 ms / 24-frame call but is audibly
-        //            noisy on voiced speech.
-        //
-        // The monolithic T=256 fallback build can't use ANE anyway: its
-        // activation tensor exceeds the W ≤ 16384 limit on space-to-batch
-        // lowering of the dilated convs and ANECCompile() fails
-        // whole-graph.
-        //
-        // Noise floor (quietest 0.3 s window, post-norm):
-        //   PyTorch sin² (gold)              -77.4 dBFS
-        //   T=24 chunked, fp32 weights, CPU  -73.6 dBFS  (clean, default)
-        //   T=24 chunked, fp16 weights, CPU  -73.9 dBFS  (audibly noisy)
-        //   T=24 chunked, fp16 weights, ANE  -66.8 dBFS  (audibly noisy)
-        //
-        // See Phase F in `mobius/.../per_module/results/STATUS.md` for
-        // the full mixed-precision sweep that closed off any per-stage
-        // or per-op-type fp16/fp32 island.
+        // Nanocodec compute units track precision: fp32 → CPU-only (ANE is
+        // fp16-only); fp16 → ANE unless caller explicitly pinned CPU.
         let nanocodecConfig = MLModelConfiguration()
         switch nanocodecPrecision {
         case .fp32:
@@ -158,16 +102,8 @@ public actor MagpieModelStore {
             config: aneConfig,
             required: true)
 
-        // Pick the requested precision's chunked build first. If it isn't
-        // in the repo, fall back to the other precision's chunked build
-        // (with a warning), and finally to the legacy monolithic v1
-        // (`nanocodec_decoder.mlmodelc`). Exactly one of the three must
-        // exist for synthesis to work.
-        //
-        // Naming:
-        //   v1 → `nanocodec_decoder.mlmodelc`     (legacy mono, fp16, noisy)
-        //   v2 → `nanocodec_decoder_v2.mlmodelc`  (chunked, fp16, noisy)
-        //   v3 → `nanocodec_decoder_v3.mlmodelc`  (chunked, fp32, clean — default)
+        // Try the requested precision, then the other chunked build, then
+        // the legacy monolithic v1.
         let primaryName: String
         let secondaryName: String
         switch nanocodecPrecision {
@@ -186,11 +122,8 @@ public actor MagpieModelStore {
             required: false)
         if nanocodecDecoderModel == nil {
             logger.warning(
-                "Requested \(nanocodecPrecision.rawValue) nanocodec (\(primaryName)) absent; trying alternate precision \(secondaryName)"
+                "Requested \(nanocodecPrecision.rawValue) nanocodec (\(primaryName)) absent; trying \(secondaryName)"
             )
-            // Loading the alternate-precision build under the requested
-            // compute config is fine: fp32 weights will force CPU at
-            // runtime regardless, fp16 weights honour the chosen units.
             nanocodecDecoderModel = try loadModel(
                 repoDir: repoDir,
                 fileName: secondaryName,

--- a/Sources/FluidAudio/TTS/Magpie/MagpieTtsManager.swift
+++ b/Sources/FluidAudio/TTS/Magpie/MagpieTtsManager.swift
@@ -38,6 +38,7 @@ public actor MagpieTtsManager {
     private let directory: URL?
     private let computeUnits: MLComputeUnits
     private let preferredLanguages: Set<MagpieLanguage>
+    private let nanocodecPrecision: MagpieNanocodecPrecision
 
     private var store: MagpieModelStore?
     private var tokenizer: MagpieTokenizer?
@@ -46,11 +47,13 @@ public actor MagpieTtsManager {
     public init(
         directory: URL? = nil,
         computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
-        preferredLanguages: Set<MagpieLanguage> = [.english]
+        preferredLanguages: Set<MagpieLanguage> = [.english],
+        nanocodecPrecision: MagpieNanocodecPrecision = .fp32
     ) {
         self.directory = directory
         self.computeUnits = computeUnits
         self.preferredLanguages = preferredLanguages
+        self.nanocodecPrecision = nanocodecPrecision
     }
 
     public var isAvailable: Bool {
@@ -61,12 +64,14 @@ public actor MagpieTtsManager {
     public static func downloadAndCreate(
         languages: Set<MagpieLanguage> = [.english],
         cacheDirectory: URL? = nil,
-        computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
+        nanocodecPrecision: MagpieNanocodecPrecision = .fp32
     ) async throws -> MagpieTtsManager {
         let manager = MagpieTtsManager(
             directory: cacheDirectory,
             computeUnits: computeUnits,
-            preferredLanguages: languages)
+            preferredLanguages: languages,
+            nanocodecPrecision: nanocodecPrecision)
         try await manager.initialize()
         return manager
     }
@@ -83,7 +88,8 @@ public actor MagpieTtsManager {
         let store = MagpieModelStore(
             directory: directory,
             computeUnits: computeUnits,
-            preferredLanguages: preferredLanguages)
+            preferredLanguages: preferredLanguages,
+            nanocodecPrecision: nanocodecPrecision)
         try await store.loadIfNeeded()
         self.store = store
 

--- a/Sources/FluidAudio/TTS/Magpie/Pipeline/Synthesize/MagpieNanocodec.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Pipeline/Synthesize/MagpieNanocodec.swift
@@ -3,30 +3,30 @@ import Foundation
 
 /// Wraps `nanocodec_decoder*.mlmodelc`. Three builds are supported,
 /// dispatched automatically from the model's input shape (the precision
-/// of a t24 build is opaque to this wrapper — `MagpieModelStore` decides
-/// which file to load):
+/// of a chunked build is opaque to this wrapper — `MagpieModelStore`
+/// decides which file to load):
 ///
-/// - **Monolithic T=256** (`nanocodec_decoder.mlmodelc`): single call, the
-///   input row count = 256 codec frames, output = 262144 audio samples.
-///   Runs on CPU only because the activation tensor exceeds the ANE's
-///   `W ≤ 16384` limit on the space-to-batch lowering of dilated convs.
-///   Legacy fallback only.
+/// - **v1 — monolithic T=256** (`nanocodec_decoder.mlmodelc`): single
+///   call, input row count = 256 codec frames, output = 262144 audio
+///   samples. fp16 weights, CPU only because the activation tensor
+///   exceeds the ANE's `W ≤ 16384` limit on the space-to-batch lowering
+///   of dilated convs. Both slow and audibly noisy. Legacy fallback only.
 ///
-/// - **Chunked T_in=24, fp32** (`nanocodec_decoder_t24_v2.mlmodelc`,
+/// - **v3 — chunked T_in=24, fp32** (`nanocodec_decoder_v3.mlmodelc`,
 ///   default): 24-frame input, 24576 audio samples per call. fp32
 ///   weights — pinned to CPU because ANE is fp16-only. Audibly clean,
 ///   matches the PyTorch sin² reference within the Snake-approximation
 ///   noise floor. Nanocodec wall ~8.5–9.7 s on a ~11 s utterance (M2),
 ///   still real-time at RTFx ~1.3× end-to-end.
 ///
-/// - **Chunked T_in=24, fp16** (`nanocodec_decoder_t24.mlmodelc`): same
-///   shape contract as the fp32 build. Runs ~43 % ANE-resident at
-///   ~38.4 ms / 24-frame call, so ~4× faster than fp32, but fp16 weight
-///   quantization adds ~27 dB of speech-correlated noise that silence-
-///   RMS metrics hide. Phase F (per-op + per-location mixed-precision
-///   sweep, see `mobius/.../per_module/results/STATUS.md`) confirmed
-///   no mixed-precision island recovers cleanliness. Use only when
-///   throughput dominates quality.
+/// - **v2 — chunked T_in=24, fp16** (`nanocodec_decoder_v2.mlmodelc`):
+///   same shape contract as v3. Runs ~43 % ANE-resident at ~38.4 ms /
+///   24-frame call, so ~4× faster than v3, but fp16 weight quantization
+///   adds ~27 dB of speech-correlated noise that silence-RMS metrics
+///   hide. Phase F (per-op + per-location mixed-precision sweep, see
+///   `mobius/.../per_module/results/STATUS.md`) confirmed no mixed-
+///   precision island recovers cleanliness. Use only when throughput
+///   dominates quality.
 ///
 /// In both chunked builds, the runtime slides the 24-frame window with
 /// stride 8 and overlap 16 frames over the codec sequence and

--- a/Sources/FluidAudio/TTS/Magpie/Pipeline/Synthesize/MagpieNanocodec.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Pipeline/Synthesize/MagpieNanocodec.swift
@@ -1,66 +1,161 @@
 @preconcurrency import CoreML
 import Foundation
 
-/// Wraps the `nanocodec_decoder.mlmodelc` model. Takes `(numCodebooks, Ttotal)`
-/// int32 codes, pads to `maxFrames = 256`, runs the decoder, returns fp32 PCM.
+/// Wraps `nanocodec_decoder*.mlmodelc`. Two builds are supported, dispatched
+/// automatically from the model's input shape:
+///
+/// - **Monolithic T=256** (`nanocodec_decoder.mlmodelc`): single call, the
+///   input row count = 256 codec frames, output = 262144 audio samples.
+///   Runs on CPU only because the activation tensor exceeds the ANE's
+///   `W ≤ 16384` limit on the space-to-batch lowering of dilated convs.
+///
+/// - **Chunked T_in=24** (`nanocodec_decoder_t24.mlmodelc`): 24-frame input,
+///   24576 audio samples per call. The runtime slides this window with
+///   stride 8 and overlap 16 frames over the codec sequence and concatenates
+///   the trailing 8192 audio samples of each call. Shipped with fp32
+///   weights (`compute_precision=FLOAT32` in `convert_nanocodec.py`) and
+///   pinned to CPU in `MagpieModelStore`: the fp16 weight build was
+///   audibly noisy on voiced segments (speech-correlated quantization
+///   noise that silence-RMS metrics hide), so fp32 is the production
+///   choice. fp32 forces CPU (ANE is fp16-only). Nanocodec wall ~8.5–
+///   9.7 s on a ~11 s utterance (M2), still real-time at RTFx ~1.3×
+///   end-to-end.
+///
+/// The 16-frame overlap is the dilated-conv stack's input-side receptive
+/// field; below 16 frames of left context, [`per_module/chunked_parity.py`]
+/// in `mobius` measures < 6 dB SNR vs the single-call reference, which is
+/// audibly broken at boundaries. At 16 frames overlap SNR matches the
+/// Taylor5Clipped Snake noise floor (~11.5 dB).
 public struct MagpieNanocodec {
 
     public let model: MLModel
     public let numCodebooks: Int
-    public let maxFrames: Int
+    /// Input frames per `model.prediction(...)` call. 256 for the monolithic
+    /// build, 24 for the chunked build. Detected from the model's input
+    /// description at init time.
+    public let tIn: Int
+    /// Fresh frames produced per call. Equals `tIn` for the monolithic
+    /// build (no chunking) and `tIn - overlap` for the chunked build.
+    public let stride: Int
     public let samplesPerFrame: Int
+
+    /// Receptive field of the dilated-conv stack at the codec input level,
+    /// measured empirically in `mobius/.../per_module/chunked_parity.py`.
+    private static let receptiveFieldFrames: Int = 16
 
     public init(
         model: MLModel,
         numCodebooks: Int = MagpieConstants.numCodebooks,
-        maxFrames: Int = MagpieConstants.maxNanocodecFrames,
         samplesPerFrame: Int = MagpieConstants.codecSamplesPerFrame
     ) {
         self.model = model
         self.numCodebooks = numCodebooks
-        self.maxFrames = maxFrames
         self.samplesPerFrame = samplesPerFrame
+        let detected = Self.detectTIn(
+            model: model, fallback: MagpieConstants.maxNanocodecFrames)
+        self.tIn = detected
+        // Monolithic single-call build (tIn = full sequence): no chunking.
+        // Chunked build: stride = tIn - 16 receptive-field overlap.
+        if detected >= MagpieConstants.maxNanocodecFrames {
+            self.stride = detected
+        } else {
+            self.stride = max(1, detected - Self.receptiveFieldFrames)
+        }
     }
 
+    private var overlap: Int { tIn - stride }
+
     /// - Parameter frames: row-major `[numCodebooks][Ttotal]` codes.
+    /// - Returns: `Ttotal * samplesPerFrame` fp32 PCM samples.
     public func decode(frames: [[Int32]]) throws -> [Float] {
         precondition(frames.count == numCodebooks, "expected \(numCodebooks) codebook rows")
-        let tTotal = min(frames[0].count, maxFrames)
+        let tTotal = frames[0].count
+        if tTotal == 0 {
+            return []
+        }
+        let totalSamples = tTotal * samplesPerFrame
+        var output = Swift.Array<Float>(repeating: 0, count: totalSamples)
 
-        // Build tokens tensor: (1, numCodebooks, maxFrames) int32, zero-padded.
+        // Reusable input tensor — same shape every call.
         let tokens = try MLMultiArray(
-            shape: [1, NSNumber(value: numCodebooks), NSNumber(value: maxFrames)],
+            shape: [1, NSNumber(value: numCodebooks), NSNumber(value: tIn)],
             dataType: .int32)
-        tokens.withUnsafeMutableBytes { ptr, strides in
-            let base = ptr.bindMemory(to: Int32.self).baseAddress!
-            let total = numCodebooks * maxFrames
-            for i in 0..<total { base[i] = 0 }
-            for cb in 0..<numCodebooks {
-                for t in 0..<tTotal {
-                    base[cb * maxFrames + t] = frames[cb][t]
+
+        // Slide a tIn-frame window with `stride` fresh frames per call.
+        // Out-of-range indices use **edge replication** rather than zero
+        // padding: the first call's left context replays `row[0]`, the
+        // last call's right context replays `row[tTotal - 1]`. Code 0 is
+        // a real codebook entry the codec was never trained to see in
+        // sequence, so zero-padding produces a sharp pop in the first
+        // ~30 ms of the rendered audio (measured at peak 0.64 vs mono's
+        // 0.001). Edge replication makes the dilated convs see a
+        // stationary signal that matches the AR loop's near-silent first
+        // frame, killing the transient.
+        var outFrame = 0
+        let overlap = self.overlap
+        let lastIdx = tTotal - 1
+        while outFrame < tTotal {
+            let ctxStart = outFrame - overlap
+            tokens.withUnsafeMutableBytes { rawPtr, _ in
+                let base = rawPtr.bindMemory(to: Int32.self).baseAddress!
+                for cb in 0..<numCodebooks {
+                    let row = frames[cb]
+                    let rowOffset = cb * tIn
+                    for t in 0..<tIn {
+                        let src = ctxStart + t
+                        let clamped = max(0, min(lastIdx, src))
+                        base[rowOffset + t] = row[clamped]
+                    }
                 }
             }
-            _ = strides
-        }
 
-        let provider = try MLDictionaryFeatureProvider(dictionary: [
-            "tokens": MLFeatureValue(multiArray: tokens)
-        ])
-        let output = try model.prediction(from: provider)
-        guard let audio = output.featureValue(for: "audio")?.multiArrayValue else {
-            throw MagpieError.inferenceFailed(
-                stage: "nanocodec", underlying: "missing 'audio' output key")
-        }
-
-        let expected = tTotal * samplesPerFrame
-        var samples = Swift.Array<Float>(repeating: 0, count: expected)
-        audio.withUnsafeBytes { raw in
-            let ptr = raw.bindMemory(to: Float.self)
-            let available = min(expected, audio.count)
-            for i in 0..<available {
-                samples[i] = ptr[i]
+            let provider = try MLDictionaryFeatureProvider(dictionary: [
+                "tokens": MLFeatureValue(multiArray: tokens)
+            ])
+            let result = try model.prediction(from: provider)
+            guard let audio = result.featureValue(for: "audio")?.multiArrayValue else {
+                throw MagpieError.inferenceFailed(
+                    stage: "nanocodec", underlying: "missing 'audio' output key")
             }
+
+            // Audio buffer is (1, tIn * samplesPerFrame) fp32. Discard the
+            // first `overlap * samplesPerFrame` samples (dilated convs'
+            // warmup region) and copy the next `stride * samplesPerFrame`
+            // samples into the output, clamped to the audio buffer length
+            // and to the requested totalSamples.
+            let writeStart = outFrame * samplesPerFrame
+            let keepStart = overlap * samplesPerFrame
+            let writeCount = min(
+                stride * samplesPerFrame,
+                totalSamples - writeStart,
+                audio.count - keepStart)
+            if writeCount > 0 {
+                audio.withUnsafeBytes { raw in
+                    let ptr = raw.bindMemory(to: Float.self)
+                    for i in 0..<writeCount {
+                        output[writeStart + i] = ptr[keepStart + i]
+                    }
+                }
+            }
+            outFrame += stride
         }
-        return samples
+        return output
+    }
+
+    /// Read the `tokens` input shape from the model description and return
+    /// the third dimension (frame count). Falls back to `fallback` if the
+    /// description is missing or malformed.
+    private static func detectTIn(model: MLModel, fallback: Int) -> Int {
+        guard let description = model.modelDescription.inputDescriptionsByName["tokens"],
+            let constraint = description.multiArrayConstraint
+        else {
+            return fallback
+        }
+        let shape = constraint.shape
+        guard shape.count >= 3 else {
+            return fallback
+        }
+        let value = shape[2].intValue
+        return value > 0 ? value : fallback
     }
 }

--- a/Sources/FluidAudio/TTS/Magpie/Pipeline/Synthesize/MagpieNanocodec.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Pipeline/Synthesize/MagpieNanocodec.swift
@@ -1,57 +1,25 @@
 @preconcurrency import CoreML
 import Foundation
 
-/// Wraps `nanocodec_decoder*.mlmodelc`. Three builds are supported,
-/// dispatched automatically from the model's input shape (the precision
-/// of a chunked build is opaque to this wrapper — `MagpieModelStore`
-/// decides which file to load):
+/// Wraps `nanocodec_decoder*.mlmodelc`. Dispatches by input shape:
 ///
-/// - **v1 — monolithic T=256** (`nanocodec_decoder.mlmodelc`): single
-///   call, input row count = 256 codec frames, output = 262144 audio
-///   samples. fp16 weights, CPU only because the activation tensor
-///   exceeds the ANE's `W ≤ 16384` limit on the space-to-batch lowering
-///   of dilated convs. Both slow and audibly noisy. Legacy fallback only.
+/// - v1 (`nanocodec_decoder`): T=256 mono, fp16, CPU. Legacy fallback.
+/// - v2 (`nanocodec_decoder_v2`): T_in=24 chunked, fp16. Fast, noisy.
+/// - v3 (`nanocodec_decoder_v3`, default): T_in=24 chunked, fp32, CPU. Clean.
 ///
-/// - **v3 — chunked T_in=24, fp32** (`nanocodec_decoder_v3.mlmodelc`,
-///   default): 24-frame input, 24576 audio samples per call. fp32
-///   weights — pinned to CPU because ANE is fp16-only. Audibly clean,
-///   matches the PyTorch sin² reference within the Snake-approximation
-///   noise floor. Nanocodec wall ~8.5–9.7 s on a ~11 s utterance (M2),
-///   still real-time at RTFx ~1.3× end-to-end.
-///
-/// - **v2 — chunked T_in=24, fp16** (`nanocodec_decoder_v2.mlmodelc`):
-///   same shape contract as v3. Runs ~43 % ANE-resident at ~38.4 ms /
-///   24-frame call, so ~4× faster than v3, but fp16 weight quantization
-///   adds ~27 dB of speech-correlated noise that silence-RMS metrics
-///   hide. Phase F (per-op + per-location mixed-precision sweep, see
-///   `mobius/.../per_module/results/STATUS.md`) confirmed no mixed-
-///   precision island recovers cleanliness. Use only when throughput
-///   dominates quality.
-///
-/// In both chunked builds, the runtime slides the 24-frame window with
-/// stride 8 and overlap 16 frames over the codec sequence and
-/// concatenates the trailing 8192 audio samples of each call.
-///
-/// The 16-frame overlap is the dilated-conv stack's input-side receptive
-/// field; below 16 frames of left context, [`per_module/chunked_parity.py`]
-/// in `mobius` measures < 6 dB SNR vs the single-call reference, which is
-/// audibly broken at boundaries. At 16 frames overlap SNR matches the
-/// Taylor5Clipped Snake noise floor (~11.5 dB).
+/// Chunked builds slide a 24-frame window with stride 8 / overlap 16
+/// (= dilated-conv input receptive field).
 public struct MagpieNanocodec {
 
     public let model: MLModel
     public let numCodebooks: Int
-    /// Input frames per `model.prediction(...)` call. 256 for the monolithic
-    /// build, 24 for the chunked build. Detected from the model's input
-    /// description at init time.
+    /// Input frames per call (256 mono, 24 chunked). Detected from input shape.
     public let tIn: Int
-    /// Fresh frames produced per call. Equals `tIn` for the monolithic
-    /// build (no chunking) and `tIn - overlap` for the chunked build.
+    /// Fresh frames produced per call (= `tIn - overlap`, or `tIn` for mono).
     public let stride: Int
     public let samplesPerFrame: Int
 
-    /// Receptive field of the dilated-conv stack at the codec input level,
-    /// measured empirically in `mobius/.../per_module/chunked_parity.py`.
+    /// Dilated-conv input receptive field. Empirical floor for clean seams.
     private static let receptiveFieldFrames: Int = 16
 
     public init(
@@ -65,10 +33,8 @@ public struct MagpieNanocodec {
         let detected = Self.detectTIn(
             model: model, fallback: MagpieConstants.maxNanocodecFrames)
         self.tIn = detected
-        // Monolithic single-call build (tIn = full sequence): no chunking.
-        // Chunked build: stride = tIn - 16 receptive-field overlap.
         if detected >= MagpieConstants.maxNanocodecFrames {
-            self.stride = detected
+            self.stride = detected  // mono: no chunking
         } else {
             self.stride = max(1, detected - Self.receptiveFieldFrames)
         }
@@ -92,16 +58,9 @@ public struct MagpieNanocodec {
             shape: [1, NSNumber(value: numCodebooks), NSNumber(value: tIn)],
             dataType: .int32)
 
-        // Slide a tIn-frame window with `stride` fresh frames per call.
-        // Out-of-range indices use **edge replication** rather than zero
-        // padding: the first call's left context replays `row[0]`, the
-        // last call's right context replays `row[tTotal - 1]`. Code 0 is
-        // a real codebook entry the codec was never trained to see in
-        // sequence, so zero-padding produces a sharp pop in the first
-        // ~30 ms of the rendered audio (measured at peak 0.64 vs mono's
-        // 0.001). Edge replication makes the dilated convs see a
-        // stationary signal that matches the AR loop's near-silent first
-        // frame, killing the transient.
+        // Slide a tIn-frame window. Out-of-range indices use edge
+        // replication; zero-padding produces an audible pop because
+        // code 0 is a real, untrained-in-sequence codebook entry.
         var outFrame = 0
         let overlap = self.overlap
         let lastIdx = tTotal - 1
@@ -129,11 +88,7 @@ public struct MagpieNanocodec {
                     stage: "nanocodec", underlying: "missing 'audio' output key")
             }
 
-            // Audio buffer is (1, tIn * samplesPerFrame) fp32. Discard the
-            // first `overlap * samplesPerFrame` samples (dilated convs'
-            // warmup region) and copy the next `stride * samplesPerFrame`
-            // samples into the output, clamped to the audio buffer length
-            // and to the requested totalSamples.
+            // Drop the overlap warmup, copy the next `stride` frames of audio.
             let writeStart = outFrame * samplesPerFrame
             let keepStart = overlap * samplesPerFrame
             let writeCount = min(
@@ -153,9 +108,7 @@ public struct MagpieNanocodec {
         return output
     }
 
-    /// Read the `tokens` input shape from the model description and return
-    /// the third dimension (frame count). Falls back to `fallback` if the
-    /// description is missing or malformed.
+    /// Read frame count from the `tokens` input shape's third dimension.
     private static func detectTIn(model: MLModel, fallback: Int) -> Int {
         guard let description = model.modelDescription.inputDescriptionsByName["tokens"],
             let constraint = description.multiArrayConstraint

--- a/Sources/FluidAudio/TTS/Magpie/Pipeline/Synthesize/MagpieNanocodec.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Pipeline/Synthesize/MagpieNanocodec.swift
@@ -1,25 +1,36 @@
 @preconcurrency import CoreML
 import Foundation
 
-/// Wraps `nanocodec_decoder*.mlmodelc`. Two builds are supported, dispatched
-/// automatically from the model's input shape:
+/// Wraps `nanocodec_decoder*.mlmodelc`. Three builds are supported,
+/// dispatched automatically from the model's input shape (the precision
+/// of a t24 build is opaque to this wrapper — `MagpieModelStore` decides
+/// which file to load):
 ///
 /// - **Monolithic T=256** (`nanocodec_decoder.mlmodelc`): single call, the
 ///   input row count = 256 codec frames, output = 262144 audio samples.
 ///   Runs on CPU only because the activation tensor exceeds the ANE's
 ///   `W ≤ 16384` limit on the space-to-batch lowering of dilated convs.
+///   Legacy fallback only.
 ///
-/// - **Chunked T_in=24** (`nanocodec_decoder_t24.mlmodelc`): 24-frame input,
-///   24576 audio samples per call. The runtime slides this window with
-///   stride 8 and overlap 16 frames over the codec sequence and concatenates
-///   the trailing 8192 audio samples of each call. Shipped with fp32
-///   weights (`compute_precision=FLOAT32` in `convert_nanocodec.py`) and
-///   pinned to CPU in `MagpieModelStore`: the fp16 weight build was
-///   audibly noisy on voiced segments (speech-correlated quantization
-///   noise that silence-RMS metrics hide), so fp32 is the production
-///   choice. fp32 forces CPU (ANE is fp16-only). Nanocodec wall ~8.5–
-///   9.7 s on a ~11 s utterance (M2), still real-time at RTFx ~1.3×
-///   end-to-end.
+/// - **Chunked T_in=24, fp32** (`nanocodec_decoder_t24_v2.mlmodelc`,
+///   default): 24-frame input, 24576 audio samples per call. fp32
+///   weights — pinned to CPU because ANE is fp16-only. Audibly clean,
+///   matches the PyTorch sin² reference within the Snake-approximation
+///   noise floor. Nanocodec wall ~8.5–9.7 s on a ~11 s utterance (M2),
+///   still real-time at RTFx ~1.3× end-to-end.
+///
+/// - **Chunked T_in=24, fp16** (`nanocodec_decoder_t24.mlmodelc`): same
+///   shape contract as the fp32 build. Runs ~43 % ANE-resident at
+///   ~38.4 ms / 24-frame call, so ~4× faster than fp32, but fp16 weight
+///   quantization adds ~27 dB of speech-correlated noise that silence-
+///   RMS metrics hide. Phase F (per-op + per-location mixed-precision
+///   sweep, see `mobius/.../per_module/results/STATUS.md`) confirmed
+///   no mixed-precision island recovers cleanliness. Use only when
+///   throughput dominates quality.
+///
+/// In both chunked builds, the runtime slides the 24-frame window with
+/// stride 8 and overlap 16 frames over the codec sequence and
+/// concatenates the trailing 8192 audio samples of each call.
 ///
 /// The 16-frame overlap is the dilated-conv stack's input-side receptive
 /// field; below 16 frames of left context, [`per_module/chunked_parity.py`]

--- a/Tests/FluidAudioTests/TTS/Magpie/MagpieConstantsTests.swift
+++ b/Tests/FluidAudioTests/TTS/Magpie/MagpieConstantsTests.swift
@@ -66,10 +66,11 @@ final class MagpieConstantsTests: XCTestCase {
         }
 
         // Sanity: the three core CoreML models + the constants directory are
-        // the minimum required for English synthesis.
+        // the minimum required for English synthesis. The nanocodec
+        // production default is v3 (`nanocodecDecoderV3File`).
         XCTAssertTrue(required.contains(ModelNames.Magpie.textEncoderFile))
         XCTAssertTrue(required.contains(ModelNames.Magpie.decoderStepFile))
-        XCTAssertTrue(required.contains(ModelNames.Magpie.nanocodecDecoderFile))
+        XCTAssertTrue(required.contains(ModelNames.Magpie.nanocodecDecoderV3File))
         XCTAssertTrue(required.contains(ModelNames.Magpie.constantsDir))
     }
 }


### PR DESCRIPTION
## Summary

Companion to mobius PR FluidInference/mobius#53. Wires the new nanocodec v2/v3 builds into the FluidAudio Magpie runtime, plus pins `decoder_step` to ANE for ~2× wall speedup.

## Commits

- `5879a32b3` — `fix(tts/magpie): pin decoder_step to ANE for ~2x speedup + correct EOS`
  - `decoder_step.mlmodelc` was running CPU+GPU. Pinning to `.cpuAndNeuralEngine` halves wall on M2.
  - EOS handling: don't emit the post-EOS frame.
- `ec7051504` — `feat(tts/magpie): chunked T=24 fp32 nanocodec + edge-pad (Phase C v2)`
  - Slide a 24-frame window with stride 8, overlap 16 (= dilated-conv input receptive field).
  - Edge-replicate context at sequence boundaries instead of zero-padding (zero-pad produces a sharp pop in the first ~30 ms).
- `2f0aab7a7` — `feat(tts/magpie): dual fp16/fp32 nanocodec t24 builds via MagpieNanocodecPrecision`
  - New `MagpieNanocodecPrecision` enum (`.fp16` / `.fp32`).
  - Compute-unit dispatch: fp32 → `.cpuOnly` (ANE is fp16-only); fp16 → `.cpuAndNeuralEngine` unless caller pinned CPU.
  - Plumbed through `MagpieModelStore.init` and `MagpieTtsManager.init` / `downloadAndCreate`.
- `4bd31469f` — `refactor(tts/magpie): nanocodec v1/v2/v3 versioning (drop t24 prefix)`
  - Final naming: v1 = legacy mono, v2 = chunked fp16, v3 = chunked fp32.
  - `requiredModels` now lists `nanocodecDecoderV3File` so legacy v1-only users auto-upgrade on next bulk fetch.
  - Load chain: primary (precision-matched) → secondary (cross-precision warning) → legacy v1 fallback.

## Production state

| Build | File | Precision | Shape | Selector | Audio |
|---|---|---|---|---|---|
| v1 | `nanocodec_decoder.mlmodelc` | fp16 | T=256 monolithic | legacy fallback | noisy + slow |
| v2 | `nanocodec_decoder_v2.mlmodelc` | fp16 | T_in=24 chunked | `MagpieNanocodecPrecision.fp16` | noisy / fast |
| v3 | `nanocodec_decoder_v3.mlmodelc` | fp32 | T_in=24 chunked | `MagpieNanocodecPrecision.fp32` (default) | clean |

All three live on `FluidInference/magpie-tts-multilingual-357m-coreml`.

## Background

Phase F mixed-precision sweep (mobius#53) confirmed no fp16 op/location combination recovers cleanliness — production stays on v3 (fp32) with v2 as opt-in for throughput-bound callers willing to accept the 27 dB SNR floor.

## Test plan

- [x] `swift format` clean
- [x] `swift build` clean
- [ ] Sanity-check `swift test --filter MagpieTtsTests` (if present)
- [ ] Spot-check synthesis via CLI on default speaker