### PR TITLE
ci: use CLAUDE_CODE_OAUTH_TOKEN for Claude Code Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,4 +34,4 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Switches the Claude Code Action auth from `ANTHROPIC_API_KEY` to `CLAUDE_CODE_OAUTH_TOKEN`, which uses a Claude Max/Pro subscription instead of pay-per-token API billing.

The PR #599 workflow run failed with:
\`\`\`
Environment variable validation failed:
- Either ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required
\`\`\`

## Required setup (one-time, maintainer)

\`\`\`bash
# Generate an OAuth token tied to your Claude account
claude setup-token

# Store it in repo secrets
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo FluidInference/FluidAudio
# (paste the token when prompted)
\`\`\`

Verify:
\`\`\`bash
gh secret list --repo FluidInference/FluidAudio
\`\`\`

## Test plan

- [ ] Maintainer runs the two commands above to populate the secret
- [ ] After merge, post \`@claude help\` on a throwaway issue and confirm the workflow runs without env-var errors