### PR TITLE
fix(asr): honor caller modelNames in DownloadUtils for non-baseline files (#524)

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -201,14 +201,24 @@ public class DownloadUtils {
 
         let repoPath = directory.appendingPathComponent(repo.folderName)
         let requiredModels = ModelNames.getRequiredModelNames(for: repo, variant: variant)
-        let allModelsExist = requiredModels.allSatisfy { model in
+        // The caller-supplied `modelNames` may include files outside the repo's
+        // default "required" set (e.g. CtcHead.mlmodelc inside parakeet-ctc-110m
+        // when loaded by the TDT-CTC manager — see issue #524). Union them in
+        // so the cache-validity check and the download filter both consider
+        // every model the caller actually needs.
+        let extraModelNames = Set(modelNames).subtracting(requiredModels)
+        let effectiveModels = requiredModels.union(extraModelNames)
+        let allModelsExist = effectiveModels.allSatisfy { model in
             let modelPath = repoPath.appendingPathComponent(model)
             return FileManager.default.fileExists(atPath: modelPath.path)
         }
 
         if !allModelsExist {
             logger.info("Models not found in cache at \(repoPath.path)")
-            try await downloadRepo(repo, to: directory, variant: variant, progressHandler: progressHandler)
+            try await downloadRepo(
+                repo, to: directory, variant: variant,
+                additionalModelNames: extraModelNames,
+                progressHandler: progressHandler)
         } else {
             logger.info("Found \(repo.folderName) locally, no download needed")
             progressHandler?(
@@ -276,11 +286,18 @@ public class DownloadUtils {
         return models
     }
 
-    /// Download a HuggingFace repository using URLSession (does not load models)
+    /// Download a HuggingFace repository using URLSession (does not load models).
+    ///
+    /// - Parameter additionalModelNames: Extra model directory names (e.g.
+    ///   `"CtcHead.mlmodelc"`) to fetch in addition to the repo's default
+    ///   `ModelNames.getRequiredModelNames(...)` set. Used by `loadModels` to
+    ///   forward caller-requested files that are not part of the repo's
+    ///   baseline required set.
     public static func downloadRepo(
         _ repo: Repo,
         to directory: URL,
         variant: String? = nil,
+        additionalModelNames: Set<String> = [],
         progressHandler: ProgressHandler? = nil
     ) async throws {
         logger.info("Downloading \(repo.folderName) from HuggingFace...")
@@ -289,6 +306,7 @@ public class DownloadUtils {
         try FileManager.default.createDirectory(at: repoPath, withIntermediateDirectories: true)
 
         let requiredModels = ModelNames.getRequiredModelNames(for: repo, variant: variant)
+            .union(additionalModelNames)
         let subPath = repo.subPath  // e.g., "160ms" for parakeetEou160
 
         // Build patterns for filtering (relative to subPath if present)

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
@@ -428,4 +428,67 @@ final class AsrModelsTests: XCTestCase {
         XCTAssertFalse(AsrModelVersion.tdtCtc110m.isCtcOnly)
         XCTAssertFalse(AsrModelVersion.tdtJa.isCtcOnly)
     }
+
+    // MARK: - Issue #524: CTC head download in parakeet-ctc-110m repo
+
+    /// Regression guard for
+    /// https://github.com/FluidInference/FluidAudio/issues/524.
+    ///
+    /// `AsrModels.load(version: .tdtCtc110m)` optionally pulls
+    /// `CtcHead.mlmodelc` from the `parakeet-ctc-110m` repo, but that repo's
+    /// default required set is the standalone CTC frontend
+    /// (`MelSpectrogram` + `AudioEncoder`) and does NOT include the CTC head.
+    /// `DownloadUtils.loadModels` threads the caller's `modelNames` into
+    /// `downloadRepo` via `additionalModelNames` so the HF filter recurses
+    /// into the `CtcHead.mlmodelc/` directory.
+    func testParakeetCtc110mRequiredSetExcludesCtcHead() {
+        let required = ModelNames.getRequiredModelNames(for: .parakeetCtc110m, variant: nil)
+        XCTAssertTrue(required.contains(ModelNames.CTC.melSpectrogramPath))
+        XCTAssertTrue(required.contains(ModelNames.CTC.audioEncoderPath))
+        XCTAssertFalse(
+            required.contains(ModelNames.ASR.ctcHeadFile),
+            "CtcHead must not be in the parakeet-ctc-110m baseline required set; "
+                + "callers needing it must pass it via DownloadUtils.loadModels' "
+                + "modelNames parameter."
+        )
+    }
+
+    /// Verifies that the cache-validity check in `loadModelsOnce` (and the
+    /// matching filter in `downloadRepo`) sees `CtcHead.mlmodelc` as
+    /// missing even when the baseline required set is fully present on
+    /// disk. Pre-fix, the local cache check returned `true` here and the
+    /// download was skipped, leading to a silent `fileNoSuchFile` in the
+    /// model-loading loop.
+    func testLoadModelsCacheCheckIncludesExtraModelNames() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AsrModelsTests-#524-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let repoDir = tempDir.appendingPathComponent(Repo.parakeetCtc110m.folderName)
+        let fm = FileManager.default
+        for name in [ModelNames.CTC.melSpectrogramPath, ModelNames.CTC.audioEncoderPath] {
+            let modelDir = repoDir.appendingPathComponent(name)
+            try fm.createDirectory(at: modelDir, withIntermediateDirectories: true)
+            try Data().write(to: modelDir.appendingPathComponent("coremldata.bin"))
+        }
+
+        // Baseline required set is present on disk.
+        let required = ModelNames.getRequiredModelNames(for: .parakeetCtc110m, variant: nil)
+        for name in required {
+            XCTAssertTrue(fm.fileExists(atPath: repoDir.appendingPathComponent(name).path))
+        }
+
+        // Caller asks for the CTC head — which is *not* on disk and *not* in
+        // the baseline required set. The fix's effective-models union must
+        // recognise this as a cache miss.
+        let requested: Set<String> = [ModelNames.ASR.ctcHeadFile]
+        let effective = required.union(requested)
+        let allEffectiveExist = effective.allSatisfy {
+            fm.fileExists(atPath: repoDir.appendingPathComponent($0).path)
+        }
+        XCTAssertFalse(
+            allEffectiveExist,
+            "Cache check must treat caller-requested model names as required."
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Closes #524.

`AsrModels.load(version: .tdtCtc110m)` pulls `CtcHead.mlmodelc` from the `parakeet-ctc-110m` HF repo, but that repo's `ModelNames.getRequiredModelNames(...)` returns the standalone CTC frontend (`MelSpectrogram`, `AudioEncoder`) and does **not** include the CTC head. `DownloadUtils.loadModels` used the baseline required set for both its cache-validity check and the HF tree filter in `downloadRepo`, so:

- `downloadRepo`'s pattern filter excluded the `CtcHead.mlmodelc/` directory and never recursed into it.
- When the caller's `modelNames` listed `CtcHead.mlmodelc`, the loop after download tripped `CocoaError(.fileNoSuchFile)`, which `AsrModels` swallowed as a warning, leaving `ctcHeadModel == nil`.
- With `MelSpectrogram` + `AudioEncoder` already on disk from a prior CTC-only run, `allModelsExist` returned `true` and no download was attempted at all — silent failure with no network call.

### Reproduction

Replaying `downloadRepo`'s filter logic against the live HF tree API for `FluidInference/parakeet-ctc-110m-coreml`:

```
Filter patterns: ['AudioEncoder.mlmodelc/', 'MelSpectrogram.mlmodelc/']

Top-level dirs in HF repo:
  - AudioEncoder.mlmodelc
  - CtcHead.mlmodelc        <-- requested by caller
  - CtcHead.mlpackage
  - MelSpectrogram.mlmodelc
  - convert

Dirs the downloader will recurse into:
  - AudioEncoder.mlmodelc
  - MelSpectrogram.mlmodelc

Was the requested model dir 'CtcHead.mlmodelc' selected for download? False
```

### Fix

Thread the caller-supplied `modelNames` through `loadModelsOnce` into `downloadRepo` via a new optional `additionalModelNames: Set<String>` parameter. The union with `getRequiredModelNames(...)` is used for both the cache-validity check and the pattern construction, so requested files outside the repo's baseline set are correctly detected as missing and downloaded.

Existing public callers of `downloadRepo` are unaffected — the new parameter defaults to empty.

### Tests

`Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift`:
- `testParakeetCtc110mRequiredSetExcludesCtcHead` — regression guard documenting that `CtcHead` is not in the baseline required set, so the threading is what makes the auto-download work.
- `testLoadModelsCacheCheckIncludesExtraModelNames` — pre-stages the baseline files on disk and verifies the union-based cache check correctly flags a missing extra file.

## Test plan

- [x] `swift build` (debug)
- [x] `swift format lint` clean on touched files
- [ ] CI runs `swift test --parallel` on macos-15 (local toolchain is CLT-only, no `XCTest.framework`)
- [ ] Manual: `swift run fluidaudiocli transcribe <audio.wav> --model-version tdt-ctc-110m` no longer logs "CTC head model not available" and the `CtcHead.mlmodelc/` directory shows up in the local `parakeet-ctc-110m-coreml/` cache after a fresh download.