### PR TITLE
docs: remove stray leading "d" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-d![banner.png](banner.png)
+![banner.png](banner.png)
 
 # FluidAudio - Transcription, Text-to-speech, VAD, Speaker diarization with CoreML Models
 


### PR DESCRIPTION
The README starts with a stray `d` character immediately before the banner image markdown:

```
d![banner.png](banner.png)
```

This renders a literal `d` at the very top of the rendered page. This PR removes it so the banner image is the first element.