### PR TITLE
Supertonic-3: built-in voice enum + on-demand voice download

### DIFF
--- a/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ResourceDownloader.swift
@@ -40,6 +40,58 @@ public enum Supertonic3ResourceDownloader {
         return repoDir
     }
 
+    /// Ensure a built-in voice style JSON is present locally, downloading it
+    /// from `FluidInference/supertonic-3-coreml/voice_styles/` if missing, and
+    /// return its local file URL. Custom voices can skip this and load any file
+    /// directly via `Supertonic3VoiceStyle.load(from:)`.
+    @discardableResult
+    public static func downloadVoiceStyle(
+        _ voice: Supertonic3Voice,
+        directory: URL? = nil,
+        progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws -> URL {
+        let modelsRoot = try directory ?? defaultCacheRoot()
+        let repoDir = modelsRoot.appendingPathComponent(Repo.supertonic3.folderName)
+        let localURL = repoDir.appendingPathComponent(voice.fileName)
+
+        if FileManager.default.fileExists(atPath: localURL.path) {
+            logger.info("Supertonic-3 voice \(voice.rawValue) found in cache")
+            return localURL
+        }
+
+        logger.info("Downloading Supertonic-3 voice \(voice.rawValue) from HuggingFace…")
+        do {
+            // The HF tree API only lists directories, so pull the single file
+            // out of voice_styles/ by skipping every other entry.
+            try await DownloadUtils.downloadSubdirectory(
+                .supertonic3,
+                subdirectory: "voice_styles",
+                to: repoDir,
+                progressHandler: progressHandler,
+                shouldSkip: { $0 != voice.fileName }
+            )
+        } catch {
+            throw Supertonic3Error.downloadFailed("voice \(voice.rawValue): \(error)")
+        }
+
+        guard FileManager.default.fileExists(atPath: localURL.path) else {
+            throw Supertonic3Error.downloadFailed(
+                "voice \(voice.rawValue) missing after download")
+        }
+        return localURL
+    }
+
+    /// Download (if needed) and decode a built-in voice style in one call.
+    public static func loadVoiceStyle(
+        _ voice: Supertonic3Voice,
+        directory: URL? = nil,
+        progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws -> Supertonic3VoiceStyle {
+        let url = try await downloadVoiceStyle(
+            voice, directory: directory, progressHandler: progressHandler)
+        return try Supertonic3VoiceStyle.load(from: url)
+    }
+
     private static func defaultCacheRoot() throws -> URL {
         // Delegate to the shared TTS cache root (Application Support on iOS,
         // ~/.cache/fluidaudio on macOS) so all backends share one location.

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
@@ -58,6 +58,38 @@ public struct Supertonic3Config: Codable, Sendable {
             latentDim: Supertonic3Constants.latentDim))
 }
 
+/// The 10 built-in Supertonic-3 voice styles published at
+/// `FluidInference/supertonic-3-coreml/voice_styles/`: female `f1`-`f5`,
+/// male `m1`-`m5`. Fetch one with
+/// `Supertonic3ResourceDownloader.downloadVoiceStyle(_:)` (or download + decode
+/// in one call via `loadVoiceStyle(_:)`). Custom styles can still be supplied
+/// as any file via `Supertonic3VoiceStyle.load(from:)`.
+public enum Supertonic3Voice: String, CaseIterable, Sendable {
+    case f1 = "F1"
+    case f2 = "F2"
+    case f3 = "F3"
+    case f4 = "F4"
+    case f5 = "F5"
+    case m1 = "M1"
+    case m2 = "M2"
+    case m3 = "M3"
+    case m4 = "M4"
+    case m5 = "M5"
+
+    /// Default voice (`M1`), the style shipped before the others were added.
+    public static let `default`: Supertonic3Voice = .m1
+
+    /// Repo-relative path of this voice's style JSON
+    /// (e.g. `voice_styles/F3.json`).
+    public var fileName: String { "voice_styles/\(rawValue).json" }
+
+    /// Parse a voice name case-insensitively, e.g. `"f3"` or `"M1"`.
+    /// Returns `nil` for unknown names.
+    public init?(name: String) {
+        self.init(rawValue: name.uppercased())
+    }
+}
+
 /// On-disk schema of a Supertonic-3 voice style JSON file (the `M1` /
 /// `F1` / etc. presets shipped under `assets/voice_styles/` in the
 /// reference repo).

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -272,7 +272,7 @@ public struct TTS {
         case .supertonic3:
             await runSupertonic3(
                 text: text, output: output, language: supertonicLanguage,
-                voiceStylePath: supertonicVoiceStylePath,
+                voiceStylePath: supertonicVoiceStylePath, voiceName: voice,
                 totalSteps: supertonicTotalSteps, speed: supertonicSpeed,
                 metricsPath: metricsPath, cpuOnly: cpuOnly)
         }
@@ -731,19 +731,15 @@ public struct TTS {
         }
     }
 
