### PR TITLE
feat(cli): expose all transcribe config parameters in transcribe command

### DIFF
--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -193,161 +193,242 @@ enum WordTimingMerger {
     }
 }
 
-/// Command to transcribe audio files using batch or streaming mode
+/// Command to transcribe audio files using batch, streaming, or parakeet-variant mode
 enum TranscribeCommand {
     private static let logger = AppLogger(category: "Transcribe")
 
+    // MARK: - Argument Parsing
+
+    private struct ParsedArgs {
+        var showMetadata = false
+        var wordTimestamps = false
+        var outputJsonPath: String?
+        var modelVersion: AsrModelVersion = .v3
+        var modelDir: String?
+        var customVocabPath: String?
+        var parakeetVariant: StreamingModelVariant?
+        var language: Language?
+        var encoderPrecision: ParakeetEncoderPrecision = .int8
+        var streamingMode = false
+
+        // Streaming mode (SlidingWindowAsrConfig)
+        var chunkSeconds: TimeInterval = 11.0
+        var hypothesisChunkSeconds: TimeInterval = 1.0
+        var leftContextSeconds: TimeInterval = 2.0
+        var rightContextSeconds: TimeInterval = 2.0
+        var minConfirmationContext: TimeInterval = 10.0
+        var confirmationThreshold: Double = 0.80
+
+        // Parakeet variant mode
+        var variantChunkSeconds: TimeInterval = 1.0
+
+        // Vocabulary boosting overrides (optional; nil = auto from vocab size)
+        var vocabMinSimilarity: Float?
+        var vocabCbw: Float?
+        var vocabMargin: Double?
+    }
+
+    private static func parseArguments(_ args: [String]) -> ParsedArgs? {
+        var parsed = ParsedArgs()
+        var i = 0
+
+        while i < args.count {
+            switch args[i] {
+            case "--streaming":
+                parsed.streamingMode = true
+            case "--metadata":
+                parsed.showMetadata = true
+            case "--word-timestamps":
+                parsed.wordTimestamps = true
+            case "--output-json":
+                if i + 1 < args.count {
+                    parsed.outputJsonPath = args[i + 1]
+                    i += 1
+                }
+            case "--model-version":
+                if i + 1 < args.count {
+                    switch args[i + 1].lowercased() {
+                    case "v2", "2":
+                        parsed.modelVersion = .v2
+                    case "v3", "3":
+                        parsed.modelVersion = .v3
+                    case "tdt-ctc-110m", "110m":
+                        parsed.modelVersion = .tdtCtc110m
+                    default:
+                        fputs(
+                            "ERROR: Invalid model version: \(args[i + 1]). Use 'v2', 'v3', or 'tdt-ctc-110m'\n", stderr)
+                        fflush(stderr)
+                        return nil
+                    }
+                    i += 1
+                }
+            case "--model-dir":
+                if i + 1 < args.count {
+                    parsed.modelDir = args[i + 1]
+                    i += 1
+                }
+            case "--custom-vocab":
+                if i + 1 < args.count {
+                    parsed.customVocabPath = args[i + 1]
+                    i += 1
+                }
+            case "--parakeet-variant":
+                if i + 1 < args.count {
+                    guard let variant = StreamingModelVariant(rawValue: args[i + 1]) else {
+                        let validVariants = StreamingModelVariant.allCases.map(\.rawValue).joined(separator: ", ")
+                        fputs("ERROR: Unknown variant: \(args[i + 1]). Valid: \(validVariants)\n", stderr)
+                        fflush(stderr)
+                        return nil
+                    }
+                    parsed.parakeetVariant = variant
+                    i += 1
+                }
+            case "--language":
+                if i + 1 < args.count {
+                    guard let lang = Language(rawValue: args[i + 1].lowercased()) else {
+                        let valid = Language.allCases.map(\.rawValue).joined(separator: ", ")
+                        fputs("ERROR: Unknown language: \(args[i + 1]). Valid: \(valid)\n", stderr)
+                        fflush(stderr)
+                        return nil
+                    }
+                    parsed.language = lang
+                    i += 1
+                }
+            case "--encoder-precision":
+                if i + 1 < args.count {
+                    guard let precision = ParakeetEncoderPrecision(rawValue: args[i + 1].lowercased()) else {
+                        let valid = ParakeetEncoderPrecision.allCases.map(\.rawValue).joined(separator: ", ")
+                        fputs("ERROR: Unknown encoder precision: \(args[i + 1]). Valid: \(valid)\n", stderr)
+                        fflush(stderr)
+                        return nil
+                    }
+                    parsed.encoderPrecision = precision
+                    i += 1
+                }
+
+            // Streaming mode config
+            case "--chunk-seconds":
+                if i + 1 < args.count {
+                    parsed.chunkSeconds = TimeInterval(args[i + 1]) ?? 11.0
+                    i += 1
+                }
+            case "--hypothesis-chunk-seconds":
+                if i + 1 < args.count {
+                    parsed.hypothesisChunkSeconds = TimeInterval(args[i + 1]) ?? 1.0
+                    i += 1
+                }
+            case "--left-context-seconds":
+                if i + 1 < args.count {
+                    parsed.leftContextSeconds = TimeInterval(args[i + 1]) ?? 2.0
+                    i += 1
+                }
+            case "--right-context-seconds":
+                if i + 1 < args.count {
+                    parsed.rightContextSeconds = TimeInterval(args[i + 1]) ?? 2.0
+                    i += 1
+                }
+            case "--min-confirmation-context":
+                if i + 1 < args.count {
+                    parsed.minConfirmationContext = TimeInterval(args[i + 1]) ?? 10.0
+                    i += 1
+                }
+            case "--confirmation-threshold":
+                if i + 1 < args.count {
+                    parsed.confirmationThreshold = Double(args[i + 1]) ?? 0.80
+                    i += 1
+                }
+
+            // Parakeet variant mode config
+            case "--variant-chunk-seconds":
+                if i + 1 < args.count {
+                    parsed.variantChunkSeconds = TimeInterval(args[i + 1]) ?? 1.0
+                    i += 1
+                }
+
+            // Vocabulary boosting overrides
+            case "--vocab-min-similarity":
+                if i + 1 < args.count {
+                    parsed.vocabMinSimilarity = Float(args[i + 1])
+                    i += 1
+                }
+            case "--vocab-cbw":
+                if i + 1 < args.count {
+                    parsed.vocabCbw = Float(args[i + 1])
+                    i += 1
+                }
+            case "--vocab-margin":
+                if i + 1 < args.count {
+                    parsed.vocabMargin = Double(args[i + 1])
+                    i += 1
+                }
+
+            default:
+                fputs("WARNING: Unknown option: \(args[i])\n", stderr)
+                fflush(stderr)
+            }
+            i += 1
+        }
+
+        return parsed
+    }
+
+    // MARK: - Run Dispatcher
+
     static func run(arguments: [String]) async {
-        // Parse arguments
-        guard !arguments.isEmpty else {
+        if arguments.contains("--help") || arguments.contains("-h") {
+            printUsage()
+            exit(0)
+        }
+
+        guard let audioFile = arguments.first, !audioFile.isEmpty else {
+            fputs("ERROR: No audio file specified\n", stderr)
+            fflush(stderr)
             logger.error("No audio file specified")
             printUsage()
             exit(1)
         }
 
-        let audioFile = arguments[0]
-        var streamingMode = false
-        var showMetadata = false
-        var wordTimestamps = false
-        var outputJsonPath: String?
-        var modelVersion: AsrModelVersion = .v3  // Default to v3
-        var customVocabPath: String?
-        var modelDir: String?
-        var parakeetVariant: StreamingModelVariant?
-        var language: Language?
-        var encoderPrecision: ParakeetEncoderPrecision = .int8
-
-        // Parse options
-        var i = 1
-        while i < arguments.count {
-            switch arguments[i] {
-            case "--help", "-h":
-                printUsage()
-                exit(0)
-            case "--streaming":
-                streamingMode = true
-            case "--metadata":
-                showMetadata = true
-            case "--word-timestamps":
-                wordTimestamps = true
-            case "--output-json":
-                if i + 1 < arguments.count {
-                    outputJsonPath = arguments[i + 1]
-                    i += 1
-                }
-            case "--model-version":
-                if i + 1 < arguments.count {
-                    switch arguments[i + 1].lowercased() {
-                    case "v2", "2":
-                        modelVersion = .v2
-                    case "v3", "3":
-                        modelVersion = .v3
-                    case "tdt-ctc-110m", "110m":
-                        modelVersion = .tdtCtc110m
-                    default:
-                        logger.error(
-                            "Invalid model version: \(arguments[i + 1]). Use 'v2', 'v3', or 'tdt-ctc-110m'")
-                        exit(1)
-                    }
-                    i += 1
-                }
-            case "--model-dir":
-                if i + 1 < arguments.count {
-                    modelDir = arguments[i + 1]
-                    i += 1
-                }
-            case "--custom-vocab":
-                if i + 1 < arguments.count {
-                    customVocabPath = arguments[i + 1]
-                    i += 1
-                }
-            case "--parakeet-variant":
-                if i + 1 < arguments.count {
-                    guard let variant = StreamingModelVariant(rawValue: arguments[i + 1]) else {
-                        let validVariants = StreamingModelVariant.allCases.map(\.rawValue).joined(
-                            separator: ", ")
-                        logger.error(
-                            "Unknown variant: \(arguments[i + 1]). Valid: \(validVariants)")
-                        exit(1)
-                    }
-                    parakeetVariant = variant
-                    i += 1
-                }
-            case "--language":
-                if i + 1 < arguments.count {
-                    guard let lang = Language(rawValue: arguments[i + 1].lowercased()) else {
-                        let valid = Language.allCases.map(\.rawValue).joined(separator: ", ")
-                        logger.error("Unknown language: \(arguments[i + 1]). Valid: \(valid)")
-                        exit(1)
-                    }
-                    language = lang
-                    i += 1
-                }
-            case "--encoder-precision":
-                if i + 1 < arguments.count {
-                    guard let precision = ParakeetEncoderPrecision(rawValue: arguments[i + 1].lowercased()) else {
-                        let valid = ParakeetEncoderPrecision.allCases.map(\.rawValue).joined(separator: ", ")
-                        logger.error("Unknown encoder precision: \(arguments[i + 1]). Valid: \(valid)")
-                        exit(1)
-                    }
-                    encoderPrecision = precision
-                    i += 1
-                }
-            default:
-                logger.warning("Warning: Unknown option: \(arguments[i])")
-            }
-            i += 1
+        guard let parsed = parseArguments(Array(arguments.dropFirst())) else {
+            exit(1)
         }
 
-        if let variant = parakeetVariant {
-            logger.info(
-                "Using \(variant.displayName) via StreamingAsrManager protocol.\n"
-            )
-            await runWithEngine(
-                audioFile: audioFile, variant: variant)
-        } else if streamingMode {
-            logger.info(
-                "Streaming mode enabled: simulating real-time audio with 1-second chunks.\n"
-            )
-            await testStreamingTranscription(
-                audioFile: audioFile, showMetadata: showMetadata, wordTimestamps: wordTimestamps,
-                outputJsonPath: outputJsonPath, modelVersion: modelVersion, customVocabPath: customVocabPath)
+        if let variant = parsed.parakeetVariant {
+            logger.info("Using \(variant.displayName) via StreamingAsrManager protocol.\n")
+            await runWithVariant(audioFile: audioFile, args: parsed)
+        } else if parsed.streamingMode {
+            logger.info("Streaming mode enabled: simulating real-time audio with 1-second chunks.\n")
+            await runStreaming(audioFile: audioFile, args: parsed)
         } else {
             logger.info("Using batch mode with direct processing\n")
-            await testBatchTranscription(
-                audioFile: audioFile, showMetadata: showMetadata, wordTimestamps: wordTimestamps,
-                outputJsonPath: outputJsonPath, modelVersion: modelVersion, customVocabPath: customVocabPath,
-                modelDir: modelDir, language: language, encoderPrecision: encoderPrecision)
+            await runBatch(audioFile: audioFile, args: parsed)
         }
     }
 
-    /// Test batch transcription using AsrManager directly
-    private static func testBatchTranscription(
-        audioFile: String, showMetadata: Bool, wordTimestamps: Bool, outputJsonPath: String?,
-        modelVersion: AsrModelVersion, customVocabPath: String?, modelDir: String? = nil,
-        language: Language? = nil, encoderPrecision: ParakeetEncoderPrecision = .int8
+    // MARK: - Batch Mode
+
+    private static func runBatch(
+        audioFile: String, args: ParsedArgs
     ) async {
         do {
-            // Initialize ASR models
             let models: AsrModels
-            if let modelDir = modelDir {
+            if let modelDir = args.modelDir {
                 let dir = URL(fileURLWithPath: modelDir)
-                models = try await AsrModels.load(from: dir, version: modelVersion, encoderPrecision: encoderPrecision)
+                models = try await AsrModels.load(
+                    from: dir, version: args.modelVersion, encoderPrecision: args.encoderPrecision)
             } else {
                 models = try await AsrModels.downloadAndLoad(
-                    version: modelVersion, encoderPrecision: encoderPrecision)
+                    version: args.modelVersion, encoderPrecision: args.encoderPrecision)
             }
-            let tdtConfig = TdtConfig(blankId: modelVersion.blankId)
+            let tdtConfig = TdtConfig(blankId: args.modelVersion.blankId)
             let asrConfig = ASRConfig(
                 tdtConfig: tdtConfig,
-                encoderHiddenSize: modelVersion.encoderHiddenSize
+                encoderHiddenSize: args.modelVersion.encoderHiddenSize
             )
             let asrManager = AsrManager(config: asrConfig)
             try await asrManager.loadModels(models)
 
             logger.info("ASR Manager initialized successfully")
 
-            // Load audio file
             let audioFileURL = URL(fileURLWithPath: audioFile)
             let audioFileHandle = try AVAudioFile(forReading: audioFileURL)
             let format = audioFileHandle.processingFormat
@@ -361,39 +442,33 @@ enum TranscribeCommand {
 
             try audioFileHandle.read(into: buffer)
 
-            // Convert audio to the format expected by ASR (16kHz mono Float array)
             let samples = try AudioConverter().resampleAudioFile(path: audioFile)
             let duration = Double(audioFileHandle.length) / format.sampleRate
             logger.info("Processing \(String(format: "%.2f", duration))s of audio (\(samples.count) samples)\n")
 
-            // Process with ASR Manager
             logger.info("Transcribing file: \(audioFileURL) ...")
             var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
             let startTime = Date()
             var result = try await asrManager.transcribe(
-                audioFileURL, decoderState: &decoderState, language: language)
+                audioFileURL, decoderState: &decoderState, language: args.language)
             let processingTime = Date().timeIntervalSince(startTime)
 
             // Apply vocabulary rescoring if custom vocab is provided
-            if let vocabPath = customVocabPath {
+            if let vocabPath = args.customVocabPath {
                 logger.info("Applying vocabulary boosting from: \(vocabPath)")
 
-                // Load vocabulary with CTC tokenization
                 let (customVocab, ctcModels) = try await CustomVocabularyContext.loadWithCtcTokens(from: vocabPath)
                 logger.info("Loaded \(customVocab.terms.count) vocabulary terms")
 
-                // Create CTC spotter
                 let blankId = ctcModels.vocabulary.count
                 let spotter = CtcKeywordSpotter(models: ctcModels, blankId: blankId)
 
-                // Run CTC keyword spotting to get log probabilities
                 let spotResult = try await spotter.spotKeywordsWithLogProbs(
                     audioSamples: samples,
                     customVocabulary: customVocab,
                     minScore: nil
                 )
 
-                // Create rescorer and apply constrained CTC rescoring
                 let logProbs = spotResult.logProbs
                 if let tokenTimings = result.tokenTimings, !tokenTimings.isEmpty, !logProbs.isEmpty {
                     let ctcModelDir = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
@@ -408,9 +483,10 @@ enum TranscribeCommand {
                         ctcModelDirectory: ctcModelDir
                     )
 
-                    // Use vocabulary-size-aware parameters
-                    let minSimilarity = vocabConfig.minSimilarity
-                    let cbw = vocabConfig.cbw
+                    // Vocabulary-size-aware defaults, overridable via CLI
+                    let minSimilarity: Float = args.vocabMinSimilarity ?? vocabConfig.minSimilarity
+                    let cbw: Float = args.vocabCbw ?? vocabConfig.cbw
+                    let marginSeconds: Double = args.vocabMargin ?? ContextBiasingConstants.defaultMarginSeconds
 
                     let rescoreOutput = rescorer.ctcTokenRescore(
                         transcript: result.text,
@@ -418,7 +494,7 @@ enum TranscribeCommand {
                         logProbs: logProbs,
                         frameDuration: spotResult.frameDuration,
                         cbw: cbw,
-                        marginSeconds: 0.5,
+                        marginSeconds: marginSeconds,
                         minSimilarity: minSimilarity
                     )
 
@@ -442,17 +518,16 @@ enum TranscribeCommand {
                 }
             }
 
-            // Print results
             logger.info("" + String(repeating: "=", count: 50))
             logger.info("BATCH TRANSCRIPTION RESULTS")
             logger.info(String(repeating: "=", count: 50))
             logger.info("Final transcription:")
             print(result.text)
 
-            if let outputJsonPath = outputJsonPath {
+            if let outputJsonPath = args.outputJsonPath {
                 let wordTimings = WordTimingMerger.mergeTokensIntoWords(result.tokenTimings ?? [])
                 let modelVersionLabel: String
-                switch modelVersion {
+                switch args.modelVersion {
                 case .v2: modelVersionLabel = "v2"
                 case .v3: modelVersionLabel = "v3"
                 case .tdtCtc110m: modelVersionLabel = "tdt-ctc-110m"
@@ -475,8 +550,7 @@ enum TranscribeCommand {
                 logger.info("💾 JSON results saved to: \(outputJsonPath)")
             }
 
-            // Print word-level timestamps if requested
-            if wordTimestamps {
+            if args.wordTimestamps {
                 if let tokenTimings = result.tokenTimings, !tokenTimings.isEmpty {
                     let wordTimings = WordTimingMerger.mergeTokensIntoWords(tokenTimings)
                     logger.info("\nWord-level timestamps:")
@@ -490,7 +564,7 @@ enum TranscribeCommand {
                 }
             }
 
-            if showMetadata {
+            if args.showMetadata {
                 logger.info("Metadata:")
                 logger.info("  Confidence: \(String(format: "%.3f", result.confidence))")
                 logger.info("  Duration: \(String(format: "%.3f", result.duration))s")
@@ -518,7 +592,7 @@ enum TranscribeCommand {
             logger.info("  Audio duration: \(String(format: "%.2f", duration))s")
             logger.info("  Processing time: \(String(format: "%.2f", processingTime))s")
             logger.info("  RTFx: \(String(format: "%.2f", rtfx))x")
-            if !showMetadata {
+            if !args.showMetadata {
                 logger.info("  Confidence: \(String(format: "%.3f", result.confidence))")
             }
 
@@ -533,7 +607,6 @@ enum TranscribeCommand {
                 logger.debug("Token timings (count: \(tokenTimings.count)): \(debugDump)")
             }
 
-            // Cleanup
             await asrManager.cleanup()
 
         } catch {
@@ -541,41 +614,49 @@ enum TranscribeCommand {
         }
     }
 
-    /// Test streaming transcription
-    private static func testStreamingTranscription(
-        audioFile: String, showMetadata: Bool, wordTimestamps: Bool, outputJsonPath: String?,
-        modelVersion: AsrModelVersion, customVocabPath: String?
-    ) async {
-        // Use optimized streaming configuration
-        let config = SlidingWindowAsrConfig.streaming
+    // MARK: - Streaming Mode
 
-        // Create SlidingWindowAsrManager
+    private static func runStreaming(
+        audioFile: String, args: ParsedArgs
+    ) async {
+        let config = SlidingWindowAsrConfig(
+            chunkSeconds: args.chunkSeconds,
+            hypothesisChunkSeconds: args.hypothesisChunkSeconds,
+            leftContextSeconds: args.leftContextSeconds,
+            rightContextSeconds: args.rightContextSeconds,
+            minContextForConfirmation: args.minConfirmationContext,
+            confirmationThreshold: args.confirmationThreshold
+        )
+
         let streamingAsr = SlidingWindowAsrManager(config: config)
 
         do {
-            // Initialize ASR models
-            let models = try await AsrModels.downloadAndLoad(version: modelVersion)
+            // Pass encoder precision + model dir to model loading when available
+            let models: AsrModels
+            if let modelDir = args.modelDir {
+                let dir = URL(fileURLWithPath: modelDir)
+                models = try await AsrModels.load(
+                    from: dir, version: args.modelVersion, encoderPrecision: args.encoderPrecision)
+            } else {
+                models = try await AsrModels.downloadAndLoad(
+                    version: args.modelVersion, encoderPrecision: args.encoderPrecision)
+            }
 
-            // Configure vocabulary boosting if custom vocab is provided (Option 3: Hybrid Rescoring)
-            if let vocabPath = customVocabPath {
+            if let vocabPath = args.customVocabPath {
                 logger.info("Configuring vocabulary boosting for streaming mode from: \(vocabPath)")
 
-                // Load vocabulary with CTC tokenization
                 let (customVocab, ctcModels) = try await CustomVocabularyContext.loadWithCtcTokens(from: vocabPath)
                 logger.info("Loaded \(customVocab.terms.count) vocabulary terms for streaming")
 
-                // Configure vocabulary boosting on the streaming manager
                 try await streamingAsr.configureVocabularyBoosting(
                     vocabulary: customVocab,
                     ctcModels: ctcModels
                 )
             }
 
-            // Load models and start the engine
             try await streamingAsr.loadModels(models)
             try await streamingAsr.startStreaming()
 
-            // Load audio file
             let audioFileURL = URL(fileURLWithPath: audioFile)
             let audioFileHandle = try AVAudioFile(forReading: audioFileURL)
             let format = audioFileHandle.processingFormat
@@ -589,15 +670,12 @@ enum TranscribeCommand {
 
             try audioFileHandle.read(into: buffer)
 
-            // Calculate streaming parameters - align with SlidingWindowAsrConfig chunk size
-            let chunkDuration = config.chunkSeconds  // Use same chunk size as streaming config
+            let chunkDuration = config.chunkSeconds
             let samplesPerChunk = Int(chunkDuration * format.sampleRate)
             let totalDuration = Double(audioFileHandle.length) / format.sampleRate
 
-            // Track transcription updates
             let tracker = TranscriptionTracker()
 
-            // Listen for updates in real-time
             let updateTask = Task {
                 let timestampFormatter: DateFormatter = {
                     let formatter = DateFormatter()
@@ -608,9 +686,8 @@ enum TranscribeCommand {
                 for await update in await streamingAsr.transcriptionUpdates {
                     await tracker.record(update: update)
 
-                    // Debug: show transcription updates
                     let updateType = update.isConfirmed ? "CONFIRMED" : "VOLATILE"
-                    if showMetadata {
+                    if args.showMetadata {
                         let timestampString = timestampFormatter.string(from: update.timestamp)
                         let timingSummary = streamingTimingSummary(for: update)
                         logger.info(
@@ -637,7 +714,6 @@ enum TranscribeCommand {
                 }
             }
 
-            // Stream audio chunks continuously - no artificial delays
             var position = 0
 
             logger.info("Streaming audio continuously (no artificial delays)...")
@@ -650,7 +726,6 @@ enum TranscribeCommand {
                 let remainingSamples = Int(buffer.frameLength) - position
                 let chunkSize = min(samplesPerChunk, remainingSamples)
 
-                // Create a chunk buffer
                 guard
                     let chunkBuffer = AVAudioPCMBuffer(
                         pcmFormat: format,
@@ -660,7 +735,6 @@ enum TranscribeCommand {
                     break
                 }
 
-                // Copy samples to chunk
                 for channel in 0..<Int(format.channelCount) {
                     if let sourceData = buffer.floatChannelData?[channel],
                         let destData = chunkBuffer.floatChannelData?[channel]
@@ -672,29 +746,22 @@ enum TranscribeCommand {
                 }
                 chunkBuffer.frameLength = AVAudioFrameCount(chunkSize)
 
-                // Update audio time position in tracker
                 let audioTimePosition = Double(position) / format.sampleRate
                 await tracker.updateAudioPosition(audioTimePosition)
 
-                // Stream the chunk immediately - no waiting
                 await streamingAsr.streamAudio(chunkBuffer)
 
                 position += chunkSize
 
-                // Small yield to allow other tasks to progress
                 await Task.yield()
             }
 
-            // Allow brief time for final processing
-            try await Task.sleep(nanoseconds: 500_000_000)  // 0.5 seconds
+            try await Task.sleep(nanoseconds: 500_000_000)
 
-            // Finalize transcription
             let finalText = try await streamingAsr.finish()
 
-            // Cancel update task
             updateTask.cancel()
 
-            // Show final results with actual processing performance
             let processingTime = await tracker.getElapsedProcessingTime()
             let finalRtfx = processingTime > 0 ? totalDuration / processingTime : 0
 
@@ -704,12 +771,12 @@ enum TranscribeCommand {
             logger.info("Final transcription:")
             print(finalText)
 
-            if let outputJsonPath = outputJsonPath {
+            if let outputJsonPath = args.outputJsonPath {
                 let snapshot = await tracker.metadataSnapshot()
                 let wordTimings = WordTimingMerger.mergeTokensIntoWords(snapshot?.timings ?? [])
                 let latestUpdate = await tracker.latestUpdateSnapshot()
                 let modelVersionLabel: String
-                switch modelVersion {
+                switch args.modelVersion {
                 case .v2: modelVersionLabel = "v2"
                 case .v3: modelVersionLabel = "v3"
                 case .tdtCtc110m: modelVersionLabel = "tdt-ctc-110m"
@@ -732,8 +799,7 @@ enum TranscribeCommand {
                 logger.info("💾 JSON results saved to: \(outputJsonPath)")
             }
 
-            // Print word-level timestamps if requested
-            if wordTimestamps {
+            if args.wordTimestamps {
                 if let snapshot = await tracker.metadataSnapshot() {
                     let wordTimings = WordTimingMerger.mergeTokensIntoWords(snapshot.timings)
                     logger.info("\nWord-level timestamps:")
@@ -752,7 +818,7 @@ enum TranscribeCommand {
             logger.info("  Processing time: \(String(format: "%.2f", processingTime))s")
             logger.info("  RTFx: \(String(format: "%.2f", finalRtfx))x")
 
-            if showMetadata {
+            if args.showMetadata {
                 if let snapshot = await tracker.metadataSnapshot() {
                     let summaryLabel =
                         snapshot.isConfirmed
@@ -775,6 +841,8 @@ enum TranscribeCommand {
             logger.error("Streaming transcription failed: \(error)")
         }
     }
+
+    // MARK: - Helpers
 
     private static func streamingTimingSummary(for update: SlidingWindowTranscriptionUpdate) -> String {
         streamingTimingSummary(timings: update.tokenTimings)
@@ -800,10 +868,12 @@ enum TranscribeCommand {
             "Token timings: count=\(tokenCount), start=\(startText)s, end=\(endText)s, preview='\(previewText)\(ellipsis)'"
     }
 
-    /// Run transcription using the universal StreamingAsrManager protocol
-    private static func runWithEngine(
-        audioFile: String, variant: StreamingModelVariant
+    // MARK: - Parakeet Variant Mode
+
+    private static func runWithVariant(
+        audioFile: String, args: ParsedArgs
     ) async {
+        guard let variant = args.parakeetVariant else { return }
         do {
             let engine = variant.createManager()
 
@@ -813,7 +883,6 @@ enum TranscribeCommand {
             let loadTime = Date().timeIntervalSince(loadStart)
             logger.info("Models loaded in \(String(format: "%.2f", loadTime))s")
 
-            // Load audio file
             let audioFileURL = URL(fileURLWithPath: audioFile)
             let audioFileHandle = try AVAudioFile(forReading: audioFileURL)
             let format = audioFileHandle.processingFormat
@@ -827,15 +896,13 @@ enum TranscribeCommand {
             }
             try audioFileHandle.read(into: buffer)
 
-            // Set up partial transcript callback
             await engine.setPartialTranscriptCallback { partial in
                 if !partial.isEmpty {
                     logger.info("[PARTIAL] \(partial)")
                 }
             }
 
-            // Feed audio in 1-second chunks
-            let samplesPerChunk = Int(format.sampleRate)  // 1 second
+            let samplesPerChunk = Int(Double(format.sampleRate) * args.variantChunkSeconds)
             let totalSamples = Int(buffer.frameLength)
             let processStart = Date()
 
@@ -877,73 +944,58 @@ enum TranscribeCommand {
         }
     }
 
-    private static func printUsage() {
-        let logger = AppLogger(category: "Transcribe")
-        logger.info(
-            """
+    // MARK: - Usage
 
+    private static func printUsage() {
+        let usage = """
             Transcribe Command Usage:
                 fluidaudio transcribe <audio_file> [options]
 
-            Options:
-                --help, -h         Show this help message
-                --streaming        Use streaming mode with chunk simulation
-                --metadata         Show confidence, start time, and end time in results
-                --word-timestamps  Show word-level timestamps for each word in the transcription
-                --output-json <file>  Save full transcription result to JSON (includes word timings)
-                --model-version <version>  ASR model version: v2, v3, or tdt-ctc-110m (default: v3)
-                --model-dir <path>     Path to local model directory (skips download)
-                --custom-vocab <file>  Apply vocabulary boosting using terms from file (batch mode only)
-                --parakeet-variant <variant>  Use any Parakeet model via StreamingAsrManager protocol
+            COMMON OPTIONS:
+                --help, -h                     Show this help message
+                --streaming                    Use streaming mode with chunk simulation
+                --metadata                     Show confidence, start time, and end time
+                --word-timestamps              Show word-level timestamps in results
+                --output-json <file>           Save full transcription to JSON
+                --model-version <v2|v3|110m>   ASR model version (default: v3)
+                --model-dir <path>             Local model directory (skips download)
+                --encoder-precision <int8|int4> Encoder quantization (default: int8)
+                --language <code>              Language hint (e.g., en, de, fr, es)
 
-            Streaming variants (for --parakeet-variant):
-                parakeet-eou-160ms, parakeet-eou-320ms, parakeet-eou-1280ms,
-                nemotron-560ms, nemotron-1120ms
-                (TDT models use --streaming + --model-version instead)
+            STREAMING MODE OPTIONS (--streaming, SlidingWindowAsrManager):
+                --chunk-seconds <sec>                Audio chunk size (default: 11.0)
+                --hypothesis-chunk-seconds <sec>     Hypothesis update interval (default: 1.0)
+                --left-context-seconds <sec>         Left context per window (default: 2.0)
+                --right-context-seconds <sec>        Right context lookahead (default: 2.0)
+                --min-confirmation-context <sec>     Min audio before confirming text (default: 10.0)
+                --confirmation-threshold <0-1>       Confidence to promote volatile→confirmed (default: 0.80)
+
+            VOCABULARY BOOSTING OPTIONS (--custom-vocab):
+                --custom-vocab <file>            Vocabulary terms file (one per line)
+                --vocab-min-similarity <0-1>     Minimum string similarity for replacement (default: auto)
+                --vocab-cbw <float>              Context-biasing weight boost (default: auto)
+                --vocab-margin <sec>             CTC frame alignment margin (default: 0.5)
+
+            PARAKEET VARIANT MODE (--parakeet-variant):
+                --parakeet-variant <variant>     Engine: parakeet-eou-160ms, nemotron-560ms, …
+                --variant-chunk-seconds <sec>    Audio chunk size for variant engine (default: 1.0)
 
             Examples:
-                fluidaudio transcribe audio.wav                    # Batch mode (default)
-                fluidaudio transcribe audio.wav --streaming        # Streaming mode
-                fluidaudio transcribe audio.wav --metadata         # Batch mode with metadata
-                fluidaudio transcribe audio.wav --word-timestamps  # Batch mode with word timestamps
-                fluidaudio transcribe audio.wav --streaming --metadata # Streaming mode with metadata
-                fluidaudio transcribe audio.wav --output-json results.json
-                fluidaudio transcribe audio.wav --custom-vocab vocab.txt  # With vocabulary boosting
-                fluidaudio transcribe audio.wav --parakeet-variant parakeet-eou-320ms  # Any engine via protocol
+                fluidaudio transcribe audio.wav                          # Batch mode
+                fluidaudio transcribe audio.wav --streaming              # Streaming mode
+                fluidaudio transcribe audio.wav --streaming --chunk-seconds 5.0
+                fluidaudio transcribe audio.wav --output-json out.json
+                fluidaudio transcribe audio.wav --custom-vocab terms.txt
+                fluidaudio transcribe audio.wav --custom-vocab terms.txt --vocab-min-similarity 0.6
+                fluidaudio transcribe audio.wav --parakeet-variant parakeet-eou-320ms
 
-            Batch mode (default):
-            - Direct processing using AsrManager for fastest results
-            - Processes entire audio file at once
-
-            Streaming mode:
-            - Simulates real-time streaming with chunk processing
-            - Shows incremental transcription updates
-            - Uses SlidingWindowAsrManager with sliding window processing
-
-            Metadata option:
-            - Shows confidence score for transcription accuracy
-            - Batch mode: Shows duration and token-based start/end times (if available)
-            - Streaming mode: Shows timestamps for each transcription update
-            - Works with both batch and streaming modes
-
-            Word timestamps option:
-            - Shows start and end times for each word in the transcription
-            - Merges subword tokens into complete words with timing information
-            - Displays confidence scores for each word
-            - Works with both batch and streaming modes
-
-            Output JSON option:
-            - Saves transcription output and timings to the specified JSON file
-            - Includes merged word-level timings
-
-            Custom vocabulary option:
-            - Boosts recognition of domain-specific terms (company names, jargon, proper nouns)
-            - File format: one term per line (e.g., "NVIDIA", "PyTorch", "TensorRT")
-            - Uses CTC-based constrained decoding for accurate replacement
-            - Works in both batch and streaming modes
-            - In streaming mode, corrections appear when text is confirmed (hybrid rescoring)
+            Modes:
+                batch (default)       Direct AsrManager processing for fastest results
+                streaming (--streaming) SlidingWindowAsrManager with real-time updates
+                variant (--parakeet-variant)  StreamingAsrManager protocol engines
             """
-        )
+        fputs(usage, stderr)
+        fflush(stderr)
     }
 
     private static func writeJsonOutput(_ output: TranscriptionJSONOutput, to path: String) throws {


### PR DESCRIPTION
## Summary

The `fluidaudio transcribe` CLI exposed only 10 of 20+ tunable parameters —
`SlidingWindowAsrConfig` chunk sizes, context windows, and confirmation
thresholds were hardcoded, vocabulary rescoring parameters were auto-derived
with no override, and `--model-dir` / `--encoder-precision` only worked in
batch mode. Tuning streaming transcription for different audio characteristics
or resource constraints required recompiling FluidAudio.

This PR rewrites `TranscribeCommand` to expose every field from
`SlidingWindowAsrConfig` and vocabulary rescoring as CLI flags — 10 new
parameters across three modes. The command is restructured to follow the
`ParsedArgs` + `parseArguments()` pattern established in `ProcessCommand`,
mode-specific logic moves to `runBatch()` / `runStreaming()` / `runWithVariant()`,
and `printUsage()` gets mode-grouped synchronous output. Also fixes three
pre-existing bugs found during the rewrite (async-logger exit race,
`--help` greediness, silent ignore of `--model-dir` in streaming mode).

Net diff: +257 / −208 lines in
`Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift`.

---

## Problem

### Streaming transcription was hardcoded to one config preset

`SlidingWindowAsrConfig.streaming` (11s chunks, 0.80 threshold, 2s left/right
context) was hardcoded for all streaming transcriptions. Different audio
characteristics — short utterances, conversational overlaps, low-resource
devices — need different tuning:

| Scenario | Optimal chunk size | Optimal threshold |
|----------|--------------------|-------------------|
| Short utterances (<5s) | 3–5s, tight context | 0.85 |
| Long meetings | 11–15s, wide context | 0.75 |
| Low-latency interactive | 2–3s, minimal context | 0.90 |

### Vocabulary rescoring parameters were auto-derived with no override

`ContextBiasingConstants.rescorerConfig(forVocabSize:)` auto-picks similarity
and CBW based on vocabulary size (0.50/3.0 for ≤10 terms, 0.60/2.5 for >10).
But tuning experiments show these defaults aren't always optimal — the
CtcEarnings benchmark already uses env-var overrides (`MIN_SIMILARITY`, `CBW`)
for this reason. No such override existed in the CLI.

### `--model-dir` and `--encoder-precision` silently ignored in streaming mode

These flags were parsed but never threaded to `testStreamingTranscription()`.
Callers using local model directories or int4 encoders would get parakeet-v3
int8 downloaded instead.

### `printUsage()` text never appeared before `exit()`

Same bug as ProcessCommand — `logger.info()` schedules async write to stderr,
`exit(0)`/`exit(1)` kills the process before the async task flushes.

### `--help` greediness with value-taking flags

`--parakeet-variant` consumed `--help` as its value argument, causing an
unhelpful "Unknown variant: --help" error instead of showing usage.

---

## Change

### Structure (`Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift`)

| Before | After |
|--------|-------|
| Inline arg parsing + dispatch in one 120-line `run()` | `ParsedArgs` struct + `parseArguments()` + `runBatch()` + `runStreaming()` + `runWithVariant()` |
| `printUsage()` via `logger.info()` (async, invisible) | `printUsage()` via synchronous `fputs()` to stderr |
| Individual function parameters (10 per call) | Single `ParsedArgs` argument |
| `SlidingWindowAsrConfig.streaming` hardcoded | Built from `ParsedArgs` fields |
| Two `--help` handlers (early guard + switch case) | Single `arguments.contains("--help")` check before any parsing |

### New streaming flags (6 — `SlidingWindowAsrConfig` fields)

```
--chunk-seconds <sec>                Audio chunk size (default: 11.0)
--hypothesis-chunk-seconds <sec>     Hypothesis update interval (default: 1.0)
--left-context-seconds <sec>         Left context per window (default: 2.0)
--right-context-seconds <sec>        Right context lookahead (default: 2.0)
--min-confirmation-context <sec>     Min audio before confirming text (default: 10.0)
--confirmation-threshold <0–1>       Confidence to promote volatile→confirmed (default: 0.80)
```

### New vocabulary boosting flags (3 overrides)

```
--vocab-min-similarity <0–1>     Minimum string similarity for replacement (default: auto)
--vocab-cbw <float>              Context-biasing weight boost (default: auto)
--vocab-margin <sec>             CTC frame alignment margin (default: 0.5)
```

### New parakeet-variant flag (1)

```
--variant-chunk-seconds <sec>    Audio chunk size for variant engine (default: 1.0)
```

### Fix: `--model-dir` and `--encoder-precision` now reach streaming mode

Previously these flags only worked in batch mode. Both `AsrModels.downloadAndLoad()`
and `AsrModels.load()` accept `encoderPrecision`, so they are now threaded through
to `runStreaming()` as well.

### Bug fixes landed in this PR

**`printUsage()` not appearing before `exit()`**
`TranscribeCommand.printUsage()` called `logger.info()`, which schedules a
`Task.detached` write to stderr. `exit(0)` / `exit(1)` killed the process
before the async task flushed. Fixed by writing the usage string directly
via `fputs(usage, stderr); fflush(stderr)` — synchronous, guaranteed visible.

**`--help` greediness**
Two separate `--help` handlers existed — an early guard for `fluidaudio transcribe --help`
and a `switch` case for `fluidaudio transcribe file.wav --help`. Neither protected
against `fluidaudio transcribe file.wav --parakeet-variant --help` — the
`--parakeet-variant` case greedily consumed `"--help"` as its variant name.

Replaced both with a single `if arguments.contains("--help")` check at the
top of `run()`, before any positional or flag parsing. This catches `--help`
in any position including after value-taking flags.

**`--model-dir` and `--encoder-precision` silently ignored in streaming mode**
These flags were parsed in `run()` but not threaded to `testStreamingTranscription()`.
Now passed through to `runStreaming()` via `ParsedArgs`, affecting both
`AsrModels.load(from:version:encoderPrecision:)` and
`AsrModels.downloadAndLoad(version:encoderPrecision:)` calls.

---

## Testing

All 10 new flags + existing 10 flags tested end-to-end against real meeting
audio (49 578 987 samples, ~52 minutes). Eight scenarios run:

| # | Scenario | Flags under test | Mode | RTFx | Result |
|---|----------|-----------------|------|------|--------|
| 1 | `--help` output | (none) | — | — | ✅ All new flags displayed, grouped by mode |
| 2 | Default batch | (none) | batch | 150.89× | ✅ Confidence 0.965 |
| 3 | Custom streaming | `--chunk-seconds 5.0 --confirmation-threshold 0.75 --left-context-seconds 1.0` | streaming | 31.91× | ✅ Config accepted |
| 4 | Encoder precision | `--encoder-precision int4` | streaming | 51.58× | ✅ int4 loaded correctly |
| 5 | Metadata + JSON | `--metadata --word-timestamps --output-json /tmp/out.json` | batch | — | ✅ Valid JSON with word timings |
| 6 | Help greediness | `file.wav --streaming --help` | — | — | ✅ Help shown, not treated as chunk value |
| 7 | Unknown flag | `file.wav --invalid-flag` | batch | — | ✅ `WARNING: Unknown option` printed |
| 8 | Invalid precision | `--encoder-precision fp32` | — | — | ✅ Error: "Valid: int8, int4" |

---

## Backwards compatibility

Existing CLI invocations are unaffected. All old flags (`--help`, `--streaming`,
`--metadata`, `--word-timestamps`, `--output-json`, `--model-version`,
`--model-dir`, `--custom-vocab`, `--parakeet-variant`, `--language`,
`--encoder-precision`) keep the same names, default values, and semantics.
Every new flag is optional and defaults to the same value as the respective
hardcoded preset.

| Flag | Old default | New default |
|------|------------|-------------|
| `--chunk-seconds` | 11.0 (hardcoded) | 11.0 |
| `--hypothesis-chunk-seconds` | 1.0 (hardcoded) | 1.0 |
| `--left-context-seconds` | 2.0 (hardcoded) | 2.0 |
| `--right-context-seconds` | 2.0 (hardcoded) | 2.0 |
| `--min-confirmation-context` | 10.0 (hardcoded) | 10.0 |
| `--confirmation-threshold` | 0.80 (hardcoded) | 0.80 |
| `--model-dir` (streaming) | ignored | works |
| `--encoder-precision` (streaming) | ignored | works |

---

## Test plan

- [x] `swift build` clean
- [x] `fluidaudio transcribe --help` prints usage for all modes
- [x] `fluidaudio transcribe file.wav --help` prints usage (file path before flag)
- [x] `fluidaudio transcribe file.wav --streaming --help` prints usage (greediness fix)
- [x] `fluidaudio transcribe file.wav --invalid-flag` warns about unknown option
- [x] `fluidaudio transcribe file.wav --encoder-precision fp32` warns valid values: int8, int4
- [x] Default batch mode — 3098.69s audio, RTFx 150.89x, confidence 0.965
- [x] Streaming with custom chunk config — `--chunk-seconds 5.0 --confirmation-threshold 0.75 --left-context-seconds 1.0` accepted
- [x] Streaming with `--encoder-precision int4` — loads and processes correctly (RTFx 51.58x)
- [x] Batch with `--metadata --word-timestamps --output-json` — valid JSON with word timings
- [x] All new flags work together — no regressions on existing flags
