### PR TITLE
fix(tts): guard direct Float16 reads with #if arch(arm64) (CosyVoice3, StyleTTS2)

### DIFF
--- a/Sources/FluidAudio/TTS/CosyVoice3/Pipeline/Synthesize/CosyVoice3SpeechEmbeddings.swift
+++ b/Sources/FluidAudio/TTS/CosyVoice3/Pipeline/Synthesize/CosyVoice3SpeechEmbeddings.swift
@@ -60,6 +60,7 @@ public final class CosyVoice3SpeechEmbeddings {
         let rowStart = Int(tokenId) * rowByteSize
         let dim = embedDim
         let lastStride = array.strides.last?.intValue ?? 1
+        #if arch(arm64)
         tableBytes.withUnsafeBytes { src in
             let basePtr = src.baseAddress!.advanced(by: rowStart)
             let fp16Ptr = basePtr.assumingMemoryBound(to: Float16.self)
@@ -68,5 +69,11 @@ public final class CosyVoice3SpeechEmbeddings {
                 dstPtr[i * lastStride] = Float(fp16Ptr[i])
             }
         }
+        #else
+        // Float16 is only available on Apple Silicon — the speech_embedding
+        // safetensors table ships as fp16, with no fp32 alternative on disk.
+        throw CosyVoice3Error.predictionFailed(
+            "CosyVoice3 speech embeddings require Apple Silicon (arm64); fp16 lookup table cannot be read on x86_64")
+        #endif
     }
 }

--- a/Sources/FluidAudio/TTS/CosyVoice3/Pipeline/Synthesize/CosyVoice3Synthesizer.swift
+++ b/Sources/FluidAudio/TTS/CosyVoice3/Pipeline/Synthesize/CosyVoice3Synthesizer.swift
@@ -549,6 +549,7 @@ public actor CosyVoice3Synthesizer {
         // Branch on src dtype so the fp16 ANE-port Flow output doesn't get
         // reinterpreted as fp32 (would read past end of buffer → SIGSEGV).
         switch fullMel.dataType {
+        #if arch(arm64)
         case .float16:
             let srcBase = fullMel.dataPointer.bindMemory(
                 to: Float16.self, capacity: fullMel.count)
@@ -559,6 +560,7 @@ public actor CosyVoice3Synthesizer {
                     dstBase[dstOff] = Float(srcBase[srcOff])
                 }
             }
+        #endif
         case .float32:
             let srcBase = fullMel.dataPointer.bindMemory(
                 to: Float.self, capacity: fullMel.count)

--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Synthesizer.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Synthesizer.swift
@@ -284,9 +284,11 @@ public actor StyleTTS2Synthesizer {
         case .float32:
             let p = arr.dataPointer.bindMemory(to: Float.self, capacity: count)
             fill { p[$0] }
+        #if arch(arm64)
         case .float16:
             let p = arr.dataPointer.bindMemory(to: Float16.self, capacity: count)
             fill { Float(p[$0]) }
+        #endif
         case .double:
             let p = arr.dataPointer.bindMemory(to: Double.self, capacity: count)
             fill { Float(p[$0]) }
@@ -537,11 +539,13 @@ public actor StyleTTS2Synthesizer {
             for i in 0..<n {
                 out[i] = p[i]
             }
+        #if arch(arm64)
         case .float16:
             let p = arr.dataPointer.bindMemory(to: Float16.self, capacity: arr.count)
             for i in 0..<n {
                 out[i] = Float(p[i])
             }
+        #endif
         case .double:
             let p = arr.dataPointer.bindMemory(to: Double.self, capacity: arr.count)
             for i in 0..<n {


### PR DESCRIPTION
## Summary

`Float16` is an arm64-only Swift built-in, so any direct `Float16` typing fails to compile in the x86_64 slice of a Universal build. Four sites in CosyVoice3 and StyleTTS2 do raw `Float16` pointer binds with no arch guard, which currently breaks Universal archive builds with errors like:

```
'Float16' is unavailable in macOS
No exact matches in call to initializer
Failed to produce diagnostic for expression; please submit a bug report
```

Affected sites:
- `Sources/FluidAudio/TTS/CosyVoice3/Pipeline/Synthesize/CosyVoice3SpeechEmbeddings.swift:65` — `assumingMemoryBound(to: Float16.self)` for the fp16 safetensors lookup table.
- `Sources/FluidAudio/TTS/CosyVoice3/Pipeline/Synthesize/CosyVoice3Synthesizer.swift:554` — fp16 branch of the Flow→HiFT mel copy in `runHiFT`.
- `Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Synthesizer.swift:288` — fp16 case in `sliceFirstAxis2D`.
- `Sources/FluidAudio/TTS/StyleTTS2/Pipeline/StyleTTS2Synthesizer.swift:541` — fp16 case in `readMLMultiArrayPrefix`.

This PR mirrors the package's existing pattern for fp16 reads on non-arm64 (`ASR/Qwen3/Qwen3AsrModels.swift:310`, `Diarizer/Sortformer/SortformerModelInference.swift:278`): wrap each `Float16`-touching arm in `#if arch(arm64) ... #endif`.

## Behavior on x86_64

- **CosyVoice3SpeechEmbeddings** — throws `CosyVoice3Error.predictionFailed("requires Apple Silicon (arm64); fp16 lookup table cannot be read on x86_64")`. The `speech_embedding` safetensors table is fp16-only on disk with no fp32 alternative, so this matches the Qwen3-ASR posture (its embedding table is also fp16-only on disk; it `fatalError`s on x86_64).
- **CosyVoice3Synthesizer.runHiFT** — the `case .float16:` arm is omitted on x86_64. The `case .float32:` path is unchanged. If a Flow variant emits fp16 at runtime on Intel, control falls into the existing `default:` arm, which already throws `"runHiFT: unexpected Flow mel dtype …"`.
- **StyleTTS2Synthesizer (`sliceFirstAxis2D`, `readMLMultiArrayPrefix`)** — the `case .float16:` arm is omitted on x86_64. fp16 arrays fall through to the existing NSNumber-bridged `default:` arm (`arr[i].floatValue` / `fill { arr[$0].floatValue }`), which already converts fp16 correctly. Slightly slower on Intel; no behavior regression.

No new error types or dependencies. Diff is +13 lines across 3 files.

## Why this approach (vs. vImage byte-level conversion)

FluidAudio already uses two patterns for cross-arch fp16 handling:
- **`#if arch(arm64)` guard** — used for fp16 *reads* in `Qwen3AsrModels.swift` and `SortformerModelInference.swift`.
- **vImage `Planar16FtoPlanarF` / `PlanarFtoPlanar16F`** — used for fp16 *writes* in `KokoroAneSynthesizer+Conversion.swift`, `TtsModels.swift`, `KokoroSynthesizer.swift`, with the explicit comment in `TtsModels.swift:182`: *"This avoids direct Float16 usage which isn't available in all build configurations"*.

This PR matches the existing fp16-read precedent (Pattern A). A follow-up could port these read paths to vImage for full Intel runtime support (Pattern B), but that's a larger change and would need testing on Intel hardware. The minimal goal here is unblocking the Universal compile.

## Test plan

- [x] Universal archive build of a downstream macOS app that links FluidAudio as a local SPM package now succeeds (failed prior to this patch with the errors above).
- [ ] CI lint / build on the package itself.
- [ ] No CosyVoice3 / StyleTTS2 runtime regression on Apple Silicon (the arm64 path is byte-identical to before).