### PR TITLE
feat(tts/magpie): nanocodec v4 (fp32 + int8 palettize) precision

### DIFF
--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -774,6 +774,11 @@ public enum ModelNames {
         public static let nanocodecDecoderV2 = "nanocodec_decoder_v2"
         /// v3: T_in=24 chunked, fp32, CPU. Audibly clean (default).
         public static let nanocodecDecoderV3 = "nanocodec_decoder_v3"
+        /// v4: T_in=24 chunked, fp32 compute + 8-bit kmeans palettized weights, CPU.
+        /// Acoustically transparent vs v3 (33.6 dB SNR on AR speech, identical
+        /// quiet floor) at ~4× smaller on disk (31 MB vs 121 MB) and ~11 %
+        /// lower peak RSS. Same recipe Kokoro Noise uses (`fp32 + int8pal`).
+        public static let nanocodecDecoderV4 = "nanocodec_decoder_v4"
 
         public static let textEncoderFile = textEncoder + ".mlmodelc"
         public static let decoderPrefillFile = decoderPrefill + ".mlmodelc"
@@ -781,6 +786,7 @@ public enum ModelNames {
         public static let nanocodecDecoderFile = nanocodecDecoder + ".mlmodelc"
         public static let nanocodecDecoderV2File = nanocodecDecoderV2 + ".mlmodelc"
         public static let nanocodecDecoderV3File = nanocodecDecoderV3 + ".mlmodelc"
+        public static let nanocodecDecoderV4File = nanocodecDecoderV4 + ".mlmodelc"
 
         public static let constantsDir = "constants"
         public static let tokenizerDir = "tokenizer"

--- a/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Assets/MagpieModelStore.swift
@@ -3,10 +3,13 @@ import Foundation
 
 /// Which chunked nanocodec build to load.
 /// `.fp32` (v3) is the audibly-clean default; `.fp16` (v2) is faster
-/// (~4×, partial ANE) but noisy on voiced speech.
+/// (~4×, partial ANE) but noisy on voiced speech. `.fp32Pal` (v4) is
+/// fp32 compute with 8-bit kmeans palettized weights — acoustically
+/// transparent vs v3 at ~4× smaller on disk and ~11 % lower peak RSS.
 public enum MagpieNanocodecPrecision: String, Sendable {
     case fp16
     case fp32
+    case fp32Pal
 }
 
 /// Actor-based store for Magpie CoreML models + constants + LocalTransformer weights.
@@ -77,18 +80,29 @@ public actor MagpieModelStore {
         aneConfig.computeUnits =
             computeUnits == .cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
 
-        // Nanocodec compute units track precision: fp32 → CPU-only (ANE is
-        // fp16-only); fp16 → ANE unless caller explicitly pinned CPU.
+        // Nanocodec compute units track precision: fp32 / fp32Pal → CPU-only
+        // (ANE is fp16-only; palettized weights dequantize to fp32 at runtime
+        // so compute is still fp32); fp16 → ANE unless caller explicitly
+        // pinned CPU.
         func nanocodecConfig(for precision: MagpieNanocodecPrecision) -> MLModelConfiguration {
             let cfg = MLModelConfiguration()
             switch precision {
-            case .fp32:
+            case .fp32, .fp32Pal:
                 cfg.computeUnits = .cpuOnly
             case .fp16:
                 cfg.computeUnits =
                     computeUnits == .cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
             }
             return cfg
+        }
+
+        // Filename for a chunked nanocodec build.
+        func nanocodecFile(for precision: MagpieNanocodecPrecision) -> String {
+            switch precision {
+            case .fp16: return ModelNames.Magpie.nanocodecDecoderV2File
+            case .fp32: return ModelNames.Magpie.nanocodecDecoderV3File
+            case .fp32Pal: return ModelNames.Magpie.nanocodecDecoderV4File
+            }
         }
 
         let loadStart = Date()
@@ -105,40 +119,39 @@ public actor MagpieModelStore {
             config: aneConfig,
             required: true)
 
-        // Try the requested precision, then the other chunked build, then
-        // the legacy monolithic v1. Each candidate carries its own config so
-        // the fallback doesn't inherit the primary's compute-unit selection.
-        let secondaryPrecision: MagpieNanocodecPrecision =
-            nanocodecPrecision == .fp32 ? .fp16 : .fp32
-        let primaryName: String
-        let secondaryName: String
+        // Try the requested precision, then the other chunked builds in a
+        // sensible audibility-preserving order, then the legacy monolithic
+        // v1. Each candidate carries its own config so the fallback doesn't
+        // inherit the primary's compute-unit selection. fp16 (v2) is only
+        // reached when explicitly requested or when no other candidate is
+        // present, since it's audibly noisy on voiced speech.
+        let fallbackOrder: [MagpieNanocodecPrecision]
         switch nanocodecPrecision {
+        case .fp32Pal:
+            fallbackOrder = [.fp32Pal, .fp32, .fp16]
         case .fp32:
-            primaryName = ModelNames.Magpie.nanocodecDecoderV3File
-            secondaryName = ModelNames.Magpie.nanocodecDecoderV2File
+            fallbackOrder = [.fp32, .fp32Pal, .fp16]
         case .fp16:
-            primaryName = ModelNames.Magpie.nanocodecDecoderV2File
-            secondaryName = ModelNames.Magpie.nanocodecDecoderV3File
+            fallbackOrder = [.fp16, .fp32Pal, .fp32]
         }
 
-        nanocodecDecoderModel = try loadModel(
-            repoDir: repoDir,
-            fileName: primaryName,
-            config: nanocodecConfig(for: nanocodecPrecision),
-            required: false)
-        if nanocodecDecoderModel == nil {
-            logger.warning(
-                "Requested \(nanocodecPrecision.rawValue) nanocodec (\(primaryName)) absent; trying \(secondaryName)"
-            )
+        for (index, candidate) in fallbackOrder.enumerated() {
+            let candidateName = nanocodecFile(for: candidate)
+            if index > 0 {
+                logger.warning(
+                    "Requested \(fallbackOrder[0].rawValue) nanocodec absent; trying \(candidate.rawValue) (\(candidateName))"
+                )
+            }
             nanocodecDecoderModel = try loadModel(
                 repoDir: repoDir,
-                fileName: secondaryName,
-                config: nanocodecConfig(for: secondaryPrecision),
+                fileName: candidateName,
+                config: nanocodecConfig(for: candidate),
                 required: false)
+            if nanocodecDecoderModel != nil { break }
         }
         if nanocodecDecoderModel == nil {
             logger.notice(
-                "No chunked nanocodec (v2/v3) present; falling back to legacy monolithic CPU-only nanocodec_decoder.mlmodelc (audibly noisy)"
+                "No chunked nanocodec (v2/v3/v4) present; falling back to legacy monolithic CPU-only nanocodec_decoder.mlmodelc (audibly noisy)"
             )
             let monolithicConfig = MLModelConfiguration()
             monolithicConfig.computeUnits = .cpuOnly


### PR DESCRIPTION
## Summary

Add `MagpieNanocodecPrecision.fp32Pal` selecting `nanocodec_decoder_v4`: v3's fp32 architecture with 8-bit kmeans-palettized weights. Acoustically transparent vs v3 at ~4× smaller on disk and ~11% lower peak RSS. Same recipe Kokoro Noise uses for `fp32 + int8pal`.

Compute units track precision: `.fp32Pal` pins `.cpuOnly` (palettized weights dequantize to fp32 at runtime; ANE refuses fp32 / GPU is 50%+ slower than CPU on fp32 codec).

## Bench (M2, 16 GB, .cpuOnly, T_in=24, 5 warmup + 50 timed iters)

| metric              | v3 fp32 | v4 fp32+int8pal | delta  |
|---------------------|---------|-----------------|--------|
| mlpackage on disk   | 121.0MB |          30.9MB |   -74% |
| post-load RSS delta | +59.9MB |         +61.7MB |    eq. |
| peak RSS            | 700.8MB |         621.8MB |   -11% |
| latency median      | 117.6ms |         117.1ms |    eq. |
| latency p95         | 145.9ms |         123.6ms |   -15% |
| RTFx (codec)        |   9.48× |           9.52× |    eq. |
| SNR vs v3 (AR codes)|    inf. |          33.6dB | clean* |

*User-confirmed acoustically transparent on AR-emitted speech.

## Fallback chain

Each candidate carries its own config so the fallback doesn't inherit the primary's compute-unit selection. fp16 (v2) is only reached when explicitly requested or when no other candidate is present, since it's audibly noisy on voiced speech:

| Requested      | Order                    |
|----------------|--------------------------|
| `.fp32Pal`     | v4 → v3 → v2             |
| `.fp32`        | v3 → v4 → v2             |
| `.fp16`        | v2 → v4 → v3             |

If every chunked artifact is missing the loader falls through to legacy monolithic v1 with `.cpuOnly` (audibly noisy).

## HF artifacts

Already uploaded to `FluidInference/magpie-tts-multilingual-357m-coreml`:
- `nanocodec_decoder_v4.mlmodelc/`
- `nanocodec_decoder_v4.mlpackage/`

## Companion PR

mobius converter: https://github.com/FluidInference/mobius/pull/54

## Test plan
- [x] `swift build` green
- [x] `swift test --filter MagpieConstantsTests` 5/5 pass
- [x] `swift format lint` clean for changed files
- [ ] End-to-end `MagpieTtsManager` synth with `.fp32Pal` once HF artifacts propagate to user caches