### PR TITLE
docs(asr): document parallel chunk processing in LongTranscription.md

### DIFF
--- a/Documentation/ASR/LongTranscription.md
+++ b/Documentation/ASR/LongTranscription.md
@@ -38,6 +38,7 @@ phrase at the wrong point.
 | Default mel-context | `ASRConfig.melChunkContext = true` | Batch TDT long audio | Preserves the existing 80 ms left-context behavior for non-first chunks. |
 | v3 no-mel | `ASRConfig.melChunkContext = false`, CLI `--no-mel-context` | Parakeet TDT v3 batch long audio | Avoids the v3 multilingual drift introduced by prepending mel context at chunk boundaries. |
 | v3 dual-decode arbitration | `melChunkContext = false` plus `ASRConfig.dualDecodeArbitration = true`, CLI `--no-mel-context --dual-decode-arbitration` | Parakeet TDT v3 no-mel batch long audio | Opt-in quality mode for files where one boundary strategy is clearly safer than another. |
+| Parallel chunk workers | `ASRConfig.parallelChunkConcurrency` (default `4`, clamped to `>= 1`) | Stateless chunked batch TDT (all of the above) | Decodes independent chunks concurrently across a worker pool of cloned `AsrManager` instances. |
 
 The dual-decode path probes the first few non-first chunks with three strategies:
 
@@ -66,6 +67,51 @@ The no-mel v3 path removes that context shift and prefers acoustic boundaries
 near low-energy regions. The arbitration mode adds a short probe for cases where
 different boundary strategies preserve different content. Committing globally to
 one strategy favors consistency over per-chunk switching.
+
+## Parallel Chunk Processing
+
+Long files are split into independent chunks that share no decoder state across
+seams, so chunk decoding parallelizes cleanly. `ChunkProcessor` runs a worker
+pool of cloned `AsrManager` instances and merges results in chunk-emission
+order, preserving the same overlap merge logic used by the single-worker path.
+
+| Field | Default | Notes |
+|---|---|---|
+| `ASRConfig.parallelChunkConcurrency` | `4` | Number of chunks decoded concurrently. Clamped to `max(1, …)`. Applies only to stateless chunked transcription paths (long-form batch TDT). |
+
+How it works:
+
+- `ChunkProcessor.process(using:)` reads `manager.parallelChunkConcurrency` and
+  builds a worker pool via `manager.makeWorkerClone()`. Each clone reuses the
+  already-loaded encoder/decoder/joint Core ML models, so no model
+  re-initialization happens per worker.
+- Chunks are dispatched with `ThrowingTaskGroup`. The dispatch loop reuses an
+  `availableWorkers` index list so the number of in-flight tasks never exceeds
+  `parallelChunkConcurrency` (backpressure).
+- Each task constructs a fresh `TdtDecoderState` (stateless per-chunk
+  decoding), runs `transcribeChunk` against its assigned worker, and returns a
+  `TaskResult { index, tokens, workerIndex }`. Results are gathered into a
+  pre-sized `chunkOutputs` array indexed by chunk order, then merged exactly
+  as the serial path did.
+- Streaming and real-time paths
+  (`StreamingAsrManager`, `SlidingWindowAsrManager`) are unaffected: they
+  remain single-decoder and cache-aware, since they depend on persistent
+  decoder/encoder state across windows.
+
+Notes for tuning:
+
+- Default `4` was selected from device-matrix testing; benchmarks on Apple M3
+  with a 1-hour file show roughly 2.2–2.8× wall-clock speedup over the serial
+  path across Parakeet v2/v3 variants, with about 19–31 MiB extra resident
+  memory for the additional worker clones.
+- Setting `parallelChunkConcurrency = 1` is the closest configuration to the
+  pre-parallel behavior and is useful for A/B-ing transcripts against older
+  output. It does not bypass `ChunkProcessor`; the worker pool collapses to a
+  single worker that reuses the calling `AsrManager`.
+- Word timings and per-chunk decoding are unchanged by the parallel path —
+  the parallelization is in chunk dispatch, not in decoder behavior, and
+  transcripts and timings remain identical to the serial version for the same
+  inputs.
 
 ## Validation Strategy
 