-    /// Run Supertonic-3 multilingual TTS. Requires a voice-style JSON
-    /// (any preset from `voice_styles/` in the HF repo, e.g. `M1.json`).
+    /// Run Supertonic-3 multilingual TTS. Voice comes from a built-in style
+    /// (`--voice F1`..`M5`, downloaded on demand, default `M1`) or an explicit
+    /// `--voice-style <file.json>`, which overrides `--voice`.
     private static func runSupertonic3(
         text: String, output: String, language: String,
-        voiceStylePath: String?,
+        voiceStylePath: String?, voiceName: String,
         totalSteps: Int, speed: Float,
         metricsPath: String?, cpuOnly: Bool
     ) async {
-        guard let voiceStylePath else {
-            logger.error(
-                "supertonic3 backend requires --voice-style <path/to/style.json>")
-            return
-        }
         do {
             let tStart = Date()
             let computeUnits: MLComputeUnits = cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
@@ -753,9 +749,27 @@ public struct TTS {
             try await manager.initialize()
             let tLoad1 = Date()
 
-            let voiceStyleURL = resolveInputURL(voiceStylePath)
-            let style = try Supertonic3VoiceStyle.load(from: voiceStyleURL)
-            logger.info("Supertonic-3 voice style: \(voiceStyleURL.path)")
+            // Voice resolution: an explicit --voice-style <path> wins; otherwise
+            // --voice names a built-in (F1-F5, M1-M5), defaulting to M1.
+            let style: Supertonic3VoiceStyle
+            if let voiceStylePath {
+                let voiceStyleURL = resolveInputURL(voiceStylePath)
+                style = try Supertonic3VoiceStyle.load(from: voiceStyleURL)
+                logger.info("Supertonic-3 voice style (file): \(voiceStyleURL.path)")
+            } else {
+                let selected = Supertonic3Voice(name: voiceName) ?? .default
+                if Supertonic3Voice(name: voiceName) == nil
+                    && voiceName != TtsConstants.recommendedVoice
+                {
+                    logger.warning(
+                        "Unknown Supertonic-3 voice '\(voiceName)'; using "
+                            + "\(Supertonic3Voice.default.rawValue). Valid voices: "
+                            + Supertonic3Voice.allCases.map(\.rawValue).joined(separator: ", ")
+                            + ".")
+                }
+                style = try await Supertonic3ResourceDownloader.loadVoiceStyle(selected)
+                logger.info("Supertonic-3 voice: \(selected.rawValue) (built-in)")
+            }
             logger.info(
                 "Supertonic-3 lang=\(language) totalSteps=\(totalSteps) "
                     + "speed=\(String(format: "%.2f", speed))")
@@ -795,7 +809,7 @@ public struct TTS {
                     "backend": "supertonic3",
                     "text": text,
                     "language": language,
-                    "voice_style": voiceStyleURL.path,
+                    "voice_style": style.name,
                     "total_steps": totalSteps,
                     "speed": Double(speed),
                     "output": outURL.path,
@@ -839,7 +853,8 @@ public struct TTS {
                                      --seed N                   RNG seed for fused sampler
                                      --ipa "…"                  bypass G2P, feed raw IPA
                                    Supertonic-3 (multilingual, 31 langs, 44.1 kHz):
-                                     --voice-style <file.json>  required (e.g. voice_styles/M1.json)
+                                     --voice F3                 built-in voice F1-F5/M1-M5 (default M1)
+                                     --voice-style <file.json>  custom style file (overrides --voice)
                                      --lang en                  ISO-639-1 language code (default en)
                                      --total-steps 8            denoising step count (default 8)
                                      --speed 1.05               duration multiplier (default 1.05)

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsVoiceClonerTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsVoiceClonerTests.swift
@@ -166,7 +166,8 @@ final class PocketTtsVoiceClonerTests: XCTestCase {
     }
 
     func testExtractConditioningContiguousFloat32() {
-        let frames = 4, embDim = 8
+        let frames = 4
+        let embDim = 8
         let (arr, expected) = makeConditioning(
             frames: frames, embDim: embDim, framePad: 0, dataType: .float32
         ) { f, d in Float(f * 100 + d) }
@@ -177,7 +178,8 @@ final class PocketTtsVoiceClonerTests: XCTestCase {
     func testExtractConditioningStridedFloat32() {
         // framePad > 0: a naive contiguous read would interleave the -99
         // padding into the output. Stride-aware extraction must not.
-        let frames = 5, embDim = 8
+        let frames = 5
+        let embDim = 8
         let (arr, expected) = makeConditioning(
             frames: frames, embDim: embDim, framePad: 3, dataType: .float32
         ) { f, d in Float(f * 1000 + d) }
@@ -204,7 +206,8 @@ final class PocketTtsVoiceClonerTests: XCTestCase {
 
     #if arch(arm64)
     func testExtractConditioningContiguousFloat16() {
-        let frames = 3, embDim = 8
+        let frames = 3
+        let embDim = 8
         let (arr, expected) = makeConditioning(
             frames: frames, embDim: embDim, framePad: 0, dataType: .float16
         ) { f, d in Float(f) + Float(d) * 0.25 }  // fp16-exact
@@ -213,7 +216,8 @@ final class PocketTtsVoiceClonerTests: XCTestCase {
     }
 
     func testExtractConditioningStridedFloat16() {
-        let frames = 4, embDim = 8
+        let frames = 4
+        let embDim = 8
         let (arr, expected) = makeConditioning(
             frames: frames, embDim: embDim, framePad: 4, dataType: .float16
         ) { f, d in Float(f) + Float(d) * 0.5 }  // fp16-exact

--- a/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3VoiceTests.swift
+++ b/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3VoiceTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Unit tests for the `Supertonic3Voice` enum: the 10 built-in voice styles
+/// (F1-F5, M1-M5), their repo-relative paths, and case-insensitive name parsing.
+final class Supertonic3VoiceTests: XCTestCase {
+
+    func testHasTenVoices() {
+        XCTAssertEqual(Supertonic3Voice.allCases.count, 10)
+        XCTAssertEqual(
+            Supertonic3Voice.allCases.map(\.rawValue),
+            ["F1", "F2", "F3", "F4", "F5", "M1", "M2", "M3", "M4", "M5"])
+    }
+
+    func testDefaultIsM1() {
+        XCTAssertEqual(Supertonic3Voice.default, .m1)
+        XCTAssertEqual(Supertonic3Voice.default.rawValue, "M1")
+    }
+
+    func testFileNameMapping() {
+        XCTAssertEqual(Supertonic3Voice.f3.fileName, "voice_styles/F3.json")
+        XCTAssertEqual(Supertonic3Voice.m1.fileName, "voice_styles/M1.json")
+        for v in Supertonic3Voice.allCases {
+            XCTAssertEqual(v.fileName, "voice_styles/\(v.rawValue).json")
+        }
+    }
+
+    func testNameParsingIsCaseInsensitive() {
+        XCTAssertEqual(Supertonic3Voice(name: "F3"), .f3)
+        XCTAssertEqual(Supertonic3Voice(name: "f3"), .f3)
+        XCTAssertEqual(Supertonic3Voice(name: "m1"), .m1)
+        XCTAssertEqual(Supertonic3Voice(name: "M5"), .m5)
+    }
+
+    func testNameParsingRejectsUnknown() {
+        XCTAssertNil(Supertonic3Voice(name: "xyz"))
+        XCTAssertNil(Supertonic3Voice(name: ""))
+        XCTAssertNil(Supertonic3Voice(name: "F6"))
+        // A Kokoro-style voice name (the CLI's default) must not parse here, so
+        // the Supertonic-3 path can safely fall back to the default voice.
+        XCTAssertNil(Supertonic3Voice(name: "af_heart"))
+    }
+
+    func testRawValueRoundTrip() {
+        for v in Supertonic3Voice.allCases {
+            XCTAssertEqual(Supertonic3Voice(rawValue: v.rawValue), v)
+            XCTAssertEqual(Supertonic3Voice(name: v.rawValue.lowercased()), v)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The `FluidInference/supertonic-3-coreml` mirror now ships all 10 upstream voice styles (F1-F5, M1-M5), but FluidAudio gave no way to discover or fetch them: callers had to know the `voice_styles/` layout and pass `--voice-style <file>` with a path they'd sourced themselves. This adds first-class, on-demand voice selection.

## Changes

- **`Supertonic3Voice` enum** (`.f1`-`.f5`, `.m1`-`.m5`), `String`-backed and `CaseIterable`:
  - `fileName` -> repo-relative `voice_styles/<name>.json`
  - `init?(name:)` parses case-insensitively (`"f3"`, `"M1"`), `nil` for unknown
  - `.default` == `.m1`
- **`Supertonic3ResourceDownloader.downloadVoiceStyle(_:)` / `loadVoiceStyle(_:)`** — fetch a chosen voice JSON from the mirror into the model cache (cached/skip on repeat) and return its URL, or a decoded `Supertonic3VoiceStyle`. Custom voices can still load any file directly via `Supertonic3VoiceStyle.load(from:)`.
- **CLI**: `--voice F3` selects a built-in voice (default `M1`, downloaded on demand). `--voice-style <path>` still works and takes precedence. An unknown `--voice` value warns and falls back to `M1`.

The single voice file is pulled via `downloadSubdirectory(subdirectory: "voice_styles", shouldSkip:)` because the HF tree API only lists directories, not single file paths.

## Tests

`Supertonic3VoiceTests` covers the 10-voice set and ordering, `M1` default, `fileName` mapping, case-insensitive parsing, unknown-name rejection (including that a Kokoro-style default name does not parse), and raw-value round-trips.

## Verification

- `swift build` passes.
- Could not run the XCTest suite locally (no Xcode/XCTest on the dev machine; CI covers it). The enum tests are pure logic; the download path reuses the existing, tested `downloadSubdirectory` plumbing, and I confirmed the mirror's `voice_styles/` tree lists all 10 files so the `shouldSkip` filter resolves correctly.

Depends on the mirror carrying all 10 voices (now live).