### PR TITLE
Showcase: add Parleq

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[Resonant](https://onresonant.com)** | macOS voice workspace for dictation, meetings, and ambient work context. Uses FluidAudio for local transcription and speaker diarization. |
 | **[Thoth](https://thoth-app.com)** | Privacy-first meeting recorder for Mac. Records both sides of any call with dual-channel audio, transcribes locally with speaker diarization, and summarizes with on-device AI or BYOK cloud. Available on the Mac App Store. Featured in [MacGeneration](https://www.macg.co/logiciels/2026/05/thoth-une-nouvelle-app-de-transcription-axee-sur-les-reunions-et-le-temps-reel-308471). Uses Parakeet EOU and Parakeet TDT ASR. |
 | **[Dettivo](https://dettivo.com)** | Local-first Mac app for private dictation, transcripts, and meeting workflows in one place, with developer tooling across CLI, MCP, REST, and app automation. Uses FluidAudio Parakeet TDT ASR and offline speaker diarization. |
+| **[Parleq](https://parleq.app/)** | Privacy-first macOS dictation — press a hotkey, speak, paste cleaned-up text. On-device Parakeet TDT v3 ASR with CTC vocabulary boosting (audio never leaves the Mac), provider-pluggable LLM cleanup (Gemini/Vertex, Bedrock, Azure), and reference windows that bring on-screen context into the cleanup. Open source. |
 
 ## Installation
 


### PR DESCRIPTION
Adds **Parleq** to the Showcase, appended in chronological order per the contributing note.

[Parleq](https://parleq.app/) is a privacy-first, open-source macOS dictation app: press a hotkey, speak, and paste cleaned-up text. It runs FluidAudio's **Parakeet TDT v3** on the Apple Neural Engine with CTC vocabulary boosting (audio never leaves the device), plus provider-pluggable LLM cleanup.

Logo for the curated logo block whenever convenient:
- Light: https://parleq.app/logo.svg
- Dark: https://parleq.app/logo-dark.svg

Thanks for maintaining FluidAudio and the showcase!