@@ -96,10 +142,16 @@ auditable instead of relying on memory of why a clip was added.
 - `Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift`
   - `ASRConfig.melChunkContext`
   - `ASRConfig.dualDecodeArbitration`
+  - `ASRConfig.parallelChunkConcurrency`
+- `Sources/FluidAudio/ASR/Parakeet/AsrManager.swift`
+  - `parallelChunkConcurrency` actor-isolated accessor
+  - `makeWorkerClone()` factory used to populate the chunk worker pool
 - `Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift`
   - routes long audio through `ChunkProcessor`
 - `Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift`
-  - chunk sizing, boundary search, regular long-form chunk loop, and overlap merge
+  - chunk sizing, boundary search, regular long-form chunk loop, overlap merge,
+    worker-pool construction (`makeWorkerPool`), and the static
+    `transcribeChunk(...)` task body used by the parallel dispatch loop
 - `Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/DualDecodeArbitration.swift`
   - opt-in v3/no-mel arbitration path
 - `Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV3.swift`
@@ -118,4 +170,5 @@ Useful focused checks:
 swift test --filter ChunkProcessorTests
 swift test --filter TdtRefactoredComponentsTests
 swift test --filter TdtDecoderV2Tests
+swift test --filter ASRConfigTests   # covers parallelChunkConcurrency default, clamping, override
 ```

--- a/Documentation/ASR/LongTranscription.md
+++ b/Documentation/ASR/LongTranscription.md
@@ -15,6 +15,29 @@ drifts into the wrong language after several boundaries. FLEURS is useful as a
 multilingual smoke test, but most FLEURS samples are short read-speech clips, so
 they do not exercise repeated seam behavior very much.
 
+## Chunk Geometry
+
+The numbers below come from `ASRConstants` and `ChunkProcessor`. They are not
+configurable at runtime — they are derived from the encoder's frame rate and
+the Core ML window size — so they are the same on every device.
+
+| Quantity | Value | Source |
+|---|---|---|
+| Sample rate | 16,000 Hz | `ASRConstants.sampleRate` |
+| Encoder window | 240,000 samples (≈ 15.00 s) | `ASRConstants.maxModelSamples` |
+| Encoder frame | 1,280 samples (80 ms) | `ASRConstants.samplesPerEncoderFrame` |
+| Mel hop | 160 samples (10 ms) | `ASRConstants.melHopSize` |
+| Visible chunk | ≈ 14.96 s, frame-aligned | `ChunkProcessor.chunkSamples(...)` |
+| Overlap target | 2.0 s, frame-aligned, capped at `chunkSamples / 2` | `ChunkProcessor.overlapSeconds` |
+| Stride | `chunkSamples − overlap`, frame-aligned | `ChunkProcessor.strideSamples(...)` |
+| Minimum seam overlap | 6 encoder frames (480 ms) | `silenceAlignedChunkStarts` |
+
+`chunkSamples` is the *visible* window decoded into transcript tokens; it is
+slightly smaller than `maxModelSamples` to reserve room for either an 80 ms
+mel-context prepend (default path) or a 0–7 frame acoustic warmup prefix
+(no-mel paths). Visible windows are always whole numbers of encoder frames, so
+chunk timestamps land on frame boundaries.
+
 ## Failure Modes
 
 When reviewing long-form ASR output, check the transcript for:
@@ -54,19 +77,91 @@ The choice is based on decoder confidence, emitted-token counts, and agreement
 between probe paths. It is meant to decide between chunking strategies, not to
 rewrite transcript text.
 
+## Boundary Search
+
+`ChunkProcessor` picks the start sample of each non-first chunk by one of two
+strategies, selected from `melChunkContext` and `modelVersion`:
+
+| Mode | When | Behavior |
+|---|---|---|
+| `regularChunkStarts` | Default mel-context path, or non-v3 models | Fixed stride: `start_i = i × strideSamples`. Cheap, predictable, but ignores acoustic content at the seam. |
+| `silenceAlignedChunkStarts` | `melChunkContext = false` *and* model version is v3 | Searches for a low-energy frame near the target boundary and starts the chunk there. |
+
+The silence-aligned search is two-tier:
+
+1. **Silence pass.** Within `±4 s` of the target frame, score each candidate
+   frame by mean-square energy in a `±80 ms` window (`boundaryEnergyScore`).
+   A candidate is accepted as "near silence" if its score is at most
+   `0.05 × medianScore` over the window. Adaptive thresholds let the search
+   tolerate noisy recordings without re-tuning a hardcoded absolute energy.
+2. **Valley fallback.** If no near-silence candidate is found, repeat the same
+   search within `±0.5 s` and accept the best candidate if it scores below
+   `0.35 × medianScore`. This catches inter-word valleys when the audio has
+   no real silence near the target.
+3. **Speech-tail check.** If using a silence boundary would force the *next*
+   forced boundary (`candidate + chunkSamples − minOverlap`) into speech,
+   fall back to the original target start. This prevents pulling a boundary
+   too early when doing so would dump a speech-only tail onto the following
+   chunk.
+
+The search keeps at least 6 encoder frames (480 ms) of overlap with the
+previous chunk so the overlap merger always has at least a handful of
+candidate tokens to align on.
+
+## Warmup Prefix vs Mel Context
+
+Non-first chunks always include some samples from before the visible window,
+but the two mechanisms behave differently:
+
+- **Mel context** (`melContextSamples`, 1 encoder frame / 80 ms). Prepended to
+  the chunk so the FastConformer encoder's depthwise convolutions have stable
+  left context for the first emitted frame. The decoder is told to *skip*
+  those leading frames via `contextSamples`; they do not produce tokens.
+  Enabled when `ASRConfig.melChunkContext = true` (the default).
+- **Warmup prefix** (`warmupPrefixSamples`, 0–7 encoder frames). Real audio
+  from before the chunk start, decoded normally from frame 0; emitted tokens
+  are suppressed up to the chunk start via `emitTokensAfterFrame`. Used only
+  by the v3 no-mel arbitration probe (path B); the default v3 no-mel path
+  keeps `warmupPrefixFrames = 0`.
+
+`shouldUseWarmupPrefix` further gates the warmup decision when a silence
+boundary is available: if there is at least 200 ms of stable quiet audio in
+the 500 ms lookahead from the boundary (`rms < 0.003`), warmup is skipped —
+the encoder will see real silence anyway, so there is no language-prior
+drift to warm out of.
+
 ## Why This Helps
 
-The original long-form path used an 80 ms mel-context prepend so non-first
-chunks had stable leading encoder frames. That helps avoid blank-boundary
-failures, but on multilingual v3 audio it can also change the first-frame
-distribution enough that the decoder starts a chunk from the wrong prior. The
-visible symptom is usually not random noise; it is a plausible-looking phrase in
-the wrong language near a seam.
+The original long-form path (PR #264) used an 80 ms mel-context prepend so
+non-first chunks had stable leading encoder frames. That helps avoid
+blank-boundary failures on long English audio (where the encoder otherwise
+emits nothing for the first few frames of a chunk).
 
-The no-mel v3 path removes that context shift and prefers acoustic boundaries
-near low-energy regions. The arbitration mode adds a short probe for cases where
-different boundary strategies preserve different content. Committing globally to
-one strategy favors consistency over per-chunk switching.
+Issue #594 surfaced a second, opposite failure on `parakeet-tdt-0.6b-v3-coreml`
+multilingual audio: the 80 ms prepend can shift the encoder's first-frame
+distribution enough that the SOS-primed TDT decoder drifts back to v3's
+English prior. The visible symptom is usually not random noise; it is a
+plausible-looking phrase in the *wrong* language near a seam (commonly
+French → English, also observed Spanish → English).
+
+The earlier attempt to fix that — persisting decoder state across chunks and
+extending the audio prefix to 2.0 s of real audio (commit `eb9c19f7`) — was
+correct in isolation but incompatible with parallel chunk decoding
+(`fcd80f10`, PR #507): every chunk needs to start from a fresh
+`TdtDecoderState` for the worker pool to be independent. The shipped fix
+keeps decoding stateless per chunk and instead removes the shifting prepend
+on v3, with the no-mel path preferring silence-aligned boundaries so the
+encoder sees a natural acoustic onset rather than a discontinuity. The
+arbitration mode adds a short probe for cases where different boundary
+strategies preserve different content; committing globally to one strategy
+favors consistency over per-chunk switching.
+
+A third interacting issue from #594 — the decoder occasionally entering a
+BLANK-trap after a sentence-final token — was masked by the per-chunk SOS
+reset and re-surfaced briefly under persistent state. With stateless
+per-chunk decoding restored, this trap is again not reachable through
+chunked transcription; long-form streaming paths still guard against it
+explicitly.
 
 ## Parallel Chunk Processing
 
@@ -113,6 +208,54 @@ Notes for tuning:
   transcripts and timings remain identical to the serial version for the same
   inputs.
 
+## Overlap Merge
+
+After each chunk decodes independently, `ChunkProcessor.mergeChunks` stitches
+adjacent chunks into a single token timeline. The merger never re-runs the
+decoder and never invents tokens; it only chooses which side of the overlap
+each token comes from. The strategy is a three-step ladder:
+
+1. **Disjoint shortcut.** If the left chunk's last token ends before the
+   right chunk's first token begins, concatenate without merging.
+2. **Contiguous time-tolerant match.** Tokens in the overlap region are
+   compared with a tolerance of `overlapSeconds / 2`. `SequenceMatcher`
+   finds the longest contiguous run where the same token ID appears in both
+   chunks within the tolerance window; if that run is at least half of the
+   overlap, the merger splices both halves around it.
+3. **LCS fallback.** If no good contiguous run exists, fall back to a
+   longest-common-subsequence match over the same overlap window with the
+   same tolerance, then splice using each LCS pair.
+4. **Midpoint fallback.** If LCS also returns nothing, split at the midpoint
+   of the overlap (`mergeByMidpoint`): keep left-chunk tokens before the
+   midpoint and right-chunk tokens after it.
+
+The matcher uses *token ID + frame-time tolerance* rather than text — so it
+cannot collapse two different words that happen to share a substring, and it
+is robust to small per-chunk timestamp jitter. The contiguous-match path
+preserves order strictly; LCS is only entered when adjacent chunks disagree
+enough that a contiguous run would be dishonest.
+
+## Streaming Threshold for Large Files
+
+`ASRConfig` also exposes two knobs that are not about chunk boundary quality
+but about memory pressure on very long files:
+
+| Field | Default | Notes |
+|---|---|---|
+| `ASRConfig.streamingEnabled` | `true` | When `true`, files larger than `streamingThreshold` are read incrementally from disk by the chunked path instead of being loaded entirely into memory. |
+| `ASRConfig.streamingThreshold` | `480_000` samples (≈ 30 s at 16 kHz) | Threshold above which `streamingEnabled` actually kicks in. Below this, the file is held in a single `[Float]` buffer. |
+
+This pair affects which `AudioSampleSource` `ChunkProcessor` is constructed
+with; it does not change chunk geometry or boundary search. For files
+significantly longer than the threshold (an hour of audio is ≈ 57.6 M
+samples) the streaming path is the difference between a few hundred MiB of
+peak resident memory and a few hundred KiB. Both knobs are orthogonal to
+`parallelChunkConcurrency` — worker pool size is bounded independently — but
+the worker pool's clones each hold their own short-lived decoder/encoder
+buffers, so for the most memory-constrained environments setting
+`parallelChunkConcurrency = 1` and leaving streaming enabled is the lowest
+high-water-mark configuration.
+
 ## Validation Strategy
 
 A long-transcription change should be checked with a fixed matrix, not only with
@@ -139,19 +282,32 @@ auditable instead of relying on memory of why a clip was added.
 
 ## Relevant Code
 
+- `Sources/FluidAudio/Shared/ASRConstants.swift`
+  - `maxModelSamples`, `samplesPerEncoderFrame`, `melHopSize`,
+    `secondsPerEncoderFrame` — fixed encoder geometry
 - `Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift`
   - `ASRConfig.melChunkContext`
   - `ASRConfig.dualDecodeArbitration`
   - `ASRConfig.parallelChunkConcurrency`
+  - `ASRConfig.streamingEnabled` / `ASRConfig.streamingThreshold`
 - `Sources/FluidAudio/ASR/Parakeet/AsrManager.swift`
   - `parallelChunkConcurrency` actor-isolated accessor
   - `makeWorkerClone()` factory used to populate the chunk worker pool
 - `Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift`
   - routes long audio through `ChunkProcessor`
 - `Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift`
-  - chunk sizing, boundary search, regular long-form chunk loop, overlap merge,
-    worker-pool construction (`makeWorkerPool`), and the static
-    `transcribeChunk(...)` task body used by the parallel dispatch loop
+  - `chunkLayout(...)` and `chunkSamples(...)` — frame-aligned chunk sizing
+  - `regularChunkStarts(...)` / `silenceAlignedChunkStarts(...)` /
+    `bestBoundaryCandidate(...)` — boundary search
+  - `shouldUseWarmupPrefix(...)` / `wouldCompressSpeechTail(...)` — warmup
+    gating
+  - `mergeChunks(...)` / `mergeUsingMatches(...)` / `mergeByMidpoint(...)` —
+    overlap merge ladder (contiguous → LCS → midpoint)
+  - `makeWorkerPool(...)` and the static `transcribeChunk(...)` task body
+    used by the parallel dispatch loop
+- `Sources/FluidAudio/ASR/Parakeet/TokenDeduplication/SequenceMatcher.swift`
+  - `findContiguousMatches` and `findLongestCommonSubsequence` used by the
+    overlap merger
 - `Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/DualDecodeArbitration.swift`
   - opt-in v3/no-mel arbitration path
 - `Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV3.swift`


### PR DESCRIPTION
## Summary

Brings `Documentation/ASR/LongTranscription.md` up to date with the parallel chunked Parakeet batch transcription work (PR #507, commit `fcd80f10`) and with the surrounding long-transcription history that was only documented in source comments and commit messages.

### Added sections

- **Chunk Geometry** — concrete values from `ASRConstants` (encoder window 240k samples, encoder frame 1280 samples / 80 ms, mel hop 160 samples, visible chunk ≈ 14.96 s, 2.0 s overlap, frame-aligned stride, 6-frame minimum seam overlap) and why the visible window is smaller than `maxModelSamples`.
- **Boundary Search** — fixed-stride vs silence-aligned (±4 s) + valley fallback (±0.5 s) + speech-tail-compression guard, including the adaptive `0.05× medianScore` / `0.35× medianScore` thresholds.
- **Warmup Prefix vs Mel Context** — clarifies the two prefix mechanisms: mel context (80 ms, decoder-skipped) vs warmup prefix (0–7 frames, decoded from frame 0 with emitted tokens suppressed up to chunk start), and documents the `shouldUseWarmupPrefix` quiet-lookahead gate (≥ 200 ms of `rms < 0.003`).
- **Why This Helps** rewrite — traces the real issue history end-to-end:
  - PR #264 introduced the 80 ms mel-context prepend to fix English blank-boundary failures.
  - Issue #594 exposed the opposite failure on `parakeet-tdt-0.6b-v3-coreml` multilingual audio (English-prior drift at every seam).
  - Commit `eb9c19f7` tried persisting `TdtDecoderState` and extending the audio prefix to 2.0 s, but that was incompatible with the parallel chunk dispatch in `fcd80f10` (PR #507).
  - The shipped fix keeps decoding stateless per chunk and instead removes the shifting prepend on v3 via `melChunkContext = false` with silence-aligned starts.
  - Notes the sentence-final BLANK-trap that the per-chunk SOS reset now keeps unreachable for the chunked path.
- **Parallel Chunk Processing** — `ASRConfig.parallelChunkConcurrency` (default `4`, clamped `>= 1`), worker-pool construction via `AsrManager.makeWorkerClone()`, `ThrowingTaskGroup` dispatch with the `availableWorkers` backpressure list, ordered merge via `TaskResult { index, tokens, workerIndex }`, and a callout that `StreamingAsrManager` / `SlidingWindowAsrManager` are intentionally unaffected. Tuning notes cover the 2.2–2.8× wall-clock speedup on M3 with a 1-hour file, ~19–31 MiB extra resident memory, and `parallelChunkConcurrency = 1` as the closest-to-serial / lowest-memory configuration.
- **Overlap Merge** — the actual `mergeChunks` ladder: disjoint shortcut → contiguous time-tolerant `SequenceMatcher` (must cover ≥ half the overlap) → LCS fallback → midpoint fallback. Emphasizes that the merger is token-id-keyed with a `overlapSeconds / 2` time tolerance and never re-runs the decoder.
- **Streaming Threshold for Large Files** — `ASRConfig.streamingEnabled` / `streamingThreshold` (480k samples ≈ 30 s) and how they compose with `parallelChunkConcurrency` for memory-constrained environments.

### Updated sections

- **Current Paths** table — adds the `Parallel chunk workers` row.
- **Relevant Code** — `ASRConstants` geometry constants; `ASRConfig.streaming*`; `AsrManager.makeWorkerClone()` / `parallelChunkConcurrency`; `ChunkProcessor` boundary helpers (`regularChunkStarts`, `silenceAlignedChunkStarts`, `bestBoundaryCandidate`, `shouldUseWarmupPrefix`, `wouldCompressSpeechTail`); merge helpers (`mergeChunks`, `mergeUsingMatches`, `mergeByMidpoint`); `makeWorkerPool` and static `transcribeChunk(...)`; `TokenDeduplication/SequenceMatcher.swift`.
- **Focused Tests** — adds `ASRConfigTests` (covers `parallelChunkConcurrency` default, clamp, override).

Pure documentation change — no source files touched.

## Commits

- `f1e8694` docs(asr): document parallel chunk processing in LongTranscription.md
- `b013476` docs(asr): expand LongTranscription.md with geometry, boundary search, merge, streaming

## Test plan

- [ ] Render `Documentation/ASR/LongTranscription.md` and visually confirm the section ordering and tables.
- [ ] Verify the referenced symbols exist on `main`:
  - `ASRConstants.maxModelSamples`, `samplesPerEncoderFrame`, `melHopSize`, `secondsPerEncoderFrame`
  - `ASRConfig.parallelChunkConcurrency`, `melChunkContext`, `dualDecodeArbitration`, `streamingEnabled`, `streamingThreshold`
  - `AsrManager.makeWorkerClone()`, `AsrManager.parallelChunkConcurrency`
  - `ChunkProcessor.chunkLayout`, `regularChunkStarts`, `silenceAlignedChunkStarts`, `bestBoundaryCandidate`, `shouldUseWarmupPrefix`, `wouldCompressSpeechTail`, `mergeChunks`, `mergeUsingMatches`, `mergeByMidpoint`, `makeWorkerPool`, `transcribeChunk`
  - `TokenDeduplication/SequenceMatcher.swift` exposing `findContiguousMatches` and `findLongestCommonSubsequence`
- [ ] `swift test --filter ASRConfigTests` and `swift test --filter ChunkProcessorTests`.