### PR TITLE
Diarization progress

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(swift format *)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(swift format *)"
-    ]
-  }
-}

--- a/Documentation/Diarization/GettingStarted.md
+++ b/Documentation/Diarization/GettingStarted.md
@@ -217,6 +217,38 @@ let result = try await manager.process(url)
 
 The file-based API internally uses memory-mapped streaming to avoid materializing the entire buffer in memory.
 
+#### Progress Tracking
+
+All three `process` overloads accept an optional `progressCallback` that fires after each segmentation chunk, reporting `(chunksProcessed, totalChunks)`:
+
+```swift
+let result = try await manager.process(audio: samples) { chunksProcessed, totalChunks in
+    let percent = Int(Double(chunksProcessed) / Double(totalChunks) * 100)
+    print("Progress: \(percent)% (\(chunksProcessed)/\(totalChunks) chunks)")
+}
+```
+
+The callback is invoked on a background task. To update UI state, dispatch to the main actor from inside the callback:
+
+```swift
+@MainActor
+class TranscriptionViewModel: ObservableObject {
+    @Published var progress: Double = 0
+
+    func run(url: URL) async throws {
+        let manager = OfflineDiarizerManager()
+        let result = try await manager.process(url) { chunksProcessed, totalChunks in
+            Task { @MainActor in
+                self.progress = Double(chunksProcessed) / Double(totalChunks)
+            }
+        }
+        // use result...
+    }
+}
+```
+
+`totalChunks` is derived from the audio length and `OfflineDiarizerConfig.samplesPerStep` before processing starts, so it is consistent across all callback invocations. The final call always has `chunksProcessed == totalChunks`.
+
 The offline controller mirrors the reference pipeline:
 
 - **Segmentation:** `SegmentationRunner` feeds 10 s/160 k sample chunks through the Core ML segmentation model. Each chunk yields 589 frame-level log probabilities over the 7 local powerset classes.

--- a/Documentation/Diarization/GettingStarted.md
+++ b/Documentation/Diarization/GettingStarted.md
@@ -228,7 +228,7 @@ let result = try await manager.process(audio: samples) { chunksProcessed, totalC
 }
 ```
 
-The callback is invoked on a background task. To update UI state, dispatch to the main actor from inside the callback:
+The callback is invoked on an unspecified executor — not guaranteed to be a background thread or the main actor. To update UI state, hop to `@MainActor` from inside the callback:
 
 ```swift
 @MainActor

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -129,6 +129,8 @@ public final class OfflineDiarizerManager {
     }
 
     /// - Parameters:
+    ///   - audioSource: Audio sample source to process.
+    ///   - audioLoadingSeconds: Time spent loading/converting the audio, included in timing logs.
     ///   - progressCallback: Optional callback receiving `(chunksProcessed, totalChunks)` after each segmentation chunk.
     public func process(
         audioSource: AudioSampleSource,

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -88,18 +88,32 @@ public final class OfflineDiarizerManager {
         }
     }
 
