### PR TITLE
ci: add Claude Code Action workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,37 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/claude.yml` so the repo can respond to `@claude` mentions in issues, issue comments, PR reviews, and PR review comments via [anthropics/claude-code-action@v1](https://github.com/anthropics/claude-code-action).

Motivation: PR #596 had a reviewer post `@claude review` and nothing happened because no workflow was wired up. This PR fixes that for future reviews.

## What it does

- Triggers on `issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues` (opened/assigned)
- Job runs only when the body/title contains `@claude` (cheap filter, prevents wasted runs)
- Uses `ANTHROPIC_API_KEY` repo secret for auth
- Minimal `read` permissions on contents/PRs/issues; `id-token: write` for OIDC

## Required configuration (repo settings)

Before this workflow can run, a maintainer needs to:

1. Install the [Claude GitHub App](https://github.com/apps/claude) on `FluidInference/FluidAudio`
2. Add an `ANTHROPIC_API_KEY` secret in repo Settings -> Secrets and variables -> Actions

Without those, the workflow file is inert (no failed runs, just no-op).

## Test plan

- [ ] Maintainer installs the Claude GitHub App and sets `ANTHROPIC_API_KEY`
- [ ] After merge, post `@claude help` on a throwaway issue and confirm the workflow fires
- [ ] Confirm non-`@claude` comments do not trigger the job

🤖 Generated with [Claude Code](https://claude.com/claude-code)