### PR TITLE
feat(tts/pockettts): add 5 native-language voices + slim language-pack downloads ~40%

### DIFF
--- a/Documentation/TTS/PocketTTS.md
+++ b/Documentation/TTS/PocketTTS.md
@@ -306,8 +306,15 @@ that matches your input text — there is no automatic language detection.
 Notes:
 - French only ships a 24-layer pack upstream (no 6-layer variant).
 - 24-layer packs are higher quality but slower and larger.
-- The 21 voice names (alba, anna, eve, michael, …) are shared across
-  languages, but the underlying acoustic embeddings are per-language.
+- 26 voice names are shared across every language pack, but the underlying
+  acoustic embeddings are per-language. The set is 21 English-trained
+  "literary" voices (alba, anna, azelma, bill_boerst, caro_davy, charles,
+  cosette, eponine, eve, fantine, george, jane, javert, jean, marius, mary,
+  michael, paul, peter_yearsley, stuart_bell, vera) plus 5 voices recorded
+  natively in their target language: `estelle` (French), `lola` (Spanish),
+  `juergen` (German), `rafael` (Portuguese), `giovanni` (Italian). The
+  native-language voices generally produce the most idiomatic prosody for
+  their matching language pack.
 - Mimi encoder weights (used for voice cloning) are language-agnostic and
   always live at the repo root.
 

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -569,11 +569,17 @@ public class DownloadUtils {
     ///   - subdirectory: Path within the repo to download (e.g. `"mimi_encoder.mlmodelc"`).
     ///   - repoDirectory: Local directory corresponding to the repo root.
     ///     Files are saved at `repoDirectory/<remote_path>`.
+    ///   - shouldSkip: Optional predicate evaluated on each remote path
+    ///     (both files and directories). Returning `true` excludes the file
+    ///     or, for directories, skips the whole subtree without recursing.
+    ///     Used to avoid pulling redundant artifacts (e.g. `.mlpackage`
+    ///     sources next to compiled `.mlmodelc`).
     public static func downloadSubdirectory(
         _ repo: Repo,
         subdirectory: String,
         to repoDirectory: URL,
-        progressHandler: ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil,
+        shouldSkip: (@Sendable (String) -> Bool)? = nil
     ) async throws {
         progressHandler?(DownloadProgress(fractionCompleted: 0.0, phase: .listing))
         var filesToDownload: [(path: String, size: Int)] = []
@@ -599,6 +605,10 @@ public class DownloadUtils {
                 guard let itemPath = item["path"] as? String,
                     let itemType = item["type"] as? String
                 else { continue }
+
+                if shouldSkip?(itemPath) == true {
+                    continue
+                }
 
                 if itemType == "directory" {
                     try await listFiles(at: itemPath)

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -25,9 +25,15 @@ public enum PocketTtsResourceDownloader {
     ///
     /// Note: the upstream `v2/<lang>/` directory ships both flowlm variants,
     /// so a fresh download pulls the unused variant too. After download
-    /// completes, the unused FlowLM `.mlmodelc` and `.mlpackage` directories
-    /// are deleted so only the requested precision occupies disk
-    /// (~217 MB savings for `.int8`, ~75 MB savings for `.fp16`).
+    /// completes, the unused FlowLM `.mlmodelc` directory is deleted so only
+    /// the requested precision occupies disk (~140 MB savings for `.int8`,
+    /// ~75 MB savings for `.fp16`).
+    ///
+    /// The downloader also skips redundant repo artifacts entirely:
+    /// `.mlpackage` sources (CoreML never loads them — the compiled
+    /// `.mlmodelc` next to each one is what Swift uses), `constants/`
+    /// `.npy/.npz` intermediates (`constants_bin/*.bin` files are the
+    /// loaded form), and incidental files (`verify.wav`, `.DS_Store`).
     public static func ensureModels(
         language: PocketTtsLanguage,
         directory: URL? = nil,
@@ -79,7 +85,8 @@ public enum PocketTtsResourceDownloader {
             .pocketTts,
             subdirectory: subdir,
             to: repoDir,
-            progressHandler: progressHandler
+            progressHandler: progressHandler,
+            shouldSkip: Self.shouldSkipAsset(at:)
         )
 
         // The HF subdir contains both FlowLM precisions; delete the one we
@@ -87,6 +94,31 @@ public enum PocketTtsResourceDownloader {
         removeUnusedFlowlmVariant(at: languageRoot, keeping: precision)
 
         return languageRoot
+    }
+
+    /// Skip filter applied to every remote path the HF lister walks for a
+    /// PocketTTS language pack. Excluded categories were identified during
+    /// the v2 repo cleanup audit: every `.mlpackage` ships with a compiled
+    /// `.mlmodelc` next to it and CoreML only loads the latter; `constants/`
+    /// holds intermediate `.npy/.npz` files whose binary equivalents live
+    /// under `constants_bin/`; `verify.wav` is an upstream debug artifact;
+    /// `.DS_Store` is macOS junk.
+    @Sendable
+    private static func shouldSkipAsset(at path: String) -> Bool {
+        let basename = (path as NSString).lastPathComponent
+        if basename == ".DS_Store" || basename == "verify.wav" {
+            return true
+        }
+        if basename.hasSuffix(".mlpackage") || path.contains(".mlpackage/") {
+            return true
+        }
+        // Only skip the intermediate "constants/" subdirectory, never
+        // "constants_bin/" (which contains the .bin and voice .safetensors
+        // files Swift loads at runtime).
+        for component in path.split(separator: "/") where component == "constants" {
+            return true
+        }
+        return false
     }
 
     /// Backfill `constants_bin/bos_before_voice.bin` for cached language packs
@@ -117,9 +149,10 @@ public enum PocketTtsResourceDownloader {
         logger.info("Wrote bos_before_voice.bin (\(data.count) bytes)")
     }
 
-    /// Delete the FlowLM `.mlmodelc` and `.mlpackage` directories that don't
-    /// match the requested precision. Idempotent — silently skips paths that
-    /// don't exist.
+    /// Delete the FlowLM `.mlmodelc` directory that doesn't match the
+    /// requested precision. Idempotent — silently skips paths that don't
+    /// exist. `.mlpackage` siblings are no longer downloaded (see
+    /// `shouldSkipAsset`), so this only touches `.mlmodelc` directories.
     private static func removeUnusedFlowlmVariant(
         at languageRoot: URL,
         keeping precision: PocketTtsPrecision
@@ -128,16 +161,10 @@ public enum PocketTtsResourceDownloader {
         switch precision {
         case .fp16:
             // Loading flowlm_step.mlmodelc; drop the int8 variant.
-            unusedNames = [
-                ModelNames.PocketTTS.flowlmStepV2 + ".mlmodelc",
-                ModelNames.PocketTTS.flowlmStepV2 + ".mlpackage",
-            ]
+            unusedNames = [ModelNames.PocketTTS.flowlmStepV2 + ".mlmodelc"]
         case .int8:
             // Loading flowlm_stepv2.mlmodelc; drop the default variant.
-            unusedNames = [
-                ModelNames.PocketTTS.flowlmStep + ".mlmodelc",
-                ModelNames.PocketTTS.flowlmStep + ".mlpackage",
-            ]
+            unusedNames = [ModelNames.PocketTTS.flowlmStep + ".mlmodelc"]
         }
         for name in unusedNames {
             let url = languageRoot.appendingPathComponent(name)


### PR DESCRIPTION
## Summary

Closes #619, #620, #621, #622, #623.

Two related PocketTTS improvements:

### 1. New native-language voices (closes the 5 issues)

The 5 native-language voices already exist upstream in `kyutai/pocket-tts-without-voice-cloning` but were missing from the `FluidInference/pocket-tts-coreml` mirror. They've now been packed and uploaded:

| Voice | Language(s) | Issue |
|-------|------------|-------|
| `estelle`  | French (`french_24l`)                        | #619 |
| `lola`     | Spanish (`spanish`, `spanish_24l`)           | #620 |
| `juergen`  | German (`german`, `german_24l`)              | #621 |
| `rafael`   | Portuguese (`portuguese`, `portuguese_24l`)  | #622 |
| `giovanni` | Italian (`italian`, `italian_24l`)           | #623 |

Every language pack now ships **26 voices** (21 English-trained "literary" voices + 5 native voices). Verified end-to-end with TTS synthesis + Parakeet ASR roundtrip on all 10 packs — all pass.

**No library code changes were required for the voices** — `PocketTtsResourceDownloader.ensureVoice` already accepts any voice name dynamically and downloads `<voice>.safetensors` from `constants_bin/`. This PR just updates the voice table in `Documentation/TTS/PocketTTS.md`.

### 2. Slim language-pack downloads (~40-45% smaller)

Audit of `FluidInference/pocket-tts-coreml` v2/ found roughly half of every download is dead weight that Swift never touches:

- **`.mlpackage` source artifacts** — every pack has a compiled `.mlmodelc` next to each `.mlpackage`; CoreML only loads the `.mlmodelc`. On 24L packs each `cond_step.mlpackage` is 1.17 GB and each `flowlm_step.mlpackage` is 1.21 GB.
- **`constants/*.npy/.npz`** — intermediates from the conversion pipeline; `PocketTtsConstantsLoader` only reads the `.bin` files under `constants_bin/`.
- **`verify.wav`** — upstream debug clip, one per pack.
- **`.DS_Store`** — macOS junk in 11 directories.

Added an opt-in `shouldSkip: (@Sendable (String) -> Bool)?` predicate to `DownloadUtils.downloadSubdirectory`. Default `nil` keeps all 5 existing callers byte-compatible. `PocketTtsResourceDownloader.ensureModels` wires in a `shouldSkipAsset(at:)` predicate that excludes the categories above (carefully not skipping `constants_bin/` — only the sibling `constants/` directory).

Also removed the `.mlpackage` paths from `removeUnusedFlowlmVariant` since those files are never on disk anymore.

### Verified against the live HF file list

| Pack | Before | After | Saved |
|------|--------|-------|-------|
| `v2/german` (6L)         | 77 files / 1.66 GB  | 55 files / 0.91 GB | **-45%** |
| `v2/portuguese_24l` (24L) | 104 files / 6.90 GB | 81 files / 4.12 GB | **-40%** |

Predicate spot-checks (all correct):
- `constants_bin/bos_before_voice.bin` → keep
- `constants_bin/alba.safetensors` → keep
- `cond_step.mlmodelc/coremldata.bin` → keep
- `constants/bos_emb.npy` → skip
- `cond_step.mlpackage/...` → skip
- `verify.wav`, `.DS_Store` → skip

## Test plan

- [x] `swift build` green
- [x] TTS synthesis + Parakeet ASR roundtrip on all 10 packs (`english`, `french_24l`, `german`, `german_24l`, `italian`, `italian_24l`, `portuguese`, `portuguese_24l`, `spanish`, `spanish_24l`) using the 5 new voices — every transcript matches the input text
- [x] Predicate verified against live HF file list for both a 6L and a 24L pack
- [ ] Reviewer: optionally delete local cache and re-download one language to confirm the smaller on-disk footprint