### PR TITLE
PocketTTS: stride-aware conditioning extraction for cloned voices

### DIFF
--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsVoiceCloner.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsVoiceCloner.swift
@@ -92,7 +92,7 @@ public enum PocketTtsVoiceCloner {
             realSampleCount: realSampleCount, availableFrames: numFrames)
         logger.info("Encoded to \(numFrames) frames, using \(usableFrames)")
 
-        // Extract conditioning with bulk memory copy (no zero-padding)
+        // Extract conditioning, honoring the array's strides (no zero-padding).
         let totalFloats = usableFrames * embDim
         let voiceData = extractConditioning(conditioning, frames: usableFrames, embDim: embDim)
 
@@ -205,43 +205,81 @@ public enum PocketTtsVoiceCloner {
         return min(availableFrames, realFrames, maxVoiceFrames)
     }
 
-    /// Extract conditioning floats from MLMultiArray `[1, frames, embDim]`.
+    /// Extract conditioning floats from MLMultiArray `[1, frames, embDim]`
+    /// into packed row-major `[frames * embDim]`.
     ///
-    /// Both dtype paths assume contiguous storage starting at the array's
-    /// base pointer: the encoder writes `[1, 125, 1024]` in row-major order
-    /// and we read the leading `frames` rows. The Float32 path is a bulk
-    /// `UnsafeBufferPointer` copy; the Float16 path uses
-    /// `vDSP.convertElements` (vectorized fp16→fp32 conversion) so
-    /// `mimi_encoderv2`'s Float16 output doesn't have to pay 128 k
-    /// MLMultiArray subscript calls per clone. Falls back to NSNumber
-    /// subscripting on x86 hosts where Swift `Float16` isn't available.
-    private static func extractConditioning(
+    /// CoreML can return the `conditioning` array strided / non-contiguous
+    /// (padding between frames, or `dimStride != 1`), so we read using the
+    /// array's reported strides rather than assuming packed storage. Reading
+    /// a strided buffer as if it were contiguous scrambles the embedding
+    /// order and produces clipped / clicky cloned audio (see FluidAudio
+    /// #612).
+    ///
+    /// A genuinely contiguous array (`dimStride == 1 && frameStride == embDim`)
+    /// keeps the fast bulk path: a single `UnsafeBufferPointer` copy for
+    /// Float32, or vectorized `vDSP.convertElements` (fp16→fp32) for Float16,
+    /// avoiding 128 k MLMultiArray subscript calls per clone. A strided array
+    /// falls back to stride-aware pointer arithmetic; cloning runs once per
+    /// voice (not in the generation loop), so the per-element copy is cheap.
+    /// On x86 (no Swift `Float16`) the fp16 path routes through NSNumber
+    /// subscripting, which is stride-correct by construction.
+    ///
+    /// Exposed at internal access for unit tests.
+    static func extractConditioning(
         _ conditioning: MLMultiArray, frames: Int, embDim: Int
     ) -> [Float] {
         let count = frames * embDim
+        let strides = conditioning.strides.map { $0.intValue }
+        let frameStride = strides.count >= 3 ? strides[1] : embDim
+        let dimStride = strides.count >= 3 ? strides[2] : 1
+        let isContiguous = (dimStride == 1 && frameStride == embDim)
+        // Highest element index reachable under the reported strides.
+        let lastIndex = max(0, (frames - 1) * frameStride + (embDim - 1) * dimStride)
+
         if conditioning.dataType == .float16 {
             var result = [Float](repeating: 0, count: count)
             #if arch(arm64)
-            let srcPtr = conditioning.dataPointer.bindMemory(to: Float16.self, capacity: count)
-            let srcBuffer = UnsafeBufferPointer(start: srcPtr, count: count)
-            result.withUnsafeMutableBufferPointer { dst in
-                vDSP.convertElements(of: srcBuffer, to: &dst)
+            let srcPtr = conditioning.dataPointer.bindMemory(
+                to: Float16.self, capacity: lastIndex + 1)
+            if isContiguous {
+                let srcBuffer = UnsafeBufferPointer(start: srcPtr, count: count)
+                result.withUnsafeMutableBufferPointer { dst in
+                    vDSP.convertElements(of: srcBuffer, to: &dst)
+                }
+            } else {
+                for frame in 0..<frames {
+                    let base = frame * frameStride
+                    for dim in 0..<embDim {
+                        result[frame * embDim + dim] = Float(srcPtr[base + dim * dimStride])
+                    }
+                }
             }
             #else
-            // x86: Swift Float16 unavailable. Route through NSNumber.
-            for i in 0..<count {
-                let frame = i / embDim
-                let dim = i % embDim
-                result[i] =
-                    conditioning[[0, NSNumber(value: frame), NSNumber(value: dim)]]
-                    .floatValue
+            // x86: Swift Float16 unavailable. NSNumber subscripting is stride-safe.
+            for frame in 0..<frames {
+                for dim in 0..<embDim {
+                    result[frame * embDim + dim] =
+                        conditioning[[0, NSNumber(value: frame), NSNumber(value: dim)]]
+                        .floatValue
+                }
             }
             #endif
             return result
         }
-        // Float32: contiguous bulk copy
-        let srcPtr = conditioning.dataPointer.bindMemory(to: Float.self, capacity: count)
-        return Array(UnsafeBufferPointer(start: srcPtr, count: count))
+
+        // Float32
+        let srcPtr = conditioning.dataPointer.bindMemory(to: Float.self, capacity: lastIndex + 1)
+        if isContiguous {
+            return Array(UnsafeBufferPointer(start: srcPtr, count: count))
+        }
+        var result = [Float](repeating: 0, count: count)
+        for frame in 0..<frames {
+            let base = frame * frameStride
+            for dim in 0..<embDim {
+                result[frame * embDim + dim] = srcPtr[base + dim * dimStride]
+            }
+        }
+        return result
     }
 
     /// Load audio from a file and convert to 24kHz mono Float32.

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsVoiceClonerTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsVoiceClonerTests.swift
@@ -1,3 +1,4 @@
+import CoreML
 import Foundation
 import XCTest
 
@@ -104,4 +105,121 @@ final class PocketTtsVoiceClonerTests: XCTestCase {
             realSampleCount: 100, availableFrames: 125)
         XCTAssertEqual(usable, 1)
     }
+
+    // MARK: - extractConditioning stride handling (FluidAudio #612)
+
+    /// Build an MLMultiArray of shape `[1, frames, embDim]` whose logical
+    /// element `[0, f, d]` holds `value(f, d)`. `framePad` extra elements are
+    /// inserted (and poisoned with -99) between frames, so the array is
+    /// non-contiguous: a naive contiguous read would pick up the padding
+    /// instead of the next frame. `framePad == 0` yields a contiguous array.
+    /// Returns the array plus the expected packed row-major extraction.
+    private func makeConditioning(
+        frames: Int, embDim: Int, framePad: Int,
+        dataType: MLMultiArrayDataType,
+        value: (Int, Int) -> Float
+    ) -> (MLMultiArray, [Float]) {
+        let frameStride = embDim + framePad
+        let total = frames * frameStride
+        let shape: [NSNumber] = [1, NSNumber(value: frames), NSNumber(value: embDim)]
+        let strides: [NSNumber] = [
+            NSNumber(value: total), NSNumber(value: frameStride), NSNumber(value: 1),
+        ]
+        var expected = [Float]()
+        expected.reserveCapacity(frames * embDim)
+
+        if dataType == .float16 {
+            #if arch(arm64)
+            let buf = UnsafeMutablePointer<Float16>.allocate(capacity: total)
+            buf.initialize(repeating: Float16(-99), count: total)
+            for f in 0..<frames {
+                for d in 0..<embDim {
+                    let v = value(f, d)
+                    buf[f * frameStride + d] = Float16(v)
+                    expected.append(Float(Float16(v)))  // round-trip through fp16
+                }
+            }
+            let array = try! MLMultiArray(
+                dataPointer: UnsafeMutableRawPointer(buf),
+                shape: shape, dataType: .float16, strides: strides,
+                deallocator: { _ in buf.deallocate() })
+            return (array, expected)
+            #else
+            fatalError("fp16 conditioning test requires arm64")
+            #endif
+        }
+
+        let buf = UnsafeMutablePointer<Float>.allocate(capacity: total)
+        buf.initialize(repeating: -99, count: total)
+        for f in 0..<frames {
+            for d in 0..<embDim {
+                let v = value(f, d)
+                buf[f * frameStride + d] = v
+                expected.append(v)
+            }
+        }
+        let array = try! MLMultiArray(
+            dataPointer: UnsafeMutableRawPointer(buf),
+            shape: shape, dataType: .float32, strides: strides,
+            deallocator: { _ in buf.deallocate() })
+        return (array, expected)
+    }
+
+    func testExtractConditioningContiguousFloat32() {
+        let frames = 4, embDim = 8
+        let (arr, expected) = makeConditioning(
+            frames: frames, embDim: embDim, framePad: 0, dataType: .float32
+        ) { f, d in Float(f * 100 + d) }
+        let out = PocketTtsVoiceCloner.extractConditioning(arr, frames: frames, embDim: embDim)
+        XCTAssertEqual(out, expected)
+    }
+
+    func testExtractConditioningStridedFloat32() {
+        // framePad > 0: a naive contiguous read would interleave the -99
+        // padding into the output. Stride-aware extraction must not.
+        let frames = 5, embDim = 8
+        let (arr, expected) = makeConditioning(
+            frames: frames, embDim: embDim, framePad: 3, dataType: .float32
+        ) { f, d in Float(f * 1000 + d) }
+        let out = PocketTtsVoiceCloner.extractConditioning(arr, frames: frames, embDim: embDim)
+        XCTAssertEqual(out, expected)
+        XCTAssertFalse(out.contains(-99), "padding must not leak into the extraction")
+    }
+
+    func testExtractConditioningReadsLeadingFramesOnly() {
+        // Encoder emits more frames than usable; extraction must read only the
+        // leading `frames` rows, stride-correct.
+        let embDim = 8
+        let (arr, _) = makeConditioning(
+            frames: 10, embDim: embDim, framePad: 2, dataType: .float32
+        ) { f, d in Float(f * 1000 + d) }
+        let out = PocketTtsVoiceCloner.extractConditioning(arr, frames: 3, embDim: embDim)
+        XCTAssertEqual(out.count, 3 * embDim)
+        for f in 0..<3 {
+            for d in 0..<embDim {
+                XCTAssertEqual(out[f * embDim + d], Float(f * 1000 + d))
+            }
+        }
+    }
+
+    #if arch(arm64)
+    func testExtractConditioningContiguousFloat16() {
+        let frames = 3, embDim = 8
+        let (arr, expected) = makeConditioning(
+            frames: frames, embDim: embDim, framePad: 0, dataType: .float16
+        ) { f, d in Float(f) + Float(d) * 0.25 }  // fp16-exact
+        let out = PocketTtsVoiceCloner.extractConditioning(arr, frames: frames, embDim: embDim)
+        XCTAssertEqual(out, expected)
+    }
+
+    func testExtractConditioningStridedFloat16() {
+        let frames = 4, embDim = 8
+        let (arr, expected) = makeConditioning(
+            frames: frames, embDim: embDim, framePad: 4, dataType: .float16
+        ) { f, d in Float(f) + Float(d) * 0.5 }  // fp16-exact
+        let out = PocketTtsVoiceCloner.extractConditioning(arr, frames: frames, embDim: embDim)
+        XCTAssertEqual(out, expected)
+        XCTAssertFalse(out.contains(-99), "padding must not leak into the extraction")
+    }
+    #endif
 }


### PR DESCRIPTION
## Summary

Addresses the remaining half of #612 (clipped/clicky cloned voices).

`PocketTtsVoiceCloner.extractConditioning` read the Mimi encoder's `conditioning` `MLMultiArray` as packed row-major on both the fp32 bulk-copy and fp16 `vDSP.convertElements` paths. When CoreML hands back a strided / non-contiguous array (padding between frames, or `dimStride != 1`), reading it as contiguous scrambles the embedding order, which matches the reported clipped/clicky cloned audio.

This reads the array using its reported strides instead:

- A genuinely contiguous array (`dimStride == 1 && frameStride == embDim`) keeps the fast bulk path: a single `UnsafeBufferPointer` copy for Float32, or vectorized `vDSP.convertElements` for Float16 — no regression in the common case.
- A strided array falls back to stride-aware pointer arithmetic. Voice cloning runs once per voice (not in the generation loop), so the per-element copy on that path is cheap.
- x86 (no Swift `Float16`) uses NSNumber subscripting, which is stride-correct by construction.

## Scope

The issue's other half (prepending `bos_before_voice` for cloned voices) was already fixed in #592 — `bos_before_voice.bin` is loaded, downloaded/backfilled, and prepended in `prefillKVCacheVoice`. The old prompt-length concern ("using 250") is also moot: `usableFrameCount` now caps at `maxVoiceFrames = 125`.

## Tests

`extractConditioning` is now `internal`. Added unit tests covering:
- contiguous extraction (fp32, fp16)
- strided extraction with inter-frame padding (fp32, fp16) — asserts the padding does not leak into the output
- leading-frame subsetting on a strided array (encoder emits more frames than usable)

## Verification

- `swift build` passes.
- The XCTest suite was validated logically via a standalone CoreML reproduction: stride-aware extraction matches expected output with no padding leak, and a contiguous read of the same strided array demonstrably corrupts the data (padding leaks in), confirming the bug and the fix. (Could not run the full XCTest suite locally — no Xcode/XCTest on the dev machine; CI covers it.)

Note: this verifies stride/numerical correctness; it does not include an end-to-end audio listening test.

Closes #612.