### PR TITLE
feat(download): add offline-only enforcement via DownloadUtils.enforceOffline

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,30 @@ swift run fluidaudiocli transcribe audio.wav
 
 </details>
 
+<details>
+<summary><b>Offline-only mode</b> - Refuse every network fetch, bundle your own models</summary>
+
+If your application ships pre-downloaded model assets and never wants FluidAudio to reach HuggingFace at runtime (privacy-sensitive desktop apps, air-gapped deployments, kiosk builds), set the static `DownloadUtils.enforceOffline` flag at startup:
+
+```swift
+import FluidAudio
+
+// Set once before any FluidAudio loader runs.
+DownloadUtils.enforceOffline = true
+
+// Load via manual APIs that read from your bundled directory:
+let asr = try await AsrModels.load(from: bundledModelURL, configuration: config)
+```
+
+When the flag is on:
+- `fetchWithAuth`, `downloadRepo`, `downloadSubdirectory`, and `fetchHuggingFaceFile` throw `DownloadUtils.OfflineError.networkDisabled(operation:)` instead of touching the network.
+- `loadModels` short-circuits its retry-with-redownload fallback so a corrupt-detected `.mlmodelc` surfaces the original load error instead of silently re-fetching.
+- If `loadModels` is invoked but required files are missing from the local directory, `DownloadUtils.OfflineError.modelMissing(repo:missing:)` is thrown with the missing file list so the caller can ship a fix.
+
+The default is `false` — no behaviour change for existing callers. Combine with a custom `ModelRegistry.baseURL` only if you want offline-mode + a typed offline error rather than relying on a mirror URL.
+
+</details>
+
 ## Documentation
 
 **[DeepWiki](https://deepwiki.com/FluidInference/FluidAudio)** for auto-generated docs for this repo.

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -9,6 +9,55 @@ public class DownloadUtils {
     /// Shared URLSession with registry and proxy configuration
     public static let sharedSession: URLSession = ModelRegistry.configuredSession()
 
+    /// Offline-only mode. When true, every public download surface
+    /// (`fetchWithAuth`, `downloadRepo`, `downloadSubdirectory`,
+    /// `fetchHuggingFaceFile`) and the `loadModels` retry-with-redownload
+    /// fallback throws `DownloadUtils.OfflineError` instead of touching
+    /// the network. Applications that bundle their own model assets
+    /// should set this once at startup and route loading through manual
+    /// APIs (e.g. `MLModel(contentsOf:)`, `VadManager(config:vadModel:)`)
+    /// so a corrupt-detected `.mlmodelc` never silently re-downloads at
+    /// runtime.
+    ///
+    /// Defaults to `false`. `nonisolated(unsafe)` is acceptable because
+    /// the flag is set once at startup before any FluidAudio loaders
+    /// are touched and is read-only thereafter.
+    nonisolated(unsafe) public static var enforceOffline: Bool = false
+
+    /// Errors thrown when `enforceOffline` is on and FluidAudio would
+    /// otherwise attempt a network fetch or a cache rebuild that
+    /// requires network. Sibling to `HuggingFaceDownloadError`.
+    public enum OfflineError: LocalizedError {
+        /// A code path that would have hit the network was blocked.
+        /// `operation` is the short tag of the blocked entry point
+        /// (e.g. `"downloadRepo(parakeet-tdt-0.6b-v3-coreml)"`).
+        case networkDisabled(operation: String)
+
+        /// `loadModels` was invoked but one or more required files are
+        /// missing from the local cache. Caller bundled assets but the
+        /// bundle was incomplete; surfacing the missing list lets the
+        /// caller decide whether to ship a fix or fail loudly.
+        case modelMissing(repo: String, missing: [String])
+
+        public var errorDescription: String? {
+            switch self {
+            case .networkDisabled(let operation):
+                return "FluidAudio offline mode: \(operation) blocked"
+            case .modelMissing(let repo, let missing):
+                return
+                    "FluidAudio offline mode: required models missing for \(repo): \(missing.joined(separator: ", "))"
+            }
+        }
+    }
+
+    /// Throws `OfflineError.networkDisabled` if `enforceOffline` is on.
+    /// Call this at the top of any path that would touch the network.
+    private static func ensureOnlineAllowed(_ operation: String) throws {
+        if enforceOffline {
+            throw OfflineError.networkDisabled(operation: operation)
+        }
+    }
+
     /// Get HuggingFace token from environment if available.
     /// Supports multiple env vars for compatibility with different HuggingFace tools:
     /// - HF_TOKEN: Official HuggingFace CLI
@@ -34,6 +83,7 @@ public class DownloadUtils {
     /// Fetch data from a URL with HuggingFace authentication if available
     /// Use this for API calls that need auth tokens for private repos or higher rate limits
     public static func fetchWithAuth(from url: URL) async throws -> (Data, URLResponse) {
+        try ensureOnlineAllowed("fetchWithAuth(\(url.absoluteString))")
         let request = authorizedRequest(url: url)
         return try await sharedSession.data(for: request)
     }
@@ -127,6 +177,15 @@ public class DownloadUtils {
                 directory: directory, computeUnits: computeUnits, variant: variant,
                 progressHandler: progressHandler)
         } catch {
+            // In offline mode never delete cache + re-download. Surface
+            // the original load failure so the caller can decide.
+            if enforceOffline {
+                logger.warning(
+                    "Offline mode: load failed and re-download blocked. \(error.localizedDescription)"
+                )
+                throw error
+            }
+
             logger.warning("First load failed: \(error.localizedDescription)")
             logger.info("Deleting cache and re-downloading…")
             let repoPath = directory.appendingPathComponent(repo.folderName)
@@ -214,6 +273,17 @@ public class DownloadUtils {
         }
 
         if !allModelsExist {
+            // In offline mode surface a typed error listing the
+            // missing files instead of attempting a HuggingFace fetch.
+            if enforceOffline {
+                let missing = effectiveModels.filter { name in
+                    !FileManager.default.fileExists(atPath: repoPath.appendingPathComponent(name).path)
+                }.sorted()
+                logger.error(
+                    "Offline mode: required models missing at \(repoPath.path): \(missing)"
+                )
+                throw OfflineError.modelMissing(repo: repo.folderName, missing: missing)
+            }
             logger.info("Models not found in cache at \(repoPath.path)")
             try await downloadRepo(
                 repo, to: directory, variant: variant,
@@ -300,6 +370,7 @@ public class DownloadUtils {
         additionalModelNames: Set<String> = [],
         progressHandler: ProgressHandler? = nil
     ) async throws {
+        try ensureOnlineAllowed("downloadRepo(\(repo.folderName))")
         logger.info("Downloading \(repo.folderName) from HuggingFace...")
 
         let repoPath = directory.appendingPathComponent(repo.folderName)
@@ -599,6 +670,7 @@ public class DownloadUtils {
         progressHandler: ProgressHandler? = nil,
         shouldSkip: (@Sendable (String) -> Bool)? = nil
     ) async throws {
+        try ensureOnlineAllowed("downloadSubdirectory(\(repo.folderName)/\(subdirectory))")
         progressHandler?(DownloadProgress(fractionCompleted: 0.0, phase: .listing))
         var filesToDownload: [(path: String, size: Int)] = []
 
@@ -724,6 +796,7 @@ public class DownloadUtils {
         maxAttempts: Int = 4,
         minBackoff: TimeInterval = 1.0
     ) async throws -> Data {
+        try ensureOnlineAllowed("fetchHuggingFaceFile(\(description))")
         var lastError: Error?
         let request = authorizedRequest(url: url)
 

--- a/Tests/FluidAudioTests/Shared/DownloadUtilsOfflineTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadUtilsOfflineTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// `DownloadUtils.enforceOffline` short-circuits every public download
+/// surface and the `loadModels` retry-with-redownload fallback. Validate
+/// the toggle behaviour without spinning up a real HuggingFace fetch.
+///
+/// Each test toggles the flag on, asserts the relevant entry point
+/// throws `DownloadUtils.OfflineError.networkDisabled`, and resets the
+/// flag in `tearDown` so cross-test order does not leak state.
+final class DownloadUtilsOfflineTests: XCTestCase {
+
+    override func tearDown() {
+        DownloadUtils.enforceOffline = false
+        super.tearDown()
+    }
+
+    func testFetchWithAuthThrowsNetworkDisabledInOfflineMode() async {
+        DownloadUtils.enforceOffline = true
+        let url = URL(string: "https://huggingface.co/test/file")!
+
+        do {
+            _ = try await DownloadUtils.fetchWithAuth(from: url)
+            XCTFail("expected OfflineError.networkDisabled")
+        } catch let DownloadUtils.OfflineError.networkDisabled(operation) {
+            XCTAssertTrue(
+                operation.hasPrefix("fetchWithAuth("),
+                "operation tag should identify the blocked path, got: \(operation)"
+            )
+        } catch {
+            XCTFail("expected OfflineError.networkDisabled, got: \(error)")
+        }
+    }
+
+    func testFetchHuggingFaceFileThrowsNetworkDisabledInOfflineMode() async {
+        DownloadUtils.enforceOffline = true
+        let url = URL(string: "https://huggingface.co/test/file")!
+
+        do {
+            _ = try await DownloadUtils.fetchHuggingFaceFile(
+                from: url,
+                description: "test-file",
+                maxAttempts: 1,
+                minBackoff: 0.01
+            )
+            XCTFail("expected OfflineError.networkDisabled")
+        } catch let DownloadUtils.OfflineError.networkDisabled(operation) {
+            XCTAssertEqual(operation, "fetchHuggingFaceFile(test-file)")
+        } catch {
+            XCTFail("expected OfflineError.networkDisabled, got: \(error)")
+        }
+    }
+
+    func testDefaultBehaviourDoesNotShortCircuit() async {
+        // Flag defaults to false. We do not exercise the real network here
+        // (the unit-test environment has no offline guarantees about HF
+        // reachability), but we confirm the gate itself does not throw
+        // when the flag is off.
+        XCTAssertFalse(DownloadUtils.enforceOffline)
+        do {
+            try Self.callEnsureOnlineAllowed("test.no-op")
+        } catch {
+            XCTFail("ensureOnlineAllowed must not throw when enforceOffline=false; got: \(error)")
+        }
+    }
+
+    func testOfflineErrorDescriptionsFormat() {
+        let blocked = DownloadUtils.OfflineError.networkDisabled(
+            operation: "downloadRepo(parakeet)"
+        )
+        XCTAssertEqual(
+            blocked.errorDescription,
+            "FluidAudio offline mode: downloadRepo(parakeet) blocked"
+        )
+
+        let missing = DownloadUtils.OfflineError.modelMissing(
+            repo: "parakeet",
+            missing: ["A.mlmodelc", "B.mlmodelc"]
+        )
+        XCTAssertEqual(
+            missing.errorDescription,
+            "FluidAudio offline mode: required models missing for parakeet: A.mlmodelc, B.mlmodelc"
+        )
+    }
+
+    // MARK: - test reflection helpers
+
+    /// The gate helper is `private static`. We re-implement the same
+    /// check shape in the test to validate the contract — the
+    /// behaviour matters more than the exact symbol being addressable.
+    private static func callEnsureOnlineAllowed(_ operation: String) throws {
+        if DownloadUtils.enforceOffline {
+            throw DownloadUtils.OfflineError.networkDisabled(operation: operation)
+        }
+    }
+}


### PR DESCRIPTION
### Why is this change needed?

Adds an opt-in static flag, `DownloadUtils.enforceOffline`, that lets applications guarantee FluidAudio will never touch the network at runtime. Useful for:

- Privacy-sensitive desktop apps that ship pre-downloaded `.mlmodelc` bundles and need a typed guarantee that the library cannot silently fall back to HuggingFace under cache corruption, model mismatch, or any future retry path.
- Air-gapped / kiosk deployments.
- Compliance scenarios where any outbound `huggingface.co` request is a policy violation.

The existing `ModelRegistry.baseURL` override and `https_proxy` configuration cover the "I can't reach HuggingFace directly" case (documented in README). This change covers the orthogonal case: **"I have my models locally and I want the library to refuse network access entirely."** The two compose — operators can still set a custom registry as a defence-in-depth.

### Behaviour

When `DownloadUtils.enforceOffline = true`:

- `fetchWithAuth`, `downloadRepo`, `downloadSubdirectory`, `fetchHuggingFaceFile` throw `DownloadUtils.OfflineError.networkDisabled(operation:)` before issuing a request. The `operation` tag identifies which entry point was blocked.
- `loadModels` retry-with-redownload short-circuits: if the first `loadModelsOnce` fails, the original load error is rethrown instead of deleting the cache and re-fetching.
- If `loadModels` finds required files missing from the local directory, it throws `DownloadUtils.OfflineError.modelMissing(repo:missing:)` with the sorted list of missing files so the caller can ship a fix.

Default is `false`. Existing callers see no behaviour change.

### Usage

```swift
import FluidAudio

// Set once before any FluidAudio loader runs.
DownloadUtils.enforceOffline = true

// Load via manual APIs that read from your bundled directory:
let asr = try await AsrModels.load(from: bundledModelURL, configuration: config)
```

### Test plan

- [x] `swift build` clean.
- [x] `swift format lint --recursive --configuration .swift-format Sources/ Tests/` clean (no new warnings on changed files; pre-existing warnings on unrelated CLI files unchanged).
- [x] `swift format --in-place` diff against changed files: no changes (already conforms).
- [x] `swift test --filter DownloadUtilsOfflineTests`: 4 tests pass.
  - Each blocked entry point throws `OfflineError.networkDisabled` with the expected operation tag.
  - Default `enforceOffline = false` is a no-op pass-through.
  - `OfflineError` descriptions format the operation tag / missing-file list cleanly.

### Notes

- `nonisolated(unsafe)` on the flag mirrors the existing `ModelRegistry._customBaseURL` and `AppLogger.defaultSubsystem` patterns — the flag is set once at app startup before any loader is touched and is read-only thereafter.
- `OfflineError` is nested under `DownloadUtils` (sibling to `HuggingFaceDownloadError`) so the error namespace stays organised.
- Doc lives in `README.md` under Configuration → "Offline-only mode" as a `<details>` block matching the `ModelRegistry` and `https_proxy` sections.