### PR TITLE
fix(asr): reduce English drift on French recordings via token blocklist

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV3.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV3.swift
@@ -37,6 +37,46 @@ internal struct TdtDecoderV3: Sendable {
     private let modelInference = TdtModelInference()
     // Parakeet‑TDT‑v3: duration head has 5 bins mapping directly to frame advances
 
+    // English-exclusive whole-word token IDs used by applyEnglishBlocklist.
+    // Space-prefixed SentencePiece tokens that are essentially impossible in French prose.
+    static let englishBlocklistIds: Set<Int> = [
+        506, 1502,  // ' the', ' The'
+        575, 1976,  // ' and', ' And'
+        2530,  // ' they'
+        1180, 3247,  // ' you', ' You'
+        1868,  // ' with'
+        1050, 7603,  // ' that', ' That'
+        1974, 5831,  // ' this', ' This'
+        1647,  // ' have'
+        3109,  // ' from'
+        924, 4020,  // ' was', ' Was'
+        4250,  // ' were'
+        1714,  // ' are'
+        4908,  // ' been'
+        4223,  // ' would'
+        6167,  // ' could'
+        2783,  // ' will'
+        4396,  // ' their'
+        3357,  // ' there'
+        4611,  // ' when'
+        3470,  // ' what'
+        6843,  // ' where'
+        4333,  // ' which'
+        4980,  // ' who'
+        1491,  // ' not'
+        3592, 2681,  // ' But', ' but'
+        1960, 547,  // ' So', ' so'
+        2336,  // ' It'
+        750, 1842,  // ' we', ' We'
+        3285,  // ' our'
+        3629,  // ' your'
+        1103,  // ' my'
+        4384,  // ' him'
+        1535,  // ' her'
+        4421,  // ' them'
+        5726,  // ' these'
+    ]
+
     init(config: ASRConfig) {
         self.config = config
     }
@@ -250,6 +290,13 @@ internal struct TdtDecoderV3: Sendable {
                 vocabulary: vocabulary,
                 blankId: blankId
             )
+            if let lang = language, lang.script == .latin, lang != .english,
+                let ids = decision.topKIds, let logits = decision.topKLogits, let vocab = vocabulary
+            {
+                Self.applyEnglishBlocklist(
+                    label: &label, score: &score,
+                    topKIds: ids, topKLogits: logits, vocabulary: vocab, blankId: blankId)
+            }
 
             // Map duration bin to actual frame count
             // durationBins typically = [0,1,2,3,4] meaning skip 0-4 frames
@@ -330,6 +377,14 @@ internal struct TdtDecoderV3: Sendable {
                     vocabulary: vocabulary,
                     blankId: blankId
                 )
+                if let lang = language, lang.script == .latin, lang != .english,
+                    let ids = innerDecision.topKIds, let logits = innerDecision.topKLogits,
+                    let vocab = vocabulary
+                {
+                    Self.applyEnglishBlocklist(
+                        label: &label, score: &score,
+                        topKIds: ids, topKLogits: logits, vocabulary: vocab, blankId: blankId)
+                }
 
                 duration = try TdtDurationMapping.mapDurationBin(
                     innerDecision.durationBin, durationBins: config.tdtConfig.durationBins)
@@ -560,6 +615,48 @@ internal struct TdtDecoderV3: Sendable {
     }
 
     // MARK: - Private Helper Methods
+
+    /// When the target language is a non-English Latin-script language and the
+    /// winning token is in the English-exclusive blocklist, replace it with the
+    /// highest-logit top-K token that is not in the blocklist.
+    ///
+    /// This runs AFTER `tokenLanguageFilter` (which only distinguishes
+    /// Latin from Cyrillic and leaves English/French ambiguous). It targets
+    /// the spontaneous-speech translation phenomenon where the model falls back
+    /// to its English prior on acoustically ambiguous frames.
+    static func applyEnglishBlocklist(
+        label: inout Int,
+        score: inout Float,
+        topKIds: [Int],
+        topKLogits: [Float],
+        vocabulary: [Int: String],
+        blankId: Int
+    ) {
+        guard label != blankId, englishBlocklistIds.contains(label) else { return }
+
+        var bestIdx = -1
+        var bestLogit: Float = -.infinity
+        for i in 0..<min(topKIds.count, topKLogits.count) {
+            let id = topKIds[i]
+            let logit = topKLogits[i]
+            guard id != blankId, !englishBlocklistIds.contains(id) else { continue }
+            if let text = vocabulary[id], TokenLanguageFilter.matches(text, script: .latin) {
+                if bestIdx < 0 || logit > bestLogit {
+                    bestLogit = logit
+                    bestIdx = i
+                }
+            }
+        }
+
+        guard bestIdx >= 0 else { return }
+        label = topKIds[bestIdx]
+
+        var maxLogit: Float = -.infinity
+        for l in topKLogits { if l > maxLogit { maxLogit = l } }
+        var sumExp: Float = 0
+        for l in topKLogits { sumExp += expf(l - maxLogit) }
+        score = sumExp > 0 ? expf(bestLogit - maxLogit) / sumExp : 0
+    }
 
     /// Replace `label`/`score` with the best right-language top-K candidate
     /// when the joint's top-1 token is in the wrong language for `language`.

--- a/Tests/FluidAudioTests/ASR/Parakeet/EnglishBlocklistTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/EnglishBlocklistTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+
+@testable import FluidAudio
+
+final class EnglishBlocklistTests: XCTestCase {
+
+    // Minimal vocab: a few English-exclusive and Latin-script French tokens.
+    // Token IDs match the SentencePiece vocabulary used by Parakeet TDT v3.
+    private let vocab: [Int: String] = [
+        506: " the",
+        575: " and",
+        1868: " with",
+        481: " le",
+        393: " la",
+        453: " et",
+        999: " rendre",
+        8192: "<blank>",
+    ]
+    private let blankId = 8192
+
+    func testNoSubstitutionWhenLabelIsBlank() {
+        var label = blankId
+        var score: Float = 1.0
+        TdtDecoderV3.applyEnglishBlocklist(
+            label: &label,
+            score: &score,
+            topKIds: [481, 393],
+            topKLogits: [1.0, 0.5],
+            vocabulary: vocab,
+            blankId: blankId
+        )
+        XCTAssertEqual(label, blankId)
+        XCTAssertEqual(score, 1.0)
+    }
+
+    func testNoSubstitutionWhenLabelNotInBlocklist() {
+        var label = 999  // ' rendre' — not an English-exclusive token
+        var score: Float = 0.9
+        TdtDecoderV3.applyEnglishBlocklist(
+            label: &label,
+            score: &score,
+            topKIds: [999, 481],
+            topKLogits: [2.0, 1.0],
+            vocabulary: vocab,
+            blankId: blankId
+        )
+        XCTAssertEqual(label, 999)
+        XCTAssertEqual(score, 0.9)
+    }
+
+    func testNoSubstitutionWhenNoValidAlternativeInTopK() {
+        var label = 506  // ' the'
+        var score: Float = 0.8
+        // Top-K contains only blocked English tokens and blank — nothing to substitute.
+        TdtDecoderV3.applyEnglishBlocklist(
+            label: &label,
+            score: &score,
+            topKIds: [506, 575, blankId],
+            topKLogits: [3.0, 2.0, 1.0],
+            vocabulary: vocab,
+            blankId: blankId
+        )
+        XCTAssertEqual(label, 506)
+        XCTAssertEqual(score, 0.8)
+    }
+
+    func testSubstitutesEnglishTokenWithBestLatinAlternative() {
+        var label = 506  // ' the' — in blocklist
+        var score: Float = 0.7
+        // Top-K: ' the' wins, but ' le' (481) and ' et' (453) are valid French alternatives.
+        TdtDecoderV3.applyEnglishBlocklist(
+            label: &label,
+            score: &score,
+            topKIds: [506, 481, 453],
+            topKLogits: [5.0, 4.0, 2.0],
+            vocabulary: vocab,
+            blankId: blankId
+        )
+        // Should pick ' le' (highest logit among non-blocked Latin alternatives)
+        XCTAssertEqual(label, 481)
+        XCTAssertGreaterThan(score, 0)
+        XCTAssertLessThanOrEqual(score, 1)
+    }
+
+    func testSubstitutedScoreIsNormalisedProbability() {
+        var label = 575  // ' and' — in blocklist
+        var score: Float = 0.5
+        // Two alternatives; substitution picks ' la' (393, logit 3.0).
+        TdtDecoderV3.applyEnglishBlocklist(
+            label: &label,
+            score: &score,
+            topKIds: [575, 393, 453],
+            topKLogits: [4.0, 3.0, 1.0],
+            vocabulary: vocab,
+            blankId: blankId
+        )
+        XCTAssertEqual(label, 393)
+        // Softmax over [4, 3, 1]: exp(3-4) / (exp(0) + exp(-1) + exp(-3))
+        let maxL: Float = 4.0
+        let sumExp = exp(4.0 - maxL) + exp(3.0 - maxL) + exp(1.0 - maxL)
+        let expected = exp(3.0 - maxL) / sumExp
+        XCTAssertEqual(score, expected, accuracy: 1e-5)
+    }
+
+    func testBlocklistContainsExpectedTokens() {
+        XCTAssertTrue(TdtDecoderV3.englishBlocklistIds.contains(506))  // ' the'
+        XCTAssertTrue(TdtDecoderV3.englishBlocklistIds.contains(575))  // ' and'
+        XCTAssertTrue(TdtDecoderV3.englishBlocklistIds.contains(1868))  // ' with'
+        XCTAssertFalse(TdtDecoderV3.englishBlocklistIds.contains(481))  // ' le'
+        XCTAssertFalse(TdtDecoderV3.englishBlocklistIds.contains(453))  // ' et'
+    }
+}


### PR DESCRIPTION
Parakeet TDT v3 has no language conditioning token. On spontaneous non-English speech, the model falls back to its English training prior and produces output that reads like a real-time translation. This is a known architectural limitation.

This PR adds a post-processing step in the decoder that partially mitigates it for French.

## Mechanism

When the joint model picks a token from an English-exclusive blocklist (48 space-prefixed SentencePiece tokens: `' the'`, `' and'`, `' with'`, etc.), `applyEnglishBlocklist` scans the top-64 logits for the highest-scoring non-blocked Latin-script alternative and substitutes it. If nothing suitable is in top-64, the original prediction stands.

The substituted score is fed back into the transducer's LSTM state, which compounds: each forced French token nudges the following frames away from English.

Runs in O(64) per non-blank token. No additional model call, no latency impact.

## Benchmark

French recordings, drift = % sentences flagged by English function-word scan or langdetect=EN:

| Recording | Before | After |
|---|---|---|
| Children's weather segment | 0% | 0% |
| Archival 1912 | 2.9% | 2.7% |
| Weightlifting documentary | 7.1% | 0% |
| French slang documentary | 18.2% | 3.7% |
| Picard dialect documentary | 16.7% | 0% |
| Spontaneous interview (57 min) | 31.3% | 13.5% |

The remaining 13.5% on the interview is architectural: sustained English passages where no French candidate appeared in top-64 at all. The blocklist cannot help there.

## Test recordings

All INA recordings are publicly available on YouTube:

- [Argot et langage populaire (1981)](https://www.youtube.com/watch?v=zem3PVMsy8g)
- [Phonographe de 1912](https://www.youtube.com/watch?v=amPtXEaXQO0&t=12s)
- [Le parler picard (1982)](https://www.youtube.com/watch?v=W17uYuQA9Mc&t=8s)
- [Meteo pour les enfants (1980)](https://www.youtube.com/watch?v=sMSRyg172C0&t=8s)
- [Halterophilie (1975)](https://www.youtube.com/watch?v=E4xalDom8VY&t=2s)

The sixth recording (57-minute spontaneous interview) is private.

## Scope

This patch is French/English specific. The 48-token blocklist was derived empirically from the Parakeet TDT v3 SentencePiece vocabulary for French. The mechanism generalises to other language pairs but building equivalent blocklists requires the same vocabulary analysis and, critically, someone who can actually evaluate the output quality. I only speak French, so I only benchmarked French. I'm not going to claim results for languages I can't verify.

Flagging this as a starting point and leaving the generalisation to contributors who know the other languages and have audio to test against.

## Context

I'm not a professional developer. I found this problem while building a personal project on top of FluidAudio and did the diagnostic work: instrumented the decoder to log English token wins, measured that 84% of them had a French alternative in the top-64, ran before/after benchmarks across six recordings.
