### PR TITLE
feat(tts): Supertonic-3 multilingual CoreML TTS — CLI, benchmark, 10-lang results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,8 @@ fluidaudio_cli/*
 
 # Continuous Claude cache (local only)
 .claude/cache/
+
+# Supertonic-3 local model-conversion artifacts (research-only;
+# scripts + trials live in mobius repo, see models/tts/supertonic_3/).
+.venv-supertonic3/
+build/supertonic-3-coreml/

--- a/Documentation/TTS/Benchmarks.md
+++ b/Documentation/TTS/Benchmarks.md
@@ -6,8 +6,8 @@
 > by [MiniMax-Speech][mms], seed-tts-eval, and Gradium, so numbers
 > here are directly paper-comparable.
 > **Status:** Kokoro ANE (English + Mandarin), PocketTTS (English),
-> Magpie (English), and StyleTTS2 (English, zero-shot) all complete
-> the full 100-phrase MiniMax run.
+> Magpie (English), StyleTTS2 (English, zero-shot), and Supertonic-3
+> (English) all complete the full 100-phrase MiniMax run.
 >
 > [minimax]: https://huggingface.co/datasets/MiniMaxAI/TTS-Multilingual-Test-Set
 > [mms]: https://arxiv.org/abs/2505.07916
@@ -57,6 +57,7 @@ Reference each language as `--corpus minimax-<lang>`:
 | PocketTTS   | `minimax-english`  | 6L packs: `english`, `german`, `italian`, `portuguese`, `spanish`. 24L packs: `french_24l`, `german_24l`, `italian_24l`, `portuguese_24l`, `spanish_24l` |
 | Magpie      | `minimax-english`  | `english`, `spanish`, `german`, `french`, `italian`, `vietnamese`, `chinese`, `hindi` |
 | StyleTTS2   | `minimax-english`  | `english` only (LibriTTS iteration_3, zero-shot from `--reference` audio) |
+| Supertonic-3 | `minimax-english` | 31 ISO codes minus `zh`: `english`, `korean`, `japanese`, `arabic`, `bulgarian`, `czech`, `danish`, `german`, `greek`, `spanish`, `estonian`, `finnish`, `french`, `hindi`, `croatian`, `hungarian`, `indonesian`, `italian`, `lithuanian`, `latvian`, `dutch`, `polish`, `portuguese`, `romanian`, `russian`, `slovak`, `slovenian`, `swedish`, `turkish`, `ukrainian`, `vietnamese`. Voice styling via `--voice-style <preset.json>` |
 
 Lines beginning with `#` are comments. Custom corpora can still be
 passed with `--corpus-path <file.txt>`.
@@ -79,7 +80,7 @@ Per phrase:
 - `wer`, `cer` — via Parakeet ASR roundtrip on the rendered WAV.
 - `stage_ms` — per-stage breakdown (backend-specific keys; populated
   for Kokoro ANE; empty for / PocketTTS / Magpie /
-  StyleTTS2 in this report).
+  StyleTTS2 / Supertonic-3 in this report).
 - Backend-specific extras: `encoder_tokens`, `acoustic_frames`,
   `chunk_count`, `frame_count`, `code_count`, `generated_token_count`,
   etc.
@@ -135,6 +136,15 @@ swift run fluidaudio tts-benchmark \
   --backend styletts2 --reference ref.wav \
   --corpus minimax-english \
   --output-json bench-styletts2.json --audio-dir bench-wavs-styletts2/
+
+# Supertonic-3 (multilingual, voice-style JSON). M1.json / F1.json / …
+# ship under FluidInference/supertonic-3-coreml/assets/voice_styles/.
+# `--lang` defaults are inferred from the corpus name; override with
+# `--language <iso>` (e.g. ja, ko, fr). No `zh` — Mandarin is Kokoro ANE.
+swift run fluidaudio tts-benchmark \
+  --backend supertonic3 --voice-style M1.json \
+  --corpus minimax-english \
+  --output-json bench-supertonic3.json --audio-dir bench-wavs-sup3/
 ```
 
 The harness writes a JSON report to `--output-json` and (optionally)
@@ -169,6 +179,7 @@ peak RSS, WER, CER) so there is a single source of truth.
 | PocketTTS  | research   | en (`alba`, 6L pack)      | int8 ~0.55 GB | 24 kHz      | 80 ms Mimi frame, streams until EOS (no fixed cap)               | Yes       | **710 / 1496 ms** | 5160 / 9801 ms    | 1.10×     | 1167 MB  | 1.0%   | 0.4%   |
 | Magpie     | research   | en (`John`)               | ~1.3 GB                    | 22.05 kHz   | 256 NanoCodec frames / pass (≈11.9 s); sentence-split for longer | No        | 11470 / 26042 ms∥ | 11470 / 26042 ms∥ | 0.87×∥    | 543 MB∥  | 3.8%   | 2.6%   |
 | StyleTTS2  | research   | en (LibriTTS iteration_3) | ~0.67 GB¶                  | 24 kHz      | 256 tokens / pass (≈30 s of audio max)                           | No        | 1574 / 3088 ms    | 1574 / 3088 ms    | 4.59×     | 522 MB   | 9.4%   | 4.1%   |
+| Supertonic-3 | Apache-2.0 | en (`M1`, 31-lang)        | ~0.40 GB                   | 44.1 kHz    | 128 codepoints / pass (chunker splits ≥110 char Latin / 90 CJK)  | No        | **479 / 6491 ms** | 479 / 6491 ms     | 5.55×     | 679 MB   | 0.8%   | 0.3%   |
 
 \* TTFT for **PocketTTS** is first-frame emit through the streaming
 API (perceptual TTFA). **Kokoro ANE / Magpie / StyleTTS2** all run
@@ -234,6 +245,40 @@ This document does not currently re-publish the per-stage table on
 `main`: the AR loop dominates and its absolute numbers are
 in active flux on `feat/magpie-lt-fusion` (fused sampler + 24-frame
 NanoCodec cap). Republish here once that branch lands on `main`.
+
+### Supertonic-3 — per-language breakdown (M2, default preset, `M1` voice)
+
+Same harness, same `M1.json` voice style, same default
+(`--total-steps 8 --speed 1.05 --compute-units default`). All 10
+languages complete the full 100-phrase `minimax-<lang>` run. WER /
+CER are populated only for English (Parakeet TDT roundtrip); the
+nine non-English runs use `--skip-asr` because Parakeet is
+English-only and the FluidAudio harness's Cohere ASR fallback was
+not wired here. Peak RSS is process-wide so the English row is
+inflated by the additional Parakeet models held in memory; the
+nine non-English rows reflect Supertonic-3 in isolation.
+
+| Language        | Code | Synth p50 / p95   | Agg RTFx | Peak RSS | WER†   | CER†   |
+|-----------------|------|-------------------|----------|----------|--------|--------|
+| English         | en   | **479 / 6491 ms** | 5.55×    | 679 MB‡  | 0.84%  | 0.32%  |
+| Arabic          | ar   | 427 / 5827 ms     | 6.76×    | 396 MB   | n/a    | n/a    |
+| French          | fr   | 926 / 5897 ms     | 5.58×    | 292 MB   | n/a    | n/a    |
+| German          | de   | **313 / 2318 ms** | 8.75×    | 345 MB   | n/a    | n/a    |
+| Italian         | it   | 691 / 4626 ms     | 11.05×   | 486 MB   | n/a    | n/a    |
+| Japanese        | ja   | 643 / 2058 ms     | 8.69×    | 329 MB   | n/a    | n/a    |
+| Korean          | ko   | 438 / 1599 ms     | **11.36×** | 370 MB | n/a    | n/a    |
+| Russian         | ru   | **321 / 6563 ms** | 7.97×    | 356 MB   | n/a    | n/a    |
+| Spanish         | es   | **354 / 583 ms**  | **15.90×** | 351 MB | n/a    | n/a    |
+| Vietnamese      | vi   | 776 / 3934 ms     | 7.02×    | 440 MB   | n/a    | n/a    |
+
+† Score WER / CER for any non-English row by re-running with
+`--asr-backend cohere --asr-language <iso>` (Cohere Transcribe
+supports en, zh, ja, ko, vi, fr, de, es, it, pt, nl, pl, el, ar)
+once a local cache of `cohere-transcribe/q8` is populated.
+
+‡ English row includes Parakeet TDT loaded in-process for the
+ASR roundtrip; the other nine rows ran with `--skip-asr` so the
+RSS column reflects only the four Supertonic-3 graphs + indexer.
 
 ### About the WER / CER numbers
 

--- a/Documentation/TTS/Benchmarks.md
+++ b/Documentation/TTS/Benchmarks.md
@@ -250,35 +250,44 @@ NanoCodec cap). Republish here once that branch lands on `main`.
 
 Same harness, same `M1.json` voice style, same default
 (`--total-steps 8 --speed 1.05 --compute-units default`). All 10
-languages complete the full 100-phrase `minimax-<lang>` run. WER /
-CER are populated only for English (Parakeet TDT roundtrip); the
-nine non-English runs use `--skip-asr` because Parakeet is
-English-only and the FluidAudio harness's Cohere ASR fallback was
-not wired here. Peak RSS is process-wide so the English row is
-inflated by the additional Parakeet models held in memory; the
-nine non-English rows reflect Supertonic-3 in isolation.
+languages complete the full 100-phrase `minimax-<lang>` run.
 
-| Language        | Code | Synth p50 / p95   | Agg RTFx | Peak RSS | WER†   | CER†   |
-|-----------------|------|-------------------|----------|----------|--------|--------|
-| English         | en   | **479 / 6491 ms** | 5.55×    | 679 MB‡  | 0.84%  | 0.32%  |
-| Arabic          | ar   | 427 / 5827 ms     | 6.76×    | 396 MB   | n/a    | n/a    |
-| French          | fr   | 926 / 5897 ms     | 5.58×    | 292 MB   | n/a    | n/a    |
-| German          | de   | **313 / 2318 ms** | 8.75×    | 345 MB   | n/a    | n/a    |
-| Italian         | it   | 691 / 4626 ms     | 11.05×   | 486 MB   | n/a    | n/a    |
-| Japanese        | ja   | 643 / 2058 ms     | 8.69×    | 329 MB   | n/a    | n/a    |
-| Korean          | ko   | 438 / 1599 ms     | **11.36×** | 370 MB | n/a    | n/a    |
-| Russian         | ru   | **321 / 6563 ms** | 7.97×    | 356 MB   | n/a    | n/a    |
-| Spanish         | es   | **354 / 583 ms**  | **15.90×** | 351 MB | n/a    | n/a    |
-| Vietnamese      | vi   | 776 / 3934 ms     | 7.02×    | 440 MB   | n/a    | n/a    |
+WER / CER for English is from the in-process Parakeet TDT
+roundtrip. The nine non-English rows were synthesized with
+`--skip-asr` (Parakeet is English-only), then scored offline by
+transcribing the saved WAVs with **`mlx-community/whisper-large-v3-turbo`**
+and computing WER / CER against the corpus references with
+`jiwer` after NFKC + lowercase + punctuation-strip normalization.
+Peak RSS is process-wide so the English row is inflated by the
+additional Parakeet models held in memory; the nine non-English
+rows reflect Supertonic-3 in isolation.
 
-† Score WER / CER for any non-English row by re-running with
-`--asr-backend cohere --asr-language <iso>` (Cohere Transcribe
-supports en, zh, ja, ko, vi, fr, de, es, it, pt, nl, pl, el, ar)
-once a local cache of `cohere-transcribe/q8` is populated.
+| Language        | Code | Synth p50 / p95   | Agg RTFx | Peak RSS | WER†    | CER†   |
+|-----------------|------|-------------------|----------|----------|---------|--------|
+| English         | en   | **479 / 6491 ms** | 5.55×    | 679 MB‡  | 0.84%   | 0.32%  |
+| Arabic          | ar   | 427 / 5827 ms     | 6.76×    | 396 MB   | 3.81%   | 1.16%  |
+| French          | fr   | 926 / 5897 ms     | 5.58×    | 292 MB   | 3.32%   | 1.13%  |
+| German          | de   | **313 / 2318 ms** | 8.75×    | 345 MB   | **0.66%** | **0.45%** |
+| Italian         | it   | 691 / 4626 ms     | 11.05×   | 486 MB   | **0.64%** | **0.29%** |
+| Japanese        | ja   | 643 / 2058 ms     | 8.69×    | 329 MB   | 98.33%§ | 9.30%  |
+| Korean          | ko   | 438 / 1599 ms     | **11.36×** | 370 MB | 11.54%§ | 4.23%  |
+| Russian         | ru   | **321 / 6563 ms** | 7.97×    | 356 MB   | 4.06%   | 1.30%  |
+| Spanish         | es   | **354 / 583 ms**  | **15.90×** | 351 MB | 1.28%   | 0.57%  |
+| Vietnamese      | vi   | 776 / 3934 ms     | 7.02×    | 440 MB   | 9.60%   | 8.33%  |
+
+† Non-English WER / CER produced offline with
+`mlx-community/whisper-large-v3-turbo` against the saved WAVs;
+text normalized (NFKC + lowercase + punctuation strip) before
+scoring. English uses the in-process Parakeet TDT roundtrip.
 
 ‡ English row includes Parakeet TDT loaded in-process for the
 ASR roundtrip; the other nine rows ran with `--skip-asr` so the
 RSS column reflects only the four Supertonic-3 graphs + indexer.
+
+§ Japanese / Korean have no whitespace word boundaries; `jiwer.wer`
+splits on whitespace, so the Japanese WER is meaningless (CER 9.3%
+is the right metric). Korean's WER is borderline meaningful because
+the corpus uses spaced words.
 
 ### About the WER / CER numbers
 

--- a/Documentation/TTS/Supertonic3.md
+++ b/Documentation/TTS/Supertonic3.md
@@ -1,0 +1,220 @@
+# Supertonic-3 (v1.7.3) Swift Inference
+
+Multilingual flow-matching diffusion TTS. 31 languages, 44.1 kHz mono
+Float32 output, voice styling via per-speaker JSON tensors. 4-stage
+CoreML pipeline at ~398 MB total.
+
+## Overview
+
+Supertonic-3 is a 4-stage CoreML port of
+[supertone-inc/supertonic](https://github.com/supertone-inc/supertonic)
+v1.7.3. Each utterance runs:
+
+```
+text → text_encoder       → text_emb       [1, 256, 128]
+text → duration_predictor → duration       [1]
+       vector_estimator   ×8 denoising steps (flow-matching diffusion w/ CFG)
+       vocoder            → 44.1 kHz mono Float32 wav
+```
+
+The `vector_estimator` stage is the cost center: 8 denoising steps with
+classifier-free guidance built into the graph (W_COND = 4.0,
+W_UNCOND = 3.0). Voice identity rides on two style tensors
+(`style_ttl`, `style_dp`) loaded from per-speaker JSON presets — the
+upstream repo ships `M1`/`F1`/`M2`/`F2`/… and the FluidInference mirror
+re-publishes them under `assets/voice_styles/`.
+
+## Quick Start
+
+### CLI
+
+```bash
+swift run fluidaudiocli tts "Hello from Supertonic three." \
+    --backend supertonic3 \
+    --lang en \
+    --voice-style path/to/M1.json \
+    --output ~/Desktop/sup3-demo.wav
+```
+
+`--voice-style` is required and must point at a Supertonic voice preset
+JSON. On first invocation the CLI downloads the four `.mlmodelc`
+bundles plus `tts.json` and `unicode_indexer.json`; subsequent calls
+reuse the disk cache.
+
+Optional flags:
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--lang <code>` | `en` | One of the 31 supported ISO codes — see [Languages](#languages) |
+| `--total-steps <n>` | `8` | Denoising step count; lower trades quality for latency |
+| `--speed <f>` | `1.05` | Speech-rate multiplier; divides predicted duration |
+
+### Swift
+
+```swift
+import FluidAudio
+
+let manager = try await Supertonic3Manager.downloadAndCreate(
+    computeUnits: .cpuAndNeuralEngine
+)
+
+let style = try Supertonic3VoiceStyle.load(
+    from: URL(fileURLWithPath: "/path/to/M1.json"))
+
+let (samples, _) = try await manager.synthesize(
+    text: "Hello from Supertonic three.",
+    language: "en",
+    style: style)
+// `samples`: Float32 PCM, 44.1 kHz mono.
+```
+
+## Pipeline
+
+```
+text                       voice style JSON (M1.json …)
+  |                                |
+  v                                v
+Supertonic3TextChunker       Supertonic3VoiceStyle.load
+  |  (paragraph → sentence       |  (style_ttl  [1, 50, 256]
+  |   → comma → word, 110         |   style_dp  [1,  8,  16])
+  |   chars Latin / 90 CJK)       |
+  v                                |
+Supertonic3UnicodeProcessor        |
+  |  (NFKD → strip emoji →         |
+  |   <lang>…</lang> tags →        |
+  |   65536-entry codepoint        |
+  |   indexer → text_ids, mask)    |
+  | text_ids   [1, 128]            |
+  | text_mask  [1, 1, 128]         |
+  v                                v
+Supertonic3Synthesizer  (4 CoreML stages, batch = 1)
+  ├─ text_encoder       text_ids + style_ttl  → text_emb     [1, 256, 128]
+  ├─ duration_predictor text_ids + style_dp   → duration     [1]
+  ├─ vector_estimator   ×8 denoising steps    → denoised_latent
+  │     (flow-matching diffusion w/ CFG; current_step/total_step
+  │      drive σ schedule; style_ttl + text_mask + latent_mask
+  │      condition each step)
+  └─ vocoder            denoised_latent       → wav (44.1 kHz mono Float32)
+```
+
+The flow-matching loop iterates `vector_estimator` `totalSteps` (= 8)
+times, feeding each `denoised_latent` back in as the next step's
+`noisy_latent`. CFG is fused into the model — Swift only supplies the
+`current_step` / `total_step` scalars.
+
+## Files
+
+| File | Role |
+|---|---|
+| `Supertonic3Manager.swift` | Public actor — `initialize()`, `downloadAndCreate()`, `synthesize(text:language:style:totalSteps:speed:silenceDuration:)`, `cleanup()` |
+| `Supertonic3Constants.swift` | Compile-time constants (44.1 kHz, T=128 token cap, 8 default steps, 31-language whitelist, chunker caps) |
+| `Supertonic3Error.swift` | Per-module `Error, LocalizedError` enum |
+| `Supertonic3Types.swift` | `Supertonic3Config` (`tts.json` schema) + `Supertonic3VoiceStyle` (decoded style tensors) |
+| `Assets/Supertonic3ModelStore.swift` | Actor — loads the 4 `.mlmodelc` bundles + `tts.json` + `unicode_indexer.json` |
+| `Assets/Supertonic3ResourceDownloader.swift` | HuggingFace pull for `FluidInference/supertonic-3-coreml` |
+| `Pipeline/Preprocess/Supertonic3UnicodeProcessor.swift` | NFKD normalize + emoji strip + symbol replace + `<lang>` wrap + 65536-entry codepoint → token-id lookup, pads to fixed T=128 |
+| `Pipeline/Preprocess/Supertonic3TextChunker.swift` | Sentence-aware chunker (110 chars Latin, 90 CJK) for long utterances |
+| `Pipeline/Synthesize/Supertonic3Synthesizer.swift` | 4-stage CoreML driver — text_encoder + duration_predictor → 8-step vector_estimator → vocoder |
+| `Pipeline/Synthesize/Supertonic3LatentSampler.swift` | Noisy-latent + latent-mask sampling for the flow-matching loop |
+| `Pipeline/Synthesize/Supertonic3MultiArray.swift` | `MLMultiArray` ergonomics shared by the synthesizer stages |
+
+## Text preprocessing
+
+Mirrors the upstream `UnicodeProcessor` from
+[Helper.swift](https://github.com/supertone-inc/supertonic/blob/main/swift/Sources/Helper.swift):
+
+1. NFKD decompose (`decomposedStringWithCompatibilityMapping`).
+2. Strip emoji codepoints in the wide Unicode planes.
+3. Replace dashes / quotes / brackets / arrows with ASCII equivalents.
+4. Drop decorative symbols (`♥`, `☆`, `\\`, …).
+5. Expand a small set of abbreviations (`@` → " at ", `e.g.,` →
+   "for example,", `i.e.,` → "that is,").
+6. Tighten spacing around punctuation; collapse repeated quotes.
+7. Append `.` if no terminal punctuation.
+8. Wrap with `<lang>…</lang>` tags.
+9. Map each Unicode scalar through `unicode_indexer.json` (a flat
+   `[Int64]` array keyed by codepoint) — unknown scalars receive `-1`
+   so the model can mask them.
+
+The `text_encoder` + `duration_predictor` models pin the T axis at
+**128**; longer inputs are truncated and shorter ones zero-padded. The
+chunker keeps each pass under 110 (Latin) / 90 (CJK) characters so the
+NFKD-expanded codepoint sequence plus `<lang>` overhead fits inside
+the 128-token window.
+
+## Voice styles
+
+`Supertonic3VoiceStyle` loads two style tensors from a per-speaker JSON:
+
+| Field | Shape | Consumed by |
+|---|---|---|
+| `style_ttl` | `[1, 50, 256]` | `text_encoder` + every `vector_estimator` step |
+| `style_dp` | `[1, 8, 16]` | `duration_predictor` |
+
+The upstream repo ships `M1` / `M2` / `F1` / `F2` etc. as static JSON
+files under
+[`FluidInference/supertonic-3-coreml/assets/voice_styles/`](https://huggingface.co/FluidInference/supertonic-3-coreml/tree/main/assets/voice_styles).
+Pass any of those to `Supertonic3VoiceStyle.load(from:)`; the decoded
+struct is `Sendable` and can be reused across many synthesize calls.
+
+## Languages
+
+31 ISO codes plus `"na"` (language-agnostic / numeric):
+
+```
+en  ko  ja  ar  bg  cs  da  de  el  es  et  fi
+fr  hi  hr  hu  id  it  lt  lv  nl  pl  pt  ro
+ru  sk  sl  sv  tr  uk  vi  na
+```
+
+No Chinese (`zh`) — Supertonic-3 was not trained on Mandarin. Use
+[`KokoroAne`](KokoroAne.md) with `--variant mandarin` for Mandarin
+TTS in FluidAudio.
+
+`Supertonic3Constants.cjkLanguages = ["ko", "ja"]` uses a tighter
+90-char chunk cap to leave headroom inside the 128-token window —
+CJK uses more codepoints per visible character after NFKD.
+
+## Models
+
+All CoreML packages live under
+[`FluidInference/supertonic-3-coreml`](https://huggingface.co/FluidInference/supertonic-3-coreml).
+
+| Stage | mlmodelc | Notes |
+|---|---|---|
+| Text encoder | `TextEncoder.mlmodelc` | T=128 fixed, outputs `text_emb [1, 256, 128]` |
+| Duration predictor | `DurationPredictor.mlmodelc` | T=128 fixed, outputs scalar `duration` |
+| Vector estimator | `VectorEstimator.mlmodelc` | 8 denoising steps with fused CFG (W_COND = 4.0, W_UNCOND = 3.0) |
+| Vocoder | `Vocoder.mlmodelc` | Outputs `wav` at 44.1 kHz mono Float32 |
+
+Companion assets:
+
+| File | Role |
+|---|---|
+| `tts.json` | Sample rate, chunk-compress factor, base chunk size — overrides the compile-time defaults in `Supertonic3Constants` |
+| `unicode_indexer.json` | Flat `[Int64]` array, indexed by codepoint, mapping every Unicode scalar to a model token id |
+| `assets/voice_styles/*.json` | Per-speaker `style_ttl` / `style_dp` tensors |
+
+## Known issues
+
+- **No Chinese.** Supertonic-3's training set does not include Mandarin.
+  Use KokoroAne `--variant mandarin` for `zh`.
+- **Voice styles are not auto-downloaded.** The four model files +
+  `unicode_indexer.json` + `tts.json` come down on first init, but
+  voice style JSONs must be supplied by the caller (path on disk or
+  fetched separately from the HF repo).
+- **Fixed 128-token cap.** Single-pass utterances are bounded by the
+  encoder window. The chunker silently splits longer text and
+  concatenates per-chunk audio with `silenceDuration` (default 0.3 s)
+  in between — fine for paragraphs, but per-chunk prosody continuity
+  is not preserved.
+- **WER on whitespace-free scripts.** Korean / Japanese have no word
+  boundaries; `WERCalculator` splits on whitespace and reports
+  near-100% WER. Trust CER on those rows.
+
+## License
+
+- **Supertonic-3 model weights:** Apache 2.0, inherited from
+  [supertone-inc/supertonic](https://github.com/supertone-inc/supertonic)
+  upstream.
+- **FluidAudio SDK:** Apache 2.0.

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -867,10 +867,10 @@ public enum ModelNames {
     /// JSON files. File names match the HuggingFace tree at
     /// `FluidInference/supertonic-3-coreml/`.
     public enum Supertonic3 {
-        public static let textEncoder = "text_encoder"
-        public static let durationPredictor = "duration_predictor"
-        public static let vectorEstimator = "vector_estimator"
-        public static let vocoder = "vocoder"
+        public static let textEncoder = "TextEncoder"
+        public static let durationPredictor = "DurationPredictor"
+        public static let vectorEstimator = "VectorEstimator"
+        public static let vocoder = "Vocoder"
 
         public static let textEncoderFile = textEncoder + ".mlmodelc"
         public static let durationPredictorFile = durationPredictor + ".mlmodelc"

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -45,6 +45,12 @@ public enum Repo: String, CaseIterable, Sendable {
     /// (`.mlpackage` source) and `swift/` (a debug harness) that the Swift
     /// loader never touches.
     case styletts2 = "FluidInference/StyleTTS-2-coreml/iteration_3/compiled"
+    /// Supertonic-3 multilingual TTS (31 langs). Republished CoreML
+    /// conversion of the upstream `Supertone/supertonic-3` ONNX checkpoint;
+    /// see `Scripts/convert_supertonic3_to_coreml.py` for the conversion
+    /// recipe. Ships four `.mlmodelc` bundles + `tts.json` +
+    /// `unicode_indexer.json` at the repo root.
+    case supertonic3 = "FluidInference/supertonic-3-coreml"
 
     /// Repository slug (without owner)
     public var name: String {
@@ -111,6 +117,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "magpie-tts-multilingual-357m-coreml"
         case .styletts2:
             return "StyleTTS-2-coreml/iteration_3/compiled"
+        case .supertonic3:
+            return "supertonic-3-coreml"
         }
     }
 
@@ -235,6 +243,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "magpie-tts"
         case .styletts2:
             return "styletts2"
+        case .supertonic3:
+            return "supertonic-3"
         default:
             return name.replacingOccurrences(of: "-coreml", with: "")
         }
@@ -853,6 +863,36 @@ public enum ModelNames {
         }
     }
 
+    /// Supertonic-3 multilingual TTS — 4 `.mlmodelc` bundles + 2 companion
+    /// JSON files. File names match the HuggingFace tree at
+    /// `FluidInference/supertonic-3-coreml/`.
+    public enum Supertonic3 {
+        public static let textEncoder = "text_encoder"
+        public static let durationPredictor = "duration_predictor"
+        public static let vectorEstimator = "vector_estimator"
+        public static let vocoder = "vocoder"
+
+        public static let textEncoderFile = textEncoder + ".mlmodelc"
+        public static let durationPredictorFile = durationPredictor + ".mlmodelc"
+        public static let vectorEstimatorFile = vectorEstimator + ".mlmodelc"
+        public static let vocoderFile = vocoder + ".mlmodelc"
+
+        public static let configFile = "tts.json"
+        public static let unicodeIndexerFile = "unicode_indexer.json"
+
+        /// The four CoreML bundles required by `Supertonic3Synthesizer`.
+        public static let requiredModels: Set<String> = [
+            textEncoderFile,
+            durationPredictorFile,
+            vectorEstimatorFile,
+            vocoderFile,
+        ]
+
+        /// Models + companion JSON files the downloader must fetch.
+        public static let requiredFiles: Set<String> =
+            requiredModels.union([configFile, unicodeIndexerFile])
+    }
+
     /// Multilingual G2P (CharsiuG2P ByT5) model names
     public enum MultilingualG2P {
         public static let encoder = "MultilingualG2PEncoder"
@@ -1045,6 +1085,8 @@ public enum ModelNames {
             default:
                 return ModelNames.StyleTTS2.requiredModels
             }
+        case .supertonic3:
+            return ModelNames.Supertonic3.requiredFiles
         }
     }
 }

--- a/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ModelStore.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ModelStore.swift
@@ -1,0 +1,137 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Actor-based store for the four Supertonic-3 CoreML models plus the two
+/// companion config files (`tts.json`, `unicode_indexer.json`).
+///
+/// The four stages are:
+///   1. `text_encoder`        — text IDs + style → text embedding
+///   2. `duration_predictor`  — text IDs + style → per-utterance duration
+///   3. `vector_estimator`    — denoising loop input (called N times)
+///   4. `vocoder`             — final latent → 44.1 kHz waveform
+///
+/// All four are intentionally loaded with `.cpuAndNeuralEngine` by default —
+/// the converted graphs are FP16 and small enough to fit in ANE working
+/// memory. Callers can override at init time (`.cpuOnly` is recommended for
+/// Intel Macs and for the smoke tests).
+public actor Supertonic3ModelStore {
+
+    private let logger = AppLogger(category: "Supertonic3ModelStore")
+
+    private let directory: URL?
+    private let computeUnits: MLComputeUnits
+
+    private var repoDirectory: URL?
+    private var textEncoderModel: MLModel?
+    private var durationPredictorModel: MLModel?
+    private var vectorEstimatorModel: MLModel?
+    private var vocoderModel: MLModel?
+
+    private(set) var config: Supertonic3Config = .defaults
+
+    public init(
+        directory: URL? = nil,
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+    ) {
+        self.directory = directory
+        self.computeUnits = computeUnits
+    }
+
+    // MARK: - Public API
+
+    /// Download (if missing) the four `.mlmodelc` bundles + `tts.json` +
+    /// `unicode_indexer.json` and load the CoreML stages.
+    public func loadIfNeeded() async throws {
+        if textEncoderModel != nil { return }
+
+        let repoDir = try await Supertonic3ResourceDownloader.ensureModels(directory: directory)
+        self.repoDirectory = repoDir
+
+        // tts.json — optional override of the compile-time defaults. If parsing
+        // fails we keep the defaults and warn so callers can debug.
+        let configURL = repoDir.appendingPathComponent(ModelNames.Supertonic3.configFile)
+        if FileManager.default.fileExists(atPath: configURL.path) {
+            do {
+                let data = try Data(contentsOf: configURL)
+                self.config = try JSONDecoder().decode(Supertonic3Config.self, from: data)
+            } catch {
+                logger.warning(
+                    "Failed to decode tts.json (\(error)); using compile-time defaults")
+            }
+        }
+
+        logger.info("Loading Supertonic-3 CoreML models from \(repoDir.path)…")
+        let loadStart = Date()
+
+        let cfg = MLModelConfiguration()
+        cfg.computeUnits = computeUnits
+
+        textEncoderModel = try loadModel(
+            repoDir: repoDir,
+            fileName: ModelNames.Supertonic3.textEncoderFile, config: cfg)
+        durationPredictorModel = try loadModel(
+            repoDir: repoDir,
+            fileName: ModelNames.Supertonic3.durationPredictorFile, config: cfg)
+        vectorEstimatorModel = try loadModel(
+            repoDir: repoDir,
+            fileName: ModelNames.Supertonic3.vectorEstimatorFile, config: cfg)
+        vocoderModel = try loadModel(
+            repoDir: repoDir,
+            fileName: ModelNames.Supertonic3.vocoderFile, config: cfg)
+
+        let elapsed = Date().timeIntervalSince(loadStart)
+        logger.info(
+            "Supertonic-3 models loaded in \(String(format: "%.2f", elapsed))s")
+    }
+
+    // MARK: - Accessors
+
+    public func textEncoder() throws -> MLModel { try unwrap(textEncoderModel, name: "text_encoder") }
+    public func durationPredictor() throws -> MLModel {
+        try unwrap(durationPredictorModel, name: "duration_predictor")
+    }
+    public func vectorEstimator() throws -> MLModel {
+        try unwrap(vectorEstimatorModel, name: "vector_estimator")
+    }
+    public func vocoder() throws -> MLModel { try unwrap(vocoderModel, name: "vocoder") }
+
+    public func repoDir() throws -> URL {
+        guard let dir = repoDirectory else { throw Supertonic3Error.notInitialized }
+        return dir
+    }
+
+    /// Path to `unicode_indexer.json` after `loadIfNeeded()` has succeeded.
+    public func unicodeIndexerURL() throws -> URL {
+        try repoDir().appendingPathComponent(ModelNames.Supertonic3.unicodeIndexerFile)
+    }
+
+    public func unload() {
+        textEncoderModel = nil
+        durationPredictorModel = nil
+        vectorEstimatorModel = nil
+        vocoderModel = nil
+    }
+
+    // MARK: - Helpers
+
+    private func unwrap(_ model: MLModel?, name: String) throws -> MLModel {
+        guard let model else { throw Supertonic3Error.notInitialized }
+        return model
+    }
+
+    private func loadModel(
+        repoDir: URL, fileName: String, config: MLModelConfiguration
+    ) throws -> MLModel {
+        let modelURL = repoDir.appendingPathComponent(fileName)
+        guard FileManager.default.fileExists(atPath: modelURL.path) else {
+            throw Supertonic3Error.modelFileNotFound(fileName)
+        }
+        do {
+            let model = try MLModel(contentsOf: modelURL, configuration: config)
+            logger.info("Loaded \(fileName)")
+            return model
+        } catch {
+            throw Supertonic3Error.corruptedModel(fileName, underlying: "\(error)")
+        }
+    }
+}

--- a/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ResourceDownloader.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Downloads the Supertonic-3 CoreML assets from HuggingFace.
+///
+/// FluidAudio republishes the upstream ONNX checkpoint as four `.mlmodelc`
+/// bundles plus the original `tts.json` + `unicode_indexer.json` companion
+/// files at `FluidInference/supertonic-3-coreml`. The bundle layout is
+/// produced by `Scripts/convert_supertonic3_to_coreml.py`; see that script
+/// for conversion details.
+public enum Supertonic3ResourceDownloader {
+
+    private static let logger = AppLogger(category: "Supertonic3ResourceDownloader")
+
+    /// Ensure all required Supertonic-3 model + companion files are present
+    /// locally. Returns the resolved repo directory.
+    @discardableResult
+    public static func ensureModels(
+        directory: URL? = nil,
+        progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws -> URL {
+        let modelsRoot = try directory ?? defaultCacheRoot()
+        let repoDir = modelsRoot.appendingPathComponent(Repo.supertonic3.folderName)
+
+        let allPresent = ModelNames.Supertonic3.requiredFiles.allSatisfy { file in
+            FileManager.default.fileExists(atPath: repoDir.appendingPathComponent(file).path)
+        }
+
+        if !allPresent {
+            logger.info("Downloading Supertonic-3 CoreML assets from HuggingFace…")
+            do {
+                try await DownloadUtils.downloadRepo(
+                    .supertonic3, to: modelsRoot, progressHandler: progressHandler)
+            } catch {
+                throw Supertonic3Error.downloadFailed("\(error)")
+            }
+        } else {
+            logger.info("Supertonic-3 assets found in cache at \(repoDir.path)")
+        }
+
+        return repoDir
+    }
+
+    private static func defaultCacheRoot() throws -> URL {
+        let base: URL
+        #if os(macOS)
+        base = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache")
+        #else
+        guard
+            let first = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+        else {
+            throw Supertonic3Error.downloadFailed("failed to locate caches directory")
+        }
+        base = first
+        #endif
+        let root = base.appendingPathComponent("fluidaudio").appendingPathComponent("Models")
+        if !FileManager.default.fileExists(atPath: root.path) {
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        }
+        return root
+    }
+}

--- a/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Preprocess/Supertonic3TextChunker.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Preprocess/Supertonic3TextChunker.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+/// Long-text chunker that mirrors `chunkText()` from the upstream Supertonic
+/// reference `Helper.swift`.
+///
+/// The chunker splits by paragraphs first, then by sentences (abbreviation-
+/// aware), then by commas, and finally falls back to whitespace boundaries
+/// so individual chunks never exceed the configured `maxLen`. The default
+/// cap is 300 characters for Latin-script input and 120 characters for CJK
+/// (Korean / Japanese), matching what the upstream Swift CLI ships.
+enum Supertonic3TextChunker {
+
+    private static let abbreviations: [String] = [
+        "Dr.", "Mr.", "Mrs.", "Ms.", "Prof.", "Sr.", "Jr.",
+        "St.", "Ave.", "Rd.", "Blvd.", "Dept.", "Inc.", "Ltd.",
+        "Co.", "Corp.", "etc.", "vs.", "i.e.", "e.g.", "Ph.D.",
+    ]
+
+    static func chunk(text rawText: String, maxLen: Int) -> [String] {
+        let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return []
+        }
+
+        let paragraphs = splitParagraphs(trimmed)
+        var chunks: [String] = []
+
+        for paragraph in paragraphs {
+            let para = paragraph.trimmingCharacters(in: .whitespacesAndNewlines)
+            if para.isEmpty { continue }
+
+            if para.count <= maxLen {
+                chunks.append(para)
+                continue
+            }
+
+            packSentences(para, maxLen: maxLen, into: &chunks)
+        }
+
+        return chunks
+    }
+
+    // MARK: - Paragraph split (blank line boundary)
+
+    private static func splitParagraphs(_ text: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: "\\n\\s*\\n") else {
+            return [text]
+        }
+        let nsrange = NSRange(text.startIndex..., in: text)
+        var lastEnd = text.startIndex
+        var paragraphs: [String] = []
+
+        regex.enumerateMatches(in: text, range: nsrange) { match, _, _ in
+            if let match = match, let r = Range(match.range, in: text) {
+                paragraphs.append(String(text[lastEnd..<r.lowerBound]))
+                lastEnd = r.upperBound
+            }
+        }
+        if lastEnd < text.endIndex {
+            paragraphs.append(String(text[lastEnd...]))
+        }
+        return paragraphs.isEmpty ? [text] : paragraphs
+    }
+
+    // MARK: - Sentence packing (with comma + word fallbacks)
+
+    private static func packSentences(
+        _ paragraph: String, maxLen: Int, into chunks: inout [String]
+    ) {
+        let sentences = splitSentences(paragraph)
+        var current = ""
+
+        for sentence in sentences {
+            let trimmed = sentence.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty { continue }
+
+            if trimmed.count > maxLen {
+                flush(&current, into: &chunks)
+                packCommas(trimmed, maxLen: maxLen, into: &chunks)
+                continue
+            }
+
+            if current.count + trimmed.count + 1 > maxLen, !current.isEmpty {
+                chunks.append(current)
+                current = ""
+            }
+            current = current.isEmpty ? trimmed : "\(current) \(trimmed)"
+        }
+        flush(&current, into: &chunks)
+    }
+
+    private static func packCommas(
+        _ sentence: String, maxLen: Int, into chunks: inout [String]
+    ) {
+        var current = ""
+        for rawPart in sentence.components(separatedBy: ",") {
+            let part = rawPart.trimmingCharacters(in: .whitespacesAndNewlines)
+            if part.isEmpty { continue }
+
+            if part.count > maxLen {
+                flush(&current, into: &chunks)
+                packWords(part, maxLen: maxLen, into: &chunks)
+                continue
+            }
+
+            if current.count + part.count + 2 > maxLen, !current.isEmpty {
+                chunks.append(current)
+                current = ""
+            }
+            current = current.isEmpty ? part : "\(current), \(part)"
+        }
+        flush(&current, into: &chunks)
+    }
+
+    private static func packWords(
+        _ phrase: String, maxLen: Int, into chunks: inout [String]
+    ) {
+        var current = ""
+        for word in phrase.split(whereSeparator: { $0.isWhitespace }) {
+            let w = String(word)
+            if current.count + w.count + 1 > maxLen, !current.isEmpty {
+                chunks.append(current)
+                current = ""
+            }
+            current = current.isEmpty ? w : "\(current) \(w)"
+        }
+        flush(&current, into: &chunks)
+    }
+
+    @inline(__always)
+    private static func flush(_ buffer: inout String, into chunks: inout [String]) {
+        let trimmed = buffer.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            chunks.append(trimmed)
+        }
+        buffer = ""
+    }
+
+    // MARK: - Sentence boundary detection (abbreviation aware)
+
+    private static func splitSentences(_ text: String) -> [String] {
+        guard let regex = try? NSRegularExpression(pattern: "([.!?])\\s+") else {
+            return [text]
+        }
+        let nsrange = NSRange(text.startIndex..., in: text)
+        let matches = regex.matches(in: text, range: nsrange)
+        if matches.isEmpty { return [text] }
+
+        var sentences: [String] = []
+        var lastEnd = text.startIndex
+
+        for match in matches {
+            guard let matchRange = Range(match.range, in: text) else { continue }
+            let beforePunc = String(text[lastEnd..<matchRange.lowerBound])
+            guard let puncRange = Range(NSRange(location: match.range.location, length: 1), in: text)
+            else { continue }
+            let punc = String(text[puncRange])
+            let combined = beforePunc.trimmingCharacters(in: .whitespaces) + punc
+
+            let isAbbreviation = abbreviations.contains { combined.hasSuffix($0) }
+            if !isAbbreviation {
+                sentences.append(String(text[lastEnd..<matchRange.upperBound]))
+                lastEnd = matchRange.upperBound
+            }
+        }
+        if lastEnd < text.endIndex {
+            sentences.append(String(text[lastEnd...]))
+        }
+        return sentences.isEmpty ? [text] : sentences
+    }
+}

--- a/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Preprocess/Supertonic3TextChunker.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Preprocess/Supertonic3TextChunker.swift
@@ -6,8 +6,10 @@ import Foundation
 /// The chunker splits by paragraphs first, then by sentences (abbreviation-
 /// aware), then by commas, and finally falls back to whitespace boundaries
 /// so individual chunks never exceed the configured `maxLen`. The default
-/// cap is 300 characters for Latin-script input and 120 characters for CJK
-/// (Korean / Japanese), matching what the upstream Swift CLI ships.
+/// cap is 110 characters for Latin-script input and 90 characters for CJK
+/// (Korean / Japanese), matching `Supertonic3Constants.maxChunkLengthLatin`
+/// / `maxChunkLengthCJK` (sized to fit the fixed `textTFixed = 128` window
+/// after NFKD expansion and `<lang>…</lang>` wrapping).
 enum Supertonic3TextChunker {
 
     private static let abbreviations: [String] = [

--- a/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Preprocess/Supertonic3UnicodeProcessor.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Preprocess/Supertonic3UnicodeProcessor.swift
@@ -51,14 +51,17 @@ struct Supertonic3UnicodeProcessor {
             processed.append(cleaned)
         }
 
-        let lengths = processed.map { $0.unicodeScalars.count }
-        let maxLen = lengths.max() ?? 0
+        // The text_encoder + duration_predictor models pin the T axis at
+        // `textTFixed` (128). Truncate longer inputs and zero-pad shorter
+        // ones so the bound MLMultiArray shape always matches the spec.
+        let maxLen = Supertonic3Constants.textTFixed
+        let lengths = processed.map { min($0.unicodeScalars.count, maxLen) }
 
         var ids: [[Int64]] = []
         ids.reserveCapacity(processed.count)
         for text in processed {
             var row = [Int64](repeating: 0, count: maxLen)
-            for (j, scalar) in text.unicodeScalars.enumerated() {
+            for (j, scalar) in text.unicodeScalars.prefix(maxLen).enumerated() {
                 let value = Int(scalar.value)
                 if value < indexer.count {
                     row[j] = indexer[value]

--- a/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Preprocess/Supertonic3UnicodeProcessor.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Preprocess/Supertonic3UnicodeProcessor.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/// Text preprocessor that mirrors the upstream `UnicodeProcessor` from
+/// `https://github.com/supertone-inc/supertonic/blob/main/swift/Sources/Helper.swift`.
+///
+/// Pipeline:
+///   1. NFKD-decompose the input (`decomposedStringWithCompatibilityMapping`).
+///   2. Strip emoji blocks (wide Unicode ranges the model never saw).
+///   3. Replace dashes/quotes/brackets/arrows with ASCII equivalents.
+///   4. Drop a fixed set of decorative symbols (`♥`, `☆`, `\\`, …).
+///   5. Expand known abbreviations (`@` → " at ", `e.g.,` → "for example,", …).
+///   6. Collapse whitespace around punctuation + duplicate quotes.
+///   7. Append a period if the text doesn't end with sentence-ending
+///      punctuation or a closing bracket/quote.
+///   8. Wrap the cleaned string with `<lang>…</lang>` tags.
+///   9. Map each Unicode scalar through the loaded `unicode_indexer.json`;
+///      unknown scalars receive `-1` so the model can mask them.
+///
+/// `unicode_indexer.json` ships as a flat `[Int64]` keyed by codepoint, so
+/// the lookup is an O(1) index into a Swift array.
+struct Supertonic3UnicodeProcessor {
+
+    let indexer: [Int64]
+
+    init(unicodeIndexerURL: URL) throws {
+        do {
+            let data = try Data(contentsOf: unicodeIndexerURL)
+            self.indexer = try JSONDecoder().decode([Int64].self, from: data)
+        } catch {
+            throw Supertonic3Error.unicodeIndexerLoadFailed("\(error)")
+        }
+    }
+
+    /// Encode a batch of (text, language) pairs into padded Int64 IDs +
+    /// per-row float masks (`[bsz, 1, maxLen]`).
+    func encode(
+        texts: [String], languages: [String]
+    ) throws -> (ids: [[Int64]], mask: [[[Float]]]) {
+        precondition(texts.count == languages.count, "texts/languages length mismatch")
+
+        var processed: [String] = []
+        processed.reserveCapacity(texts.count)
+        for (text, lang) in zip(texts, languages) {
+            guard Supertonic3Constants.availableLanguages.contains(lang) else {
+                throw Supertonic3Error.unsupportedLanguage(lang)
+            }
+            let cleaned = Self.preprocess(text: text, lang: lang)
+            if cleaned.isEmpty {
+                throw Supertonic3Error.emptyText
+            }
+            processed.append(cleaned)
+        }
+
+        let lengths = processed.map { $0.unicodeScalars.count }
+        let maxLen = lengths.max() ?? 0
+
+        var ids: [[Int64]] = []
+        ids.reserveCapacity(processed.count)
+        for text in processed {
+            var row = [Int64](repeating: 0, count: maxLen)
+            for (j, scalar) in text.unicodeScalars.enumerated() {
+                let value = Int(scalar.value)
+                if value < indexer.count {
+                    row[j] = indexer[value]
+                } else {
+                    row[j] = -1
+                }
+            }
+            ids.append(row)
+        }
+
+        let mask = Self.mask(from: lengths, maxLen: maxLen)
+        return (ids, mask)
+    }
+
+    // MARK: - Text normalization (pure function for unit tests)
+
+    static func preprocess(text rawText: String, lang: String) -> String {
+        var text = rawText.decomposedStringWithCompatibilityMapping
+
+        // Drop emoji codepoints in the wide Unicode planes.
+        text = String(
+            text.unicodeScalars.filter { !Self.isEmojiCodepoint($0.value) })
+
+        for (old, new) in Self.symbolReplacements {
+            text = text.replacingOccurrences(of: old, with: new)
+        }
+        for symbol in Self.decorativeSymbols {
+            text = text.replacingOccurrences(of: symbol, with: "")
+        }
+        for (old, new) in Self.expressionReplacements {
+            text = text.replacingOccurrences(of: old, with: new)
+        }
+
+        // Tighten spacing around terminal punctuation that the input may
+        // have over-spaced after NFKD decomposition.
+        for old in [" ,", " .", " !", " ?", " ;", " :", " '"] {
+            text = text.replacingOccurrences(of: old, with: String(old.dropFirst()))
+        }
+
+        for repeated in [("\"\"", "\""), ("''", "'"), ("``", "`")] {
+            while text.contains(repeated.0) {
+                text = text.replacingOccurrences(of: repeated.0, with: repeated.1)
+            }
+        }
+
+        if let regex = try? NSRegularExpression(pattern: "\\s+") {
+            let range = NSRange(text.startIndex..., in: text)
+            text = regex.stringByReplacingMatches(
+                in: text, range: range, withTemplate: " ")
+        }
+        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if !text.isEmpty,
+            let regex = try? NSRegularExpression(
+                pattern: "[.!?;:,'\"\\u201C\\u201D\\u2018\\u2019)\\]}…。」』】〉》›»]$")
+        {
+            let range = NSRange(text.startIndex..., in: text)
+            if regex.firstMatch(in: text, range: range) == nil {
+                text += "."
+            }
+        }
+
+        return "<\(lang)>\(text)</\(lang)>"
+    }
+
+    static func mask(from lengths: [Int], maxLen: Int) -> [[[Float]]] {
+        var rows: [[[Float]]] = []
+        rows.reserveCapacity(lengths.count)
+        for len in lengths {
+            var row = [Float](repeating: 0, count: maxLen)
+            for j in 0..<min(len, maxLen) {
+                row[j] = 1
+            }
+            rows.append([row])
+        }
+        return rows
+    }
+
+    // MARK: - Tables (verbatim from upstream `helper.py` / `Helper.swift`)
+
+    private static let symbolReplacements: KeyValuePairs<String, String> = [
+        "\u{2013}": "-",  // en dash
+        "\u{2011}": "-",  // non-breaking hyphen
+        "\u{2014}": "-",  // em dash
+        "_": " ",
+        "\u{201C}": "\"",
+        "\u{201D}": "\"",
+        "\u{2018}": "'",
+        "\u{2019}": "'",
+        "\u{00B4}": "'",  // acute
+        "`": "'",
+        "[": " ",
+        "]": " ",
+        "|": " ",
+        "/": " ",
+        "#": " ",
+        "\u{2192}": " ",  // right arrow
+        "\u{2190}": " ",  // left arrow
+    ]
+
+    private static let decorativeSymbols: [String] = [
+        "\u{2665}",  // ♥
+        "\u{2606}",  // ☆
+        "\u{2661}",  // ♡
+        "\u{00A9}",  // ©
+        "\\",
+    ]
+
+    private static let expressionReplacements: KeyValuePairs<String, String> = [
+        "@": " at ",
+        "e.g.,": "for example, ",
+        "i.e.,": "that is, ",
+    ]
+
+    private static func isEmojiCodepoint(_ value: UInt32) -> Bool {
+        switch value {
+        case 0x1F600...0x1F64F: return true
+        case 0x1F300...0x1F5FF: return true
+        case 0x1F680...0x1F6FF: return true
+        case 0x1F700...0x1F77F: return true
+        case 0x1F780...0x1F7FF: return true
+        case 0x1F800...0x1F8FF: return true
+        case 0x1F900...0x1F9FF: return true
+        case 0x1FA00...0x1FA6F: return true
+        case 0x1FA70...0x1FAFF: return true
+        case 0x2600...0x26FF: return true
+        case 0x2700...0x27BF: return true
+        case 0x1F1E6...0x1F1FF: return true
+        default: return false
+        }
+    }
+}

--- a/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3LatentSampler.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3LatentSampler.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Helper that mirrors `sampleNoisyLatent()` / `getLatentMask()` from the
+/// upstream Supertonic Swift reference.
+///
+/// Both routines are pure (no CoreML dependency) so the synthesizer can keep
+/// the denoising loop testable. The Box-Muller transform matches the
+/// reference output bit-for-bit when the same RNG is supplied.
+enum Supertonic3LatentSampler {
+
+    /// Initial noisy latent + latent mask for the diffusion denoiser.
+    ///
+    /// - Parameters:
+    ///   - durations: Per-batch utterance durations in seconds.
+    ///   - sampleRate: Vocoder sample rate (used to translate duration→samples).
+    ///   - baseChunkSize: Acoustic AE `base_chunk_size` (from `tts.json`).
+    ///   - chunkCompress: `chunk_compress_factor` (from `tts.json`).
+    ///   - latentDim: Raw `latent_dim` (from `tts.json`).
+    ///   - rng: Closure producing uniform floats in [0, 1). Defaults to
+    ///     `Float.random(in:)`; tests can pass a seeded generator.
+    /// - Returns: `(noisyLatent, latentMask)` where both tensors are
+    ///   row-major `[bsz, latentDim * chunkCompress, latentLen]` and
+    ///   `[bsz, 1, latentLen]` respectively.
+    static func sampleNoisyLatent(
+        durations: [Float],
+        sampleRate: Int,
+        baseChunkSize: Int,
+        chunkCompress: Int,
+        latentDim: Int,
+        rng: () -> Float = { Float.random(in: 0..<1) }
+    ) -> (noisyLatent: [Float], latentMask: [Float], dims: (bsz: Int, channels: Int, length: Int)) {
+        let bsz = durations.count
+        let maxDur = durations.max() ?? 0
+        let wavLenMax = Int(maxDur * Float(sampleRate))
+        let chunkSize = baseChunkSize * chunkCompress
+        let latentLen = wavLenMax == 0 ? 0 : (wavLenMax + chunkSize - 1) / chunkSize
+        let channels = latentDim * chunkCompress
+
+        var noisyLatent = [Float](repeating: 0, count: bsz * channels * latentLen)
+        for b in 0..<bsz {
+            let perBatchOffset = b * channels * latentLen
+            for c in 0..<channels {
+                let rowOffset = perBatchOffset + c * latentLen
+                for t in 0..<latentLen {
+                    // Box-Muller: avoid log(0) by sampling u1 strictly > 0.
+                    let u1 = max(rng(), 1e-4)
+                    let u2 = rng()
+                    let z = sqrt(-2.0 * log(u1)) * cos(2.0 * Float.pi * u2)
+                    noisyLatent[rowOffset + t] = z
+                }
+            }
+        }
+
+        let wavLengths = durations.map { Int($0 * Float(sampleRate)) }
+        let latentLengths = wavLengths.map { ($0 + chunkSize - 1) / chunkSize }
+        let latentMask = mask(lengths: latentLengths, maxLen: latentLen)
+
+        // Apply the mask to the noisy latent so padding positions stay zero.
+        for b in 0..<bsz {
+            let validLen = latentLengths[b]
+            guard validLen < latentLen else { continue }
+            for c in 0..<channels {
+                let rowOffset = b * channels * latentLen + c * latentLen
+                for t in validLen..<latentLen {
+                    noisyLatent[rowOffset + t] = 0
+                }
+            }
+        }
+
+        return (noisyLatent, latentMask, (bsz, channels, latentLen))
+    }
+
+    /// `[bsz, 1, maxLen]` float mask flattened row-major.
+    static func mask(lengths: [Int], maxLen: Int) -> [Float] {
+        var out = [Float](repeating: 0, count: lengths.count * maxLen)
+        for (b, len) in lengths.enumerated() {
+            let base = b * maxLen
+            for t in 0..<min(len, maxLen) {
+                out[base + t] = 1
+            }
+        }
+        return out
+    }
+}

--- a/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3MultiArray.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3MultiArray.swift
@@ -10,7 +10,13 @@ import Foundation
 public enum Supertonic3MultiArray {
 
     public static func makeFloat32(_ values: [Float], shape: [Int]) throws -> MLMultiArray {
-        precondition(values.count == shape.reduce(1, *), "shape product must match buffer length")
+        let expected = shape.reduce(1, *)
+        guard values.count == expected else {
+            throw Supertonic3Error.invalidTensorShape(
+                stage: "makeFloat32",
+                expected: "\(expected) (shape \(shape))",
+                got: "\(values.count)")
+        }
         let arr = try MLMultiArray(shape: shape.map(NSNumber.init), dataType: .float32)
         let dst = arr.dataPointer.bindMemory(to: Float.self, capacity: values.count)
         values.withUnsafeBufferPointer { src in
@@ -20,7 +26,13 @@ public enum Supertonic3MultiArray {
     }
 
     public static func makeInt32(_ values: [Int32], shape: [Int]) throws -> MLMultiArray {
-        precondition(values.count == shape.reduce(1, *), "shape product must match buffer length")
+        let expected = shape.reduce(1, *)
+        guard values.count == expected else {
+            throw Supertonic3Error.invalidTensorShape(
+                stage: "makeInt32",
+                expected: "\(expected) (shape \(shape))",
+                got: "\(values.count)")
+        }
         let arr = try MLMultiArray(shape: shape.map(NSNumber.init), dataType: .int32)
         let dst = arr.dataPointer.bindMemory(to: Int32.self, capacity: values.count)
         values.withUnsafeBufferPointer { src in

--- a/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3MultiArray.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3MultiArray.swift
@@ -1,0 +1,71 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Tiny helpers for moving Float / Int32 buffers in and out of `MLMultiArray`
+/// for the Supertonic-3 stages.
+///
+/// All factories produce row-major contiguous Float32 / Int32 arrays; strides
+/// are inferred from the shape. `extractFloats` handles either Float32 or
+/// Float16 backing storage so a CoreML graph using FP16 IO is transparent.
+public enum Supertonic3MultiArray {
+
+    public static func makeFloat32(_ values: [Float], shape: [Int]) throws -> MLMultiArray {
+        precondition(values.count == shape.reduce(1, *), "shape product must match buffer length")
+        let arr = try MLMultiArray(shape: shape.map(NSNumber.init), dataType: .float32)
+        let dst = arr.dataPointer.bindMemory(to: Float.self, capacity: values.count)
+        values.withUnsafeBufferPointer { src in
+            dst.update(from: src.baseAddress!, count: values.count)
+        }
+        return arr
+    }
+
+    public static func makeInt32(_ values: [Int32], shape: [Int]) throws -> MLMultiArray {
+        precondition(values.count == shape.reduce(1, *), "shape product must match buffer length")
+        let arr = try MLMultiArray(shape: shape.map(NSNumber.init), dataType: .int32)
+        let dst = arr.dataPointer.bindMemory(to: Int32.self, capacity: values.count)
+        values.withUnsafeBufferPointer { src in
+            dst.update(from: src.baseAddress!, count: values.count)
+        }
+        return arr
+    }
+
+    /// Read out the contents of an `MLMultiArray` as a Swift `[Float]`,
+    /// handling Float32 / Float16 / Double / Int32 backing stores.
+    public static func extractFloats(_ arr: MLMultiArray) -> [Float] {
+        let n = arr.count
+        var out = [Float](repeating: 0, count: n)
+        switch arr.dataType {
+        case .float32:
+            let src = arr.dataPointer.bindMemory(to: Float.self, capacity: n)
+            out.withUnsafeMutableBufferPointer { dst in
+                dst.baseAddress!.update(from: src, count: n)
+            }
+        case .float16:
+            #if arch(arm64)
+            let src = arr.dataPointer.bindMemory(to: Float16.self, capacity: n)
+            for i in 0..<n {
+                out[i] = Float(src[i])
+            }
+            #else
+            for i in 0..<n {
+                out[i] = arr[i].floatValue
+            }
+            #endif
+        case .double:
+            let src = arr.dataPointer.bindMemory(to: Double.self, capacity: n)
+            for i in 0..<n {
+                out[i] = Float(src[i])
+            }
+        case .int32:
+            let src = arr.dataPointer.bindMemory(to: Int32.self, capacity: n)
+            for i in 0..<n {
+                out[i] = Float(src[i])
+            }
+        @unknown default:
+            for i in 0..<n {
+                out[i] = arr[i].floatValue
+            }
+        }
+        return out
+    }
+}

--- a/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3Synthesizer.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3Synthesizer.swift
@@ -12,7 +12,7 @@ import Foundation
 ///                          latent_mask, text_mask,
 ///                          current_step, total_step) → denoised_latent`
 ///      and feed `denoised_latent` back as `noisy_latent` for the next step.
-///   5. `vocoder(latent) → wav_tts` (44.1 kHz Float32 PCM).
+///   5. `vocoder(latent) → wav` (44.1 kHz Float32 PCM).
 ///
 /// Input / output tensor names match the upstream ONNX graph; the conversion
 /// script (`Scripts/convert_supertonic3_to_coreml.py`) preserves them.

--- a/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3Synthesizer.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3Synthesizer.swift
@@ -174,9 +174,9 @@ struct Supertonic3Synthesizer {
             stage: "vocoder",
             model: await store.vocoder(),
             inputs: ["latent": MLFeatureValue(multiArray: noisyLatent)])
-        guard let wavArray = vocoderOut.featureValue(for: "wav_tts")?.multiArrayValue else {
+        guard let wavArray = vocoderOut.featureValue(for: "wav")?.multiArrayValue else {
             throw Supertonic3Error.inferenceFailed(
-                stage: "vocoder", underlying: "missing 'wav_tts' output")
+                stage: "vocoder", underlying: "missing 'wav' output")
         }
 
         let wavSamples = Supertonic3MultiArray.extractFloats(wavArray)

--- a/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3Synthesizer.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3Synthesizer.swift
@@ -1,0 +1,245 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Drives the four Supertonic-3 CoreML stages end-to-end.
+///
+/// Inference flow (per chunk, batch size 1):
+///   1. `text_encoder(text_ids, text_mask, style_ttl) → text_emb`
+///   2. `duration_predictor(text_ids, text_mask, style_dp) → duration`
+///   3. Sample `[1, latentDim * chunkCompress, latentLen]` noisy latent.
+///   4. Repeat `totalStep` times:
+///        `vector_estimator(noisy_latent, text_emb, style_ttl,
+///                          latent_mask, text_mask,
+///                          current_step, total_step) → denoised_latent`
+///      and feed `denoised_latent` back as `noisy_latent` for the next step.
+///   5. `vocoder(latent) → wav_tts` (44.1 kHz Float32 PCM).
+///
+/// Input / output tensor names match the upstream ONNX graph; the conversion
+/// script (`Scripts/convert_supertonic3_to_coreml.py`) preserves them.
+struct Supertonic3Synthesizer {
+
+    private let logger = AppLogger(category: "Supertonic3Synthesizer")
+    private let store: Supertonic3ModelStore
+    private let processor: Supertonic3UnicodeProcessor
+
+    init(store: Supertonic3ModelStore, processor: Supertonic3UnicodeProcessor) {
+        self.store = store
+        self.processor = processor
+    }
+
+    // MARK: - Public synthesis
+
+    /// Synthesize a long utterance by chunking, calling `_infer` per chunk,
+    /// and concatenating with `silenceDuration` of silence between chunks.
+    func synthesize(
+        text: String,
+        language: String,
+        style: Supertonic3VoiceStyle,
+        totalSteps: Int,
+        speed: Float,
+        silenceDuration: Float
+    ) async throws -> (samples: [Float], duration: Float) {
+        let maxLen =
+            Supertonic3Constants.cjkLanguages.contains(language)
+            ? Supertonic3Constants.maxChunkLengthCJK
+            : Supertonic3Constants.maxChunkLengthLatin
+
+        let chunks = Supertonic3TextChunker.chunk(text: text, maxLen: maxLen)
+        guard !chunks.isEmpty else { throw Supertonic3Error.emptyText }
+
+        let sampleRate = await store.config.ae.sampleRate
+        let silenceSamples = max(0, Int(silenceDuration * Float(sampleRate)))
+        let silence = [Float](repeating: 0, count: silenceSamples)
+
+        var samples: [Float] = []
+        var durationCat: Float = 0
+
+        for (i, chunk) in chunks.enumerated() {
+            let (chunkSamples, chunkDuration) = try await infer(
+                text: chunk, language: language, style: style,
+                totalSteps: totalSteps, speed: speed)
+            if i == 0 {
+                samples = chunkSamples
+                durationCat = chunkDuration
+            } else {
+                samples.append(contentsOf: silence)
+                samples.append(contentsOf: chunkSamples)
+                durationCat += silenceDuration + chunkDuration
+            }
+        }
+
+        return (samples, durationCat)
+    }
+
+    // MARK: - Single-chunk inference (batch size 1)
+
+    private func infer(
+        text: String, language: String,
+        style: Supertonic3VoiceStyle,
+        totalSteps: Int, speed: Float
+    ) async throws -> (samples: [Float], duration: Float) {
+        let (idsBatch, maskBatch) = try processor.encode(
+            texts: [text], languages: [language])
+        guard let ids = idsBatch.first, let mask = maskBatch.first else {
+            throw Supertonic3Error.emptyText
+        }
+        let textLen = ids.count
+
+        let ids32 = ids.map { Int32(clamping: $0) }
+        let textIds = try makeInt32(values: ids32, shape: [1, textLen])
+
+        let maskFlat = mask[0]
+        let textMask = try makeFloat(values: maskFlat, shape: [1, 1, textLen])
+
+        let styleTTL = try makeFloat(values: style.ttlValues, shape: [1] + Array(style.ttlDims.dropFirst()))
+        let styleDP = try makeFloat(values: style.dpValues, shape: [1] + Array(style.dpDims.dropFirst()))
+
+        // --- Stage 1: duration_predictor --- //
+        let dpOut = try predict(
+            stage: "duration_predictor",
+            model: await store.durationPredictor(),
+            inputs: [
+                "text_ids": MLFeatureValue(multiArray: textIds),
+                "text_mask": MLFeatureValue(multiArray: textMask),
+                "style_dp": MLFeatureValue(multiArray: styleDP),
+            ])
+        guard let durationArray = dpOut.featureValue(for: "duration")?.multiArrayValue else {
+            throw Supertonic3Error.inferenceFailed(
+                stage: "duration_predictor", underlying: "missing 'duration' output")
+        }
+        var durations = Supertonic3MultiArray.extractFloats(durationArray)
+        for i in durations.indices {
+            durations[i] = max(0.05, durations[i] / max(speed, 0.05))
+        }
+
+        // --- Stage 2: text_encoder --- //
+        let textEncOut = try predict(
+            stage: "text_encoder",
+            model: await store.textEncoder(),
+            inputs: [
+                "text_ids": MLFeatureValue(multiArray: textIds),
+                "text_mask": MLFeatureValue(multiArray: textMask),
+                "style_ttl": MLFeatureValue(multiArray: styleTTL),
+            ])
+        guard let textEmbValue = textEncOut.featureValue(for: "text_emb")?.multiArrayValue else {
+            throw Supertonic3Error.inferenceFailed(
+                stage: "text_encoder", underlying: "missing 'text_emb' output")
+        }
+
+        // --- Stage 3: noisy latent + denoising loop --- //
+        let cfg = await store.config
+        let (initialLatent, latentMaskFlat, latentDims) =
+            Supertonic3LatentSampler.sampleNoisyLatent(
+                durations: durations,
+                sampleRate: cfg.ae.sampleRate,
+                baseChunkSize: cfg.ae.baseChunkSize,
+                chunkCompress: cfg.ttl.chunkCompressFactor,
+                latentDim: cfg.ttl.latentDim)
+
+        let latentShape = [latentDims.bsz, latentDims.channels, latentDims.length]
+        let latentMaskShape = [latentDims.bsz, 1, latentDims.length]
+
+        var noisyLatent = try makeFloat(values: initialLatent, shape: latentShape)
+        let latentMask = try makeFloat(values: latentMaskFlat, shape: latentMaskShape)
+
+        let vectorEstimator = try await store.vectorEstimator()
+        for step in 0..<totalSteps {
+            let currentStep = try makeFloat(values: [Float(step)], shape: [1])
+            let totalStep = try makeFloat(values: [Float(totalSteps)], shape: [1])
+
+            let denoisedOut = try predict(
+                stage: "vector_estimator",
+                model: vectorEstimator,
+                inputs: [
+                    "noisy_latent": MLFeatureValue(multiArray: noisyLatent),
+                    "text_emb": MLFeatureValue(multiArray: textEmbValue),
+                    "style_ttl": MLFeatureValue(multiArray: styleTTL),
+                    "latent_mask": MLFeatureValue(multiArray: latentMask),
+                    "text_mask": MLFeatureValue(multiArray: textMask),
+                    "current_step": MLFeatureValue(multiArray: currentStep),
+                    "total_step": MLFeatureValue(multiArray: totalStep),
+                ])
+            guard
+                let denoised = denoisedOut.featureValue(for: "denoised_latent")?.multiArrayValue
+            else {
+                throw Supertonic3Error.inferenceFailed(
+                    stage: "vector_estimator", underlying: "missing 'denoised_latent' output")
+            }
+            // Rebind without recopying when the shape and dtype already match.
+            noisyLatent = try reshape(denoised, to: latentShape)
+        }
+
+        // --- Stage 4: vocoder --- //
+        let vocoderOut = try predict(
+            stage: "vocoder",
+            model: await store.vocoder(),
+            inputs: ["latent": MLFeatureValue(multiArray: noisyLatent)])
+        guard let wavArray = vocoderOut.featureValue(for: "wav_tts")?.multiArrayValue else {
+            throw Supertonic3Error.inferenceFailed(
+                stage: "vocoder", underlying: "missing 'wav_tts' output")
+        }
+
+        let wavSamples = Supertonic3MultiArray.extractFloats(wavArray)
+        let firstDuration = durations.first ?? 0
+        let trimLen = min(wavSamples.count, Int(Float(cfg.ae.sampleRate) * firstDuration))
+        let trimmed = trimLen > 0 ? Array(wavSamples.prefix(trimLen)) : wavSamples
+        return (trimmed, firstDuration)
+    }
+
+    // MARK: - CoreML plumbing
+
+    private func predict(
+        stage: String, model: MLModel, inputs: [String: MLFeatureValue]
+    ) throws -> MLFeatureProvider {
+        let provider: MLFeatureProvider
+        do {
+            provider = try MLDictionaryFeatureProvider(dictionary: inputs)
+        } catch {
+            throw Supertonic3Error.inferenceFailed(
+                stage: stage, underlying: "feature provider: \(error)")
+        }
+        do {
+            return try model.prediction(from: provider)
+        } catch {
+            throw Supertonic3Error.inferenceFailed(stage: stage, underlying: "\(error)")
+        }
+    }
+
+    private func makeFloat(values: [Float], shape: [Int]) throws -> MLMultiArray {
+        do {
+            return try Supertonic3MultiArray.makeFloat32(values, shape: shape)
+        } catch {
+            throw Supertonic3Error.invalidTensorShape(
+                stage: "tensor", expected: "\(shape)",
+                got: "len=\(values.count) (\(error))")
+        }
+    }
+
+    private func makeInt32(values: [Int32], shape: [Int]) throws -> MLMultiArray {
+        do {
+            return try Supertonic3MultiArray.makeInt32(values, shape: shape)
+        } catch {
+            throw Supertonic3Error.invalidTensorShape(
+                stage: "tensor", expected: "\(shape)",
+                got: "len=\(values.count) (\(error))")
+        }
+    }
+
+    /// Re-bind a model output back into the expected `[bsz, channels, length]`
+    /// latent shape. Most CoreML graphs preserve the trace-time shape so this
+    /// is usually identity — the helper exists to gracefully recover when a
+    /// converter inserts an extra leading axis.
+    private func reshape(_ array: MLMultiArray, to shape: [Int]) throws -> MLMultiArray {
+        let totalRequested = shape.reduce(1, *)
+        if array.count != totalRequested {
+            throw Supertonic3Error.invalidTensorShape(
+                stage: "vector_estimator",
+                expected: "\(shape)", got: "count=\(array.count)")
+        }
+        if array.shape.map({ $0.intValue }) == shape, array.dataType == .float32 {
+            return array
+        }
+        let values = Supertonic3MultiArray.extractFloats(array)
+        return try Supertonic3MultiArray.makeFloat32(values, shape: shape)
+    }
+}

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
@@ -52,6 +52,12 @@ public enum Supertonic3Constants {
     /// Text-encoder output channel count fed into `vector_estimator.text_emb`.
     public static let textEmbDim: Int = 256
 
+    /// Pinned text-token sequence length expected by `text_encoder` and
+    /// `duration_predictor`. The CoreML conversion fixes the T axis at 128;
+    /// the unicode processor pads/truncates inputs to match. Mirrors
+    /// `TEXT_T_FIXED = 128` in the reference Python driver.
+    public static let textTFixed: Int = 128
+
     // MARK: - Inference
 
     /// Default number of denoising steps for the vector_estimator loop. The
@@ -67,11 +73,16 @@ public enum Supertonic3Constants {
     public static let defaultSilenceDuration: Float = 0.3
 
     /// Max characters per chunk when synthesizing long English/Latin text.
-    public static let maxChunkLengthLatin: Int = 300
+    /// Sized to fit within `textTFixed = 128` after NFKD decomposition and
+    /// `<lang>…</lang>` wrapping (~10-char overhead, allowing 8-char tags
+    /// plus a small margin for diacritic expansion). Longer text is split
+    /// by `Supertonic3TextChunker` before reaching the encoder.
+    public static let maxChunkLengthLatin: Int = 110
 
-    /// Tighter chunk cap for Korean / Japanese to keep per-call latency bounded
-    /// (the reference Swift CLI uses 120 here).
-    public static let maxChunkLengthCJK: Int = 120
+    /// Tighter chunk cap for Korean / Japanese. CJK uses more codepoints per
+    /// visible character after NFKD, so we leave additional headroom inside
+    /// the 128-token window.
+    public static let maxChunkLengthCJK: Int = 90
 
     // MARK: - Language whitelist (matches AVAILABLE_LANGS in the reference)
 

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Compile-time constants for the Supertonic-3 multilingual TTS pipeline.
+///
+/// Mirrors the hyperparameters published in the upstream `tts.json` and the
+/// reference inference flow in
+/// `https://github.com/supertone-inc/supertonic/blob/main/swift/Sources/Helper.swift`.
+///
+/// Supertonic-3 ships four ONNX models (text_encoder, duration_predictor,
+/// vector_estimator, vocoder) totalling ~398 MB. FluidAudio re-publishes those
+/// models as `.mlmodelc` bundles under
+/// `FluidInference/supertonic-3-coreml`; see
+/// `Scripts/convert_supertonic3_to_coreml.py` for the conversion recipe.
+public enum Supertonic3Constants {
+
+    // MARK: - Audio
+
+    /// Vocoder output sample rate. 44.1 kHz mono Float32.
+    public static let sampleRate: Int = 44_100
+
+    // MARK: - Latent / chunking
+
+    /// Base chunk size (samples) of the acoustic autoencoder. Drives the
+    /// `latent_len = ceil(wav_len / (base_chunk_size * chunk_compress_factor))`
+    /// calculation for the denoising loop. Matches `ae.base_chunk_size` in
+    /// the published `tts.json` (Supertonic-3 v1.7.3).
+    public static let baseChunkSize: Int = 512
+
+    /// Chunk-compress factor used by the text-to-latent module. The flattened
+    /// latent dimension passed to `vector_estimator` is
+    /// `latent_dim * chunk_compress_factor`. Matches `ttl.chunk_compress_factor`.
+    public static let chunkCompressFactor: Int = 6
+
+    /// Per-chunk latent dimensionality before applying `chunk_compress_factor`.
+    /// Matches `ttl.latent_dim` (== `ae.ldim`) in the published config.
+    public static let latentDim: Int = 24
+
+    /// Style token count expected by the text-to-latent style encoder
+    /// (`style_ttl` shape is `[bsz, ttlStyleTokens, ttlStyleDim]`).
+    public static let ttlStyleTokens: Int = 50
+
+    /// Style embedding dim for `style_ttl` (matches `style_value_dim`).
+    public static let ttlStyleDim: Int = 256
+
+    /// Style token count expected by the duration-predictor style encoder
+    /// (`style_dp` shape is `[bsz, dpStyleTokens, dpStyleDim]`).
+    public static let dpStyleTokens: Int = 8
+
+    /// Style embedding dim for `style_dp` (matches `dp.style_token_layer.style_value_dim`).
+    public static let dpStyleDim: Int = 16
+
+    /// Text-encoder output channel count fed into `vector_estimator.text_emb`.
+    public static let textEmbDim: Int = 256
+
+    // MARK: - Inference
+
+    /// Default number of denoising steps for the vector_estimator loop. The
+    /// reference CLI ships 8; lower values trade quality for latency.
+    public static let defaultTotalSteps: Int = 8
+
+    /// Default global speed factor applied to the predicted duration vector
+    /// (`duration /= speed`). The reference CLI ships 1.05.
+    public static let defaultSpeed: Float = 1.05
+
+    /// Default silence inserted between text chunks when synthesizing long
+    /// utterances. 0.3 s mirrors the reference CLI default.
+    public static let defaultSilenceDuration: Float = 0.3
+
+    /// Max characters per chunk when synthesizing long English/Latin text.
+    public static let maxChunkLengthLatin: Int = 300
+
+    /// Tighter chunk cap for Korean / Japanese to keep per-call latency bounded
+    /// (the reference Swift CLI uses 120 here).
+    public static let maxChunkLengthCJK: Int = 120
+
+    // MARK: - Language whitelist (matches AVAILABLE_LANGS in the reference)
+
+    /// 31 supported languages plus "na" (language-agnostic / numeric).
+    public static let availableLanguages: [String] = [
+        "en", "ko", "ja", "ar", "bg", "cs", "da", "de", "el", "es", "et", "fi",
+        "fr", "hi", "hr", "hu", "id", "it", "lt", "lv", "nl", "pl", "pt", "ro",
+        "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na",
+    ]
+
+    /// Languages that should use the tighter 120-char chunker.
+    public static let cjkLanguages: Set<String> = ["ko", "ja"]
+}

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
@@ -93,6 +93,6 @@ public enum Supertonic3Constants {
         "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na",
     ]
 
-    /// Languages that should use the tighter 120-char chunker.
+    /// Languages that should use the tighter `maxChunkLengthCJK` (90-char) chunker.
     public static let cjkLanguages: Set<String> = ["ko", "ja"]
 }

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Error.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Error.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Errors that can surface during Supertonic-3 initialization or synthesis.
+public enum Supertonic3Error: Error, LocalizedError, Sendable {
+    case notInitialized
+    case modelFileNotFound(String)
+    case corruptedModel(String, underlying: String)
+    case downloadFailed(String)
+    case unsupportedLanguage(String)
+    case voiceStyleLoadFailed(path: String, underlying: String)
+    case voiceStyleShapeMismatch(component: String, expected: [Int], got: [Int])
+    case unicodeIndexerLoadFailed(String)
+    case configLoadFailed(String)
+    case textTooLong(charCount: Int, maxLength: Int)
+    case inferenceFailed(stage: String, underlying: String)
+    case invalidTensorShape(stage: String, expected: String, got: String)
+    case emptyText
+
+    public var errorDescription: String? {
+        switch self {
+        case .notInitialized:
+            return "Supertonic3 manager has not been initialized. Call initialize() first."
+        case .modelFileNotFound(let name):
+            return "Supertonic3 model file not found: \(name)"
+        case .corruptedModel(let name, let underlying):
+            return "Supertonic3 model appears corrupted: \(name) (\(underlying))"
+        case .downloadFailed(let message):
+            return "Supertonic3 download failed: \(message)"
+        case .unsupportedLanguage(let lang):
+            let available = Supertonic3Constants.availableLanguages.joined(separator: ", ")
+            return "Supertonic3 unsupported language '\(lang)'. Available: \(available)"
+        case .voiceStyleLoadFailed(let path, let underlying):
+            return "Supertonic3 voice style load failed at \(path): \(underlying)"
+        case .voiceStyleShapeMismatch(let component, let expected, let got):
+            return "Supertonic3 voice style \(component) shape mismatch: expected \(expected), got \(got)"
+        case .unicodeIndexerLoadFailed(let message):
+            return "Supertonic3 unicode_indexer.json load failed: \(message)"
+        case .configLoadFailed(let message):
+            return "Supertonic3 tts.json load failed: \(message)"
+        case .textTooLong(let charCount, let maxLength):
+            return "Supertonic3 input chunk has \(charCount) chars; max chunk length is \(maxLength)."
+        case .inferenceFailed(let stage, let underlying):
+            return "Supertonic3 \(stage) inference failed: \(underlying)"
+        case .invalidTensorShape(let stage, let expected, let got):
+            return "Supertonic3 \(stage) tensor shape mismatch: expected \(expected), got \(got)"
+        case .emptyText:
+            return "Supertonic3 received empty text after normalization."
+        }
+    }
+}

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Manager.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Manager.swift
@@ -1,0 +1,135 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Top-level public API for Supertonic-3 multilingual TTS.
+///
+/// `Supertonic3Manager` orchestrates the four pieces of the on-device
+/// pipeline:
+///   1. `Supertonic3ModelStore`        — downloads + holds the four
+///      `.mlmodelc` bundles (text_encoder, duration_predictor,
+///      vector_estimator, vocoder) plus the companion `tts.json` and
+///      `unicode_indexer.json`.
+///   2. `Supertonic3UnicodeProcessor`  — NFKD text normalization, language
+///      tagging, Unicode → indexer ID lookup.
+///   3. `Supertonic3TextChunker`       — paragraph / sentence / comma /
+///      word chunker used for long-utterance synthesis.
+///   4. `Supertonic3Synthesizer`       — drives the 4-stage CoreML graph
+///      (text_encoder + duration_predictor → denoising loop → vocoder) and
+///      returns 44.1 kHz mono Float32 audio.
+///
+/// Voice styles are caller-supplied: the upstream repo ships a handful of
+/// preset speakers (`M1`, `M2`, `F1`, `F2`, …) as JSON files in
+/// `assets/voice_styles/`. Load one via
+/// `Supertonic3VoiceStyle.load(from: voiceStyleURL)` and pass it on every
+/// synthesize call.
+///
+/// Usage:
+/// ```swift
+/// let manager = try await Supertonic3Manager.downloadAndCreate()
+/// let style = try Supertonic3VoiceStyle.load(from: voiceStyleURL)
+/// let audio = try await manager.synthesize(
+///     text: "A gentle breeze moved through the open window.",
+///     language: "en",
+///     style: style)
+/// // `audio.samples` is 44.1 kHz mono Float32 PCM.
+/// ```
+public actor Supertonic3Manager {
+
+    private let logger = AppLogger(category: "Supertonic3Manager")
+
+    private let directory: URL?
+    private let computeUnits: MLComputeUnits
+
+    private var store: Supertonic3ModelStore?
+    private var synthesizer: Supertonic3Synthesizer?
+
+    public init(
+        directory: URL? = nil,
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+    ) {
+        self.directory = directory
+        self.computeUnits = computeUnits
+    }
+
+    public var isAvailable: Bool { synthesizer != nil }
+
+    /// Convenience factory: download assets and return a ready-to-use manager.
+    public static func downloadAndCreate(
+        cacheDirectory: URL? = nil,
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+    ) async throws -> Supertonic3Manager {
+        let manager = Supertonic3Manager(
+            directory: cacheDirectory,
+            computeUnits: computeUnits)
+        try await manager.initialize()
+        return manager
+    }
+
+    /// Download (if missing) and load the four Supertonic-3 CoreML stages.
+    public func initialize() async throws {
+        if synthesizer != nil { return }
+
+        let store = Supertonic3ModelStore(
+            directory: directory, computeUnits: computeUnits)
+        try await store.loadIfNeeded()
+        let indexerURL = try await store.unicodeIndexerURL()
+        let processor = try Supertonic3UnicodeProcessor(unicodeIndexerURL: indexerURL)
+
+        self.store = store
+        self.synthesizer = Supertonic3Synthesizer(store: store, processor: processor)
+
+        logger.info("Supertonic-3 ready (compute units: \(computeUnits.description))")
+    }
+
+    // MARK: - Synthesis
+
+    /// Synthesize a 44.1 kHz mono Float32 utterance.
+    ///
+    /// - Parameters:
+    ///   - text: Source utterance. The text is NFKD-normalized and chunked
+    ///     internally; pass the full passage rather than pre-chunking it.
+    ///   - language: One of `Supertonic3Constants.availableLanguages` (31
+    ///     ISO codes + `"na"` for numeric / language-agnostic input).
+    ///   - style: Voice style loaded from a Supertonic preset JSON via
+    ///     `Supertonic3VoiceStyle.load(from:)`.
+    ///   - totalSteps: Denoising step count (default 8 — mirrors the
+    ///     reference CLI). Lower trades quality for latency.
+    ///   - speed: Speech-rate multiplier (default 1.05). Divides the
+    ///     predicted duration vector.
+    ///   - silenceDuration: Silence inserted between chunks when the text
+    ///     is split into multiple chunks. Default 0.3 s.
+    public func synthesize(
+        text: String,
+        language: String,
+        style: Supertonic3VoiceStyle,
+        totalSteps: Int = Supertonic3Constants.defaultTotalSteps,
+        speed: Float = Supertonic3Constants.defaultSpeed,
+        silenceDuration: Float = Supertonic3Constants.defaultSilenceDuration
+    ) async throws -> (samples: [Float], duration: Float) {
+        guard let synthesizer = synthesizer else {
+            throw Supertonic3Error.notInitialized
+        }
+        return try await synthesizer.synthesize(
+            text: text, language: language, style: style,
+            totalSteps: totalSteps, speed: speed,
+            silenceDuration: silenceDuration)
+    }
+
+    public func cleanup() async {
+        if let store = store { await store.unload() }
+        store = nil
+        synthesizer = nil
+    }
+}
+
+extension MLComputeUnits {
+    fileprivate var description: String {
+        switch self {
+        case .cpuOnly: return "cpuOnly"
+        case .cpuAndGPU: return "cpuAndGPU"
+        case .all: return "all"
+        case .cpuAndNeuralEngine: return "cpuAndNeuralEngine"
+        @unknown default: return "unknown"
+        }
+    }
+}

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// On-disk schema of the upstream `tts.json` config.
+///
+/// The reference Swift CLI only consumes two scalars from each section
+/// (`sample_rate`, `base_chunk_size`, `chunk_compress_factor`, `latent_dim`).
+/// The Swift port duplicates those fields here so a downloaded `tts.json`
+/// can override the compile-time defaults in `Supertonic3Constants` when
+/// FluidInference republishes a tuned variant.
+public struct Supertonic3Config: Codable, Sendable {
+
+    public struct AEConfig: Codable, Sendable {
+        public let sampleRate: Int
+        public let baseChunkSize: Int
+
+        public init(sampleRate: Int, baseChunkSize: Int) {
+            self.sampleRate = sampleRate
+            self.baseChunkSize = baseChunkSize
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case sampleRate = "sample_rate"
+            case baseChunkSize = "base_chunk_size"
+        }
+    }
+
+    public struct TTLConfig: Codable, Sendable {
+        public let chunkCompressFactor: Int
+        public let latentDim: Int
+
+        public init(chunkCompressFactor: Int, latentDim: Int) {
+            self.chunkCompressFactor = chunkCompressFactor
+            self.latentDim = latentDim
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case chunkCompressFactor = "chunk_compress_factor"
+            case latentDim = "latent_dim"
+        }
+    }
+
+    public let ae: AEConfig
+    public let ttl: TTLConfig
+
+    public init(ae: AEConfig, ttl: TTLConfig) {
+        self.ae = ae
+        self.ttl = ttl
+    }
+
+    /// Fallback config that matches `Supertonic3Constants` — used when the
+    /// caller cannot supply a `tts.json` (e.g. embedded resource scenarios).
+    public static let defaults = Supertonic3Config(
+        ae: .init(
+            sampleRate: Supertonic3Constants.sampleRate,
+            baseChunkSize: Supertonic3Constants.baseChunkSize),
+        ttl: .init(
+            chunkCompressFactor: Supertonic3Constants.chunkCompressFactor,
+            latentDim: Supertonic3Constants.latentDim))
+}
+
+/// On-disk schema of a Supertonic-3 voice style JSON file (the `M1` /
+/// `F1` / etc. presets shipped under `assets/voice_styles/` in the
+/// reference repo).
+///
+/// `style_ttl` feeds the text encoder + vector estimator; `style_dp` feeds
+/// the duration predictor. Both components encode the same 3-D tensor
+/// `[1, D1, D2]` as a nested array; `dims` records the original shape so
+/// the loader can validate against the model's expected input shape.
+public struct Supertonic3VoiceStyleData: Codable, Sendable {
+
+    public struct Component: Codable, Sendable {
+        public let data: [[[Float]]]
+        public let dims: [Int]
+        public let type: String
+
+        public init(data: [[[Float]]], dims: [Int], type: String) {
+            self.data = data
+            self.dims = dims
+            self.type = type
+        }
+    }
+
+    public let styleTtl: Component
+    public let styleDp: Component
+
+    public init(styleTtl: Component, styleDp: Component) {
+        self.styleTtl = styleTtl
+        self.styleDp = styleDp
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case styleTtl = "style_ttl"
+        case styleDp = "style_dp"
+    }
+}
+
+/// Decoded voice style ready to bind into CoreML feature dictionaries.
+///
+/// Both tensors are flattened row-major matching the dims `[bsz, D1, D2]`
+/// stored on disk. The synthesizer wraps these into `MLMultiArray` instances
+/// at call time so the same `Supertonic3VoiceStyle` can be shared across
+/// many synthesis calls without re-parsing the JSON.
+public struct Supertonic3VoiceStyle: Sendable {
+    public let name: String
+    public let ttlValues: [Float]
+    public let ttlDims: [Int]
+    public let dpValues: [Float]
+    public let dpDims: [Int]
+
+    public init(
+        name: String,
+        ttlValues: [Float],
+        ttlDims: [Int],
+        dpValues: [Float],
+        dpDims: [Int]
+    ) {
+        self.name = name
+        self.ttlValues = ttlValues
+        self.ttlDims = ttlDims
+        self.dpValues = dpValues
+        self.dpDims = dpDims
+    }
+
+    /// Decode a JSON-encoded voice style file into the flattened
+    /// representation expected by the synthesizer.
+    public static func load(from url: URL) throws -> Supertonic3VoiceStyle {
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw Supertonic3Error.voiceStyleLoadFailed(
+                path: url.path, underlying: "\(error)")
+        }
+        let decoded: Supertonic3VoiceStyleData
+        do {
+            decoded = try JSONDecoder().decode(Supertonic3VoiceStyleData.self, from: data)
+        } catch {
+            throw Supertonic3Error.voiceStyleLoadFailed(
+                path: url.path, underlying: "decode: \(error)")
+        }
+
+        let ttlFlat = flatten(decoded.styleTtl.data, dims: decoded.styleTtl.dims)
+        let dpFlat = flatten(decoded.styleDp.data, dims: decoded.styleDp.dims)
+
+        return Supertonic3VoiceStyle(
+            name: url.deletingPathExtension().lastPathComponent,
+            ttlValues: ttlFlat,
+            ttlDims: decoded.styleTtl.dims,
+            dpValues: dpFlat,
+            dpDims: decoded.styleDp.dims)
+    }
+
+    private static func flatten(_ data: [[[Float]]], dims: [Int]) -> [Float] {
+        var out: [Float] = []
+        let totalCount = dims.reduce(1, *)
+        out.reserveCapacity(totalCount)
+        for plane in data {
+            for row in plane {
+                out.append(contentsOf: row)
+            }
+        }
+        return out
+    }
+}

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
@@ -139,6 +139,17 @@ public struct Supertonic3VoiceStyle: Sendable {
                 path: url.path, underlying: "decode: \(error)")
         }
 
+        let expectedTtl = [1, Supertonic3Constants.ttlStyleTokens, Supertonic3Constants.ttlStyleDim]
+        if decoded.styleTtl.dims != expectedTtl {
+            throw Supertonic3Error.voiceStyleShapeMismatch(
+                component: "style_ttl", expected: expectedTtl, got: decoded.styleTtl.dims)
+        }
+        let expectedDp = [1, Supertonic3Constants.dpStyleTokens, Supertonic3Constants.dpStyleDim]
+        if decoded.styleDp.dims != expectedDp {
+            throw Supertonic3Error.voiceStyleShapeMismatch(
+                component: "style_dp", expected: expectedDp, got: decoded.styleDp.dims)
+        }
+
         let ttlFlat = flatten(decoded.styleTtl.data, dims: decoded.styleTtl.dims)
         let dpFlat = flatten(decoded.styleDp.data, dims: decoded.styleDp.dims)
 

--- a/Sources/FluidAudio/TTS/TtsBackend.swift
+++ b/Sources/FluidAudio/TTS/TtsBackend.swift
@@ -21,4 +21,10 @@ public enum TtsBackend: Sendable {
     /// > Callers with their own espeak-compatible phonemizer can bypass
     /// > the entire stack via `StyleTTS2Manager.synthesize(ipa:...)`.
     case styletts2
+    /// Supertonic-3 v1.7.3 — 4-stage CoreML pipeline:
+    /// `text_encoder → duration_predictor → vector_estimator (8-step
+    /// flow-matching diffusion with CFG) → vocoder`. Multilingual
+    /// (31 languages), 44.1 kHz mono output. Voice styling via per-voice
+    /// JSON (`style_ttl` / `style_dp` tensors).
+    case supertonic3
 }

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -81,6 +81,11 @@ public struct TTS {
         // Optional pre-computed IPA passed via `--ipa "…"`. Bypasses
         // CharsiuG2P entirely (the espeak-parity escape hatch).
         var styletts2Ipa: String? = nil
+        // Supertonic-3 args.
+        var supertonicLanguage: String = "en"
+        var supertonicVoiceStylePath: String? = nil
+        var supertonicTotalSteps: Int = Supertonic3Constants.defaultTotalSteps
+        var supertonicSpeed: Float = Supertonic3Constants.defaultSpeed
 
         var i = 0
         while i < arguments.count {
@@ -132,9 +137,31 @@ public struct TTS {
                         backend = .kokoroAne
                     case "styletts2", "style-tts2", "stts2":
                         backend = .styletts2
+                    case "supertonic3", "supertonic-3", "sup3":
+                        backend = .supertonic3
                     default:
                         logger.warning("Unknown backend '\(arguments[i + 1])'; using kokoro-ane")
                     }
+                    i += 1
+                }
+            case "--lang":
+                if i + 1 < arguments.count {
+                    supertonicLanguage = arguments[i + 1].lowercased()
+                    i += 1
+                }
+            case "--voice-style":
+                if i + 1 < arguments.count {
+                    supertonicVoiceStylePath = arguments[i + 1]
+                    i += 1
+                }
+            case "--total-steps":
+                if i + 1 < arguments.count, let v = Int(arguments[i + 1]) {
+                    supertonicTotalSteps = v
+                    i += 1
+                }
+            case "--speed":
+                if i + 1 < arguments.count, let v = Float(arguments[i + 1]) {
+                    supertonicSpeed = v
                     i += 1
                 }
             case "--alpha":
@@ -242,6 +269,12 @@ public struct TTS {
                 seed: styletts2Seed,
                 metricsPath: metricsPath,
                 cpuOnly: styletts2CpuOnly)
+        case .supertonic3:
+            await runSupertonic3(
+                text: text, output: output, language: supertonicLanguage,
+                voiceStylePath: supertonicVoiceStylePath,
+                totalSteps: supertonicTotalSteps, speed: supertonicSpeed,
+                metricsPath: metricsPath, cpuOnly: styletts2CpuOnly)
         }
     }
 
@@ -698,6 +731,98 @@ public struct TTS {
         }
     }
 
+    /// Run Supertonic-3 multilingual TTS. Requires a voice-style JSON
+    /// (any preset from `voice_styles/` in the HF repo, e.g. `M1.json`).
+    private static func runSupertonic3(
+        text: String, output: String, language: String,
+        voiceStylePath: String?,
+        totalSteps: Int, speed: Float,
+        metricsPath: String?, cpuOnly: Bool
+    ) async {
+        guard let voiceStylePath else {
+            logger.error(
+                "supertonic3 backend requires --voice-style <path/to/style.json>")
+            return
+        }
+        do {
+            let tStart = Date()
+            let computeUnits: MLComputeUnits = cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
+            let manager = Supertonic3Manager(computeUnits: computeUnits)
+
+            let tLoad0 = Date()
+            try await manager.initialize()
+            let tLoad1 = Date()
+
+            let voiceStyleURL = resolveInputURL(voiceStylePath)
+            let style = try Supertonic3VoiceStyle.load(from: voiceStyleURL)
+            logger.info("Supertonic-3 voice style: \(voiceStyleURL.path)")
+            logger.info(
+                "Supertonic-3 lang=\(language) totalSteps=\(totalSteps) "
+                    + "speed=\(String(format: "%.2f", speed))")
+
+            let tSynth0 = Date()
+            let result = try await manager.synthesize(
+                text: text, language: language, style: style,
+                totalSteps: totalSteps, speed: speed)
+            let tSynth1 = Date()
+
+            let outURL = resolveInputURL(output)
+            try FileManager.default.createDirectory(
+                at: outURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true)
+            let wav = try AudioWAV.data(
+                from: result.samples,
+                sampleRate: Double(Supertonic3Constants.sampleRate))
+            try wav.write(to: outURL)
+
+            let loadS = tLoad1.timeIntervalSince(tLoad0)
+            let synthS = tSynth1.timeIntervalSince(tSynth0)
+            let totalS = tSynth1.timeIntervalSince(tStart)
+            let audioSecs =
+                Double(result.samples.count) / Double(Supertonic3Constants.sampleRate)
+            let rtfx = synthS > 0 ? audioSecs / synthS : 0
+
+            logger.info("Supertonic-3 synthesis complete")
+            logger.info("  Load: \(String(format: "%.3f", loadS))s")
+            logger.info("  Synthesis: \(String(format: "%.3f", synthS))s")
+            logger.info("  Audio: \(String(format: "%.3f", audioSecs))s")
+            logger.info("  RTFx: \(String(format: "%.2f", rtfx))x")
+            logger.info("  Total: \(String(format: "%.3f", totalS))s")
+            logger.info("  Output: \(outURL.path)")
+
+            if let metricsPath {
+                let metricsDict: [String: Any] = [
+                    "backend": "supertonic3",
+                    "text": text,
+                    "language": language,
+                    "voice_style": voiceStyleURL.path,
+                    "total_steps": totalSteps,
+                    "speed": Double(speed),
+                    "output": outURL.path,
+                    "model_load_time_s": loadS,
+                    "inference_time_s": synthS,
+                    "audio_duration_s": audioSecs,
+                    "realtime_speed": rtfx,
+                    "total_time_s": totalS,
+                ]
+                let artifactsRoot = try ensureArtifactsRoot()
+                let mURL = resolveOutputURL(
+                    metricsPath, artifactsRoot: artifactsRoot, expectsDirectory: false)
+                try FileManager.default.createDirectory(
+                    at: mURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true)
+                let json = try JSONSerialization.data(
+                    withJSONObject: metricsDict, options: [.prettyPrinted])
+                try json.write(to: mURL)
+                logger.info("Metrics saved: \(mURL.path)")
+            }
+        } catch {
+            logger.error("Supertonic-3 Error: \(error)")
+            print("Supertonic-3 failed: \(error)")
+            exit(1)
+        }
+    }
+
     private static func printUsage() {
         print(
             """
@@ -706,13 +831,19 @@ public struct TTS {
             Options:
               --output, -o         Output WAV path (default: output.wav)
               --voice, -v          Voice name (default: af_heart for KokoroAne, alba for PocketTTS)
-              --backend            TTS backend: kokoro-ane (default), pocket, or styletts2
+              --backend            TTS backend: kokoro-ane (default), pocket, styletts2, supertonic3
                                    StyleTTS2 (zero-shot, English):
                                      --reference <speaker.wav>  required
                                      --alpha 0.3                ref-side blend (default 0.3)
                                      --beta 0.7                 prosody-side blend (default 0.7)
                                      --seed N                   RNG seed for fused sampler
                                      --ipa "…"                  bypass G2P, feed raw IPA
+                                   Supertonic-3 (multilingual, 31 langs, 44.1 kHz):
+                                     --voice-style <file.json>  required (e.g. voice_styles/M1.json)
+                                     --lang en                  ISO-639-1 language code (default en)
+                                     --total-steps 8            denoising step count (default 8)
+                                     --speed 1.05               duration multiplier (default 1.05)
+                                     --cpu-only                 disable Neural Engine
               --lexicon, -l        Custom pronunciation lexicon file (KokoroAne --variant zh only):
                                      word  pinyin1 pinyin2   (e.g. zi4 jie2)
                                      word  @bopomofo1        (escape: @-prefixed,

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -75,7 +75,7 @@ public struct TTS {
         // StyleTTS2 zero-shot args.
         var styletts2ReferencePath: String? = nil
         var styletts2Seed: UInt64 = 42
-        var styletts2CpuOnly: Bool = false
+        var cpuOnly: Bool = false
         var styletts2Alpha: Float = StyleTTS2Constants.defaultAlpha
         var styletts2Beta: Float = StyleTTS2Constants.defaultBeta
         // Optional pre-computed IPA passed via `--ipa "…"`. Bypasses
@@ -191,7 +191,7 @@ public struct TTS {
                     i += 1
                 }
             case "--cpu-only":
-                styletts2CpuOnly = true
+                cpuOnly = true
             case "--text":
                 if i + 1 < arguments.count {
                     text = arguments[i + 1]
@@ -268,13 +268,13 @@ public struct TTS {
                 alpha: styletts2Alpha, beta: styletts2Beta,
                 seed: styletts2Seed,
                 metricsPath: metricsPath,
-                cpuOnly: styletts2CpuOnly)
+                cpuOnly: cpuOnly)
         case .supertonic3:
             await runSupertonic3(
                 text: text, output: output, language: supertonicLanguage,
                 voiceStylePath: supertonicVoiceStylePath,
                 totalSteps: supertonicTotalSteps, speed: supertonicSpeed,
-                metricsPath: metricsPath, cpuOnly: styletts2CpuOnly)
+                metricsPath: metricsPath, cpuOnly: cpuOnly)
         }
     }
 

--- a/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
@@ -14,6 +14,7 @@ import Foundation
 ///   pocket-tts    — streaming flow-matching (no per-stage timings)
 ///   magpie        — encoder-decoder + NanoCodec (6-stage timings, slow)
 ///   styletts2     — LibriTTS iteration_3, zero-shot w/ reference audio
+///   supertonic3   — 4-stage multilingual flow-matching diffusion (31 langs)
 ///
 /// Usage:
 ///   fluidaudio tts-benchmark --backend kokoro-ane \
@@ -107,6 +108,9 @@ public enum TtsBenchmarkCommand {
         var cohereComputeUnitsArg: String?
         var referencePath: String?
         var variantArg: String?
+        var voiceStylePath: String?
+        var totalStepsArg: Int?
+        var speedArg: Float?
 
         var i = 0
         while i < arguments.count {
@@ -187,6 +191,21 @@ public enum TtsBenchmarkCommand {
             case "--variant":
                 if i + 1 < arguments.count {
                     variantArg = arguments[i + 1]
+                    i += 1
+                }
+            case "--voice-style":
+                if i + 1 < arguments.count {
+                    voiceStylePath = arguments[i + 1]
+                    i += 1
+                }
+            case "--total-steps":
+                if i + 1 < arguments.count {
+                    totalStepsArg = Int(arguments[i + 1])
+                    i += 1
+                }
+            case "--speed":
+                if i + 1 < arguments.count {
+                    speedArg = Float(arguments[i + 1])
                     i += 1
                 }
             case "--help", "-h":
@@ -279,6 +298,16 @@ public enum TtsBenchmarkCommand {
                 try await runStyleTTS2(
                     phrases: phrases, corpusLabel: corpusLabel,
                     referencePath: referencePath,
+                    preset: preset, outputJson: outputJson, audioDir: audioDir,
+                    asrChoice: asrChoice)
+            case .supertonic3:
+                try await runSupertonic3(
+                    phrases: phrases, corpusLabel: corpusLabel,
+                    voiceStylePath: voiceStylePath,
+                    languageName: languageName,
+                    totalSteps: totalStepsArg
+                        ?? Supertonic3Constants.defaultTotalSteps,
+                    speed: speedArg ?? Supertonic3Constants.defaultSpeed,
                     preset: preset, outputJson: outputJson, audioDir: audioDir,
                     asrChoice: asrChoice)
             }
@@ -586,6 +615,103 @@ public enum TtsBenchmarkCommand {
         }
     }
 
+    // MARK: - Supertonic-3 driver
+
+    private static func runSupertonic3(
+        phrases: [(category: String, text: String)],
+        corpusLabel: String,
+        voiceStylePath: String?,
+        languageName: String?,
+        totalSteps: Int,
+        speed: Float,
+        preset: TtsComputeUnitPreset,
+        outputJson: String?,
+        audioDir: String?,
+        asrChoice: AsrChoice
+    ) async throws {
+        guard let voiceStylePath, !voiceStylePath.isEmpty else {
+            logger.error(
+                "supertonic3 backend requires --voice-style <path-to-voice.json> "
+                    + "(e.g. M1.json from FluidInference/supertonic-3-coreml).")
+            exit(1)
+        }
+        let voiceURL = resolveURL(voiceStylePath, isDirectory: false)
+        guard FileManager.default.fileExists(atPath: voiceURL.path) else {
+            logger.error("Voice style JSON not found: \(voiceURL.path)")
+            exit(1)
+        }
+        let style: Supertonic3VoiceStyle
+        do {
+            style = try Supertonic3VoiceStyle.load(from: voiceURL)
+        } catch {
+            logger.error("Failed to load voice style: \(error.localizedDescription)")
+            exit(1)
+        }
+
+        let language = resolveSupertonic3Language(
+            explicit: languageName, corpus: corpusLabel)
+        logger.info(
+            "Supertonic-3 voice=\(style.name) lang=\(language) "
+                + "steps=\(totalSteps) speed=\(speed)")
+
+        let units = preset.uniformUnits ?? .cpuAndNeuralEngine
+        let manager = Supertonic3Manager(computeUnits: units)
+
+        let coldStart = Date()
+        try await manager.initialize()
+        let coldStartS = Date().timeIntervalSince(coldStart)
+        logger.info(String(format: "Cold start (initialize): %.2fs", coldStartS))
+
+        let firstStart = Date()
+        _ = try await manager.synthesize(
+            text: "Initialization warm-up.",
+            language: language,
+            style: style,
+            totalSteps: totalSteps,
+            speed: speed)
+        let firstSynthMs = Date().timeIntervalSince(firstStart) * 1000
+        logger.info(String(format: "First synth: %.0f ms", firstSynthMs))
+
+        try await runPhraseLoop(
+            backendId: "supertonic3",
+            voiceLabel: style.name,
+            corpusLabel: corpusLabel,
+            phrases: phrases,
+            preset: preset,
+            coldStartS: coldStartS,
+            firstSynthMs: firstSynthMs,
+            outputJson: outputJson,
+            audioDir: audioDir,
+            asrChoice: asrChoice,
+            extraSummary: [
+                "voice_style": style.name,
+                "language": language,
+                "total_steps": totalSteps,
+                "speed": Double(speed),
+            ]
+        ) { text in
+            // Supertonic-3 is a one-shot diffusion synthesizer — `synthesize`
+            // returns the full waveform after the 8-step vector_estimator
+            // loop completes, so TTFT == synthMs (no incremental yield).
+            let t0 = Date()
+            let result = try await manager.synthesize(
+                text: text, language: language, style: style,
+                totalSteps: totalSteps, speed: speed)
+            let synthMs = Date().timeIntervalSince(t0) * 1000
+            return BackendPhraseSample(
+                synthMs: synthMs,
+                ttftMs: synthMs,
+                samples: result.samples,
+                sampleRate: Supertonic3Constants.sampleRate,
+                stageMs: [:],
+                extraFields: [
+                    "total_steps": totalSteps,
+                    "speed": Double(speed),
+                ]
+            )
+        }
+    }
+
     // MARK: - Shared per-phrase loop + summary
 
     private static func runPhraseLoop(
@@ -850,6 +976,7 @@ public enum TtsBenchmarkCommand {
         case pocketTts
         case magpie
         case styleTts2
+        case supertonic3
 
         var defaultCorpus: String {
             return "minimax-english"
@@ -866,6 +993,8 @@ public enum TtsBenchmarkCommand {
             return .magpie
         case "styletts2", "style-tts2", "styletts", "style-tts":
             return .styleTts2
+        case "supertonic3", "supertonic-3", "sup3", "supertonic":
+            return .supertonic3
         default:
             logger.warning("Unknown backend '\(name)' — defaulting to kokoro-ane")
             return .kokoroAne
@@ -896,6 +1025,57 @@ public enum TtsBenchmarkCommand {
         default: return .john
         }
     }
+
+    /// Map an explicit `--language` flag or a `minimax-<lang>` corpus name
+    /// onto one of the 31 ISO codes accepted by Supertonic-3
+    /// (`Supertonic3Constants.availableLanguages`). Falls back to English.
+    private static func resolveSupertonic3Language(
+        explicit: String?, corpus: String
+    ) -> String {
+        if let explicit, !explicit.isEmpty {
+            let lower = explicit.lowercased()
+            if Supertonic3Constants.availableLanguages.contains(lower) {
+                return lower
+            }
+            if let mapped = supertonic3LanguageAliases[lower] {
+                return mapped
+            }
+        }
+        let lower = corpus.lowercased()
+        for (needle, code) in supertonic3CorpusToLanguage where lower.contains(needle) {
+            return code
+        }
+        return "en"
+    }
+
+    /// Long-name → ISO code aliases for the `--language` flag.
+    private static let supertonic3LanguageAliases: [String: String] = [
+        "english": "en", "korean": "ko", "japanese": "ja", "arabic": "ar",
+        "bulgarian": "bg", "czech": "cs", "danish": "da", "german": "de",
+        "greek": "el", "spanish": "es", "estonian": "et", "finnish": "fi",
+        "french": "fr", "hindi": "hi", "croatian": "hr", "hungarian": "hu",
+        "indonesian": "id", "italian": "it", "lithuanian": "lt",
+        "latvian": "lv", "dutch": "nl", "polish": "pl", "portuguese": "pt",
+        "romanian": "ro", "russian": "ru", "slovak": "sk", "slovenian": "sl",
+        "swedish": "sv", "turkish": "tr", "ukrainian": "uk",
+        "vietnamese": "vi",
+    ]
+
+    /// Ordered scan list for `minimax-<lang>` corpus labels — longest /
+    /// least-ambiguous matches first.
+    private static let supertonic3CorpusToLanguage: [(String, String)] = [
+        ("korean", "ko"), ("japanese", "ja"), ("arabic", "ar"),
+        ("bulgarian", "bg"), ("czech", "cs"), ("danish", "da"),
+        ("german", "de"), ("greek", "el"), ("spanish", "es"),
+        ("estonian", "et"), ("finnish", "fi"), ("french", "fr"),
+        ("hindi", "hi"), ("croatian", "hr"), ("hungarian", "hu"),
+        ("indonesian", "id"), ("italian", "it"), ("lithuanian", "lt"),
+        ("latvian", "lv"), ("dutch", "nl"), ("polish", "pl"),
+        ("portuguese", "pt"), ("romanian", "ro"), ("russian", "ru"),
+        ("slovak", "sk"), ("slovenian", "sl"), ("swedish", "sv"),
+        ("turkish", "tr"), ("ukrainian", "uk"), ("vietnamese", "vi"),
+        ("english", "en"),
+    ]
 
     private static func parseKokoroAneVariant(_ name: String?) -> KokoroAneVariant {
         switch name?.lowercased() {
@@ -1155,6 +1335,8 @@ public enum TtsBenchmarkCommand {
               pocket-tts    Streaming flow-matching (multilingual)
               magpie        Encoder-decoder + NanoCodec (per-stage, slow)
               styletts2     LibriTTS iteration_3, zero-shot, requires --reference
+              supertonic3   4-stage multilingual flow-matching (31 langs);
+                            requires --voice-style <preset.json>
 
             Options:
               --backend <name>          See list above (default: kokoro-ane)
@@ -1199,6 +1381,14 @@ public enum TtsBenchmarkCommand {
                                         resampled to 24 kHz mono internally)
               --variant <name>          Kokoro ANE variant: english (default) or
                                         mandarin (aliases: zh, chinese)
+              --voice-style <path>      Supertonic-3 voice style JSON
+                                        (required for --backend supertonic3;
+                                        e.g. M1.json shipped under
+                                        FluidInference/supertonic-3-coreml).
+              --total-steps <n>         Supertonic-3 denoising steps
+                                        (default 8 — matches reference CLI).
+              --speed <f>               Supertonic-3 speech-rate multiplier
+                                        (default 1.05; divides duration).
               --help, -h                Show this help
 
             Examples:
@@ -1208,6 +1398,8 @@ public enum TtsBenchmarkCommand {
               fluidaudio tts-benchmark --backend pocket-tts --corpus minimax-german --language german
               fluidaudio tts-benchmark --backend magpie --speaker sofia --language en
               fluidaudio tts-benchmark --backend styletts2 --reference speaker.wav
+              fluidaudio tts-benchmark --backend supertonic3 \\
+                  --voice-style M1.json --corpus minimax-english
 
             Notes:
               For Chinese (zh) and Japanese (ja), WER is meaningless because

--- a/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3LatentSamplerTests.swift
+++ b/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3LatentSamplerTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+
+@testable import FluidAudio
+
+final class Supertonic3LatentSamplerTests: XCTestCase {
+
+    // MARK: - mask()
+
+    func testMaskShapeAndOnesPerRow() {
+        let m = Supertonic3LatentSampler.mask(lengths: [3, 1, 5], maxLen: 5)
+        XCTAssertEqual(m.count, 3 * 5)
+        // Row 0: three ones then two zeros.
+        XCTAssertEqual(Array(m[0..<5]), [1, 1, 1, 0, 0])
+        XCTAssertEqual(Array(m[5..<10]), [1, 0, 0, 0, 0])
+        XCTAssertEqual(Array(m[10..<15]), [1, 1, 1, 1, 1])
+    }
+
+    func testMaskClampsLengthAtMaxLen() {
+        let m = Supertonic3LatentSampler.mask(lengths: [9], maxLen: 4)
+        XCTAssertEqual(m, [1, 1, 1, 1])
+    }
+
+    // MARK: - sampleNoisyLatent()
+
+    func testNoisyLatentDimensions() {
+        // 1 s of audio at 44.1 kHz with baseChunkSize 512 and chunkCompress 6
+        // → chunkSize 3072, latentLen ceil(44100 / 3072) = 15.
+        let (noisy, mask, dims) = Supertonic3LatentSampler.sampleNoisyLatent(
+            durations: [1.0],
+            sampleRate: 44_100,
+            baseChunkSize: 512,
+            chunkCompress: 6,
+            latentDim: 24,
+            rng: { 0.5 })
+        XCTAssertEqual(dims.bsz, 1)
+        XCTAssertEqual(dims.channels, 24 * 6)
+        XCTAssertEqual(dims.length, 15)
+        XCTAssertEqual(noisy.count, dims.bsz * dims.channels * dims.length)
+        XCTAssertEqual(mask.count, dims.bsz * dims.length)
+    }
+
+    func testSeededRngProducesDeterministicOutput() {
+        // Deterministic RNG → identical buffers across runs (Box-Muller is
+        // pure given the same uniform sequence).
+        let stream: [Float] = (0..<10_000).map { Float(($0 + 7) % 97) / 97.0 }
+        var idxA = 0
+        var idxB = 0
+        let (a, _, _) = Supertonic3LatentSampler.sampleNoisyLatent(
+            durations: [0.2], sampleRate: 44_100,
+            baseChunkSize: 512, chunkCompress: 6, latentDim: 24,
+            rng: {
+                defer { idxA += 1 }
+                return stream[idxA % stream.count]
+            })
+        let (b, _, _) = Supertonic3LatentSampler.sampleNoisyLatent(
+            durations: [0.2], sampleRate: 44_100,
+            baseChunkSize: 512, chunkCompress: 6, latentDim: 24,
+            rng: {
+                defer { idxB += 1 }
+                return stream[idxB % stream.count]
+            })
+        XCTAssertEqual(a.count, b.count)
+        XCTAssertEqual(a, b)
+    }
+
+    func testPaddingPositionsAreZeroed() {
+        // Batch of two utterances where one is shorter; padding columns
+        // beyond the shorter utterance's valid length must be zero.
+        let (noisy, _, dims) = Supertonic3LatentSampler.sampleNoisyLatent(
+            durations: [0.2, 0.6],
+            sampleRate: 44_100,
+            baseChunkSize: 512,
+            chunkCompress: 6,
+            latentDim: 24,
+            rng: { 0.5 })
+        let chunkSize = 512 * 6
+        let shortValid = (Int(0.2 * 44_100) + chunkSize - 1) / chunkSize
+        let row0Start = 0
+        // Sample channel 0, padding column shortValid..<dims.length must be 0.
+        for t in shortValid..<dims.length {
+            XCTAssertEqual(
+                noisy[row0Start + t], 0,
+                "padding position \(t) for short utterance must be zero")
+        }
+    }
+
+    func testEmptyDurationsProducesEmptyTensors() {
+        let (noisy, mask, dims) = Supertonic3LatentSampler.sampleNoisyLatent(
+            durations: [],
+            sampleRate: 44_100,
+            baseChunkSize: 512,
+            chunkCompress: 6,
+            latentDim: 24,
+            rng: { 0.5 })
+        XCTAssertEqual(dims.bsz, 0)
+        XCTAssertEqual(noisy, [])
+        XCTAssertEqual(mask, [])
+    }
+}

--- a/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3MultiArrayTests.swift
+++ b/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3MultiArrayTests.swift
@@ -1,0 +1,88 @@
+import CoreML
+import XCTest
+
+@testable import FluidAudio
+
+final class Supertonic3MultiArrayTests: XCTestCase {
+
+    // MARK: - Float32 round-trip
+
+    func testMakeFloat32RoundTripsValuesAndShape() throws {
+        let values: [Float] = [1, 2, 3, 4, 5, 6]
+        let arr = try Supertonic3MultiArray.makeFloat32(values, shape: [1, 2, 3])
+        XCTAssertEqual(arr.dataType, .float32)
+        XCTAssertEqual(arr.shape.map { $0.intValue }, [1, 2, 3])
+        XCTAssertEqual(Supertonic3MultiArray.extractFloats(arr), values)
+    }
+
+    // MARK: - Int32 round-trip
+
+    func testMakeInt32RoundTripsValuesAndShape() throws {
+        let values: [Int32] = [10, 20, 30, 40]
+        let arr = try Supertonic3MultiArray.makeInt32(values, shape: [4])
+        XCTAssertEqual(arr.dataType, .int32)
+        XCTAssertEqual(arr.shape.map { $0.intValue }, [4])
+        XCTAssertEqual(Supertonic3MultiArray.extractFloats(arr), [10, 20, 30, 40])
+    }
+
+    // MARK: - Shape mismatch
+
+    func testMakeFloat32ThrowsOnShapeMismatch() {
+        XCTAssertThrowsError(
+            try Supertonic3MultiArray.makeFloat32([1, 2, 3], shape: [2, 2])
+        ) { err in
+            guard case Supertonic3Error.invalidTensorShape(let stage, _, _) = err else {
+                XCTFail("expected invalidTensorShape, got \(err)")
+                return
+            }
+            XCTAssertEqual(stage, "makeFloat32")
+        }
+    }
+
+    func testMakeInt32ThrowsOnShapeMismatch() {
+        XCTAssertThrowsError(
+            try Supertonic3MultiArray.makeInt32([1, 2], shape: [3])
+        ) { err in
+            guard case Supertonic3Error.invalidTensorShape(let stage, _, _) = err else {
+                XCTFail("expected invalidTensorShape, got \(err)")
+                return
+            }
+            XCTAssertEqual(stage, "makeInt32")
+        }
+    }
+
+    // MARK: - extractFloats coverage
+
+    func testExtractFloatsFromInt32BackingStore() throws {
+        let arr = try MLMultiArray(shape: [3], dataType: .int32)
+        let dst = arr.dataPointer.bindMemory(to: Int32.self, capacity: 3)
+        dst[0] = -1
+        dst[1] = 0
+        dst[2] = 7
+        XCTAssertEqual(Supertonic3MultiArray.extractFloats(arr), [-1, 0, 7])
+    }
+
+    func testExtractFloatsFromDoubleBackingStore() throws {
+        let arr = try MLMultiArray(shape: [3], dataType: .double)
+        let dst = arr.dataPointer.bindMemory(to: Double.self, capacity: 3)
+        dst[0] = 1.5
+        dst[1] = -2.5
+        dst[2] = 0
+        XCTAssertEqual(Supertonic3MultiArray.extractFloats(arr), [1.5, -2.5, 0])
+    }
+
+    #if arch(arm64)
+    func testExtractFloatsFromFloat16BackingStore() throws {
+        let arr = try MLMultiArray(shape: [3], dataType: .float16)
+        let dst = arr.dataPointer.bindMemory(to: Float16.self, capacity: 3)
+        dst[0] = Float16(1.0)
+        dst[1] = Float16(-0.5)
+        dst[2] = Float16(2.0)
+        let out = Supertonic3MultiArray.extractFloats(arr)
+        XCTAssertEqual(out.count, 3)
+        XCTAssertEqual(out[0], 1.0, accuracy: 1e-3)
+        XCTAssertEqual(out[1], -0.5, accuracy: 1e-3)
+        XCTAssertEqual(out[2], 2.0, accuracy: 1e-3)
+    }
+    #endif
+}

--- a/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3TextChunkerTests.swift
+++ b/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3TextChunkerTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+@testable import FluidAudio
+
+final class Supertonic3TextChunkerTests: XCTestCase {
+
+    // MARK: - Trivial inputs
+
+    func testEmptyInputReturnsNoChunks() {
+        XCTAssertEqual(Supertonic3TextChunker.chunk(text: "", maxLen: 110), [])
+        XCTAssertEqual(Supertonic3TextChunker.chunk(text: "   \n   ", maxLen: 110), [])
+    }
+
+    func testShortInputReturnsSingleChunkUnchanged() {
+        let chunks = Supertonic3TextChunker.chunk(
+            text: "Hello there.", maxLen: 110)
+        XCTAssertEqual(chunks, ["Hello there."])
+    }
+
+    func testInputAtMaxLenBoundaryFitsInOneChunk() {
+        let text = String(repeating: "a", count: 110)
+        let chunks = Supertonic3TextChunker.chunk(text: text, maxLen: 110)
+        XCTAssertEqual(chunks.count, 1)
+        XCTAssertEqual(chunks.first?.count, 110)
+    }
+
+    // MARK: - Sentence packing
+
+    func testSentencesAreCombinedUpToMaxLen() {
+        let text = "One. Two. Three. Four."
+        let chunks = Supertonic3TextChunker.chunk(text: text, maxLen: 110)
+        XCTAssertEqual(chunks.count, 1)
+    }
+
+    func testLongSentenceTriggersBoundarySplit() {
+        // Two sentences of ~60 chars each — together exceed maxLen=80, so the
+        // packer should emit two chunks, one per sentence.
+        let sentenceA = String(repeating: "a", count: 60) + "."
+        let sentenceB = String(repeating: "b", count: 60) + "."
+        let chunks = Supertonic3TextChunker.chunk(
+            text: "\(sentenceA) \(sentenceB)", maxLen: 80)
+        XCTAssertEqual(chunks.count, 2)
+        XCTAssertTrue(chunks.allSatisfy { $0.count <= 80 })
+    }
+
+    // MARK: - Abbreviation awareness
+
+    func testAbbreviationDoesNotSplitMidSentence() {
+        // "Dr." should not be treated as a sentence terminator. The packer
+        // should keep "Dr. Smith arrived early." as one sentence.
+        let chunks = Supertonic3TextChunker.chunk(
+            text: "Dr. Smith arrived early. Then he left.", maxLen: 110)
+        XCTAssertEqual(chunks.count, 1)
+        XCTAssertTrue(chunks[0].contains("Dr. Smith"))
+        XCTAssertTrue(chunks[0].contains("Then he left."))
+    }
+
+    // MARK: - Comma fallback
+
+    func testLongSentenceFallsBackToCommaBoundaries() {
+        let parts = (0..<6).map { _ in String(repeating: "x", count: 18) }
+        let sentence = parts.joined(separator: ", ") + "."
+        let chunks = Supertonic3TextChunker.chunk(text: sentence, maxLen: 50)
+        XCTAssertGreaterThan(chunks.count, 1)
+        XCTAssertTrue(chunks.allSatisfy { $0.count <= 50 })
+    }
+
+    // MARK: - Word fallback
+
+    func testVeryLongCommaFreeRunFallsBackToWordBoundaries() {
+        let words = Array(repeating: "word", count: 40)
+        let sentence = words.joined(separator: " ") + "."
+        let chunks = Supertonic3TextChunker.chunk(text: sentence, maxLen: 30)
+        XCTAssertGreaterThan(chunks.count, 1)
+        XCTAssertTrue(chunks.allSatisfy { $0.count <= 30 })
+    }
+
+    // MARK: - Paragraph split (blank-line boundary)
+
+    func testParagraphsAreSplitOnBlankLines() {
+        let text = "First paragraph.\n\nSecond paragraph."
+        let chunks = Supertonic3TextChunker.chunk(text: text, maxLen: 110)
+        XCTAssertEqual(chunks.count, 2)
+        XCTAssertEqual(chunks[0], "First paragraph.")
+        XCTAssertEqual(chunks[1], "Second paragraph.")
+    }
+}

--- a/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3TypesTests.swift
+++ b/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3TypesTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+
+@testable import FluidAudio
+
+final class Supertonic3TypesTests: XCTestCase {
+
+    // MARK: - Supertonic3Config
+
+    func testDefaultsMatchCompileTimeConstants() {
+        let cfg = Supertonic3Config.defaults
+        XCTAssertEqual(cfg.ae.sampleRate, Supertonic3Constants.sampleRate)
+        XCTAssertEqual(cfg.ae.baseChunkSize, Supertonic3Constants.baseChunkSize)
+        XCTAssertEqual(cfg.ttl.chunkCompressFactor, Supertonic3Constants.chunkCompressFactor)
+        XCTAssertEqual(cfg.ttl.latentDim, Supertonic3Constants.latentDim)
+    }
+
+    func testConfigDecodesUpstreamSnakeCaseJSON() throws {
+        let json = """
+            {
+              "ae":  { "sample_rate": 44100, "base_chunk_size": 512 },
+              "ttl": { "chunk_compress_factor": 6, "latent_dim": 24 }
+            }
+            """.data(using: .utf8)!
+        let cfg = try JSONDecoder().decode(Supertonic3Config.self, from: json)
+        XCTAssertEqual(cfg.ae.sampleRate, 44_100)
+        XCTAssertEqual(cfg.ae.baseChunkSize, 512)
+        XCTAssertEqual(cfg.ttl.chunkCompressFactor, 6)
+        XCTAssertEqual(cfg.ttl.latentDim, 24)
+    }
+
+    // MARK: - Supertonic3VoiceStyle
+
+    func testVoiceStyleLoadsAndFlattensCorrectShapes() throws {
+        // Construct the smallest valid voice-style JSON: `[1, 50, 256]` ttl
+        // and `[1, 8, 16]` dp (matching Supertonic3Constants). Fill with a
+        // deterministic ramp so we can verify flatten order is plane→row→col.
+        let ttlTokens = Supertonic3Constants.ttlStyleTokens
+        let ttlDim = Supertonic3Constants.ttlStyleDim
+        let dpTokens = Supertonic3Constants.dpStyleTokens
+        let dpDim = Supertonic3Constants.dpStyleDim
+        let ttl: [[[Float]]] = [
+            (0..<ttlTokens).map { row in
+                (0..<ttlDim).map { col in Float(row * ttlDim + col) }
+            }
+        ]
+        let dp: [[[Float]]] = [
+            (0..<dpTokens).map { row in
+                (0..<dpDim).map { col in Float(row * dpDim + col) }
+            }
+        ]
+        let payload: [String: Any] = [
+            "style_ttl": ["data": ttl, "dims": [1, ttlTokens, ttlDim], "type": "float32"],
+            "style_dp": ["data": dp, "dims": [1, dpTokens, dpDim], "type": "float32"],
+        ]
+        let json = try JSONSerialization.data(withJSONObject: payload)
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("supertonic3_voice_style_\(UUID().uuidString).json")
+        try json.write(to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let style = try Supertonic3VoiceStyle.load(from: tmp)
+        XCTAssertEqual(style.ttlDims, [1, ttlTokens, ttlDim])
+        XCTAssertEqual(style.ttlValues.count, ttlTokens * ttlDim)
+        XCTAssertEqual(style.ttlValues.first, 0)
+        XCTAssertEqual(style.ttlValues.last, Float((ttlTokens - 1) * ttlDim + (ttlDim - 1)))
+        XCTAssertEqual(style.dpDims, [1, dpTokens, dpDim])
+        XCTAssertEqual(style.dpValues.count, dpTokens * dpDim)
+        XCTAssertFalse(style.name.isEmpty)
+    }
+
+    func testVoiceStyleRejectsWrongTtlShape() throws {
+        let json = """
+            {
+              "style_ttl": {
+                "data": [[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]],
+                "dims": [1, 2, 3],
+                "type": "float32"
+              },
+              "style_dp": {
+                "data": [[[7.0, 8.0]]],
+                "dims": [1, 1, 2],
+                "type": "float32"
+              }
+            }
+            """.data(using: .utf8)!
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("supertonic3_voice_style_bad_\(UUID().uuidString).json")
+        try json.write(to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        XCTAssertThrowsError(try Supertonic3VoiceStyle.load(from: tmp)) { err in
+            guard case Supertonic3Error.voiceStyleShapeMismatch(let component, _, _) = err else {
+                XCTFail("expected voiceStyleShapeMismatch, got \(err)")
+                return
+            }
+            XCTAssertEqual(component, "style_ttl")
+        }
+    }
+
+    func testVoiceStyleLoadFromMissingFileThrows() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("supertonic3_does_not_exist_\(UUID().uuidString).json")
+        XCTAssertThrowsError(try Supertonic3VoiceStyle.load(from: missing)) { err in
+            guard case Supertonic3Error.voiceStyleLoadFailed = err else {
+                XCTFail("expected voiceStyleLoadFailed, got \(err)")
+                return
+            }
+        }
+    }
+
+    func testVoiceStyleLoadFromMalformedJSONThrows() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("supertonic3_bad_\(UUID().uuidString).json")
+        try Data("{ not valid json".utf8).write(to: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        XCTAssertThrowsError(try Supertonic3VoiceStyle.load(from: tmp)) { err in
+            guard case Supertonic3Error.voiceStyleLoadFailed = err else {
+                XCTFail("expected voiceStyleLoadFailed, got \(err)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Constants invariants
+
+    func testCJKLanguagesMatchAvailableLanguagesSubset() {
+        for code in Supertonic3Constants.cjkLanguages {
+            XCTAssertTrue(
+                Supertonic3Constants.availableLanguages.contains(code),
+                "CJK code \(code) must appear in availableLanguages")
+        }
+    }
+
+    func testMaxChunkLengthCJKIsTighterThanLatin() {
+        XCTAssertLessThan(
+            Supertonic3Constants.maxChunkLengthCJK,
+            Supertonic3Constants.maxChunkLengthLatin)
+    }
+}

--- a/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3UnicodeProcessorTests.swift
+++ b/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3UnicodeProcessorTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+
+@testable import FluidAudio
+
+final class Supertonic3UnicodeProcessorTests: XCTestCase {
+
+    // MARK: - preprocess()
+
+    func testWrapsTextWithLangTags() {
+        let out = Supertonic3UnicodeProcessor.preprocess(text: "hello", lang: "en")
+        XCTAssertEqual(out, "<en>hello.</en>")
+    }
+
+    func testAppendsPeriodWhenMissingTerminalPunctuation() {
+        let out = Supertonic3UnicodeProcessor.preprocess(text: "hello world", lang: "en")
+        XCTAssertTrue(out.hasSuffix(".</en>"))
+    }
+
+    func testDoesNotAppendPeriodWhenAlreadyTerminated() {
+        XCTAssertEqual(
+            Supertonic3UnicodeProcessor.preprocess(text: "hello!", lang: "en"),
+            "<en>hello!</en>")
+        XCTAssertEqual(
+            Supertonic3UnicodeProcessor.preprocess(text: "hello?", lang: "en"),
+            "<en>hello?</en>")
+        XCTAssertEqual(
+            Supertonic3UnicodeProcessor.preprocess(text: "hello.", lang: "en"),
+            "<en>hello.</en>")
+    }
+
+    func testStripsEmojiCodepoints() {
+        // U+1F600 GRINNING FACE — should be removed.
+        let out = Supertonic3UnicodeProcessor.preprocess(text: "hi \u{1F600} there", lang: "en")
+        XCTAssertFalse(out.unicodeScalars.contains { $0.value == 0x1F600 })
+        XCTAssertTrue(out.contains("hi"))
+        XCTAssertTrue(out.contains("there"))
+    }
+
+    func testReplacesSmartQuotesAndDashes() {
+        let out = Supertonic3UnicodeProcessor.preprocess(
+            text: "she said \u{201C}hi\u{201D} \u{2014} then left", lang: "en")
+        XCTAssertFalse(out.contains("\u{201C}"))
+        XCTAssertFalse(out.contains("\u{201D}"))
+        XCTAssertFalse(out.contains("\u{2014}"))
+        XCTAssertTrue(out.contains("\""))
+        XCTAssertTrue(out.contains("-"))
+    }
+
+    func testExpandsAtSymbolAndCommonAbbreviations() {
+        let out = Supertonic3UnicodeProcessor.preprocess(
+            text: "ping me @ ten, e.g., now", lang: "en")
+        XCTAssertTrue(out.contains(" at "))
+        XCTAssertTrue(out.contains("for example,"))
+    }
+
+    func testDropsDecorativeSymbols() {
+        let out = Supertonic3UnicodeProcessor.preprocess(
+            text: "love \u{2665} you \u{2606}", lang: "en")
+        XCTAssertFalse(out.contains("\u{2665}"))
+        XCTAssertFalse(out.contains("\u{2606}"))
+    }
+
+    func testCollapsesRepeatedQuotesAndWhitespace() {
+        let out = Supertonic3UnicodeProcessor.preprocess(
+            text: "hello   ''world''", lang: "en")
+        XCTAssertFalse(out.contains("  "))  // no double space
+        XCTAssertFalse(out.contains("''"))  // no doubled apostrophes
+    }
+
+    // MARK: - mask()
+
+    func testMaskShapeAndOnesPerRowMatchLengths() {
+        let m = Supertonic3UnicodeProcessor.mask(from: [3, 5, 0], maxLen: 6)
+        XCTAssertEqual(m.count, 3)
+        XCTAssertTrue(m.allSatisfy { $0.count == 1 && $0[0].count == 6 })
+        XCTAssertEqual(m[0][0], [1, 1, 1, 0, 0, 0])
+        XCTAssertEqual(m[1][0], [1, 1, 1, 1, 1, 0])
+        XCTAssertEqual(m[2][0], [0, 0, 0, 0, 0, 0])
+    }
+
+    func testMaskClampsLengthAtMaxLen() {
+        let m = Supertonic3UnicodeProcessor.mask(from: [20], maxLen: 4)
+        XCTAssertEqual(m[0][0], [1, 1, 1, 1])
+    }
+}


### PR DESCRIPTION
## Summary

Lands [supertone-inc/supertonic](https://github.com/supertone-inc/supertonic) v1.7.3 in FluidAudio as a 4-stage CoreML pipeline (TextEncoder → DurationPredictor → VectorEstimator ×8 denoising → Vocoder, 44.1 kHz Float32 mono, 31 ISO codes, voice styling via per-speaker JSON tensors).

 
1. **Schema fixes** to align the Swift port with the published [`FluidInference/supertonic-3-coreml`](https://huggingface.co/FluidInference/supertonic-3-coreml) bundle — mlmodelc filename casing (UpperCamelCase), vocoder output key (`wav`, not `wav_tts`), `text_ids`/`text_mask` padding to fixed T=128, chunker caps (110 char Latin / 90 CJK to fit inside the 128-token window).
2. **`fluidaudiocli tts --backend supertonic3`** end-to-end command with `--voice-style`, `--total-steps`, `--speed` flags.
3. **`fluidaudiocli tts-benchmark --backend supertonic3`** wired into the shared harness — emits TTFT p50/p95, agg RTFx, peak RSS, WER, CER, JSON report.
4. **`Documentation/TTS/Supertonic3.md`** doc page mirroring the StyleTTS2 page layout.
5. **`Documentation/TTS/Benchmarks.md`** updated with the per-backend top-line row + a new per-language breakdown subsection (10 languages on MiniMax-100, full WER/CER for all 10).

## Per-backend top-line (MiniMax English, M2 Air, ANE)

| Backend | TTFT p50 / p95 | Agg RTFx | Peak RSS | WER | CER |
|---|---|---|---|---|---|
| Supertonic-3 (M1 voice) | **479 / 6491 ms** | **5.55×** | 679 MB | **0.84%** | **0.32%** |

## 10-language MiniMax breakdown (ANE, 100 phrases each)

WER / CER on non-English rows is scored offline against the saved WAVs with `mlx-community/whisper-large-v3-turbo` + `jiwer` (NFKC + lowercase + punctuation-strip), since the in-harness Parakeet TDT roundtrip is English-only.

| Lang | Synth p50 / p95 | RTFx | Peak RSS | WER | CER |
|---|---|---|---|---|---|
| en | 479 / 6491 ms | 5.55× | 679 MB‡ | 0.84% | 0.32% |
| ar | 427 / 5827 ms | 6.76× | 396 MB | 3.81% | 1.16% |
| fr | 926 / 5897 ms | 5.58× | 292 MB | 3.32% | 1.13% |
| de | 313 / 2318 ms | 8.75× | 345 MB | **0.66%** | **0.45%** |
| it | 691 / 4626 ms | 11.05× | 486 MB | **0.64%** | **0.29%** |
| ja | 643 / 2058 ms | 8.69× | 329 MB | 98.3%§ | 9.30% |
| ko | 438 / 1599 ms | 11.36× | 370 MB | 11.5%§ | 4.23% |
| ru | 321 / 6563 ms | 7.97× | 356 MB | 4.06% | 1.30% |
| es | 354 / 583 ms | **15.90×** | 351 MB | 1.28% | 0.57% |
| vi | 776 / 3934 ms | 7.02× | 440 MB | 9.60% | 8.33% |

‡ English RSS is higher because the in-process Parakeet TDT is loaded for the WER/CER roundtrip; non-English runs use `--skip-asr` so RSS reflects only the four Supertonic-3 graphs + indexer.

§ Japanese / Korean have no whitespace word boundaries, so `jiwer.wer` (whitespace-split) gives a misleading WER — the **CER** is the right metric for those rows.

  