### PR TITLE
feat(asr): expose tdtConfig in SlidingWindowAsrConfig

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -689,6 +689,12 @@ public struct SlidingWindowAsrConfig: Sendable {
 
     /// Confidence threshold for promoting volatile text to confirmed (0.0...1.0)
     public let confirmationThreshold: Double
+
+    /// TDT decoder configuration. When `nil`, `TdtConfig()` is used (blankId 8192, v3 default).
+    /// Pass an explicit value when using a v2 model (blankId 1024) to avoid relying on
+    /// `AsrManager`'s internal blank-token auto-adaptation.
+    public let tdtConfig: TdtConfig?
+
     /// Default configuration aligned with previous API expectations
     public static let `default` = SlidingWindowAsrConfig(
         chunkSeconds: 15.0,
@@ -717,7 +723,8 @@ public struct SlidingWindowAsrConfig: Sendable {
         leftContextSeconds: TimeInterval = 2.0,
         rightContextSeconds: TimeInterval = 2.0,
         minContextForConfirmation: TimeInterval = 10.0,
-        confirmationThreshold: Double = 0.85
+        confirmationThreshold: Double = 0.85,
+        tdtConfig: TdtConfig? = nil
     ) {
         self.chunkSeconds = chunkSeconds
         self.hypothesisChunkSeconds = hypothesisChunkSeconds
@@ -725,6 +732,20 @@ public struct SlidingWindowAsrConfig: Sendable {
         self.rightContextSeconds = rightContextSeconds
         self.minContextForConfirmation = minContextForConfirmation
         self.confirmationThreshold = confirmationThreshold
+        self.tdtConfig = tdtConfig
+    }
+
+    /// Returns a copy of this config with the given TDT configuration applied.
+    public func applying(tdtConfig: TdtConfig) -> SlidingWindowAsrConfig {
+        SlidingWindowAsrConfig(
+            chunkSeconds: chunkSeconds,
+            hypothesisChunkSeconds: hypothesisChunkSeconds,
+            leftContextSeconds: leftContextSeconds,
+            rightContextSeconds: rightContextSeconds,
+            minContextForConfirmation: minContextForConfirmation,
+            confirmationThreshold: confirmationThreshold,
+            tdtConfig: tdtConfig
+        )
     }
 
     /// Backward-compatible convenience initializer used by tests (chunkDuration label)
@@ -761,7 +782,7 @@ public struct SlidingWindowAsrConfig: Sendable {
     var asrConfig: ASRConfig {
         ASRConfig(
             sampleRate: 16000,
-            tdtConfig: TdtConfig()
+            tdtConfig: tdtConfig ?? TdtConfig()
         )
     }
 


### PR DESCRIPTION
## Problem

`SlidingWindowAsrConfig.asrConfig` (internal) hardcodes `TdtConfig()`, which defaults to `blankId = 8192` — the v3 blank token. Callers loading a **v2 model** (blankId 1024) into `SlidingWindowAsrManager` have no way to express this, and currently rely on `AsrManager`'s internal blank-token auto-adaptation to paper over the mismatch.

If that adaptation is ever removed or refactored, v2 dictation would silently produce corrupted output (tokens decoded against the wrong blank token ID) with no visible error.

## Change

- Add `public let tdtConfig: TdtConfig?` to `SlidingWindowAsrConfig`.  
  - `nil` (default) preserves the existing `TdtConfig()` behaviour — **no change for all current callers**.
- Add `applying(tdtConfig:) -> SlidingWindowAsrConfig` for a clean copy-on-write pattern when working from a preset (`.streaming`, `.default`).
- Update the internal `asrConfig` computed var to use `tdtConfig ?? TdtConfig()`.

## Usage (after this PR)

```swift
// Pass the correct blankId for the loaded model version
let config = SlidingWindowAsrConfig.streaming.applying(
    tdtConfig: TdtConfig(blankId: 1024)  // v2
)
let mgr = SlidingWindowAsrManager(config: config)
```

## Backwards compatibility

All existing call-sites are unaffected — the new parameter defaults to `nil` in the primary `init`, and the static presets are unchanged.