-    public func process(audio: [Float]) async throws -> DiarizationResult {
+    /// - Parameters:
+    ///   - audio: Mono audio samples at the model's target sample rate.
+    ///   - progressCallback: Optional callback receiving `(chunksProcessed, totalChunks)` after each segmentation chunk.
+    public func process(
+        audio: [Float], progressCallback: (@Sendable (Int, Int) -> Void)? = nil
+    )
+        async throws -> DiarizationResult
+    {
         try await process(
             audioSource: ArrayAudioSampleSource(samples: audio),
-            audioLoadingSeconds: 0
+            audioLoadingSeconds: 0,
+            progressCallback: progressCallback
         )
     }
 
     /// Process audio from a file URL using memory-mapped streaming for efficiency.
     /// Automatically converts the audio to the target sample rate and processes in chunks.
-    /// - Parameter url: Path to the audio file
+    /// - Parameters:
+    ///   - url: Path to the audio file.
+    ///   - progressCallback: Optional callback receiving `(chunksProcessed, totalChunks)` after each segmentation chunk.
     /// - Returns: Diarization result with speaker segments
-    public func process(_ url: URL) async throws -> DiarizationResult {
+    public func process(
+        _ url: URL, progressCallback: (@Sendable (Int, Int) -> Void)? = nil
+    )
+        async throws -> DiarizationResult
+    {
         let factory = AudioSourceFactory()
         let (source, loadDuration) = try factory.makeDiskBackedSource(
             from: url,
@@ -109,13 +123,17 @@ public final class OfflineDiarizerManager {
 
         return try await process(
             audioSource: source,
-            audioLoadingSeconds: loadDuration
+            audioLoadingSeconds: loadDuration,
+            progressCallback: progressCallback
         )
     }
 
+    /// - Parameters:
+    ///   - progressCallback: Optional callback receiving `(chunksProcessed, totalChunks)` after each segmentation chunk.
     public func process(
         audioSource: AudioSampleSource,
-        audioLoadingSeconds: TimeInterval
+        audioLoadingSeconds: TimeInterval,
+        progressCallback: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> DiarizationResult {
         try config.validate()
         if models == nil {
@@ -127,6 +145,8 @@ public final class OfflineDiarizerManager {
         }
 
         let totalStart = Date()
+        let totalChunks = max(
+            1, (audioSource.sampleCount + config.samplesPerStep - 1) / config.samplesPerStep)
 
         let streamPair = AsyncThrowingStream<SegmentationChunk, Error>.makeStream()
         let chunkStream = streamPair.stream
@@ -146,6 +166,7 @@ public final class OfflineDiarizerManager {
                     segmentationModel: capturedModels.segmentationModel,
                     config: capturedConfig,
                     chunkHandler: { chunk in
+                        progressCallback?(chunk.chunkIndex + 1, totalChunks)
                         switch chunkContinuation.yield(chunk) {
                         case .enqueued, .dropped:
                             return .continue

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -158,7 +158,7 @@ public final class OfflineDiarizerManager {
         let capturedModels = models
         let capturedConfig = config
 
-        let segmentationTask = Task(priority: .userInitiated) {
+        let segmentationTask = Task.detached(priority: .userInitiated) {
             [capturedModels, capturedConfig] () throws -> (SegmentationOutput, TimeInterval) in
             let processor = OfflineSegmentationProcessor()
             let start = Date()
@@ -187,7 +187,7 @@ public final class OfflineDiarizerManager {
             }
         }
 
-        let embeddingTask = Task(priority: .userInitiated) {
+        let embeddingTask = Task.detached(priority: .userInitiated) {
             [capturedModels, capturedConfig] () throws -> ([TimedEmbedding], TimeInterval) in
             let extractor = OfflineEmbeddingExtractor(
                 fbankModel: capturedModels.fbankModel,

--- a/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
@@ -175,7 +175,13 @@ enum ProcessCommand {
             let result = try await manager.process(
                 audioSource: diskSource,
                 audioLoadingSeconds: diskSourceResult.loadDuration
-            )
+            ) { chunksProcessed, totalChunks in
+                let printInterval = max(1, totalChunks / 4)
+                if chunksProcessed % printInterval == 0 || chunksProcessed == totalChunks {
+                    let percent = Int(Double(chunksProcessed) / Double(totalChunks) * 100)
+                    logger.info("   Progress: \(percent)% (\(chunksProcessed)/\(totalChunks) chunks)")
+                }
+            }
             let processingTime = Date().timeIntervalSince(startTime)
 
             let durationSeconds = Double(diskSource.sampleCount) / Double(targetSampleRate)

--- a/Tests/FluidAudioTests/Diarizer/Offline/OfflineDiarizerManagerTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Offline/OfflineDiarizerManagerTests.swift
@@ -1,0 +1,81 @@
+import os
+import XCTest
+
+@testable import FluidAudio
+
+@available(macOS 14.0, iOS 17.0, *)
+final class OfflineDiarizerManagerProgressTests: XCTestCase {
+
+    // MARK: - totalChunks calculation
+
+    func testTotalChunksForDefaultConfig() {
+        let config = OfflineDiarizerConfig.default
+        // default: samplesPerStep = 160_000 * 0.2 = 32_000
+        XCTAssertEqual(config.samplesPerStep, 32_000)
+
+        XCTAssertEqual(totalChunks(sampleCount: 1, config: config), 1)
+        XCTAssertEqual(totalChunks(sampleCount: 32_000, config: config), 1)
+        XCTAssertEqual(totalChunks(sampleCount: 32_001, config: config), 2)
+        XCTAssertEqual(totalChunks(sampleCount: 160_000, config: config), 5)
+        XCTAssertEqual(totalChunks(sampleCount: 160_001, config: config), 6)
+    }
+
+    func testTotalChunksIsAtLeastOneForZeroSamples() {
+        let config = OfflineDiarizerConfig.default
+        XCTAssertEqual(totalChunks(sampleCount: 0, config: config), 1)
+    }
+
+    // MARK: - Progress callback integration
+
+    func testProgressCallbackFiresAndIsMonotonic() async throws {
+        let modelsDir = OfflineDiarizerModels.defaultModelsDirectory()
+        guard FileManager.default.fileExists(atPath: modelsDir.path) else {
+            throw XCTSkip("Offline diarizer models not available")
+        }
+
+        let manager = OfflineDiarizerManager()
+        let audio = try DiarizationTestFixtures.fixtureAudio(sampleRate: 16_000)
+
+        let updatesLock = OSAllocatedUnfairLock<[(Int, Int)]>(initialState: [])
+        _ = try await manager.process(audio: audio) { chunksProcessed, totalChunks in
+            updatesLock.withLock { $0.append((chunksProcessed, totalChunks)) }
+        }
+        let updates = updatesLock.withLock { $0 }
+
+        XCTAssertFalse(updates.isEmpty, "Progress callback should fire at least once")
+
+        let total = updates[0].1
+        XCTAssertGreaterThan(total, 0)
+
+        for update in updates {
+            XCTAssertEqual(update.1, total, "totalChunks must be consistent across updates")
+            XCTAssertGreaterThan(update.0, 0)
+            XCTAssertLessThanOrEqual(update.0, total)
+        }
+
+        for i in 1..<updates.count {
+            XCTAssertGreaterThanOrEqual(
+                updates[i].0, updates[i - 1].0,
+                "chunksProcessed must be non-decreasing")
+        }
+
+        XCTAssertEqual(updates.last?.0, total, "Final update should reach 100%")
+    }
+
+    func testProgressCallbackIsOptional() async throws {
+        let modelsDir = OfflineDiarizerModels.defaultModelsDirectory()
+        guard FileManager.default.fileExists(atPath: modelsDir.path) else {
+            throw XCTSkip("Offline diarizer models not available")
+        }
+
+        let manager = OfflineDiarizerManager()
+        let audio = try DiarizationTestFixtures.fixtureAudio(sampleRate: 16_000)
+        _ = try await manager.process(audio: audio)
+    }
+
+    // MARK: - Helpers
+
+    private func totalChunks(sampleCount: Int, config: OfflineDiarizerConfig) -> Int {
+        max(1, (sampleCount + config.samplesPerStep - 1) / config.samplesPerStep)
+    }
+}

--- a/Tests/FluidAudioTests/Diarizer/Offline/OfflineDiarizerManagerTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Offline/OfflineDiarizerManagerTests.swift
@@ -29,7 +29,10 @@ final class OfflineDiarizerManagerProgressTests: XCTestCase {
 
     func testProgressCallbackFiresAndIsMonotonic() async throws {
         let modelsDir = OfflineDiarizerModels.defaultModelsDirectory()
-        guard FileManager.default.fileExists(atPath: modelsDir.path) else {
+        let allPresent = ModelNames.OfflineDiarizer.requiredModels.allSatisfy {
+            FileManager.default.fileExists(atPath: modelsDir.appendingPathComponent($0).path)
+        }
+        guard allPresent else {
             throw XCTSkip("Offline diarizer models not available")
         }
 
@@ -64,7 +67,10 @@ final class OfflineDiarizerManagerProgressTests: XCTestCase {
 
     func testProgressCallbackIsOptional() async throws {
         let modelsDir = OfflineDiarizerModels.defaultModelsDirectory()
-        guard FileManager.default.fileExists(atPath: modelsDir.path) else {
+        let allPresent = ModelNames.OfflineDiarizer.requiredModels.allSatisfy {
+            FileManager.default.fileExists(atPath: modelsDir.appendingPathComponent($0).path)
+        }
+        guard allPresent else {
             throw XCTSkip("Offline diarizer models not available")
         }
 


### PR DESCRIPTION
### Why is this change needed?
I would like to surface diarization progress in my UI, so in the style of `SortformerDiarizer` this adds an optional progress callback to `OfflineDiarizerManager.process`. Processing larger audio files feels broken when I can't show a progress indicator.


### Summary
  - Adds an optional progressCallback: `(@Sendable (Int, Int) -> Void)?` parameter to all three process overloads on OfflineDiarizerManager. The callback receives (chunksProcessed, totalChunks) after each
  segmentation chunk completes.
  - totalChunks is computed once from audioSource.sampleCount and config.samplesPerStep before processing starts, so it is stable across all invocations. The final call always satisfies chunksProcessed ==
  totalChunks.
  - The CLI process command now logs progress `swift run fluidaudiocli process test.wav --mode offline`
  - Adds OfflineDiarizerManagerProgressTests covering the chunk-count formula and callback contract (monotonicity, consistency, completion). Integration tests skip automatically when offline diarizer models
   are not present.
  - Documents the feature in Documentation/Diarization/GettingStarted.md with a plain example and a SwiftUI/@MainActor example showing how to dispatch back to the main thread.