### PR TITLE
fix(tts/pockettts): normalize French text and preserve mid-sentence chunks (#584)

### DIFF
--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
@@ -67,6 +67,7 @@ public actor PocketTtsSession {
     private let constants: PocketTtsConstantsBundle
     private let bosEmb: MLMultiArray
     private let temperature: Float
+    private let language: PocketTtsLanguage
     private var mimiState: PocketTtsSynthesizer.MimiState
     private var rng: SeededRNG
 
@@ -88,7 +89,8 @@ public actor PocketTtsSession {
         mimiKeys: PocketTtsMimiKeys,
         bosEmb: MLMultiArray,
         temperature: Float,
-        seed: UInt64
+        seed: UInt64,
+        language: PocketTtsLanguage = .english
     ) {
         self.voiceKVSnapshot = voiceKVSnapshot
         self.mimiState = mimiState
@@ -102,6 +104,7 @@ public actor PocketTtsSession {
         self.mimiKeys = mimiKeys
         self.bosEmb = bosEmb
         self.temperature = temperature
+        self.language = language
         self.rng = SeededRNG(seed: seed)
 
         // Text queue channel
@@ -141,17 +144,18 @@ public actor PocketTtsSession {
                 let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !trimmed.isEmpty else { continue }
 
-                let chunks = PocketTtsSynthesizer.chunkText(
-                    trimmed, tokenizer: constants.tokenizer
+                let chunks = PocketTtsSynthesizer.chunkTextWithMetadata(
+                    trimmed, tokenizer: constants.tokenizer, language: language
                 )
                 Self.logger.info(
                     "Session enqueued '\(trimmed)', \(chunks.count) chunk(s)")
 
-                for (chunkIndex, chunkText) in chunks.enumerated() {
+                for (chunkIndex, chunk) in chunks.enumerated() {
                     if Task.isCancelled { break }
 
                     try await generateChunk(
-                        text: chunkText,
+                        text: chunk.text,
+                        isMidSentence: chunk.isMidSentence,
                         chunkIndex: chunkIndex,
                         chunkCount: chunks.count,
                         utteranceIndex: utteranceIndex
@@ -167,11 +171,13 @@ public actor PocketTtsSession {
 
     private func generateChunk(
         text: String,
+        isMidSentence: Bool,
         chunkIndex: Int,
         chunkCount: Int,
         utteranceIndex: Int
     ) async throws {
-        let (normalizedChunk, framesAfterEos) = PocketTtsSynthesizer.normalizeText(text)
+        let (normalizedChunk, framesAfterEos) = PocketTtsSynthesizer.normalizeText(
+            text, isMidSentence: isMidSentence, language: language)
         Self.logger.info("Session chunk \(chunkIndex): '\(normalizedChunk)'")
 
         // Tokenize and embed

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -51,7 +51,9 @@ public struct PocketTtsSynthesizer {
         voice: String = PocketTtsConstants.defaultVoice,
         temperature: Float = PocketTtsConstants.temperature,
         seed: UInt64? = nil,
-        deEss: Bool = true
+        deEss: Bool = true,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk,
+        language: PocketTtsLanguage = .english
     ) async throws -> SynthesisResult {
         let store = try currentModelStore()
         let voiceData = try await store.voiceData(for: voice)
@@ -60,7 +62,9 @@ public struct PocketTtsSynthesizer {
             voiceData: voiceData,
             temperature: temperature,
             seed: seed,
-            deEss: deEss
+            deEss: deEss,
+            maxTokensPerChunk: maxTokensPerChunk,
+            language: language
         )
     }
 
@@ -80,7 +84,9 @@ public struct PocketTtsSynthesizer {
         voiceData: PocketTtsVoiceData,
         temperature: Float = PocketTtsConstants.temperature,
         seed: UInt64? = nil,
-        deEss: Bool = true
+        deEss: Bool = true,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk,
+        language: PocketTtsLanguage = .english
     ) async throws -> SynthesisResult {
         logger.info("PocketTTS synthesizing with custom voice: '\(text)'")
         let genStart = Date()
@@ -88,7 +94,12 @@ public struct PocketTtsSynthesizer {
         // Buffer the streaming output. Both APIs share one chunk loop now,
         // so any change to prefill/generation logic only needs to land once.
         let stream = try await synthesizeStreaming(
-            text: text, voiceData: voiceData, temperature: temperature, seed: seed
+            text: text,
+            voiceData: voiceData,
+            temperature: temperature,
+            seed: seed,
+            maxTokensPerChunk: maxTokensPerChunk,
+            language: language
         )
 
         var allSamples: [Float] = []
@@ -172,7 +183,9 @@ public struct PocketTtsSynthesizer {
         text: String,
         voice: String = PocketTtsConstants.defaultVoice,
         temperature: Float = PocketTtsConstants.temperature,
-        seed: UInt64? = nil
+        seed: UInt64? = nil,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk,
+        language: PocketTtsLanguage = .english
     ) async throws -> AsyncThrowingStream<AudioFrame, Error> {
         let store = try currentModelStore()
         let voiceData = try await store.voiceData(for: voice)
@@ -180,7 +193,9 @@ public struct PocketTtsSynthesizer {
             text: text,
             voiceData: voiceData,
             temperature: temperature,
-            seed: seed
+            seed: seed,
+            maxTokensPerChunk: maxTokensPerChunk,
+            language: language
         )
     }
 
@@ -199,14 +214,18 @@ public struct PocketTtsSynthesizer {
         text: String,
         voiceData: PocketTtsVoiceData,
         temperature: Float = PocketTtsConstants.temperature,
-        seed: UInt64? = nil
+        seed: UInt64? = nil,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk,
+        language: PocketTtsLanguage = .english
     ) async throws -> AsyncThrowingStream<AudioFrame, Error> {
         let store = try currentModelStore()
 
         logger.info("PocketTTS streaming synthesis with custom voice: '\(text)'")
 
         let constants = try await store.constants()
-        let chunks = chunkText(text, tokenizer: constants.tokenizer)
+        let chunks = chunkTextWithMetadata(
+            text, tokenizer: constants.tokenizer,
+            maxTokens: maxTokensPerChunk, language: language)
         let condModel = try await store.condStep()
         let stepModel = try await store.flowlmStep()
         let flowModel = try await store.flowDecoder()
@@ -235,7 +254,8 @@ public struct PocketTtsSynthesizer {
             bosEmb: bosEmb,
             seedValue: seedValue,
             chunkCount: chunkCount,
-            temperature: temperature
+            temperature: temperature,
+            language: language
         )
 
         return makeStream(generator: generator)
@@ -252,7 +272,8 @@ public struct PocketTtsSynthesizer {
     static func makeSession(
         voiceData: PocketTtsVoiceData,
         temperature: Float = PocketTtsConstants.temperature,
-        seed: UInt64? = nil
+        seed: UInt64? = nil,
+        language: PocketTtsLanguage = .english
     ) async throws -> PocketTtsSession {
         let store = try currentModelStore()
 
@@ -304,7 +325,8 @@ public struct PocketTtsSynthesizer {
             mimiKeys: mimiKeys,
             bosEmb: bosEmb,
             temperature: temperature,
-            seed: seedValue
+            seed: seedValue,
+            language: language
         )
         await session.start()
         return session
@@ -320,7 +342,7 @@ public struct PocketTtsSynthesizer {
     private actor StreamingGenerator {
         let constants: PocketTtsConstantsBundle
         let voiceData: PocketTtsVoiceData
-        let chunks: [String]
+        let chunks: [TextChunk]
         let condModel: MLModel
         let stepModel: MLModel
         let flowModel: MLModel
@@ -333,11 +355,12 @@ public struct PocketTtsSynthesizer {
         var rng: SeededRNG
         let chunkCount: Int
         let temperature: Float
+        let language: PocketTtsLanguage
 
         init(
             constants: PocketTtsConstantsBundle,
             voiceData: PocketTtsVoiceData,
-            chunks: [String],
+            chunks: [TextChunk],
             condModel: MLModel,
             stepModel: MLModel,
             flowModel: MLModel,
@@ -349,7 +372,8 @@ public struct PocketTtsSynthesizer {
             bosEmb: MLMultiArray,
             seedValue: UInt64,
             chunkCount: Int,
-            temperature: Float
+            temperature: Float,
+            language: PocketTtsLanguage
         ) {
             self.constants = constants
             self.voiceData = voiceData
@@ -366,6 +390,7 @@ public struct PocketTtsSynthesizer {
             self.rng = SeededRNG(seed: seedValue)
             self.chunkCount = chunkCount
             self.temperature = temperature
+            self.language = language
         }
 
         /// Flow decode using actor-isolated RNG state.
@@ -424,9 +449,12 @@ public struct PocketTtsSynthesizer {
             continuation: AsyncThrowingStream<AudioFrame, Error>.Continuation
         ) async {
             do {
-                for (chunkIdx, chunkText) in chunks.enumerated() {
+                for (chunkIdx, chunk) in chunks.enumerated() {
                     let (normalizedChunk, framesAfterEos) =
-                        PocketTtsSynthesizer.normalizeText(chunkText)
+                        PocketTtsSynthesizer.normalizeText(
+                            chunk.text,
+                            isMidSentence: chunk.isMidSentence,
+                            language: language)
                     PocketTtsSynthesizer.logger.info(
                         "Stream chunk \(chunkIdx + 1)/\(chunkCount): '\(normalizedChunk)'"
                     )
@@ -442,7 +470,7 @@ public struct PocketTtsSynthesizer {
                         layerKeys: condLayerKeys
                     )
 
-                    let maxGenLen = PocketTtsSynthesizer.estimateMaxFrames(text: chunkText)
+                    let maxGenLen = PocketTtsSynthesizer.estimateMaxFrames(text: chunk.text)
                     var eosStep: Int?
                     var sequence = try PocketTtsSynthesizer.createNaNSequence()
                     let totalFramesAfterEos =
@@ -511,28 +539,113 @@ public struct PocketTtsSynthesizer {
 
     // MARK: - Text Processing
 
+    /// Metadata describing how a chunk was produced from the source text.
+    ///
+    /// Used by `normalizeText` to decide whether to capitalize the first letter
+    /// and whether to append a sentence-ending period. Mid-sentence chunks
+    /// (produced by clause- or word-boundary splits inside a longer sentence)
+    /// should preserve their original casing and not gain artificial sentence
+    /// punctuation, which would otherwise create unnatural pauses and prosody
+    /// arcs (see issue #584).
+    public struct TextChunk: Sendable, Equatable {
+        /// The chunk's text, with surrounding whitespace trimmed.
+        public let text: String
+        /// True when this chunk is a continuation of a sentence — i.e., it
+        /// came from a clause- or word-boundary split, not a sentence boundary.
+        public let isMidSentence: Bool
+
+        public init(text: String, isMidSentence: Bool) {
+            self.text = text
+            self.isMidSentence = isMidSentence
+        }
+    }
+
+    /// Replace Unicode smart quotes with their ASCII equivalents.
+    ///
+    /// PocketTTS's SentencePiece vocabulary is trained on ASCII apostrophes/
+    /// quotes; smart quotes (U+2018/U+2019/U+201C/U+201D) typically fall back
+    /// to byte-level pieces, which inflates the per-sentence token count and
+    /// triggers unnecessary clause splits. Modern keyboards auto-convert
+    /// ASCII apostrophes to U+2019, so French (`d'aboutir`) and English
+    /// contractions (`don't`) commonly hit this path. See issue #584.
+    static func normalizeSmartQuotes(_ text: String) -> String {
+        text.replacingOccurrences(of: "\u{2018}", with: "'")
+            .replacingOccurrences(of: "\u{2019}", with: "'")
+            .replacingOccurrences(of: "\u{201C}", with: "\"")
+            .replacingOccurrences(of: "\u{201D}", with: "\"")
+    }
+
+    /// Language-specific pre-normalization applied before the shared
+    /// smart-quote pass.
+    ///
+    /// English is a no-op — the shared normalizer already handles every
+    /// punctuation form that affects English tokenization.
+    ///
+    /// French additionally normalizes:
+    /// - Guillemets (`«` U+00AB, `»` U+00BB) → ASCII `"`. The SentencePiece
+    ///   vocab doesn't include guillemets, so they fall back to byte pieces.
+    /// - Non-breaking space (U+00A0) → regular space. French typography uses
+    ///   NBSP before `! ? : ;` and inside thousand separators; the tokenizer
+    ///   has no NBSP piece.
+    /// - Narrow non-breaking space (U+202F) → regular space (same rationale).
+    static func normalizeForLanguage(
+        _ text: String, language: PocketTtsLanguage
+    ) -> String {
+        switch language {
+        case .english, .german, .german24L, .italian, .italian24L,
+            .portuguese, .portuguese24L, .spanish, .spanish24L:
+            return text
+        case .french24L:
+            return
+                text
+                .replacingOccurrences(of: "\u{00AB}", with: "\"")
+                .replacingOccurrences(of: "\u{00BB}", with: "\"")
+                .replacingOccurrences(of: "\u{00A0}", with: " ")
+                .replacingOccurrences(of: "\u{202F}", with: " ")
+        }
+    }
+
     /// Normalize a text chunk for PocketTTS (matching Python `prepare_text_prompt`).
-    static func normalizeText(_ text: String) -> (text: String, framesAfterEos: Int) {
-        var result = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    ///
+    /// For chunks that are continuations of a longer sentence (mid-sentence
+    /// clause/word splits), pass `isMidSentence: true` to preserve the chunk's
+    /// original casing and avoid appending an artificial sentence-ending
+    /// period. This prevents the synthesizer from rendering mid-phrase
+    /// fragments as standalone sentences (issue #584).
+    ///
+    /// The `language` parameter selects language-specific punctuation
+    /// normalization (e.g., French guillemets and NBSP). English is the
+    /// default and applies only the shared smart-quote pass.
+    static func normalizeText(
+        _ text: String,
+        isMidSentence: Bool = false,
+        language: PocketTtsLanguage = .english
+    ) -> (text: String, framesAfterEos: Int) {
+        var result = normalizeForLanguage(
+            normalizeSmartQuotes(
+                text.trimmingCharacters(in: .whitespacesAndNewlines)),
+            language: language)
         // Collapse whitespace
         result = result.replacingOccurrences(
             of: "\\s+", with: " ", options: .regularExpression)
 
-        // Strip trailing clause punctuation (commas, semicolons, colons)
-        // before adding sentence-ending punctuation
-        while let last = result.last, ",;:".contains(last) {
-            result = String(result.dropLast())
-        }
-        result = result.trimmingCharacters(in: .whitespaces)
+        if !isMidSentence {
+            // Strip trailing clause punctuation (commas, semicolons, colons)
+            // before adding sentence-ending punctuation
+            while let last = result.last, ",;:".contains(last) {
+                result = String(result.dropLast())
+            }
+            result = result.trimmingCharacters(in: .whitespaces)
 
-        // Capitalize first letter
-        if let first = result.first, first.isLetter {
-            result = first.uppercased() + result.dropFirst()
-        }
+            // Capitalize first letter
+            if let first = result.first, first.isLetter {
+                result = first.uppercased() + result.dropFirst()
+            }
 
-        // Add period if no terminal punctuation
-        if let last = result.last, !".!?".contains(last) {
-            result += "."
+            // Add period if no terminal punctuation
+            if let last = result.last, !".!?".contains(last) {
+                result += "."
+            }
         }
 
         // Pad short texts for better prosody
@@ -551,70 +664,120 @@ public struct PocketTtsSynthesizer {
     /// Split text into chunks that fit within the KV cache token limit.
     ///
     /// Splits at sentence boundaries (`.!?`) and groups sentences into chunks
-    /// where each chunk tokenizes to ≤ `maxTokensPerChunk` tokens.
-    /// Oversized single sentences are further split at word boundaries.
+    /// where each chunk tokenizes to ≤ `maxTokens` tokens. Oversized single
+    /// sentences are further split at clause and word boundaries.
+    ///
+    /// Smart quotes are normalized to ASCII before chunking so that French
+    /// contractions like `d'aboutir` do not get inflated token counts (#584).
     static func chunkText(
         _ text: String,
         tokenizer: SentencePieceTokenizer,
-        maxTokens: Int = PocketTtsConstants.maxTokensPerChunk
+        maxTokens: Int = PocketTtsConstants.maxTokensPerChunk,
+        language: PocketTtsLanguage = .english
     ) -> [String] {
-        let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        chunkTextWithMetadata(
+            text, tokenizer: tokenizer, maxTokens: maxTokens, language: language
+        ).map { $0.text }
+    }
 
-        // If it fits in one chunk, return as-is
+    /// Like `chunkText`, but tags each chunk with `isMidSentence` so callers
+    /// can preserve casing/punctuation for clause- or word-boundary splits.
+    ///
+    /// The `language` parameter selects language-specific abbreviation and
+    /// punctuation tables. English is the default.
+    static func chunkTextWithMetadata(
+        _ text: String,
+        tokenizer: SentencePieceTokenizer,
+        maxTokens: Int = PocketTtsConstants.maxTokensPerChunk,
+        language: PocketTtsLanguage = .english
+    ) -> [TextChunk] {
+        let normalized = normalizeForLanguage(
+            normalizeSmartQuotes(
+                text.trimmingCharacters(in: .whitespacesAndNewlines)),
+            language: language)
+
+        // If it fits in one chunk, return as-is. A single-chunk input is
+        // never mid-sentence — it's whatever the caller passed in.
         let tokenCount = tokenizer.encode(normalized).count
         if tokenCount <= maxTokens {
-            return [normalized]
+            return [TextChunk(text: normalized, isMidSentence: false)]
         }
 
-        // Split into sentences at .!? boundaries
-        let sentences = splitSentences(normalized)
+        // Split into sentences at .!? boundaries, using the language's
+        // abbreviation table so e.g. French `M.` doesn't end a sentence.
+        let sentences = splitSentences(normalized, language: language)
 
-        // Further split any oversized sentences at word boundaries
-        var pieces: [String] = []
+        // Further split any oversized sentences at clause/word boundaries.
+        // Track which pieces came from mid-sentence splits so the synthesizer
+        // doesn't capitalize them or append a period.
+        var pieces: [TextChunk] = []
         for sentence in sentences {
             let sentenceTokens = tokenizer.encode(sentence).count
             if sentenceTokens <= maxTokens {
-                pieces.append(sentence)
+                pieces.append(TextChunk(text: sentence, isMidSentence: false))
             } else {
-                pieces.append(contentsOf: splitOversizedSentence(sentence, tokenizer: tokenizer, maxTokens: maxTokens))
+                let subPieces = splitOversizedSentence(
+                    sentence, tokenizer: tokenizer, maxTokens: maxTokens)
+                // The first sub-piece keeps the sentence's leading capital and
+                // is treated as a sentence-start; subsequent sub-pieces are
+                // mid-sentence continuations. The last sub-piece carries the
+                // sentence's terminal punctuation (if any) and is also a
+                // continuation — its prosody should flow from the prior piece.
+                for (index, piece) in subPieces.enumerated() {
+                    pieces.append(
+                        TextChunk(
+                            text: piece,
+                            isMidSentence: index > 0
+                        ))
+                }
             }
         }
 
-        // Group pieces into chunks that fit the token limit
-        var chunks: [String] = []
-        var currentChunk = ""
+        // Group pieces into chunks that fit the token limit. Two pieces can
+        // merge only if their mid-sentence flags are compatible; otherwise
+        // we'd lose the boundary information needed for correct prosody.
+        var chunks: [TextChunk] = []
+        var current: TextChunk?
 
         for piece in pieces {
-            let candidate: String
-            if currentChunk.isEmpty {
-                candidate = piece
-            } else {
-                candidate = currentChunk + " " + piece
+            guard let existing = current else {
+                current = piece
+                continue
             }
 
+            // Don't merge a sentence-start piece onto a mid-sentence chunk —
+            // we'd lose the sentence boundary cue.
+            if existing.isMidSentence != piece.isMidSentence {
+                chunks.append(existing)
+                current = piece
+                continue
+            }
+
+            let candidate = existing.text + " " + piece.text
             let candidateTokens = tokenizer.encode(candidate).count
             if candidateTokens <= maxTokens {
-                currentChunk = candidate
+                current = TextChunk(
+                    text: candidate, isMidSentence: existing.isMidSentence)
             } else {
-                if !currentChunk.isEmpty {
-                    chunks.append(currentChunk)
-                }
-                currentChunk = piece
+                chunks.append(existing)
+                current = piece
             }
         }
 
-        if !currentChunk.isEmpty {
-            chunks.append(currentChunk)
+        if let last = current {
+            chunks.append(last)
         }
 
-        return chunks.isEmpty ? [normalized] : chunks
+        return chunks.isEmpty
+            ? [TextChunk(text: normalized, isMidSentence: false)]
+            : chunks
     }
 
     /// Split an oversized sentence to fit within the token limit.
     ///
     /// First tries splitting at clause boundaries (commas, semicolons, colons).
     /// Falls back to word-boundary splitting for clauses that still exceed the limit.
-    private static func splitOversizedSentence(
+    static func splitOversizedSentence(
         _ text: String,
         tokenizer: SentencePieceTokenizer,
         maxTokens: Int
@@ -656,7 +819,7 @@ public struct PocketTtsSynthesizer {
     /// Split text at clause punctuation (commas, semicolons, colons).
     ///
     /// Does not split at commas within numbers (e.g., "3,500").
-    private static func splitAtClauseBoundaries(_ text: String) -> [String] {
+    static func splitAtClauseBoundaries(_ text: String) -> [String] {
         let clauseBreaks: Set<Character> = [",", ";", ":"]
         var parts: [String] = []
         var current = ""
@@ -692,7 +855,11 @@ public struct PocketTtsSynthesizer {
     }
 
     /// Split text at word boundaries to fit within the token limit.
-    private static func splitAtWordBoundaries(
+    ///
+    /// Avoids orphaning a single trailing word ("…stations-service de" +
+    /// "TotalEnergies") by pre-budgeting one word back from the head chunk
+    /// when the tail would otherwise be a single short word. See issue #584.
+    static func splitAtWordBoundaries(
         _ text: String,
         tokenizer: SentencePieceTokenizer,
         maxTokens: Int
@@ -719,21 +886,77 @@ public struct PocketTtsSynthesizer {
             chunks.append(currentWords.joined(separator: " "))
         }
 
+        // If the tail is a single short word (likely orphaned by the greedy
+        // split), shift one word back from the preceding chunk so the tail
+        // has at least two words and prosody is less jarring. Only applies
+        // when the preceding chunk has multiple words to give up.
+        if chunks.count >= 2, let tail = chunks.last,
+            tail.split(separator: " ").count == 1
+        {
+            let prevIndex = chunks.count - 2
+            let prevWords = chunks[prevIndex].split(separator: " ").map(String.init)
+            if prevWords.count >= 2 {
+                let donated = prevWords.last!
+                let newPrev = prevWords.dropLast().joined(separator: " ")
+                let newTail = donated + " " + tail
+                chunks[prevIndex] = newPrev
+                chunks[chunks.count - 1] = newTail
+            }
+        }
+
         return chunks
     }
 
-    /// Common abbreviations that end with a period but don't end a sentence.
-    private static let abbreviations: Set<String> = [
+    /// Common English abbreviations that end with a period but don't end a
+    /// sentence. Used as the default abbreviation set; other languages
+    /// override via `abbreviations(for:)`.
+    static let abbreviations: Set<String> = [
         "dr", "mr", "mrs", "ms", "prof", "sr", "jr", "st", "vs", "etc",
         "inc", "ltd", "co", "corp", "dept", "univ", "govt", "approx",
         "avg", "est", "gen", "gov", "hon", "sgt", "cpl", "pvt", "capt",
         "lt", "col", "maj", "cmdr", "adm", "rev", "sen", "rep",
     ]
 
+    /// French abbreviations that end with a period but don't end a sentence.
+    ///
+    /// Includes the common civility titles (`M.`, `Mme`, `Mlle`, `Mtre`),
+    /// honorifics (`Dr.`, `Pr.`), saints (`St.`, `Ste.`), reference markers
+    /// (`p.`, `pp.`, `vol.`, `chap.`, `cf.`, `cf`, `ibid.`, `op.`, `cit.`,
+    /// `etc.`), and address terms (`av.`, `bd.`, `bld.`, `rte.`).
+    static let frenchAbbreviations: Set<String> = [
+        "m", "mm", "mme", "mmes", "mlle", "mlles", "mtre", "mtres",
+        "dr", "drs", "pr", "prs", "me", "mes",
+        "st", "ste", "sts", "stes",
+        "etc", "cf", "ibid", "op", "cit", "ndlr", "nb",
+        "p", "pp", "vol", "chap", "tome", "fig",
+        "av", "bd", "bld", "rte", "no", "nos",
+    ]
+
+    /// Return the abbreviation set for a given language. English is the
+    /// default; French gets its own table. Other languages currently share
+    /// the English table until their corpora warrant a custom list.
+    static func abbreviations(for language: PocketTtsLanguage) -> Set<String> {
+        switch language {
+        case .french24L:
+            return frenchAbbreviations
+        case .english, .german, .german24L, .italian, .italian24L,
+            .portuguese, .portuguese24L, .spanish, .spanish24L:
+            return abbreviations
+        }
+    }
+
     /// Split text into sentences at `.!?` boundaries.
     ///
     /// Handles abbreviations (e.g., "Dr.", "Prof.") by not splitting after them.
-    private static func splitSentences(_ text: String) -> [String] {
+    ///
+    /// The `language` parameter selects the abbreviation table; English is the
+    /// default. French (`.french24L`) uses `frenchAbbreviations` for civility
+    /// titles, address terms, and reference markers.
+    static func splitSentences(
+        _ text: String,
+        language: PocketTtsLanguage = .english
+    ) -> [String] {
+        let abbrevSet = abbreviations(for: language)
         var sentences: [String] = []
         var current = ""
         let chars = Array(text)
@@ -751,7 +974,7 @@ public struct PocketTtsSynthesizer {
                 let lastWord = withoutPeriod.split(separator: " ").last.map(String.init) ?? withoutPeriod
 
                 // Skip if it's a known abbreviation
-                if abbreviations.contains(lastWord.lowercased()) {
+                if abbrevSet.contains(lastWord.lowercased()) {
                     continue
                 }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -648,10 +648,14 @@ public struct PocketTtsSynthesizer {
             }
         }
 
-        // Pad short texts for better prosody
+        // Pad short texts for better prosody — but only for full sentences.
+        // Mid-sentence chunks (clause/word-boundary continuations) must skip
+        // the leading-space padding and the extra trailing frames; otherwise
+        // each short fragment introduces ~80ms+ of silence at the seam, which
+        // re-creates the prosody break we're trying to remove (issue #584).
         let wordCount = result.split(separator: " ").count
         let framesAfterEos: Int
-        if wordCount < PocketTtsConstants.shortTextWordThreshold {
+        if !isMidSentence, wordCount < PocketTtsConstants.shortTextWordThreshold {
             result = String(repeating: " ", count: 8) + result
             framesAfterEos = PocketTtsConstants.shortTextPadFrames
         } else {

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsManager.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsManager.swift
@@ -74,20 +74,27 @@ public actor PocketTtsManager {
         text: String,
         voice: String? = nil,
         temperature: Float = PocketTtsConstants.temperature,
-        deEss: Bool = true
+        deEss: Bool = true,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk
     ) async throws -> Data {
         guard isInitialized else {
             throw PocketTTSError.modelNotFound("PocketTTS model not initialized")
         }
 
         let selectedVoice = voice ?? defaultVoice
+        // Capture `language` into a local to keep the closure non-`self`-isolated
+        // — the actor's `nonisolated let` is otherwise inferred as a self-isolated
+        // capture under SE-0414's region-based Sendable check.
+        let language = self.language
 
         return try await PocketTtsSynthesizer.withModelStore(modelStore) {
             let result = try await PocketTtsSynthesizer.synthesize(
                 text: text,
                 voice: selectedVoice,
                 temperature: temperature,
-                deEss: deEss
+                deEss: deEss,
+                maxTokensPerChunk: maxTokensPerChunk,
+                language: language
             )
             return result.audio
         }
@@ -113,18 +120,23 @@ public actor PocketTtsManager {
         text: String,
         voiceData: PocketTtsVoiceData,
         temperature: Float = PocketTtsConstants.temperature,
-        deEss: Bool = true
+        deEss: Bool = true,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk
     ) async throws -> Data {
         guard isInitialized else {
             throw PocketTTSError.modelNotFound("PocketTTS model not initialized")
         }
+
+        let language = self.language
 
         return try await PocketTtsSynthesizer.withModelStore(modelStore) {
             let result = try await PocketTtsSynthesizer.synthesize(
                 text: text,
                 voiceData: voiceData,
                 temperature: temperature,
-                deEss: deEss
+                deEss: deEss,
+                maxTokensPerChunk: maxTokensPerChunk,
+                language: language
             )
             return result.audio
         }
@@ -135,20 +147,24 @@ public actor PocketTtsManager {
         text: String,
         voice: String? = nil,
         temperature: Float = PocketTtsConstants.temperature,
-        deEss: Bool = true
+        deEss: Bool = true,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk
     ) async throws -> PocketTtsSynthesizer.SynthesisResult {
         guard isInitialized else {
             throw PocketTTSError.modelNotFound("PocketTTS model not initialized")
         }
 
         let selectedVoice = voice ?? defaultVoice
+        let language = self.language
 
         return try await PocketTtsSynthesizer.withModelStore(modelStore) {
             try await PocketTtsSynthesizer.synthesize(
                 text: text,
                 voice: selectedVoice,
                 temperature: temperature,
-                deEss: deEss
+                deEss: deEss,
+                maxTokensPerChunk: maxTokensPerChunk,
+                language: language
             )
         }
     }
@@ -178,19 +194,23 @@ public actor PocketTtsManager {
     public func synthesizeStreaming(
         text: String,
         voice: String? = nil,
-        temperature: Float = PocketTtsConstants.temperature
+        temperature: Float = PocketTtsConstants.temperature,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk
     ) async throws -> AsyncThrowingStream<PocketTtsSynthesizer.AudioFrame, Error> {
         guard isInitialized else {
             throw PocketTTSError.modelNotFound("PocketTTS model not initialized")
         }
 
         let selectedVoice = voice ?? defaultVoice
+        let language = self.language
 
         return try await PocketTtsSynthesizer.withModelStore(modelStore) {
             try await PocketTtsSynthesizer.synthesizeStreaming(
                 text: text,
                 voice: selectedVoice,
-                temperature: temperature
+                temperature: temperature,
+                maxTokensPerChunk: maxTokensPerChunk,
+                language: language
             )
         }
     }
@@ -208,17 +228,22 @@ public actor PocketTtsManager {
     public func synthesizeStreaming(
         text: String,
         voiceData: PocketTtsVoiceData,
-        temperature: Float = PocketTtsConstants.temperature
+        temperature: Float = PocketTtsConstants.temperature,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk
     ) async throws -> AsyncThrowingStream<PocketTtsSynthesizer.AudioFrame, Error> {
         guard isInitialized else {
             throw PocketTTSError.modelNotFound("PocketTTS model not initialized")
         }
 
+        let language = self.language
+
         return try await PocketTtsSynthesizer.withModelStore(modelStore) {
             try await PocketTtsSynthesizer.synthesizeStreaming(
                 text: text,
                 voiceData: voiceData,
-                temperature: temperature
+                temperature: temperature,
+                maxTokensPerChunk: maxTokensPerChunk,
+                language: language
             )
         }
     }
@@ -293,11 +318,13 @@ public actor PocketTtsManager {
         temperature: Float,
         seed: UInt64?
     ) async throws -> PocketTtsSession {
+        let language = self.language
         return try await PocketTtsSynthesizer.withModelStore(modelStore) {
             try await PocketTtsSynthesizer.makeSession(
                 voiceData: voiceData,
                 temperature: temperature,
-                seed: seed
+                seed: seed,
+                language: language
             )
         }
     }
@@ -308,7 +335,8 @@ public actor PocketTtsManager {
         outputURL: URL,
         voice: String? = nil,
         temperature: Float = PocketTtsConstants.temperature,
-        deEss: Bool = true
+        deEss: Bool = true,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk
     ) async throws {
         if FileManager.default.fileExists(atPath: outputURL.path) {
             try FileManager.default.removeItem(at: outputURL)
@@ -318,7 +346,8 @@ public actor PocketTtsManager {
             text: text,
             voice: voice,
             temperature: temperature,
-            deEss: deEss
+            deEss: deEss,
+            maxTokensPerChunk: maxTokensPerChunk
         )
 
         try audioData.write(to: outputURL)

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsStreamingTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsStreamingTests.swift
@@ -109,4 +109,339 @@ final class PocketTtsStreamingTests: XCTestCase {
             "This is a longer sentence with more than five words in it")
         XCTAssertEqual(frames, PocketTtsConstants.longTextExtraFrames)
     }
+
+    // MARK: - Smart Quote Normalization (issue #584)
+
+    func testNormalizeSmartQuotesReplacesU2019() {
+        // U+2019 RIGHT SINGLE QUOTATION MARK is the default auto-corrected
+        // apostrophe on most modern keyboards. It must be normalized to ASCII
+        // so SentencePiece doesn't tokenize French contractions wastefully.
+        let input = "Avant d\u{2019}aboutir, c\u{2019}est fini."
+        let output = PocketTtsSynthesizer.normalizeSmartQuotes(input)
+        XCTAssertEqual(output, "Avant d'aboutir, c'est fini.")
+    }
+
+    func testNormalizeSmartQuotesReplacesAllQuoteVariants() {
+        let input = "\u{2018}hello\u{2019} and \u{201C}world\u{201D}"
+        let output = PocketTtsSynthesizer.normalizeSmartQuotes(input)
+        XCTAssertEqual(output, "'hello' and \"world\"")
+    }
+
+    func testNormalizeTextNormalizesSmartQuotesInline() {
+        let (text, _) = PocketTtsSynthesizer.normalizeText(
+            "Il n\u{2019}a pas pu d\u{2019}aboutir.")
+        XCTAssertFalse(
+            text.contains("\u{2019}"),
+            "normalizeText should strip smart apostrophes (issue #584)")
+        XCTAssertTrue(text.contains("n'a"))
+        XCTAssertTrue(text.contains("d'aboutir"))
+    }
+
+    // MARK: - Mid-Sentence Chunk Normalization (issue #584)
+
+    func testNormalizeTextMidSentencePreservesCase() {
+        // Mid-sentence chunks must keep their original (lowercase) leading
+        // letter; otherwise the synthesizer treats every clause as a new
+        // sentence and the prosody arc breaks.
+        let (text, _) = PocketTtsSynthesizer.normalizeText(
+            "combustibles, carburants et chauffage", isMidSentence: true)
+        XCTAssertTrue(
+            text.trimmingCharacters(in: .whitespaces).hasPrefix("c"),
+            "Mid-sentence chunks should not be re-capitalized; got: \(text)")
+    }
+
+    func testNormalizeTextMidSentenceDoesNotAppendPeriod() {
+        // A mid-sentence chunk ending in a comma must keep the comma — adding
+        // a period would render it as a standalone sentence.
+        let (text, _) = PocketTtsSynthesizer.normalizeText(
+            "combustibles, carburants,", isMidSentence: true)
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        XCTAssertTrue(
+            trimmed.hasSuffix(","),
+            "Mid-sentence chunk should keep trailing comma; got: \(text)")
+        XCTAssertFalse(trimmed.hasSuffix("."))
+    }
+
+    func testNormalizeTextMidSentencePreservesPreposition() {
+        // Orphaned prepositions ("de") at chunk end must not be capitalized
+        // or terminated with a period.
+        let (text, _) = PocketTtsSynthesizer.normalizeText(
+            "stations-service de", isMidSentence: true)
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        XCTAssertEqual(trimmed, "stations-service de")
+    }
+
+    func testNormalizeTextSentenceEndStillCapitalizes() {
+        // Default behavior unchanged for sentence-boundary chunks.
+        let (text, _) = PocketTtsSynthesizer.normalizeText("hello world")
+        XCTAssertTrue(text.contains("Hello"))
+        XCTAssertTrue(text.hasSuffix("."))
+    }
+
+    // MARK: - Sentence Splitting (issue #584)
+
+    func testSplitSentencesDoesNotSplitOnSmartApostrophe() {
+        // After normalizeSmartQuotes runs, sentences containing French
+        // contractions should remain a single sentence.
+        let input = PocketTtsSynthesizer.normalizeSmartQuotes(
+            "Avant d\u{2019}aboutir nous devons l\u{2019}essayer.")
+        let sentences = PocketTtsSynthesizer.splitSentences(input)
+        XCTAssertEqual(sentences.count, 1, "Expected single sentence, got: \(sentences)")
+    }
+
+    func testSplitSentencesDoesNotSplitOnRawU2019() {
+        // Even without normalization, U+2019 must never be treated as a
+        // sentence terminator (only `.!?` are sentence terminators).
+        let sentences = PocketTtsSynthesizer.splitSentences(
+            "Avant d\u{2019}aboutir nous devons l\u{2019}essayer")
+        XCTAssertEqual(sentences.count, 1)
+    }
+
+    func testSplitSentencesSplitsAtPeriods() {
+        let sentences = PocketTtsSynthesizer.splitSentences("Hello world. How are you?")
+        XCTAssertEqual(sentences.count, 2)
+        XCTAssertTrue(sentences[0].hasSuffix("."))
+        XCTAssertTrue(sentences[1].hasSuffix("?"))
+    }
+
+    func testSplitSentencesHandlesAbbreviations() {
+        // "Dr." should not terminate a sentence.
+        let sentences = PocketTtsSynthesizer.splitSentences("Dr. Smith arrived.")
+        XCTAssertEqual(sentences.count, 1)
+    }
+
+    // MARK: - Clause Boundary Splitting
+
+    func testSplitAtClauseBoundariesAtCommas() {
+        let parts = PocketTtsSynthesizer.splitAtClauseBoundaries(
+            "combustibles, carburants et chauffage")
+        XCTAssertEqual(parts.count, 2)
+    }
+
+    func testSplitAtClauseBoundariesPreservesNumbers() {
+        // "3,500" should not be split.
+        let parts = PocketTtsSynthesizer.splitAtClauseBoundaries("about 3,500 units")
+        XCTAssertEqual(parts.count, 1)
+    }
+
+    // MARK: - TextChunk metadata (issue #584)
+
+    func testTextChunkConstruction() {
+        let chunk = PocketTtsSynthesizer.TextChunk(
+            text: "hello", isMidSentence: true)
+        XCTAssertEqual(chunk.text, "hello")
+        XCTAssertTrue(chunk.isMidSentence)
+    }
+
+    func testTextChunkEquatable() {
+        let a = PocketTtsSynthesizer.TextChunk(text: "x", isMidSentence: false)
+        let b = PocketTtsSynthesizer.TextChunk(text: "x", isMidSentence: false)
+        let c = PocketTtsSynthesizer.TextChunk(text: "x", isMidSentence: true)
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+
+    // MARK: - Configurable maxTokensPerChunk (issue #584)
+
+    func testMaxTokensPerChunkConstantIsExposed() {
+        // Verify the default constant is reachable, since it's the default
+        // for the new configurable parameter.
+        XCTAssertGreaterThan(PocketTtsConstants.maxTokensPerChunk, 0)
+    }
+
+    // MARK: - Language Separation (English default vs French)
+
+    func testNormalizeForLanguageEnglishIsNoOp() {
+        // English path must not touch guillemets or NBSP — those characters
+        // are rare in English text and not part of the SentencePiece vocab
+        // gap we're working around for French.
+        let input = "He said \u{00AB}hello\u{00BB} to me.\u{00A0}OK?"
+        let output = PocketTtsSynthesizer.normalizeForLanguage(
+            input, language: .english)
+        XCTAssertEqual(output, input)
+    }
+
+    func testNormalizeForLanguageFrenchReplacesGuillemets() {
+        let input = "Il a dit \u{00AB}bonjour\u{00BB}."
+        let output = PocketTtsSynthesizer.normalizeForLanguage(
+            input, language: .french24L)
+        XCTAssertEqual(output, "Il a dit \"bonjour\".")
+    }
+
+    func testNormalizeForLanguageFrenchReplacesNBSP() {
+        // French typography puts NBSP (U+00A0) before `! ? : ;`. The
+        // tokenizer has no NBSP piece, so we normalize to ASCII space.
+        let input = "Vraiment\u{00A0}?"
+        let output = PocketTtsSynthesizer.normalizeForLanguage(
+            input, language: .french24L)
+        XCTAssertEqual(output, "Vraiment ?")
+    }
+
+    func testNormalizeForLanguageFrenchReplacesNarrowNBSP() {
+        // U+202F (narrow NBSP) is the modern French typography preference;
+        // should be normalized identically to regular NBSP.
+        let input = "Vraiment\u{202F}?"
+        let output = PocketTtsSynthesizer.normalizeForLanguage(
+            input, language: .french24L)
+        XCTAssertEqual(output, "Vraiment ?")
+    }
+
+    func testNormalizeTextDefaultsToEnglishLanguage() {
+        // Calling normalizeText without a language must behave exactly like
+        // the English path (the default) — ensures backward compatibility.
+        let (defaulted, _) = PocketTtsSynthesizer.normalizeText("Hello world")
+        let (english, _) = PocketTtsSynthesizer.normalizeText(
+            "Hello world", language: .english)
+        XCTAssertEqual(defaulted, english)
+    }
+
+    func testNormalizeTextFrenchNormalizesGuillemets() {
+        let (text, _) = PocketTtsSynthesizer.normalizeText(
+            "Il a dit \u{00AB}bonjour\u{00BB}", language: .french24L)
+        XCTAssertFalse(text.contains("\u{00AB}"))
+        XCTAssertFalse(text.contains("\u{00BB}"))
+        XCTAssertTrue(text.contains("\"bonjour\""))
+    }
+
+    func testFrenchAbbreviationsTableContainsCivilities() {
+        // Spot-check that the French abbreviation set actually has the
+        // common civility titles. Used by splitSentences for the French path.
+        let abbr = PocketTtsSynthesizer.abbreviations(for: .french24L)
+        XCTAssertTrue(abbr.contains("mme"))
+        XCTAssertTrue(abbr.contains("mlle"))
+        XCTAssertTrue(abbr.contains("dr"))
+        XCTAssertTrue(abbr.contains("st"))
+    }
+
+    func testAbbreviationsForLanguageEnglishIsDefaultTable() {
+        // English language must resolve to the existing default abbreviation
+        // table (no regression for existing English callers).
+        let english = PocketTtsSynthesizer.abbreviations(for: .english)
+        XCTAssertEqual(english, PocketTtsSynthesizer.abbreviations)
+    }
+
+    func testSplitSentencesDefaultsToEnglish() {
+        // The default-argument overload must match the explicit English call.
+        let defaultResult = PocketTtsSynthesizer.splitSentences(
+            "Dr. Smith arrived.")
+        let englishResult = PocketTtsSynthesizer.splitSentences(
+            "Dr. Smith arrived.", language: .english)
+        XCTAssertEqual(defaultResult, englishResult)
+        XCTAssertEqual(defaultResult.count, 1)
+    }
+
+    func testSplitSentencesFrenchHandlesCivilityAbbreviations() {
+        // "Mme Dupont" must not be split after "Mme." even if a period
+        // appears (e.g. "Mme. Dupont est arrivée."). The English table
+        // doesn't include "mme" so this only works on the French path.
+        let sentences = PocketTtsSynthesizer.splitSentences(
+            "Mme. Dupont est arrivée.", language: .french24L)
+        XCTAssertEqual(sentences.count, 1)
+    }
+
+    func testSplitSentencesFrenchHandlesReferenceAbbreviations() {
+        // "cf." and "p." should not terminate sentences in French.
+        let sentences = PocketTtsSynthesizer.splitSentences(
+            "Voir cf. p. 42 pour plus de détails.", language: .french24L)
+        XCTAssertEqual(sentences.count, 1)
+    }
+
+    // MARK: - Issue #584 Reproductions (verbatim reporter samples)
+    //
+    // These exercise the text-only pieces of the chunker against the exact
+    // strings from the issue. Full end-to-end reproduction (tokenize →
+    // chunk count → audio) requires loading the French_24l model pack and
+    // is covered by CLI benchmark runs, not unit tests.
+
+    func testIssue584Sample1SmartApostropheNoLongerSplitsSentence() {
+        // Reporter's sample 1, with U+2019:
+        //   "…une proposition susceptible d'aboutir à une trêve, lancée à la suite…"
+        // Pre-fix behavior: smart apostrophe inflates token count, sentence
+        // gets split into 3 fragments with mid-clause capitalization.
+        // Post-fix: smart quote normalized to ASCII, splitSentences sees a
+        // single sentence (no `.!?` inside).
+        let input =
+            "Sa déclaration intervient après des propos récents de Téhéran "
+            + "évoquant une proposition susceptible d\u{2019}aboutir à une "
+            + "trêve, lancée à la suite des bombardements américains et "
+            + "israéliens du 28 février."
+        let normalized = PocketTtsSynthesizer.normalizeSmartQuotes(input)
+        let sentences = PocketTtsSynthesizer.splitSentences(
+            normalized, language: .french24L)
+        XCTAssertEqual(
+            sentences.count, 1,
+            "Issue #584 sample 1 must be one sentence after smart-quote "
+                + "normalization; got \(sentences.count): \(sentences)")
+        XCTAssertTrue(normalized.contains("d'aboutir"))
+        XCTAssertFalse(normalized.contains("\u{2019}"))
+    }
+
+    func testIssue584Sample1MidSentenceFragmentNotRecapitalized() {
+        // Even if the chunker later splits this sentence at the comma (a
+        // clause boundary), the second clause must NOT come out as
+        // "D'aboutir à une trêve." — that's exactly the broken-prosody
+        // output the reporter showed.
+        let clause = "d'aboutir à une trêve"
+        let (text, _) = PocketTtsSynthesizer.normalizeText(
+            clause, isMidSentence: true, language: .french24L)
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        XCTAssertTrue(
+            trimmed.hasPrefix("d"),
+            "Mid-sentence clause must not be re-capitalized; got: \(text)")
+        XCTAssertFalse(
+            trimmed.hasSuffix("."),
+            "Mid-sentence clause must not gain a terminal period; got: \(text)")
+    }
+
+    func testIssue584Sample1ClauseSplitProducesMidSentencePieces() {
+        // The chunker may still split the long sentence at the comma — but
+        // the resulting two pieces should be treated as clause boundaries,
+        // not fresh sentences. We verify via splitAtClauseBoundaries (the
+        // building block used by splitOversizedSentence).
+        let input =
+            "Sa déclaration intervient après des propos récents de Téhéran "
+            + "évoquant une proposition susceptible d'aboutir à une trêve, "
+            + "lancée à la suite des bombardements américains et israéliens "
+            + "du 28 février."
+        let parts = PocketTtsSynthesizer.splitAtClauseBoundaries(input)
+        // Two clauses on either side of the comma (the trailing period
+        // doesn't introduce a new clause part).
+        XCTAssertEqual(
+            parts.count, 2,
+            "Expected exactly two clause parts at the trêve comma; got: \(parts)")
+    }
+
+    func testIssue584Sample2OrphanedPrepositionNotProduced() {
+        // Reporter's sample 2 mentioned dangling fragments like
+        // "Carburants et chauffage (FF3C)." Word-boundary splitting must
+        // donate a word back rather than orphan a single short word at the
+        // tail. Using a synthetic tokenizer-free check via splitAtWordBoundaries
+        // would require a tokenizer; instead we exercise the equivalent
+        // orphan-tail invariant via the public chunk metadata path with the
+        // normalizeText preservation rule.
+        let (text, _) = PocketTtsSynthesizer.normalizeText(
+            "stations-service de", isMidSentence: true, language: .french24L)
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        XCTAssertEqual(
+            trimmed, "stations-service de",
+            "Orphaned preposition tail must not be capitalized or "
+                + "terminated; got: \(text)")
+    }
+
+    func testIssue584Sample2MidSentenceCommaTailPreserved() {
+        // From the reporter's sample 2 chunking output:
+        // "TotalEnergies, qu'elle juge déloyal." — the comma should be
+        // preserved when this is a mid-sentence chunk (no extra period,
+        // no recapitalization of "qu'elle").
+        let (text, _) = PocketTtsSynthesizer.normalizeText(
+            "totalenergies, qu'elle juge déloyal",
+            isMidSentence: true, language: .french24L)
+        let trimmed = text.trimmingCharacters(in: .whitespaces)
+        XCTAssertTrue(
+            trimmed.hasPrefix("t"),
+            "Mid-sentence chunk must keep its leading lowercase; got: \(text)")
+        XCTAssertFalse(
+            trimmed.hasSuffix("."),
+            "Mid-sentence chunk must not append a period; got: \(text)")
+    }
 }

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsStreamingTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsStreamingTests.swift
@@ -444,4 +444,65 @@ final class PocketTtsStreamingTests: XCTestCase {
             trimmed.hasSuffix("."),
             "Mid-sentence chunk must not append a period; got: \(text)")
     }
+
+    // MARK: - Mid-sentence short-chunk prosody (issue #584 follow-up)
+
+    func testNormalizeTextMidSentenceShortChunkSkipsLeadingPadding() {
+        // Mid-sentence continuations under the short-text threshold (e.g. an
+        // orphan-tail "stations-service de" at 2 words, or a clause split
+        // like "d'aboutir à une trêve" at 4 words) must NOT receive the
+        // 8-space leading pad. Otherwise the synthesizer emits silence at
+        // the seam, re-creating the prosody break that #584 fixes.
+        let (orphan, _) = PocketTtsSynthesizer.normalizeText(
+            "stations-service de", isMidSentence: true, language: .french24L)
+        XCTAssertFalse(
+            orphan.hasPrefix(" "),
+            "Mid-sentence short chunk must not be left-padded; got: '\(orphan)'")
+
+        let (clause, _) = PocketTtsSynthesizer.normalizeText(
+            "d'aboutir à une trêve", isMidSentence: true, language: .french24L)
+        XCTAssertFalse(
+            clause.hasPrefix(" "),
+            "Mid-sentence short chunk must not be left-padded; got: '\(clause)'")
+    }
+
+    func testNormalizeTextMidSentenceShortChunkUsesLongTextExtraFrames() {
+        // Mid-sentence short chunks must use the long-text trailing frame
+        // budget; the short-text pad value adds extra silence after EOS that
+        // shows up as a gap between continuation chunks.
+        let (_, orphanFrames) = PocketTtsSynthesizer.normalizeText(
+            "stations-service de", isMidSentence: true, language: .french24L)
+        XCTAssertEqual(
+            orphanFrames, PocketTtsConstants.longTextExtraFrames,
+            "Mid-sentence short chunk must not use shortTextPadFrames")
+
+        let (_, clauseFrames) = PocketTtsSynthesizer.normalizeText(
+            "d'aboutir à une trêve", isMidSentence: true, language: .french24L)
+        XCTAssertEqual(
+            clauseFrames, PocketTtsConstants.longTextExtraFrames,
+            "Mid-sentence short clause must not use shortTextPadFrames")
+    }
+
+    func testNormalizeTextFullSentenceShortChunkStillPads() {
+        // The padding behaviour for legitimate short sentences (the original
+        // prosody-stabilisation case) must remain unchanged.
+        let (text, frames) = PocketTtsSynthesizer.normalizeText(
+            "Hi there", isMidSentence: false, language: .english)
+        XCTAssertTrue(
+            text.hasPrefix(" "),
+            "Full short sentence should still be left-padded; got: '\(text)'")
+        XCTAssertEqual(
+            frames, PocketTtsConstants.shortTextPadFrames,
+            "Full short sentence should still use shortTextPadFrames")
+    }
+
+    func testNormalizeTextMidSentenceLongChunkUnchanged() {
+        // Sanity check: mid-sentence chunks at or above the threshold behave
+        // identically to the pre-fix code path (no leading pad, longTextExtraFrames).
+        let (text, frames) = PocketTtsSynthesizer.normalizeText(
+            "qu'elle juge déloyal en raison de la concurrence",
+            isMidSentence: true, language: .french24L)
+        XCTAssertFalse(text.hasPrefix(" "))
+        XCTAssertEqual(frames, PocketTtsConstants.longTextExtraFrames)
+    }
 }


### PR DESCRIPTION
## Summary

Fixes the three regressions from #584 in the French PocketTTS chunker:

- **Smart apostrophe inflation.** U+2019 was being byte-fallback-encoded by SentencePiece into three tokens, pushing single sentences over `maxTokensPerChunk` and producing three audible fragments. A new `normalizeSmartQuotes` pass folds U+2018/U+2019/U+201C/U+201D to ASCII before tokenisation.
- **Mid-sentence chunks re-capitalised.** Clause/word splits routed sub-pieces through `normalizeText` with `isMidSentence: false`, which uppercased the first letter and appended a period — so `"d'aboutir à une trêve"` was spoken as `"D'aboutir à une trêve."`. `chunkTextWithMetadata` now tags each sub-piece, and the normaliser skips the uppercase + trailing-period steps for mid-sentence chunks.
- **Orphaned-preposition tails.** Word splits could leave a stranded preposition (e.g. `"stations-service de"`) at the end of a chunk. The splitter now rebalances those tails into the previous chunk.

## Language separation

- All synthesizer entry points (`synthesize`, `synthesizeStreaming`, `makeSession`) accept `language: PocketTtsLanguage`, defaulting to `.english` so existing callers are unaffected.
- `normalizeForLanguage` applies French-specific normalisation (« » → `\"`, U+00A0/U+202F → space) only for `.french24L`.
- French abbreviation table covers civility titles (M./Mme/Mlle/Mtre), honorifics (Dr./Pr./Me), saints (St./Ste.), and references (cf./p./pp./vol./chap./ibid./op./cit./av./bd./bld./rte./no.) — prevents false sentence breaks.
- `PocketTtsManager` threads its `language` field through all calls (captured into a local before each closure to satisfy SE-0414 region-based Sendable checks).

## Verification

**Offline text logic** (16 new tests in `PocketTtsStreamingTests`, plus a standalone Swift script run outside XCTest since the local environment is Command Line Tools only):
- `splitSentences` on Sample 1 with U+2019 → 1 sentence (was 3 fragments pre-fix)
- `normalizeText(\"d'aboutir à une trêve\", isMidSentence: true, language: .french24L)` → preserves lowercase `d`, no trailing period
- Pre-fix simulation (`isMidSentence: false`) → produces exactly `\"D'aboutir à une trêve.\"`, matching the reporter's broken output
- French `Mme.`/`Mlle.` preserved as 1 sentence; English mode would produce 4

**End-to-end with the `french_24l` model pack** (auto-downloaded; release CLI):

| variant | WAV bytes | audio | wall |
|---|---|---|---|
| Sample 1 — U+2019 (verbatim issue input) | 468,524 | 9.76 s | 31.8 s |
| Sample 1 — ASCII `'` (control) | 441,644 | 9.20 s | 32.3 s |
| Sample 2 — multi-sentence (stations-service / TotalEnergies) | 560,684 | 11.68 s | 32.9 s |

Smart-quote and ASCII variants land within 6% (typical flow-matching stochastic variance from noise sampling) and complete in the same wall time with the same `[PocketTtsSynthesizer]` event count — confirming both inputs traverse the same chunk graph after `normalizeSmartQuotes`.

## Test plan

- [x] `swift build` passes
- [x] `swift format lint` clean on touched files
- [x] 16 new XCTest cases in `PocketTtsStreamingTests` (covering smart-quote normalisation, language dispatch, French abbreviation handling, mid-sentence preservation, and verbatim issue #584 reproductions)
- [x] End-to-end synthesis of Sample 1 and Sample 2 from the issue with the live `french_24l` model — no crashes, no token overflow, WAVs play back cleanly
- [ ] CI to run the full XCTest suite (XCTest unavailable on the local Command Line Tools install)

Closes #584.