### PR TITLE
Fix: Prevent Metal crash when targetTokens is 0 in Kokoro TTS

### DIFF
--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Preprocess/KokoroModelCache.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Preprocess/KokoroModelCache.swift
@@ -48,7 +48,8 @@ public actor KokoroModelCache {
                 throw TTSError.modelNotFound(ModelNames.TTS.bundle(for: variant))
             }
             kokoroModels[variant] = model
-            tokenLengthCache[variant] = KokoroSynthesizer.inferTokenLength(from: model)
+            let tokenLength = max(1, KokoroSynthesizer.inferTokenLength(from: model))
+            tokenLengthCache[variant] = tokenLength
             logger.info("Loaded Kokoro \(variantDescription(variant)) model from cache")
         }
 
@@ -78,7 +79,7 @@ public actor KokoroModelCache {
             return cached
         }
         let model = try await model(for: variant)
-        let length = KokoroSynthesizer.inferTokenLength(from: model)
+        let length = max(1, KokoroSynthesizer.inferTokenLength(from: model))
         tokenLengthCache[variant] = length
         return length
     }
@@ -112,7 +113,8 @@ public actor KokoroModelCache {
         for (variant, model) in models.modelsByVariant {
             downloadedModels[variant] = model
             kokoroModels[variant] = model
-            tokenLengthCache[variant] = KokoroSynthesizer.inferTokenLength(from: model)
+            let tokenLength = max(1, KokoroSynthesizer.inferTokenLength(from: model))
+            tokenLengthCache[variant] = tokenLength
         }
 
         if referenceDimension == nil {

--- a/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/Kokoro/Pipeline/Synthesize/KokoroSynthesizer.swift
@@ -260,6 +260,9 @@ public struct KokoroSynthesizer {
         guard !inputIds.isEmpty else {
             throw TTSError.processingFailed("No input IDs generated for chunk: \(chunk.words.joined(separator: " "))")
         }
+        guard targetTokens > 0 else {
+            throw TTSError.processingFailed("Invalid targetTokens (\(targetTokens)) for chunk: \(chunk.words.joined(separator: " "))")
+        }
 
         let kokoro = try await model(for: variant)
 


### PR DESCRIPTION
## Summary

Fixes a crash that occurs when the Kokoro TTS CoreML model receives 0-dimension input tensors, causing Metal to dispatch with `threadgroupsPerGrid.width(0)`.

## Root Cause

When `targetTokens` is 0 (due to corrupted model metadata or `inferTokenLength()` returning 0), the `MLMultiArray` shape becomes `[1, 0]`, which causes CoreML to dispatch Metal compute shaders with 0 threadgroups.

Error message:
```
-[MTLDebugComputeCommandEncoder dispatchThreadgroups:threadsPerThreadgroup:]:1377: failed assertion `(threadgroupsPerGrid.width(0) * threadgroupsPerGrid.y(1) * threadgroupsPerGrid.depth(1))(0) must not be 0.'
```

## Changes

1. **KokoroSynthesizer.swift**: Added guard in `synthesizeChunk()` to validate `targetTokens > 0` before running ML prediction
2. **KokoroModelCache.swift**: Ensure `tokenLengthCache` never stores 0 values by using `max(1, ...)` when caching token lengths (3 locations fixed)

## Testing

- Prevents crashes when model metadata is malformed
- Ensures minimum token length of 1 is always used
- Error is now thrown with descriptive message instead of crashing

## Related Issues

Fixes crash reported when using Kokoro TTS with certain model configurations.