### PR TITLE
TTS: store downloaded models in Application Support, not Caches (iOS)

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -163,7 +163,8 @@ public class DownloadUtils {
     ///
     /// Clears both cache locations:
     /// - `~/Library/Application Support/FluidAudio/Models/` (ASR, VAD, Diarization)
-    /// - `~/.cache/fluidaudio/Models/` (TTS)
+    /// - the shared TTS root: `~/.cache/fluidaudio/` on macOS,
+    ///   `Application Support/fluidaudio/` on iOS (matches `TtsCacheDirectory`).
     public static func clearAllModelCaches() {
         let fm = FileManager.default
 
@@ -173,14 +174,16 @@ public class DownloadUtils {
             try? fm.removeItem(at: modelsDir)
         }
 
-        // TTS models (Kokoro, PocketTTS)
+        // TTS models (Kokoro, PocketTTS, Magpie, Supertonic3, StyleTTS2).
+        // Remove the whole `fluidaudio/` root so every backend subdirectory
+        // (Models/, voice packs, etc.) is cleared, not just `Models/`.
         #if os(macOS)
         let home = fm.homeDirectoryForCurrentUser
-        let ttsCache = home.appendingPathComponent(".cache/fluidaudio/Models")
+        let ttsCache = home.appendingPathComponent(".cache/fluidaudio")
         try? fm.removeItem(at: ttsCache)
         #else
-        if let cacheDir = fm.urls(for: .cachesDirectory, in: .userDomainMask).first {
-            let ttsCache = cacheDir.appendingPathComponent("fluidaudio/Models")
+        if let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            let ttsCache = appSupport.appendingPathComponent("fluidaudio")
             try? fm.removeItem(at: ttsCache)
         }
         #endif

--- a/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
@@ -328,26 +328,8 @@ public enum KokoroAneResourceDownloader {
     // MARK: - Private
 
     private static func defaultModelsDirectory() throws -> URL {
-        let baseDirectory: URL
-        #if os(macOS)
-        baseDirectory = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".cache")
-        #else
-        guard
-            let first = FileManager.default.urls(
-                for: .cachesDirectory, in: .userDomainMask
-            ).first
-        else {
-            throw KokoroAneError.downloadFailed("Failed to locate caches directory")
-        }
-        baseDirectory = first
-        #endif
-
-        let cacheDirectory = baseDirectory.appendingPathComponent("fluidaudio")
-        if !FileManager.default.fileExists(atPath: cacheDirectory.path) {
-            try FileManager.default.createDirectory(
-                at: cacheDirectory, withIntermediateDirectories: true)
-        }
-        return cacheDirectory.appendingPathComponent(modelsSubdirectory)
+        // Delegate to the shared TTS cache root (Application Support on iOS,
+        // ~/.cache/fluidaudio on macOS) so all backends share one location.
+        return try TtsCacheDirectory.ensure().appendingPathComponent(modelsSubdirectory)
     }
 }

--- a/Sources/FluidAudio/TTS/Magpie/Assets/MagpieResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/Magpie/Assets/MagpieResourceDownloader.swift
@@ -113,19 +113,9 @@ public enum MagpieResourceDownloader {
     }
 
     private static func defaultCacheRoot() throws -> URL {
-        let base: URL
-        #if os(macOS)
-        base = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".cache")
-        #else
-        guard
-            let first = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-        else {
-            throw MagpieError.downloadFailed("failed to locate caches directory")
-        }
-        base = first
-        #endif
-        let root = base.appendingPathComponent("fluidaudio").appendingPathComponent("Models")
+        // Delegate to the shared TTS cache root (Application Support on iOS,
+        // ~/.cache/fluidaudio on macOS) so all backends share one location.
+        let root = try TtsCacheDirectory.ensure().appendingPathComponent("Models")
         if !FileManager.default.fileExists(atPath: root.path) {
             try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         }

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -262,26 +262,8 @@ public enum PocketTtsResourceDownloader {
     // MARK: - Private
 
     private static func cacheDirectory() throws -> URL {
-        let baseDirectory: URL
-        #if os(macOS)
-        baseDirectory = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".cache")
-        #else
-        guard
-            let first = FileManager.default.urls(
-                for: .cachesDirectory, in: .userDomainMask
-            ).first
-        else {
-            throw PocketTTSError.processingFailed("Failed to locate caches directory")
-        }
-        baseDirectory = first
-        #endif
-
-        let cacheDirectory = baseDirectory.appendingPathComponent("fluidaudio")
-        if !FileManager.default.fileExists(atPath: cacheDirectory.path) {
-            try FileManager.default.createDirectory(
-                at: cacheDirectory, withIntermediateDirectories: true)
-        }
-        return cacheDirectory
+        // Delegate to the shared TTS cache root (Application Support on iOS,
+        // ~/.cache/fluidaudio on macOS) so all backends share one location.
+        return try TtsCacheDirectory.ensure()
     }
 }

