### PR TITLE
Make SpeakerManager a struct and de-async DiarizerManager

### DIFF
--- a/Sources/FluidAudio/Diarizer/Clustering/SpeakerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Clustering/SpeakerManager.swift
@@ -5,12 +5,7 @@ import OSLog
 /// In-memory speaker database for streaming diarization
 /// Tracks speakers across chunks and maintains consistent IDs
 ///
-/// This is an `actor` to provide thread-safe access under Swift 6 strict
-/// concurrency. Previous implementations used a `DispatchQueue` which could
-/// trigger `unsafeForcedSync` warnings (and occasional libmalloc heap
-/// corruption via concurrent `[Float]` COW mutations) when called from
-/// async contexts such as VAD / diarization buffer callbacks.
-public actor SpeakerManager {
+public struct SpeakerManager: Sendable {
     internal let logger = AppLogger(category: "SpeakerManager")
 
     // Constants
@@ -23,10 +18,29 @@ public actor SpeakerManager {
     // Track the highest speaker ID to ensure uniqueness
     private var highestSpeakerId = 0
 
-    public var speakerThreshold: Float  // Max distance for speaker assignment (default: 0.65)
-    public var embeddingThreshold: Float  // Max distance for updating embeddings (default: 0.45)
-    public var minSpeechDuration: Float  // Min duration to create speaker (default: 1.0)
-    public var minEmbeddingUpdateDuration: Float  // Min duration to update embeddings (default: 2.0)
+    /// Max distance for speaker assignment.
+    ///
+    /// The default value is `0.65`.
+    ///
+    public var speakerThreshold: Float
+
+    /// Max distance for updating embeddings.
+    ///
+    /// The default value is `0.45`.
+    ///
+    public var embeddingThreshold: Float
+
+    /// Min duration to create speaker.
+    ///
+    /// The default value is `1.0`.
+    ///
+    public var minSpeechDuration: Float
+
+    /// Min duration to update embeddings.
+    ///
+    /// The default value is `2.0`.
+    ///
+    public var minEmbeddingUpdateDuration: Float
 
     public init(
         speakerThreshold: Float = 0.65,
@@ -40,19 +54,12 @@ public actor SpeakerManager {
         self.minEmbeddingUpdateDuration = minEmbeddingUpdateDuration
     }
 
-    // MARK: - Threshold setters (actor-isolated)
-
-    public func setSpeakerThreshold(_ value: Float) { self.speakerThreshold = value }
-    public func setEmbeddingThreshold(_ value: Float) { self.embeddingThreshold = value }
-    public func setMinSpeechDuration(_ value: Float) { self.minSpeechDuration = value }
-    public func setMinEmbeddingUpdateDuration(_ value: Float) { self.minEmbeddingUpdateDuration = value }
-
     /// Add known speakers to the database
     /// - Parameters:
     ///   - speakers: Array of `Speaker`s to add
     ///   - mode: Mode for handling overlapping ID conflicts.
     ///   - preservePermanent: Whether to avoid overwriting/merging pre-existing permanent speakers
-    public func initializeKnownSpeakers(
+    public mutating func initializeKnownSpeakers(
         _ speakers: [Speaker], mode: SpeakerInitializationMode = .skip, preserveIfPermanent: Bool = true
     ) {
         if mode == .reset {
@@ -125,7 +132,7 @@ public actor SpeakerManager {
     ///    - speakerThreshold: The maximum cosine distance to an existing speaker to create a new one (uses the default threshold for this `SpeakerManager` object if none is provided)
     ///    - newName: Name to assign the speaker if a new one is created (default: `Speaker $id`)
     ///  - Returns: A `Speaker` object if a match was found or a new one was created. Returns `nil` if an error occurred.
-    public func assignSpeaker(
+    public mutating func assignSpeaker(
         _ embedding: [Float],
         speechDuration: Float,
         confidence: Float = 1.0,
@@ -213,7 +220,7 @@ public actor SpeakerManager {
 
     /// Mark a speaker as permanent
     /// - Parameter speakerId: ID of the speaker to mark as permanent
-    public func makeSpeakerPermanent(_ speakerId: String) {
+    public mutating func makeSpeakerPermanent(_ speakerId: String) {
         guard speakerDatabase[speakerId] != nil else {
             logger.warning("Failed to mark speaker \(speakerId) as permanent (speaker not found).")
             return
@@ -224,7 +231,7 @@ public actor SpeakerManager {
 
     /// Remove a speaker's permanent marker
     /// - Parameter speakerId: ID of the speaker from which to remove the permanent marker
-    public func revokePermanence(from speakerId: String) {
+    public mutating func revokePermanence(from speakerId: String) {
         guard speakerDatabase[speakerId] != nil else {
             logger.warning("Failed to revoke permanence from speaker \(speakerId) (speaker not found).")
             return
@@ -240,7 +247,7 @@ public actor SpeakerManager {
     ///   - destinationId: ID of the `Speaker` that absorbs the other one
     ///   - mergedName: New name for the merged speaker (uses `destination`'s name if not provided)
     ///   - stopIfPermanent: Whether to stop merging if the source speaker is permanent
-    public func mergeSpeaker(
+    public mutating func mergeSpeaker(
         _ sourceId: String, into destinationId: String, mergedName: String? = nil, stopIfPermanent: Bool = true
     ) {
         // don't merge a speaker into itself
@@ -324,7 +331,7 @@ public actor SpeakerManager {
     /// - Parameters:
     ///   - speakerID: ID of the speaker being removed
     ///   - keepIfPermanent: Whether to stop the removal if the speaker is marked as permanent
-    public func removeSpeaker(_ speakerID: String, keepIfPermanent: Bool = true) {
+    public mutating func removeSpeaker(_ speakerID: String, keepIfPermanent: Bool = true) {
         // determine if we should skip the removal due to permanence
         if keepIfPermanent, let speaker = self.speakerDatabase[speakerID], speaker.isPermanent {
             logger.warning("Failed to remove speaker: \(speakerID) (Speaker is permanent)")
@@ -343,7 +350,7 @@ public actor SpeakerManager {
     /// - Parameters:
     ///   - date: Speakers who have not been active after this date will be removed.
     ///   - keepIfPermanent: Whether to stop the removal if the speaker is marked as permanent
-    public func removeSpeakersInactive(since date: Date, keepIfPermanent: Bool = true) {
+    public mutating func removeSpeakersInactive(since date: Date, keepIfPermanent: Bool = true) {
         if keepIfPermanent {
             // don't remove permanent speakers
             for (speakerId, speaker) in speakerDatabase where speaker.updatedAt < date && !speaker.isPermanent {
@@ -363,7 +370,7 @@ public actor SpeakerManager {
     /// - Parameters:
     ///   - durationInactive: Minimum duration for which a speaker needs to be inactive to be removed
     ///   - keepIfPermanent: Whether to stop the removal if the speaker is marked as permanent
-    public func removeSpeakersInactive(for durationInactive: TimeInterval, keepIfPermanent: Bool = true) {
+    public mutating func removeSpeakersInactive(for durationInactive: TimeInterval, keepIfPermanent: Bool = true) {
         let date = Date().addingTimeInterval(-durationInactive)
         self.removeSpeakersInactive(since: date, keepIfPermanent: keepIfPermanent)
     }
@@ -372,7 +379,7 @@ public actor SpeakerManager {
     /// - Parameters:
     ///   - predicate: The predicate to determine whether the speaker should be removed
     ///   - keepIfPermanent: Whether to stop the removal if the speaker is marked as permanent
-    public func removeSpeakers(where predicate: @Sendable (Speaker) -> Bool, keepIfPermanent: Bool = true) {
+    public mutating func removeSpeakers(where predicate: @Sendable (Speaker) -> Bool, keepIfPermanent: Bool = true) {
         if keepIfPermanent {
             // don't remove permanent speakers
             for (speakerId, speaker) in speakerDatabase where predicate(speaker) && !speaker.isPermanent {
@@ -390,7 +397,7 @@ public actor SpeakerManager {
     /// Remove non-permanent speakers that meet a certain predicate
     /// - Parameters:
     ///   - predicate: Predicate to determine whether the speaker should be removed
-    public func removeSpeakers(where predicate: @Sendable (Speaker) -> Bool) {
+    public mutating func removeSpeakers(where predicate: @Sendable (Speaker) -> Bool) {
         removeSpeakers(where: predicate, keepIfPermanent: true)
     }
 
@@ -422,7 +429,7 @@ public actor SpeakerManager {
         return (closestSpeakerId, minDistance)
     }
 
-    private func updateExistingSpeaker(
+    private mutating func updateExistingSpeaker(
         speakerId: String,
         embedding: [Float],
         duration: Float,
@@ -452,7 +459,7 @@ public actor SpeakerManager {
         }
     }
 
-    private func createNewSpeaker(
+    private mutating func createNewSpeaker(
         embedding: [Float],
         duration: Float,
         distanceToClosest: Float,
@@ -517,7 +524,7 @@ public actor SpeakerManager {
     }
 
     /// - Parameter speaker: The Speaker object to upsert
-    public func upsertSpeaker(_ speaker: Speaker) {
+    public mutating func upsertSpeaker(_ speaker: Speaker) {
         upsertSpeaker(
             id: speaker.id,
             name: speaker.name,
@@ -542,7 +549,7 @@ public actor SpeakerManager {
     ///   - createdAt: Creation timestamp
     ///   - updatedAt: Last update timestamp
     ///   - isPermanent: Whether the speaker should be protected from merges and removals by default
-    public func upsertSpeaker(
+    public mutating func upsertSpeaker(
         id: String,
         name: String? = nil,
         currentEmbedding: [Float],
@@ -600,7 +607,7 @@ public actor SpeakerManager {
 
     /// Reset the speaker database
     /// - Parameter keepIfPermanent: Whether to keep permanent speakers
-    public func reset(keepIfPermanent: Bool = false) {
+    public mutating func reset(keepIfPermanent: Bool = false) {
         if !keepIfPermanent {
             speakerDatabase.removeAll()
             nextSpeakerId = 1
@@ -621,7 +628,7 @@ public actor SpeakerManager {
     }
 
     /// Mark all speakers as not permanent
-    public func resetPermanentFlags() {
+    public mutating func resetPermanentFlags() {
         for id in Array(speakerDatabase.keys) {
             speakerDatabase[id]?.isPermanent = false
         }

--- a/Sources/FluidAudio/Diarizer/Clustering/SpeakerOperations.swift
+++ b/Sources/FluidAudio/Diarizer/Clustering/SpeakerOperations.swift
@@ -513,7 +513,7 @@ extension SpeakerManager {
     ///   - toSpeakerId: The target speaker ID
     /// - Returns: True if successful, false if segment not found or speakers don't exist
     @discardableResult
-    public func reassignSegment(
+    public mutating func reassignSegment(
         segmentId: UUID,
         from fromSpeakerId: String,
         to toSpeakerId: String

--- a/Sources/FluidAudio/Diarizer/Core/DiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Core/DiarizerManager.swift
@@ -19,7 +19,7 @@ public final class DiarizerManager {
     private let memoryOptimizer = ANEMemoryOptimizer()
 
     // Speaker manager for consistent speaker tracking
-    public let speakerManager: SpeakerManager
+    public var speakerManager: SpeakerManager
 
     public init(config: DiarizerConfig = .default) {
         self.config = config
@@ -71,8 +71,8 @@ public final class DiarizerManager {
     /// Accepts Speaker structs and adds them to the in-memory database.
     ///
     /// - Parameter speakers: Array of Speaker structs with embeddings and metadata
-    public func initializeKnownSpeakers(_ speakers: [Speaker]) async {
-        await speakerManager.initializeKnownSpeakers(speakers)
+    public func initializeKnownSpeakers(_ speakers: [Speaker]) {
+        speakerManager.initializeKnownSpeakers(speakers)
     }
 
     /// Extract a 256-dimensional speaker embedding from audio samples.
@@ -152,7 +152,7 @@ public final class DiarizerManager {
     /// ```
     public func performCompleteDiarization<C>(
         _ samples: C, sampleRate: Int = 16000, atTime startTime: TimeInterval = 0
-    ) async throws -> DiarizationResult
+    ) throws -> DiarizationResult
     where C: RandomAccessCollection, C.Element == Float, C.Index == Int {
         guard let models else {
             throw DiarizerError.notInitialized
@@ -183,7 +183,7 @@ public final class DiarizerManager {
             let chunk = samples[chunkStart..<chunkEnd]
             let chunkOffset = Double(chunkStartOffset) / Double(sampleRate) + startTime
 
-            let (chunkSegments, chunkTimings) = try await processChunkWithSpeakerTracking(
+            let (chunkSegments, chunkTimings) = try processChunkWithSpeakerTracking(
                 chunk,
                 chunkOffset: chunkOffset,
                 models: models,
@@ -213,7 +213,7 @@ public final class DiarizerManager {
             )
 
             // Build speakerDatabase from speakerManager for debug output
-            let speakerDB = await speakerManager.getAllSpeakers().reduce(into: [String: [Float]]()) {
+            let speakerDB = speakerManager.getAllSpeakers().reduce(into: [String: [Float]]()) {
                 result, item in
                 result[item.key] = item.value.currentEmbedding
             }
@@ -251,7 +251,7 @@ public final class DiarizerManager {
         sampleRate: Int = 16000,
         chunkSize: Int,
         chunkBuffer: inout [Float]
-    ) async throws -> ([TimedSpeakerSegment], ChunkTimings)
+    ) throws -> ([TimedSpeakerSegment], ChunkTimings)
     where C: RandomAccessCollection, C.Element == Float, C.Index == Int {
         let segmentationStartTime = Date()
 
@@ -350,7 +350,7 @@ public final class DiarizerManager {
 
                     let quality = calculateEmbeddingQuality(embedding) * (activity / Float(numFrames))
 
-                    if let speaker = await speakerManager.assignSpeaker(
+                    if let speaker = speakerManager.assignSpeaker(
                         embedding,
                         speechDuration: duration,
                         confidence: quality

--- a/Sources/FluidAudio/Diarizer/Core/DiarizerModels.swift
+++ b/Sources/FluidAudio/Diarizer/Core/DiarizerModels.swift
@@ -121,7 +121,7 @@ extension DiarizerModels {
         localSegmentationModel: URL,
         localEmbeddingModel: URL,
         configuration: MLModelConfiguration? = nil
-    ) async throws -> DiarizerModels {
+    ) throws -> DiarizerModels {
 
         let logger = AppLogger(category: "DiarizerModels")
         logger.info("Loading predownloaded models")

--- a/Sources/FluidAudioCLI/Commands/DiarizationBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/DiarizationBenchmark.swift
@@ -438,8 +438,8 @@ enum StreamDiarizationBenchmark {
             diarizerManager.initialize(models: models)
 
             // Configure streaming manager
-            await diarizerManager.speakerManager.setSpeakerThreshold(assignmentThreshold)
-            await diarizerManager.speakerManager.setEmbeddingThreshold(updateThreshold)
+            diarizerManager.speakerManager.speakerThreshold = assignmentThreshold
+            diarizerManager.speakerManager.embeddingThreshold = updateThreshold
 
             // Process in chunks
             let samplesPerChunk = Int(chunkSeconds * 16000)
@@ -472,7 +472,7 @@ enum StreamDiarizationBenchmark {
 
                 // Process chunk and track timing
                 let inferenceStart = Date()
-                let chunkResult = try await diarizerManager.performCompleteDiarization(
+                let chunkResult = try diarizerManager.performCompleteDiarization(
                     paddedChunk, atTime: chunkStartTime)
                 let inferenceTime = Date().timeIntervalSince(inferenceStart)
 
@@ -515,7 +515,7 @@ enum StreamDiarizationBenchmark {
                     let processedDuration = Double(position) / 16000.0
                     let rtfx = processedDuration / elapsed
 
-                    let currentSpeakerCount = await diarizerManager.speakerManager.speakerCount
+                    let currentSpeakerCount = diarizerManager.speakerManager.speakerCount
                     logger.info(
                         String(
                             format: "    [Chunk %3d] %.1f%% | RTFx: %.1fx | Speakers: %d | Latency: %.3fs",
@@ -565,7 +565,7 @@ enum StreamDiarizationBenchmark {
             // Calculate total inference time
             let totalInferenceTime = totalSegmentationTime + totalEmbeddingTime + totalClusteringTime
 
-            let finalSpeakerCount = await diarizerManager.speakerManager.speakerCount
+            let finalSpeakerCount = diarizerManager.speakerManager.speakerCount
 
             return BenchmarkResult(
                 meetingName: meetingName,

--- a/Tests/FluidAudioTests/Diarizer/SpeakerManagerTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerManagerTests.swift
@@ -21,65 +21,65 @@ final class SpeakerManagerTests: XCTestCase {
 
     // MARK: - Basic Operations
 
-    func testInitialization() async {
+    func testInitialization() {
         let manager = SpeakerManager()
-        let speakerCount = await manager.speakerCount
-        let speakerIds = await manager.speakerIds
+        let speakerCount = manager.speakerCount
+        let speakerIds = manager.speakerIds
         XCTAssertEqual(speakerCount, 0)
         XCTAssertTrue(speakerIds.isEmpty)
     }
 
-    func testAssignNewSpeaker() async {
-        let manager = SpeakerManager()
+    func testAssignNewSpeaker() {
+        var manager = SpeakerManager()
         let embedding = createDistinctEmbedding(pattern: 1)
 
-        let speaker = await manager.assignSpeaker(embedding, speechDuration: 2.0)
+        let speaker = manager.assignSpeaker(embedding, speechDuration: 2.0)
 
         XCTAssertNotNil(speaker)
-        let speakerCount = await manager.speakerCount
+        let speakerCount = manager.speakerCount
         XCTAssertEqual(speakerCount, 1)
         // ID should be numeric (starting from 1)
         XCTAssertEqual(speaker?.id, "1")
     }
 
-    func testAssignExistingSpeaker() async {
-        let manager = SpeakerManager(speakerThreshold: 0.3)  // Low threshold for testing
+    func testAssignExistingSpeaker() {
+        var manager = SpeakerManager(speakerThreshold: 0.3)  // Low threshold for testing
 
         // Add first speaker
         let embedding1 = createDistinctEmbedding(pattern: 1)
-        let speaker1 = await manager.assignSpeaker(embedding1, speechDuration: 2.0)
+        let speaker1 = manager.assignSpeaker(embedding1, speechDuration: 2.0)
 
         // Add nearly identical embedding - should match existing speaker
         var embedding2 = embedding1
         embedding2[0] += 0.001  // Tiny variation
-        let speaker2 = await manager.assignSpeaker(embedding2, speechDuration: 2.0)
+        let speaker2 = manager.assignSpeaker(embedding2, speechDuration: 2.0)
 
         XCTAssertEqual(speaker1?.id, speaker2?.id)
-        let speakerCount = await manager.speakerCount
+        let speakerCount = manager.speakerCount
         XCTAssertEqual(speakerCount, 1)  // Should still be 1 speaker
     }
 
-    func testMultipleSpeakers() async {
-        let manager = SpeakerManager(speakerThreshold: 0.5)
+    func testMultipleSpeakers() {
+        var manager = SpeakerManager(speakerThreshold: 0.5)
 
         // Create distinct embeddings
         let embedding1 = createDistinctEmbedding(pattern: 1)
         let embedding2 = createDistinctEmbedding(pattern: 2)
 
-        let speaker1 = await manager.assignSpeaker(embedding1, speechDuration: 2.0)
-        let speaker2 = await manager.assignSpeaker(embedding2, speechDuration: 2.0)
+        let speaker1 = manager.assignSpeaker(embedding1, speechDuration: 2.0)
+        let speaker2 = manager.assignSpeaker(embedding2, speechDuration: 2.0)
 
         XCTAssertNotNil(speaker1)
         XCTAssertNotNil(speaker2)
         XCTAssertNotEqual(speaker1?.id, speaker2?.id)
-        let speakerCount = await manager.speakerCount
+        let speakerCount = manager.speakerCount
         XCTAssertEqual(speakerCount, 2)
     }
 
     // MARK: - Known Speaker Initialization
 
-    func testInitializeKnownSpeakers() async {
-        let manager = SpeakerManager()
+    func testInitializeKnownSpeakers() {
+        var manager = SpeakerManager()
 
         let knownSpeakers = [
             Speaker(
@@ -100,17 +100,17 @@ final class SpeakerManagerTests: XCTestCase {
             ),
         ]
 
-        await manager.initializeKnownSpeakers(knownSpeakers)
+        manager.initializeKnownSpeakers(knownSpeakers)
 
-        let speakerCount = await manager.speakerCount
-        let speakerIds = await manager.speakerIds
+        let speakerCount = manager.speakerCount
+        let speakerIds = manager.speakerIds
         XCTAssertEqual(speakerCount, 2)
         XCTAssertTrue(speakerIds.contains("Alice"))
         XCTAssertTrue(speakerIds.contains("Bob"))
     }
 
-    func testRecognizeKnownSpeaker() async {
-        let manager = SpeakerManager(speakerThreshold: 0.3)
+    func testRecognizeKnownSpeaker() {
+        var manager = SpeakerManager(speakerThreshold: 0.3)
 
         let aliceEmbedding = createDistinctEmbedding(pattern: 10)
         let aliceSpeaker = Speaker(
@@ -121,17 +121,17 @@ final class SpeakerManagerTests: XCTestCase {
             createdAt: Date(),
             updatedAt: Date()
         )
-        await manager.initializeKnownSpeakers([aliceSpeaker])
+        manager.initializeKnownSpeakers([aliceSpeaker])
 
         // Test with exact same embedding
         let testEmbedding = aliceEmbedding
 
-        let assignedSpeaker = await manager.assignSpeaker(testEmbedding, speechDuration: 2.0)
+        let assignedSpeaker = manager.assignSpeaker(testEmbedding, speechDuration: 2.0)
         XCTAssertEqual(assignedSpeaker?.id, "Alice")
     }
 
-    func testInitializeKnownSpeakersPreservesPermanentByDefault() async {
-        let manager = SpeakerManager()
+    func testInitializeKnownSpeakersPreservesPermanentByDefault() {
+        var manager = SpeakerManager()
 
         let original = Speaker(
             id: "Alice",
@@ -139,8 +139,8 @@ final class SpeakerManagerTests: XCTestCase {
             currentEmbedding: createDistinctEmbedding(pattern: 10),
             duration: 4.0
         )
-        await manager.initializeKnownSpeakers([original])
-        await manager.makeSpeakerPermanent("Alice")
+        manager.initializeKnownSpeakers([original])
+        manager.makeSpeakerPermanent("Alice")
 
         let replacement = Speaker(
             id: "Alice",
@@ -149,15 +149,15 @@ final class SpeakerManagerTests: XCTestCase {
             duration: 8.0
         )
 
-        await manager.initializeKnownSpeakers([replacement], mode: .overwrite, preserveIfPermanent: true)
+        manager.initializeKnownSpeakers([replacement], mode: .overwrite, preserveIfPermanent: true)
 
-        let stored = await manager.getSpeaker(for: "Alice")
+        let stored = manager.getSpeaker(for: "Alice")
         XCTAssertEqual(stored?.name, "Original")
         XCTAssertEqual(stored?.duration, 4.0)
     }
 
-    func testInitializeKnownSpeakersOverwriteCanReplacePermanentWhenAllowed() async {
-        let manager = SpeakerManager()
+    func testInitializeKnownSpeakersOverwriteCanReplacePermanentWhenAllowed() {
+        var manager = SpeakerManager()
 
         let original = Speaker(
             id: "Alice",
@@ -166,7 +166,7 @@ final class SpeakerManagerTests: XCTestCase {
             duration: 4.0,
             isPermanent: true
         )
-        await manager.initializeKnownSpeakers([original])
+        manager.initializeKnownSpeakers([original])
 
         let replacement = Speaker(
             id: "Alice",
@@ -175,15 +175,15 @@ final class SpeakerManagerTests: XCTestCase {
             duration: 10.0
         )
 
-        await manager.initializeKnownSpeakers([replacement], mode: .overwrite, preserveIfPermanent: false)
+        manager.initializeKnownSpeakers([replacement], mode: .overwrite, preserveIfPermanent: false)
 
-        let stored = await manager.getSpeaker(for: "Alice")
+        let stored = manager.getSpeaker(for: "Alice")
         XCTAssertEqual(stored?.name, "Replacement")
         XCTAssertEqual(stored?.duration, 10.0)
     }
 
-    func testInitializeKnownSpeakersMergeCombinesDurations() async {
-        let manager = SpeakerManager()
+    func testInitializeKnownSpeakersMergeCombinesDurations() {
+        var manager = SpeakerManager()
 
         let base = Speaker(
             id: "Alice",
@@ -198,47 +198,47 @@ final class SpeakerManagerTests: XCTestCase {
             duration: 3.0
         )
 
-        await manager.initializeKnownSpeakers([base])
-        await manager.initializeKnownSpeakers([incoming], mode: .merge)
+        manager.initializeKnownSpeakers([base])
+        manager.initializeKnownSpeakers([incoming], mode: .merge)
 
-        let stored = await manager.getSpeaker(for: "Alice")
+        let stored = manager.getSpeaker(for: "Alice")
         XCTAssertEqual(stored?.duration, 5.0)
     }
 
-    func testInvalidEmbeddingSize() async {
-        let manager = SpeakerManager()
+    func testInvalidEmbeddingSize() {
+        var manager = SpeakerManager()
 
         // Test with wrong size
         let invalidEmbedding = [Float](repeating: 0.5, count: 128)
-        let speaker = await manager.assignSpeaker(invalidEmbedding, speechDuration: 2.0)
+        let speaker = manager.assignSpeaker(invalidEmbedding, speechDuration: 2.0)
 
         XCTAssertNil(speaker)
-        let speakerCount = await manager.speakerCount
+        let speakerCount = manager.speakerCount
         XCTAssertEqual(speakerCount, 0)
     }
 
-    func testEmptyEmbedding() async {
-        let manager = SpeakerManager()
+    func testEmptyEmbedding() {
+        var manager = SpeakerManager()
 
         let emptyEmbedding = [Float]()
-        let speaker = await manager.assignSpeaker(emptyEmbedding, speechDuration: 2.0)
+        let speaker = manager.assignSpeaker(emptyEmbedding, speechDuration: 2.0)
 
         XCTAssertNil(speaker)
-        let speakerCount = await manager.speakerCount
+        let speakerCount = manager.speakerCount
         XCTAssertEqual(speakerCount, 0)
     }
 
     // MARK: - Speaker Info Access
 
-    func testGetSpeakerInfo() async {
-        let manager = SpeakerManager()
+    func testGetSpeakerInfo() {
+        var manager = SpeakerManager()
         let embedding = createDistinctEmbedding(pattern: 1)
 
-        let speaker = await manager.assignSpeaker(embedding, speechDuration: 3.5)
+        let speaker = manager.assignSpeaker(embedding, speechDuration: 3.5)
         XCTAssertNotNil(speaker)
 
         if let id = speaker?.id {
-            let info = await manager.getSpeaker(for: id)
+            let info = manager.getSpeaker(for: id)
             XCTAssertNotNil(info)
             XCTAssertEqual(info?.id, id)
             let normalizedExpected = VDSPOperations.l2Normalize(embedding)
@@ -247,15 +247,15 @@ final class SpeakerManagerTests: XCTestCase {
         }
     }
 
-    func testPublicSpeakerInfoMembers() async {
+    func testPublicSpeakerInfoMembers() {
         // This test verifies that all SpeakerInfo members are public as requested in PR #63
-        let manager = SpeakerManager()
+        var manager = SpeakerManager()
         let embedding = createDistinctEmbedding(pattern: 1)
 
-        let speaker = await manager.assignSpeaker(embedding, speechDuration: 5.0)
+        let speaker = manager.assignSpeaker(embedding, speechDuration: 5.0)
         XCTAssertNotNil(speaker)
 
-        if let id = speaker?.id, let info = await manager.getSpeaker(for: id) {
+        if let id = speaker?.id, let info = manager.getSpeaker(for: id) {
             // Test that all public properties are accessible
             let publicId = info.id
             let publicEmbedding = info.currentEmbedding
@@ -274,16 +274,16 @@ final class SpeakerManagerTests: XCTestCase {
     }
 
     func testGetAllSpeakerInfo() async {
-        let manager = SpeakerManager()
+        var manager = SpeakerManager()
 
         // Add multiple speakers
         let embedding1 = createDistinctEmbedding(pattern: 1)
         let embedding2 = createDistinctEmbedding(pattern: 2)
 
-        let speaker1 = await manager.assignSpeaker(embedding1, speechDuration: 2.0)
-        let speaker2 = await manager.assignSpeaker(embedding2, speechDuration: 3.0)
+        let speaker1 = manager.assignSpeaker(embedding1, speechDuration: 2.0)
+        let speaker2 = manager.assignSpeaker(embedding2, speechDuration: 3.0)
 
-        let allInfo = await manager.getAllSpeakers()
+        let allInfo = manager.getAllSpeakers()
 
         XCTAssertEqual(allInfo.count, 2)
         if let id1 = speaker1?.id {
@@ -296,13 +296,13 @@ final class SpeakerManagerTests: XCTestCase {
 
     // MARK: - Lookup Helpers
 
-    func testFindSpeakerAndMatchingSpeakers() async {
-        let manager = SpeakerManager(speakerThreshold: 0.8)
+    func testFindSpeakerAndMatchingSpeakers() {
+        var manager = SpeakerManager(speakerThreshold: 0.8)
 
-        await manager.upsertSpeaker(id: "A", currentEmbedding: normalizedEmbedding(pattern: 1), duration: 5.0)
-        await manager.upsertSpeaker(id: "B", currentEmbedding: normalizedEmbedding(pattern: 2), duration: 5.0)
+        manager.upsertSpeaker(id: "A", currentEmbedding: normalizedEmbedding(pattern: 1), duration: 5.0)
+        manager.upsertSpeaker(id: "B", currentEmbedding: normalizedEmbedding(pattern: 2), duration: 5.0)
 
-        let (matchId, distance) = await manager.findSpeaker(with: normalizedEmbedding(pattern: 1))
+        let (matchId, distance) = manager.findSpeaker(with: normalizedEmbedding(pattern: 1))
         XCTAssertEqual(matchId, "A")
         XCTAssertEqual(distance, 0.0, accuracy: 0.0001)
 
@@ -310,8 +310,8 @@ final class SpeakerManagerTests: XCTestCase {
         var orthogonalEmbedding1 = [Float](repeating: 0, count: 256)
         orthogonalEmbedding0[0] = 1
         orthogonalEmbedding1[1] = 1
-        await manager.upsertSpeaker(id: "C", currentEmbedding: orthogonalEmbedding0, duration: 5.0)
-        let (missingId, missingDistance) = await manager.findSpeaker(
+        manager.upsertSpeaker(id: "C", currentEmbedding: orthogonalEmbedding0, duration: 5.0)
+        let (missingId, missingDistance) = manager.findSpeaker(
             with: orthogonalEmbedding1,
             speakerThreshold: 0.5
         )
@@ -319,7 +319,7 @@ final class SpeakerManagerTests: XCTestCase {
         XCTAssertEqual(missingDistance, .infinity)
 
         let combined = zip(normalizedEmbedding(pattern: 1), normalizedEmbedding(pattern: 2)).map { ($0 + $1) / 2 }
-        let matches = await manager.findMatchingSpeakers(
+        let matches = manager.findMatchingSpeakers(
             with: VDSPOperations.l2Normalize(combined),
             speakerThreshold: 2.0
         )
@@ -329,32 +329,32 @@ final class SpeakerManagerTests: XCTestCase {
         XCTAssertEqual(Set(matches.map(\.id)), Set(["A", "B", "C"]))
     }
 
-    func testFindSpeakersWhereFiltersByPredicate() async {
-        let manager = SpeakerManager()
-        await manager.upsertSpeaker(id: "short", currentEmbedding: normalizedEmbedding(pattern: 10), duration: 1.0)
-        await manager.upsertSpeaker(id: "long", currentEmbedding: normalizedEmbedding(pattern: 20), duration: 8.0)
+    func testFindSpeakersWhereFiltersByPredicate() {
+        var manager = SpeakerManager()
+        manager.upsertSpeaker(id: "short", currentEmbedding: normalizedEmbedding(pattern: 10), duration: 1.0)
+        manager.upsertSpeaker(id: "long", currentEmbedding: normalizedEmbedding(pattern: 20), duration: 8.0)
 
-        let filtered = await manager.findSpeakers { $0.duration > 5.0 }
+        let filtered = manager.findSpeakers { $0.duration > 5.0 }
         XCTAssertEqual(filtered.count, 1)
         XCTAssertEqual(filtered.first, "long")
     }
 
     // MARK: - Clear Operations
 
-    func testResetSpeakers() async {
-        let manager = SpeakerManager()
+    func testResetSpeakers() {
+        var manager = SpeakerManager()
 
         // Add speakers
-        _ = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
-        _ = await manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 2.0)
+        _ = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
+        _ = manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 2.0)
 
-        let countBefore = await manager.speakerCount
+        let countBefore = manager.speakerCount
         XCTAssertEqual(countBefore, 2)
 
-        await manager.reset()
+        manager.reset()
 
-        let countAfter = await manager.speakerCount
-        let idsAfter = await manager.speakerIds
+        let countAfter = manager.speakerCount
+        let idsAfter = manager.speakerIds
         XCTAssertEqual(countAfter, 0)
         XCTAssertTrue(idsAfter.isEmpty)
     }
@@ -395,87 +395,39 @@ final class SpeakerManagerTests: XCTestCase {
 
     // MARK: - Statistics
 
-    func testGetStatistics() async {
-        let manager = SpeakerManager()
+    func testGetStatistics() {
+        var manager = SpeakerManager()
 
         // Add speakers with different durations
-        _ = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 10.0)
-        _ = await manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 20.0)
+        _ = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 10.0)
+        _ = manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 20.0)
 
         // getStatistics method was removed - test speaker count instead
-        let speakerCount = await manager.speakerCount
+        let speakerCount = manager.speakerCount
         XCTAssertEqual(speakerCount, 2)
 
         // Verify speakers were added with correct info
-        let allInfo = await manager.getAllSpeakers()
+        let allInfo = manager.getAllSpeakers()
         XCTAssertEqual(allInfo.count, 2)
-    }
-
-    // MARK: - Thread Safety
-
-    func testConcurrentAccess() async {
-        let manager = SpeakerManager(speakerThreshold: 0.5)  // Set threshold for distinct embeddings
-        let iterations = 10  // Reduced iterations for more reliable test
-
-        // Use a serial queue to ensure embeddings are distinct
-        let embeddings = (0..<iterations).map { i -> [Float] in
-            // Create very distinct embeddings using different patterns
-            var embedding = [Float](repeating: 0, count: 256)
-            for j in 0..<256 {
-                // Use different functions for each speaker
-                switch i % 3 {
-                case 0:
-                    embedding[j] = sin(Float(j * (i + 1)) * 0.05)
-                case 1:
-                    embedding[j] = cos(Float(j * (i + 1)) * 0.05)
-                default:
-                    embedding[j] = Float(j % (i + 2)) / Float(i + 2) - 0.5
-                }
-            }
-            return embedding
-        }
-
-        // Concurrent writes and reads via structured concurrency
-        await withTaskGroup(of: Void.self) { group in
-            for i in 0..<iterations {
-                let embedding = embeddings[i]
-                group.addTask {
-                    _ = await manager.assignSpeaker(embedding, speechDuration: 2.0)
-                }
-            }
-
-            for _ in 0..<iterations {
-                group.addTask {
-                    _ = await manager.speakerCount
-                    _ = await manager.speakerIds
-                }
-            }
-        }
-
-        // Due to concurrent operations and clustering, we may not get exactly iterations speakers
-        // But we should have at least some distinct speakers
-        let finalCount = await manager.speakerCount
-        XCTAssertGreaterThan(finalCount, 0)
-        XCTAssertLessThanOrEqual(finalCount, iterations)
     }
 
     // MARK: - Upsert Tests
 
-    func testUpsertNewSpeaker() async {
-        let manager = SpeakerManager()
+    func testUpsertNewSpeaker() {
+        var manager = SpeakerManager()
         let embedding = createDistinctEmbedding(pattern: 1)
 
         // Upsert a new speaker
-        await manager.upsertSpeaker(
+        manager.upsertSpeaker(
             id: "TestSpeaker1",
             currentEmbedding: embedding,
             duration: 5.0
         )
 
-        let speakerCount = await manager.speakerCount
+        let speakerCount = manager.speakerCount
         XCTAssertEqual(speakerCount, 1)
 
-        let info = await manager.getSpeaker(for: "TestSpeaker1")
+        let info = manager.getSpeaker(for: "TestSpeaker1")
         XCTAssertNotNil(info)
         XCTAssertEqual(info?.id, "TestSpeaker1")
         let normalizedExpected = VDSPOperations.l2Normalize(embedding)
@@ -485,35 +437,35 @@ final class SpeakerManagerTests: XCTestCase {
     }
 
     func testUpsertExistingSpeaker() async {
-        let manager = SpeakerManager()
+        var manager = SpeakerManager()
         let embedding1 = createDistinctEmbedding(pattern: 1)
         let embedding2 = createDistinctEmbedding(pattern: 2)
 
         // Insert initial speaker
-        await manager.upsertSpeaker(
+        manager.upsertSpeaker(
             id: "TestSpeaker1",
             currentEmbedding: embedding1,
             duration: 5.0
         )
 
-        let originalInfo = await manager.getSpeaker(for: "TestSpeaker1")
+        let originalInfo = manager.getSpeaker(for: "TestSpeaker1")
         let originalCreatedAt = originalInfo?.createdAt
 
         // Wait a bit to ensure different timestamp
         try? await Task.sleep(nanoseconds: 10_000_000)
 
         // Update the same speaker
-        await manager.upsertSpeaker(
+        manager.upsertSpeaker(
             id: "TestSpeaker1",
             currentEmbedding: embedding2,
             duration: 10.0,
             updateCount: 5
         )
 
-        let speakerCount = await manager.speakerCount
+        let speakerCount = manager.speakerCount
         XCTAssertEqual(speakerCount, 1)  // Should still be 1 speaker
 
-        let updatedInfo = await manager.getSpeaker(for: "TestSpeaker1")
+        let updatedInfo = manager.getSpeaker(for: "TestSpeaker1")
         XCTAssertNotNil(updatedInfo)
         XCTAssertEqual(updatedInfo?.id, "TestSpeaker1")
         XCTAssertEqual(updatedInfo?.currentEmbedding, embedding2)
@@ -525,8 +477,8 @@ final class SpeakerManagerTests: XCTestCase {
         XCTAssertNotEqual(updatedInfo?.updatedAt, originalCreatedAt)
     }
 
-    func testUpsertWithSpeakerObject() async {
-        let manager = SpeakerManager()
+    func testUpsertWithSpeakerObject() {
+        var manager = SpeakerManager()
         let embedding = createDistinctEmbedding(pattern: 1)
 
         var speaker = Speaker(
@@ -540,12 +492,12 @@ final class SpeakerManagerTests: XCTestCase {
         let rawEmbedding = RawEmbedding(embedding: embedding)
         speaker.addRawEmbedding(rawEmbedding)
 
-        await manager.upsertSpeaker(speaker)
+        manager.upsertSpeaker(speaker)
 
-        let speakerCount = await manager.speakerCount
+        let speakerCount = manager.speakerCount
         XCTAssertEqual(speakerCount, 1)
 
-        let info = await manager.getSpeaker(for: "Alice")
+        let info = manager.getSpeaker(for: "Alice")
         XCTAssertNotNil(info)
         XCTAssertEqual(info?.id, "Alice")
         let normalizedExpected = VDSPOperations.l2Normalize(embedding)
@@ -556,74 +508,74 @@ final class SpeakerManagerTests: XCTestCase {
 
     // MARK: - Permanence & Merge Operations
 
-    func testMakeAndRevokePermanentSpeakers() async throws {
-        let manager = SpeakerManager()
-        let speaker = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.5)
+    func testMakeAndRevokePermanentSpeakers() throws {
+        var manager = SpeakerManager()
+        let speaker = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.5)
         let id = try XCTUnwrap(speaker?.id)
 
-        await manager.makeSpeakerPermanent(id)
-        let permanentIds = await manager.permanentSpeakerIds
+        manager.makeSpeakerPermanent(id)
+        let permanentIds = manager.permanentSpeakerIds
         XCTAssertTrue(permanentIds.contains(id))
 
-        await manager.removeSpeaker(id)
-        let stillHas = await manager.hasSpeaker(id)
+        manager.removeSpeaker(id)
+        let stillHas = manager.hasSpeaker(id)
         XCTAssertTrue(stillHas)
 
-        await manager.revokePermanence(from: id)
-        await manager.removeSpeaker(id)
-        let removedNow = await manager.hasSpeaker(id)
+        manager.revokePermanence(from: id)
+        manager.removeSpeaker(id)
+        let removedNow = manager.hasSpeaker(id)
         XCTAssertFalse(removedNow)
     }
 
-    func testMergeSpeakerRespectsPermanentFlag() async throws {
-        let manager = SpeakerManager()
-        let speaker1 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 3.0)
-        let speaker2 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 4.0)
+    func testMergeSpeakerRespectsPermanentFlag() throws {
+        var manager = SpeakerManager()
+        let speaker1 = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 3.0)
+        let speaker2 = manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 4.0)
 
         let id1 = try XCTUnwrap(speaker1?.id)
         let id2 = try XCTUnwrap(speaker2?.id)
 
-        await manager.makeSpeakerPermanent(id1)
-        await manager.mergeSpeaker(id1, into: id2)
-        let has1 = await manager.hasSpeaker(id1)
-        let has2 = await manager.hasSpeaker(id2)
+        manager.makeSpeakerPermanent(id1)
+        manager.mergeSpeaker(id1, into: id2)
+        let has1 = manager.hasSpeaker(id1)
+        let has2 = manager.hasSpeaker(id2)
         XCTAssertTrue(has1)
         XCTAssertTrue(has2)
 
-        await manager.mergeSpeaker(id1, into: id2, mergedName: "Merged Speaker", stopIfPermanent: false)
-        let hasAfterMerge1 = await manager.hasSpeaker(id1)
+        manager.mergeSpeaker(id1, into: id2, mergedName: "Merged Speaker", stopIfPermanent: false)
+        let hasAfterMerge1 = manager.hasSpeaker(id1)
         XCTAssertFalse(hasAfterMerge1)
-        let mergedOpt = await manager.getSpeaker(for: id2)
+        let mergedOpt = manager.getSpeaker(for: id2)
         let merged = try XCTUnwrap(mergedOpt)
         XCTAssertEqual(merged.name, "Merged Speaker")
-        let finalCount = await manager.speakerCount
+        let finalCount = manager.speakerCount
         XCTAssertEqual(finalCount, 1)
         XCTAssertGreaterThan(merged.duration, 4.0)
     }
 
     func testFindMergeablePairsRespectsPermanentExclusion() async {
-        let manager = SpeakerManager(speakerThreshold: 0.3)
+        var manager = SpeakerManager(speakerThreshold: 0.3)
         let base = normalizedEmbedding(pattern: 1)
         var close = base
         close[0] += 0.001
         close = VDSPOperations.l2Normalize(close)
         let far = normalizedEmbedding(pattern: 80)
 
-        await manager.upsertSpeaker(id: "A", currentEmbedding: base, duration: 5.0)
-        await manager.upsertSpeaker(id: "B", currentEmbedding: close, duration: 5.0)
-        await manager.upsertSpeaker(id: "C", currentEmbedding: far, duration: 5.0)
+        manager.upsertSpeaker(id: "A", currentEmbedding: base, duration: 5.0)
+        manager.upsertSpeaker(id: "B", currentEmbedding: close, duration: 5.0)
+        manager.upsertSpeaker(id: "C", currentEmbedding: far, duration: 5.0)
 
-        let pairs = await manager.findMergeablePairs(speakerThreshold: 0.2)
+        let pairs = manager.findMergeablePairs(speakerThreshold: 0.2)
         XCTAssertEqual(pairs.count, 1)
         XCTAssertEqual(Set([pairs[0].speakerToMerge, pairs[0].destination]), Set(["A", "B"]))
 
-        await manager.makeSpeakerPermanent("A")
-        await manager.makeSpeakerPermanent("B")
+        manager.makeSpeakerPermanent("A")
+        manager.makeSpeakerPermanent("B")
 
-        let filtered = await manager.findMergeablePairs(speakerThreshold: 0.2, excludeIfBothPermanent: true)
+        let filtered = manager.findMergeablePairs(speakerThreshold: 0.2, excludeIfBothPermanent: true)
         XCTAssertTrue(filtered.isEmpty)
 
-        let unfiltered = await manager.findMergeablePairs(speakerThreshold: 0.2, excludeIfBothPermanent: false)
+        let unfiltered = manager.findMergeablePairs(speakerThreshold: 0.2, excludeIfBothPermanent: false)
         XCTAssertEqual(unfiltered.count, 1)
         XCTAssertEqual(Set([unfiltered[0].speakerToMerge, unfiltered[0].destination]), Set(["A", "B"]))
     }
@@ -631,51 +583,51 @@ final class SpeakerManagerTests: XCTestCase {
     // MARK: - Removal & Reset
 
     func testRemoveSpeakersInactiveAndPredicateVariants() async {
-        let manager = SpeakerManager()
+        var manager = SpeakerManager()
         let now = Date()
-        await manager.upsertSpeaker(
+        manager.upsertSpeaker(
             id: "old",
             currentEmbedding: normalizedEmbedding(pattern: 3),
             duration: 2.0,
             updatedAt: now.addingTimeInterval(-120)
         )
-        await manager.upsertSpeaker(
+        manager.upsertSpeaker(
             id: "recent",
             currentEmbedding: normalizedEmbedding(pattern: 4),
             duration: 2.0,
             updatedAt: now
         )
 
-        await manager.removeSpeakersInactive(since: now.addingTimeInterval(-60))
-        let hasOld = await manager.hasSpeaker("old")
-        let hasRecent = await manager.hasSpeaker("recent")
+        manager.removeSpeakersInactive(since: now.addingTimeInterval(-60))
+        let hasOld = manager.hasSpeaker("old")
+        let hasRecent = manager.hasSpeaker("recent")
         XCTAssertFalse(hasOld)
         XCTAssertTrue(hasRecent)
 
-        await manager.makeSpeakerPermanent("recent")
-        await manager.removeSpeakers { $0.duration <= 2.0 }
-        let hasRecentAfterKeep = await manager.hasSpeaker("recent")
+        manager.makeSpeakerPermanent("recent")
+        manager.removeSpeakers { $0.duration <= 2.0 }
+        let hasRecentAfterKeep = manager.hasSpeaker("recent")
         XCTAssertTrue(hasRecentAfterKeep)
 
-        await manager.removeSpeakers(where: { $0.duration <= 2.0 }, keepIfPermanent: false)
-        let hasRecentAfterForce = await manager.hasSpeaker("recent")
+        manager.removeSpeakers(where: { $0.duration <= 2.0 }, keepIfPermanent: false)
+        let hasRecentAfterForce = manager.hasSpeaker("recent")
         XCTAssertFalse(hasRecentAfterForce)
     }
 
     func testResetKeepsPermanentSpeakers() async throws {
-        let manager = SpeakerManager()
-        let speaker1 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
-        let speaker2 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 2.0)
+        var manager = SpeakerManager()
+        let speaker1 = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
+        let speaker2 = manager.assignSpeaker(createDistinctEmbedding(pattern: 2), speechDuration: 2.0)
 
         let id1 = try XCTUnwrap(speaker1?.id)
         let id2 = try XCTUnwrap(speaker2?.id)
 
-        await manager.makeSpeakerPermanent(id1)
-        await manager.reset(keepIfPermanent: true)
+        manager.makeSpeakerPermanent(id1)
+        manager.reset(keepIfPermanent: true)
 
-        let has1 = await manager.hasSpeaker(id1)
-        let has2 = await manager.hasSpeaker(id2)
-        let ids = await manager.speakerIds
+        let has1 = manager.hasSpeaker(id1)
+        let has2 = manager.hasSpeaker(id2)
+        let ids = manager.speakerIds
         XCTAssertTrue(has1)
         XCTAssertFalse(has2)
         XCTAssertEqual(ids, [id1])
@@ -683,8 +635,8 @@ final class SpeakerManagerTests: XCTestCase {
 
     // MARK: - Embedding Update Tests
 
-    func testEmbeddingUpdateWithinAssignSpeaker() async {
-        let manager = SpeakerManager(
+    func testEmbeddingUpdateWithinAssignSpeaker() {
+        var manager = SpeakerManager(
             speakerThreshold: 0.3,
             embeddingThreshold: 0.2,
             minEmbeddingUpdateDuration: 2.0
@@ -692,28 +644,28 @@ final class SpeakerManagerTests: XCTestCase {
 
         // Create initial speaker
         let emb1 = createDistinctEmbedding(pattern: 1)
-        let speaker1 = await manager.assignSpeaker(emb1, speechDuration: 3.0)
+        let speaker1 = manager.assignSpeaker(emb1, speechDuration: 3.0)
         XCTAssertNotNil(speaker1)
 
         // Get initial state
-        let initialInfo = await manager.getSpeaker(for: speaker1!.id)
+        let initialInfo = manager.getSpeaker(for: speaker1!.id)
         let initialUpdateCount = initialInfo?.updateCount ?? 0
 
         // Assign similar embedding with sufficient duration - should update
         var emb2 = emb1
         emb2[0] += 0.01  // Very similar
-        let speaker2 = await manager.assignSpeaker(emb2, speechDuration: 3.0)
+        let speaker2 = manager.assignSpeaker(emb2, speechDuration: 3.0)
 
         XCTAssertEqual(speaker2?.id, speaker1?.id)  // Same speaker
 
         // Check that embedding was updated
-        let updatedInfo = await manager.getSpeaker(for: speaker1!.id)
+        let updatedInfo = manager.getSpeaker(for: speaker1!.id)
         XCTAssertGreaterThan(updatedInfo?.updateCount ?? 0, initialUpdateCount)
         XCTAssertNotEqual(updatedInfo?.currentEmbedding, emb1)  // Embedding changed
     }
 
-    func testNoEmbeddingUpdateForShortDuration() async {
-        let manager = SpeakerManager(
+    func testNoEmbeddingUpdateForShortDuration() {
+        var manager = SpeakerManager(
             speakerThreshold: 0.3,
             embeddingThreshold: 0.2,
             minEmbeddingUpdateDuration: 2.0
@@ -721,29 +673,29 @@ final class SpeakerManagerTests: XCTestCase {
 
         // Create initial speaker
         let emb1 = createDistinctEmbedding(pattern: 1)
-        let speaker1 = await manager.assignSpeaker(emb1, speechDuration: 3.0)
+        let speaker1 = manager.assignSpeaker(emb1, speechDuration: 3.0)
         XCTAssertNotNil(speaker1)
 
         // Get initial state
-        let initialInfo = await manager.getSpeaker(for: speaker1!.id)
+        let initialInfo = manager.getSpeaker(for: speaker1!.id)
         let initialUpdateCount = initialInfo?.updateCount ?? 0
 
         // Assign similar embedding with short duration - WILL update embedding now (duration check removed)
         var emb2 = emb1
         emb2[0] += 0.01
-        let speaker2 = await manager.assignSpeaker(emb2, speechDuration: 0.5)
+        let speaker2 = manager.assignSpeaker(emb2, speechDuration: 0.5)
 
         XCTAssertEqual(speaker2?.id, speaker1?.id)  // Same speaker
 
         // Check that embedding WAS updated (since duration check was removed)
-        let updatedInfo = await manager.getSpeaker(for: speaker1!.id)
+        let updatedInfo = manager.getSpeaker(for: speaker1!.id)
         XCTAssertGreaterThan(updatedInfo?.updateCount ?? 0, initialUpdateCount)  // Updated
         XCTAssertNotEqual(updatedInfo?.currentEmbedding, emb1)  // Embedding changed
         XCTAssertGreaterThan(updatedInfo?.duration ?? 0, 3.0)  // Duration still increased
     }
 
     func testRawEmbeddingFIFOInManager() async {
-        let manager = SpeakerManager(
+        var manager = SpeakerManager(
             speakerThreshold: 0.3,
             embeddingThreshold: 0.2,
             minEmbeddingUpdateDuration: 2.0
@@ -751,44 +703,44 @@ final class SpeakerManagerTests: XCTestCase {
 
         // Create initial speaker
         let emb1 = createDistinctEmbedding(pattern: 1)
-        let speaker = await manager.assignSpeaker(emb1, speechDuration: 3.0)
+        let speaker = manager.assignSpeaker(emb1, speechDuration: 3.0)
         XCTAssertNotNil(speaker)
 
         // Add many embeddings to trigger FIFO (max 50)
         for i in 0..<60 {
             var emb = emb1
             emb[0] += Float(i) * 0.001  // Slight variations
-            _ = await manager.assignSpeaker(emb, speechDuration: 2.5)
+            _ = manager.assignSpeaker(emb, speechDuration: 2.5)
         }
 
         // Check that raw embeddings are limited to 50
-        let info = await manager.getSpeaker(for: speaker!.id)
+        let info = manager.getSpeaker(for: speaker!.id)
         XCTAssertLessThanOrEqual(info?.rawEmbeddings.count ?? 0, 50)
     }
 
     // MARK: - Edge Cases
 
-    func testSpeakerThresholdBoundaries() async {
+    func testSpeakerThresholdBoundaries() {
         // Test with very low threshold (everything matches)
-        let manager1 = SpeakerManager(speakerThreshold: 0.01)
-        _ = await manager1.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
+        var manager1 = SpeakerManager(speakerThreshold: 0.01)
+        _ = manager1.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 2.0)
         var similarEmbedding = createDistinctEmbedding(pattern: 1)
         similarEmbedding[0] += 0.001  // Tiny variation
-        _ = await manager1.assignSpeaker(similarEmbedding, speechDuration: 2.0)
-        let count1 = await manager1.speakerCount
+        _ = manager1.assignSpeaker(similarEmbedding, speechDuration: 2.0)
+        let count1 = manager1.speakerCount
         XCTAssertEqual(count1, 1)  // Should match to same speaker
 
         // Test with high threshold (only exact matches)
-        let manager2 = SpeakerManager(speakerThreshold: 0.001)  // Very small threshold
+        var manager2 = SpeakerManager(speakerThreshold: 0.001)  // Very small threshold
         let emb1 = createDistinctEmbedding(pattern: 1)
-        _ = await manager2.assignSpeaker(emb1, speechDuration: 2.0)
-        _ = await manager2.assignSpeaker(emb1, speechDuration: 2.0)  // Exact same embedding
-        let count2 = await manager2.speakerCount
+        _ = manager2.assignSpeaker(emb1, speechDuration: 2.0)
+        _ = manager2.assignSpeaker(emb1, speechDuration: 2.0)  // Exact same embedding
+        let count2 = manager2.speakerCount
         XCTAssertEqual(count2, 1)  // Should match to same speaker
     }
 
     func testMinDurationFiltering() async {
-        let manager = SpeakerManager(
+        var manager = SpeakerManager(
             speakerThreshold: 0.5,
             embeddingThreshold: 0.3,
             minSpeechDuration: 2.0
@@ -797,19 +749,19 @@ final class SpeakerManagerTests: XCTestCase {
         let embedding = createDistinctEmbedding(pattern: 1)
 
         // Test with duration below threshold - should not create new speaker
-        let speaker1 = await manager.assignSpeaker(embedding, speechDuration: 0.5)
+        let speaker1 = manager.assignSpeaker(embedding, speechDuration: 0.5)
         XCTAssertNil(speaker1)  // Should return nil for short duration
-        let count0 = await manager.speakerCount
+        let count0 = manager.speakerCount
         XCTAssertEqual(count0, 0)  // No speaker created
 
         // Test with duration above threshold - should create speaker
-        let speaker2 = await manager.assignSpeaker(embedding, speechDuration: 3.0)
+        let speaker2 = manager.assignSpeaker(embedding, speechDuration: 3.0)
         XCTAssertNotNil(speaker2)
-        let count1 = await manager.speakerCount
+        let count1 = manager.speakerCount
         XCTAssertEqual(count1, 1)  // One speaker created
 
         // Test again with short duration on existing speaker
-        let speaker3 = await manager.assignSpeaker(embedding, speechDuration: 0.5)
+        let speaker3 = manager.assignSpeaker(embedding, speechDuration: 0.5)
         XCTAssertEqual(speaker3?.id, speaker2?.id)  // Should match existing speaker even with short duration
     }
 }

--- a/Tests/FluidAudioTests/Diarizer/SpeakerOperationsTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerOperationsTests.swift
@@ -434,38 +434,38 @@ final class SpeakerOperationsTests: XCTestCase {
     // MARK: - SpeakerManager Extension Tests
 
     func testReassignSegment() async {
-        let manager = SpeakerManager()
+        var manager = SpeakerManager()
 
         // Create initial speakers
         let emb1 = createDistinctEmbedding(pattern: 1)
         let emb2 = createDistinctEmbedding(pattern: 2)
 
-        let speaker1 = await manager.assignSpeaker(emb1, speechDuration: 5.0)
-        let speaker2 = await manager.assignSpeaker(emb2, speechDuration: 5.0)
+        let speaker1 = manager.assignSpeaker(emb1, speechDuration: 5.0)
+        let speaker2 = manager.assignSpeaker(emb2, speechDuration: 5.0)
 
         XCTAssertNotNil(speaker1)
         XCTAssertNotNil(speaker2)
 
         // Test that both speakers were created
-        let speakerCount = await manager.speakerCount
+        let speakerCount = manager.speakerCount
         XCTAssertEqual(speakerCount, 2)
 
         // Test reassigning an embedding that's closer to speaker2
-        let reassignedSpeaker = await manager.assignSpeaker(emb2, speechDuration: 3.0)
+        let reassignedSpeaker = manager.assignSpeaker(emb2, speechDuration: 3.0)
         XCTAssertEqual(reassignedSpeaker?.id, speaker2?.id)
     }
 
     func testGetCurrentSpeakerNames() async {
-        let manager = SpeakerManager()
+        var manager = SpeakerManager()
 
         // Add speakers with names
         let alice = Speaker(id: "alice", name: "Alice", currentEmbedding: createDistinctEmbedding(pattern: 1))
         let bob = Speaker(id: "bob", name: "Bob", currentEmbedding: createDistinctEmbedding(pattern: 2))
 
-        await manager.initializeKnownSpeakers([alice, bob])
+        manager.initializeKnownSpeakers([alice, bob])
 
         // getCurrentSpeakerNames actually returns speaker IDs, not names
-        let speakerIds = await manager.getCurrentSpeakerNames()
+        let speakerIds = manager.getCurrentSpeakerNames()
 
         XCTAssertEqual(speakerIds.count, 2)
         XCTAssertTrue(speakerIds.contains("alice"))
@@ -473,19 +473,19 @@ final class SpeakerOperationsTests: XCTestCase {
     }
 
     func testGetGlobalSpeakerStats() async {
-        let manager = SpeakerManager(speakerThreshold: 0.5)  // Use higher threshold to ensure distinct speakers
+        var manager = SpeakerManager(speakerThreshold: 0.5)  // Use higher threshold to ensure distinct speakers
 
         // Add speakers with very different embeddings to ensure they're distinct
-        let speaker1 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 10.0)
-        let speaker2 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 100), speechDuration: 20.0)
-        let speaker3 = await manager.assignSpeaker(createDistinctEmbedding(pattern: 200), speechDuration: 30.0)
+        let speaker1 = manager.assignSpeaker(createDistinctEmbedding(pattern: 1), speechDuration: 10.0)
+        let speaker2 = manager.assignSpeaker(createDistinctEmbedding(pattern: 100), speechDuration: 20.0)
+        let speaker3 = manager.assignSpeaker(createDistinctEmbedding(pattern: 200), speechDuration: 30.0)
 
         // Debug: check if all speakers were created
         XCTAssertNotNil(speaker1)
         XCTAssertNotNil(speaker2)
         XCTAssertNotNil(speaker3)
 
-        let stats = await manager.getGlobalSpeakerStats()
+        let stats = manager.getGlobalSpeakerStats()
 
         // If not all 3 speakers were created, adjust expectations
         XCTAssertGreaterThanOrEqual(stats.totalSpeakers, 2)

--- a/Tests/FluidAudioTests/Diarizer/SpeakerTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerTests.swift
@@ -49,28 +49,28 @@ final class SpeakerTests: XCTestCase {
 
     // MARK: - Speaker Enrollment Workflow
 
-    func testSpeakerEnrollmentWithName() async {
+    func testSpeakerEnrollmentWithName() {
         // Simulate the "My name is Alice" enrollment scenario
-        let manager = SpeakerManager()
+        var manager = SpeakerManager()
         let aliceEmbedding = createDistinctEmbedding(pattern: 10)
 
         // Step 1: User speaks and we get their embedding
-        let speaker = await manager.assignSpeaker(aliceEmbedding, speechDuration: 3.0)
+        let speaker = manager.assignSpeaker(aliceEmbedding, speechDuration: 3.0)
         XCTAssertNotNil(speaker)
 
         // Step 2: Transcription detects "My name is Alice"
         // Step 3: Update the speaker's name from default to actual name (persist via upsert since struct)
         if var updated = speaker {
             updated.name = "Alice"
-            await manager.upsertSpeaker(updated)
+            manager.upsertSpeaker(updated)
         }
 
-        let stored = await manager.getSpeaker(for: speaker!.id)
+        let stored = manager.getSpeaker(for: speaker!.id)
         XCTAssertEqual(stored?.name, "Alice")
         XCTAssertNotEqual(stored?.name, stored?.id)  // Name should be different from ID
 
         // Step 4: Future audio from same speaker should be identified as "Alice"
-        let futureSpeaker = await manager.assignSpeaker(aliceEmbedding, speechDuration: 2.0)
+        let futureSpeaker = manager.assignSpeaker(aliceEmbedding, speechDuration: 2.0)
         XCTAssertEqual(futureSpeaker?.id, speaker?.id)
         XCTAssertEqual(futureSpeaker?.name, "Alice")
     }


### PR DESCRIPTION
### Why is this change needed?

`DiarizerManger.performCompleteDiarization` is `async`, even though no asynchronous operations occur when running the models and processing the results - this is just plain, synchronous computation. It doesn't wait on the network or things like that. It is important to be able to integrate it in to other synchronous compute workflows.

The reason it had to be `async` until now is that the `SpeakerManager` type containing the speaker database was a `class`, meaning that it was shared mutable state. It was made an `actor` because this shared mutable state could be mutated concurrently.

But really, there should not be concurrent mutations to the `SpeakerManager` in the first place. The user of this type, `DiarizationManager`, is not actually prepared for other code to be modifying this database while it is using it, and anybody who is trying is almost certainly writing a bug because their code would be logically racing with `DiarizationManager` and the results would be unpredictable.

This change makes `SpeakerManager` a struct. It has copy-on-write value semantics because it wraps a `Dictionary` for its storage, and mutations are marked by the `mutating` keyword and require exclusive ownership of the variable -- again, just like `Dictionary`. The compiler statically diagnoses attempts to concurrently mutate the `DiarizationManager`'s speaker database, so the test for this can be removed (it no longer compiles).

<img width="1108" height="386" alt="Screenshot 2026-05-09 at 19 10 26" src="https://github.com/user-attachments/assets/04fc3395-7d46-42a8-b035-4d0b559cc8aa" />

In summary, this change significantly reduces the cognitive load of using and maintaining this code, promotes correct usage through static diagnostics rather than allowing unpredictable results through concurrent mutation of the speaker database, and enables diarization to be used in more contexts in more programs.

(BTW, `SpeakerManager` doesn't strictly _need_ to be `Sendable`, but the previous one was by virtue of being an `actor`, so I marked this one as being `Sendable` too in case anybody was relying on it. I don't think the implementation of this type is going to change radically in the future to the point where that might be a problem)