### PR TITLE
fix(asr/nemotron): seed cache_len=1 to avoid ios17.slice_by_index zero-shape warning (#607)

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
@@ -187,6 +187,12 @@ public actor StreamingNemotronAsrManager {
         cacheChannel = caches.channel
         cacheTime = caches.time
         cacheLen = caches.len
+        // Seed cache_len with 1 instead of 0 so the encoder's
+        // `ios17.slice_by_index` op never sees a zero-length slice, which would
+        // fail CoreML shape inference and skip MPSGraph caching on every
+        // session start. The cache buffers are zero, so this is equivalent to
+        // 1 frame of silence preamble. See issue #607.
+        cacheLen?[0] = 1
 
         // Mel cache (will be initialized on first chunk)
         melCache = nil


### PR DESCRIPTION
## Summary
- Closes #607.
- On every session start, the Nemotron streaming encoder was being called with `cache_len=0` (the natural output of NeMo's `get_initial_cache_state`). CoreML's iOS17 lowering emits an `ios17.slice_by_index` op whose dimension is `cache_len`; shape inference fails for a zero-length slice, which prints `E5RT encountered an STL exception. msg = Failed to PropagateInputTensorShapes: ... ios17.slice_by_index: zero shape error.` and forces a fallback off MPSGraph (`Unable to load MPSGraphExecutable ...`).
- Fix: seed `cache_len = 1` in `resetStates()`. The cache buffers are zero-initialized, so this is equivalent to 1 frame of silence preamble — no measurable semantic change, and the encoder overwrites `cache_len` from its own output on every chunk.

## Why this approach
A "proper" conversion-side fix exists (trace the encoder with non-zero `cache_len` in `mobius/.../convert_nemotron_streaming.py`), but it requires re-running the conversion and re-uploading the CoreML model to HuggingFace. The Swift-side seed achieves the same runtime outcome with no model re-release.

## Test plan
- [x] `swift build` succeeds.
- [ ] Run `swift run fluidaudiocli transcribe <audio>` against a Nemotron model and confirm the `ios17.slice_by_index zero shape error` line no longer appears in stderr.
- [ ] Re-run the benchmark that produced `benchmark_output.log` and confirm `Unable to load MPSGraphExecutable` no longer fires.
- [ ] Sanity-check a short transcription to confirm output is unchanged versus main.