### PR TITLE
fix(cli): expose missing Parakeet langs, add Greek script support

### DIFF
--- a/Sources/FluidAudio/Shared/TokenLanguageFilter.swift
+++ b/Sources/FluidAudio/Shared/TokenLanguageFilter.swift
@@ -9,6 +9,15 @@ public enum Language: String, Sendable, CaseIterable {
     case italian = "it"
     case portuguese = "pt"
     case romanian = "ro"  // uses ș, ț (Latin Extended-B)
+    case dutch = "nl"
+    case danish = "da"
+    case swedish = "sv"
+    case finnish = "fi"
+    case hungarian = "hu"
+    case estonian = "et"
+    case latvian = "lv"
+    case lithuanian = "lt"
+    case maltese = "mt"
 
     // Latin-script Slavic — prone to Cyrillic confusion in multilingual ASR.
     case polish = "pl"
@@ -24,13 +33,20 @@ public enum Language: String, Sendable, CaseIterable {
     case bulgarian = "bg"
     case serbian = "sr"
 
+    // Greek script
+    case greek = "el"
+
     public var script: Script {
         switch self {
         case .english, .spanish, .french, .german, .italian, .portuguese, .romanian,
+            .dutch, .danish, .swedish, .finnish, .hungarian, .estonian, .latvian,
+            .lithuanian, .maltese,
             .polish, .czech, .slovak, .slovenian, .croatian, .bosnian:
             return .latin
         case .russian, .ukrainian, .belarusian, .bulgarian, .serbian:
             return .cyrillic
+        case .greek:
+            return .greek
         }
     }
 }
@@ -40,6 +56,7 @@ public enum Language: String, Sendable, CaseIterable {
 public enum Script: Sendable {
     case latin
     case cyrillic
+    case greek
 }
 
 /// Filters ASR decoder tokens against the target language's alphabet.
@@ -87,6 +104,24 @@ internal struct TokenLanguageFilter: Sendable {
                 // must be rejected (see function doc).
                 if value >= 0x0020 && value <= 0x007F {
                     if (value >= 0x41 && value <= 0x5A) || (value >= 0x61 && value <= 0x7A) {
+                        return false
+                    }
+                    return true
+                }
+                return false
+            }
+        case .greek:
+            return chars.allSatisfy { char in
+                let value = char.value
+                // Greek and Coptic block (U+0370–U+03FF); Coptic subset not used
+                if value >= 0x0370 && value <= 0x03FF { return true }
+                // Greek Extended (polytonic/ancient Greek diacritics)
+                if value >= 0x1F00 && value <= 0x1FFF { return true }
+                // Allow ASCII punctuation, digits, spaces (script-neutral)
+                if value >= 0x0020 && value <= 0x007F {
+                    // Reject Latin letters A-Z/a-z
+                    if (value >= 0x41 && value <= 0x5A) ||
+                       (value >= 0x61 && value <= 0x7A) {
                         return false
                     }
                     return true

--- a/Sources/FluidAudio/Shared/TokenLanguageFilter.swift
+++ b/Sources/FluidAudio/Shared/TokenLanguageFilter.swift
@@ -118,13 +118,13 @@ internal struct TokenLanguageFilter: Sendable {
                 // Greek Extended (polytonic/ancient Greek diacritics)
                 if value >= 0x1F00 && value <= 0x1FFF { return true }
                 // Allow ASCII punctuation, digits, spaces (script-neutral)
-                if value >= 0x0020 && value <= 0x007F {
-                    // Reject Latin letters A-Z/a-z
-                    if (value >= 0x41 && value <= 0x5A) || (value >= 0x61 && value <= 0x7A) {
-                        return false
-                    }
-                    return true
+                // Reject ASCII Latin letters A-Z/a-z
+                if (value >= 0x41 && value <= 0x5A) || (value >= 0x61 && value <= 0x7A) {
+                    return false
                 }
+                // Allow remaining ASCII punctuation, digits, spaces (script-neutral)
+                if value >= 0x0020 && value <= 0x007F { return true }
+
                 return false
             }
         }

--- a/Sources/FluidAudio/Shared/TokenLanguageFilter.swift
+++ b/Sources/FluidAudio/Shared/TokenLanguageFilter.swift
@@ -120,8 +120,7 @@ internal struct TokenLanguageFilter: Sendable {
                 // Allow ASCII punctuation, digits, spaces (script-neutral)
                 if value >= 0x0020 && value <= 0x007F {
                     // Reject Latin letters A-Z/a-z
-                    if (value >= 0x41 && value <= 0x5A) ||
-                       (value >= 0x61 && value <= 0x7A) {
+                    if (value >= 0x41 && value <= 0x5A) || (value >= 0x61 && value <= 0x7A) {
                         return false
                     }
                     return true

--- a/Sources/FluidAudio/Shared/TokenLanguageFilter.swift
+++ b/Sources/FluidAudio/Shared/TokenLanguageFilter.swift
@@ -117,16 +117,19 @@ internal struct TokenLanguageFilter: Sendable {
                 if value >= 0x0370 && value <= 0x03FF { return true }
                 // Greek Extended (polytonic/ancient Greek diacritics)
                 if value >= 0x1F00 && value <= 0x1FFF { return true }
+                // Combining Diacritical Marks (NFD)
+                if value >= 0x0300 && value <= 0x036F { return true }
                 // Allow ASCII punctuation, digits, spaces (script-neutral)
-                // Reject ASCII Latin letters A-Z/a-z
-                if (value >= 0x41 && value <= 0x5A) || (value >= 0x61 && value <= 0x7A) {
-                    return false
+                if value >= 0x0020 && value <= 0x007F {
+                    // Reject Latin letters A-Z/a-z
+                    if (value >= 0x41 && value <= 0x5A) || (value >= 0x61 && value <= 0x7A) {
+                        return false
+                    }
+                    return true
                 }
-                // Allow remaining ASCII punctuation, digits, spaces (script-neutral)
-                if value >= 0x0020 && value <= 0x007F { return true }
-
                 return false
             }
+
         }
     }
 

--- a/Tests/FluidAudioTests/Shared/TokenLanguageFilterTests.swift
+++ b/Tests/FluidAudioTests/Shared/TokenLanguageFilterTests.swift
@@ -450,7 +450,7 @@ final class TokenLanguageFilterTests: XCTestCase {
         for language in Language.allCases {
             let script = language.script
             XCTAssertTrue(
-                script == .latin || script == .cyrillic,
+                script == .latin || script == .cyrillic || script == .greek,
                 "\(language.rawValue) must have a valid script")
         }
     }


### PR DESCRIPTION
## Summary

The supported languages list in `TokenLanguageFilter` omits several languages currently supported by [Parakeet-TDT-0.6B-v3](https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3):
- Danish (da)
- Dutch (nl)
- Estonian (et)
- Finnish (fi)
- Greek (el)
- Hungarian (hu)
- Latvian (lv)
- Lithuanian (lt)
- Maltese (mt)
- Swedish (sv)

This pull request proposes to incorporate these languages so that they are available to users of the FluidAudio SDK.

### Reproduction

Using the first 90 seconds of an [Greek language learning video](https://www.youtube.com/watch?v=gtmBaIKw5P4) I found online, the previous behavior:

```
$ fluidaudiocli transcribe greek-90s.wav --language el
<unk>7<unk>, Easy Greek. <unk>00<unk>, <unk><unk>2<unk> <unk> <unk>. <unk> <unk> <unk>. <unk> <unk>3<unk>00. . Aozaj, bo'ă. 100 000. 1, 5, 0, 6. O cožmo. Opa, 30. Oit 1. Pulše, 50. 10. Tit'a pärast i 6000. 800 000. <unk> 8.500, 100 000. ...5... ... 34 000. <unk> 0 <unk> 5. 50, o <unk>-vą po<unk> 2? ...Ti'6 <unk> 0.000. ...000, 1000.000, 100%. ...0or'0, <unk>...0<unk>.,5 4, 1 2.0. <unk>Meta<unk>, <unk>4<unk>, <unk>000<unk>, <unk>Ca<unk>, <unk>2.
```

After additions to code:

```
$ fluidaudiocli transcribe greek-90s.wav --language el
Πασα, φίλη του Εσυγ. Είμαι η Έλληνα και είμαι μπροστά από το λευκό πύργο. Σήμερα θα μιλήσουμε για τη Θεσσαλονίκη. Πάμε. Από που είστε. Κασαλληνο. Ωραία, τι σα αρέσει περισσότερο στη Θεσσαλονίκη. Ο κόσμο. Ο παλιό κόσμο τη Θεσσαλονίκη. Ο ήταν ένα κόσμο που σε βότανε που αγαπούσε και τον αγαπούσαν. Πού είσαι, αποκαζάνη. Ωραία. Τι σε αρέσει περισσότερο στη Θεσσαλονίκη. Ότι είναι πολύ ομορφιό και ότι έχει πολλού φοιτητέ και έχει και την παραλία δίπλα. Απ' την Κύπρο. Τι σα αρέσει περισσότερο στη Θεσσαλονίκη. Η ζωή εδώ πέρα. Η κίνηση, ο κόσμο. Από πού είστε. Εγώ είμαι από Αλβανία. Τι σα αρέσει περισσότερο στη Θεσσαλονίκη. Στη Θεσσαλονίκη περισσότερο οι άνθρωποι είναι όλοι ωραία και φελξουν η μέλη. Μα φελθωθεί και πάρα πολλά αλλά γιατί η Θεσσαλονίκη μα είναι μια να μην μπορεί πιο ομορφι, θα είναι εγγυαστικό πόλη στην Ελλάδα. Αλλά μέσα στι πιο όμορφε πόλει είναι η Θεσσαλονίκη, η Καβάλα και τον Αύγουο.
```

Also tested with Dutch language source with much longer clip, transcription was successful.

### Edits

Parakeet TDT v3 supports Dutch, Danish, Swedish, Finnish, Greek, Hungarian, Estonian, Latvian, Lithuanian, and Maltese but these were absent from the Language enum in TokenLanguageFilter.swift, causing the CLI to reject them with 'Unknown language' although the underlying model handles them correctly. 

Modified `FluidAudio/Sources/FluidAudio/Shared/TokenLanguageFilter.swift` to add missing languages supported by current version of Parakeet, as well as Greek script (U+0370-U+03FF, U+1F00-U+1FFF) case.