--- a/Sources/FluidAudio/TTS/Shared/TtsCacheDirectory.swift
+++ b/Sources/FluidAudio/TTS/Shared/TtsCacheDirectory.swift
@@ -9,7 +9,13 @@ import Foundation
 /// backend-specific manager.
 ///
 /// macOS resolves to `~/.cache/fluidaudio`; other platforms use the
-/// caches directory under `fluidaudio/`.
+/// application-support directory under `fluidaudio/`.
+///
+/// On iOS/iPadOS this deliberately avoids `.cachesDirectory`: `Library/Caches`
+/// is reclaimable by the system under disk pressure, so models (hundreds of MB)
+/// could be silently purged while backgrounded and require a full re-download.
+/// `.applicationSupportDirectory` is the recommended location for re-obtainable
+/// but expensive-to-replace data, matching the ASR side.
 public enum TtsCacheDirectory {
 
     /// Ensures the platform-appropriate cache root exists and returns it.
@@ -21,10 +27,10 @@ public enum TtsCacheDirectory {
         #else
         guard
             let first = FileManager.default.urls(
-                for: .cachesDirectory, in: .userDomainMask
+                for: .applicationSupportDirectory, in: .userDomainMask
             ).first
         else {
-            throw TTSError.processingFailed("Failed to locate caches directory")
+            throw TTSError.processingFailed("Failed to locate application support directory")
         }
         base = first
         #endif

--- a/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2ResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2ResourceDownloader.swift
@@ -145,19 +145,9 @@ public enum StyleTTS2ResourceDownloader {
     }
 
     private static func defaultCacheRoot() throws -> URL {
-        let base: URL
-        #if os(macOS)
-        base = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".cache")
-        #else
-        guard
-            let first = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-        else {
-            throw StyleTTS2Error.downloadFailed("failed to locate caches directory")
-        }
-        base = first
-        #endif
-        let root = base.appendingPathComponent("fluidaudio").appendingPathComponent("Models")
+        // Delegate to the shared TTS cache root (Application Support on iOS,
+        // ~/.cache/fluidaudio on macOS) so all backends share one location.
+        let root = try TtsCacheDirectory.ensure().appendingPathComponent("Models")
         if !FileManager.default.fileExists(atPath: root.path) {
             try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         }

--- a/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ResourceDownloader.swift
@@ -41,19 +41,9 @@ public enum Supertonic3ResourceDownloader {
     }
 
     private static func defaultCacheRoot() throws -> URL {
-        let base: URL
-        #if os(macOS)
-        base = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".cache")
-        #else
-        guard
-            let first = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-        else {
-            throw Supertonic3Error.downloadFailed("failed to locate caches directory")
-        }
-        base = first
-        #endif
-        let root = base.appendingPathComponent("fluidaudio").appendingPathComponent("Models")
+        // Delegate to the shared TTS cache root (Application Support on iOS,
+        // ~/.cache/fluidaudio on macOS) so all backends share one location.
+        let root = try TtsCacheDirectory.ensure().appendingPathComponent("Models")
         if !FileManager.default.fileExists(atPath: root.path) {
             try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         }


### PR DESCRIPTION
## Summary

On iOS/iPadOS every TTS resource downloader used `.cachesDirectory` as the storage location. `Library/Caches/` is reclaimable by the system under disk pressure, so TTS models (potentially hundreds of MB each) can be silently purged while the app is backgrounded, forcing a full re-download on next use. The ASR side already uses `.applicationSupportDirectory` (the recommended location for re-obtainable but expensive-to-replace data); this brings TTS in line.

Closes #635.

## Changes

- **`TtsCacheDirectory.ensure()`** now uses `.applicationSupportDirectory` on iOS/iPadOS. macOS is unchanged (`~/.cache/fluidaudio`).
- **All 5 backend downloaders** (Kokoro, PocketTTS, Magpie, Supertonic3, StyleTTS2) now delegate to `TtsCacheDirectory.ensure()` + their own subdir instead of each maintaining a copy-pasted `#if os(macOS) / #else .cachesDirectory` block. Path layout per backend is unchanged (still `fluidaudio/Models/`, `fluidaudio/`, etc.); only the platform base moves.
- **`DownloadUtils.clearAllModelCaches()`** clears the new location on iOS, and now removes the whole `fluidaudio/` root so every backend subdirectory is cleared, not just `Models/`.

Net: ~89 lines removed, ~32 added; every TTS `.cachesDirectory` usage is gone.

## Scope notes

- **macOS path preserved** at `~/.cache/fluidaudio` for backward compatibility.
- **No migration included.** Existing iOS installs will re-download models once after updating (no copy from `Library/Caches/` to `Library/Application Support/`). Easy to add as a follow-up if wanted.

## Testing

- `swift build` passes.
- Verified no remaining `.cachesDirectory` references in TTS source.