### PR TITLE
feat(asr): SenseVoiceSmall CoreML backend (multilingual, non-autoregressive)

### DIFF
--- a/Documentation/ASR/SenseVoice.md
+++ b/Documentation/ASR/SenseVoice.md
@@ -56,40 +56,19 @@ let text = try await manager.transcribe(audioURL: url)
 
 ## Benchmarks
 
-Measured on Apple M5 Pro with the CoreML FP16 encoder on the Neural Engine, over
-the **full** canonical test sets — directly comparable to the published
-[SenseVoice-Small results](https://github.com/FunAudioLLM/SenseVoice).
+Full canonical test sets on Apple M5 Pro (CoreML FP16 / ANE) — see
+[Benchmarks.md#sensevoice](../Benchmarks.md#sensevoice) for the full tables and methodology.
 
-### English — LibriSpeech test-clean (full, 2,620 utts)
+| Set | CoreML (ANE) | Official SenseVoice-Small |
+|-----|--------------|---------------------------|
+| LibriSpeech test-clean (2,620) | **WER 3.22%** | ~3.1% |
+| AISHELL-1 test (7,176) | **CER 3.09%** | ~2.9% |
 
-| Metric | CoreML (ANE) | Official SenseVoice-Small |
-|--------|--------------|---------------------------|
-| **WER** | **3.22%** | ~3.1% |
-| Median RTFx | 299 | — |
-
-### Chinese — AISHELL-1 test (full, ~7,176 utts)
-
-| Metric | CoreML (ANE) | Official SenseVoice-Small |
-|--------|--------------|---------------------------|
-| **CER** | **3.09%** | ~2.9% |
-| Median RTFx | 382 | — |
-
-Both reproduce the published numbers, confirming the conversion (front-end +
-encoder + decode) is faithful. Offline CoreML↔PyTorch parity was also verified on
-FLEURS (en WER Δ +0.00 pp, zh CER Δ −0.03 pp).
-
-### Reproduction
-
-English (FLEURS, in-repo) via the CLI:
+Both reproduce the published numbers; CoreML↔PyTorch parity also verified on FLEURS (en Δ +0.00 pp, zh Δ −0.03 pp).
 
 ```bash
-swift run -c release fluidaudiocli sensevoice-benchmark \
-    --languages en_us,cmn_hans_cn --samples all
+swift run -c release fluidaudiocli sensevoice-benchmark --languages en_us,cmn_hans_cn --samples all
 ```
-
-The canonical LibriSpeech / AISHELL-1 numbers above were measured with the same
-CoreML(ANE) model via the conversion repo's Python harness (the FLEURS CLI
-benchmark above is the in-repo, multilingual reproducible path).
 
 ## Conversion notes & findings
 

--- a/Documentation/ASR/SenseVoice.md
+++ b/Documentation/ASR/SenseVoice.md
@@ -90,3 +90,57 @@ swift run -c release fluidaudiocli sensevoice-benchmark \
 The canonical LibriSpeech / AISHELL-1 numbers above were measured with the same
 CoreML(ANE) model via the conversion repo's Python harness (the FLEURS CLI
 benchmark above is the in-repo, multilingual reproducible path).
+
+## Conversion notes & findings
+
+The conversion surfaced several non-obvious issues. They're recorded here so the
+design choices above are clear and the dead-ends aren't re-tried.
+
+### Conversion path
+- **PyTorch (FunASR) → `torch.jit.trace` → coremltools**, not ONNX — coremltools
+  dropped direct ONNX ingestion in 7.0, so we trace the original module.
+- **`model.encode()` is bypassed.** Its source uses `torch.rand(1) > 0.2`, Python
+  list-comprehensions and dict lookups (`lid_int_dict` / `textnorm_int_dict`) —
+  all trace-hostile. We replicate only its deterministic inference path: prepend
+  the 4 query embeddings `[language, event1, event2, style]`, then encoder + CTC.
+  The host maps the language/text-norm choice to embed indices.
+
+### The FP16-NaN investigation (the big one)
+1. **Synthetic full-length parity hid the bug.** A 1800-frame random input gave
+   100% argmax agreement; the failure only appears on *real* short audio
+   zero-padded to a large shape.
+2. **The NaN is compute-unit dependent, not a wrapper bug.** PyTorch handles the
+   padding correctly, and the *same* FP16 `.mlpackage` gives **0 NaN on
+   `CPU_AND_NE` (ANE)** but **all-NaN on `CPU_ONLY`, `CPU_AND_GPU`, and `ALL`**.
+   The CPU/GPU FP16 path overflows on the zero-padded positions; ANE does not.
+   (A freshly-loaded `MLModel(path)` defaults to `ALL` → watch the compute unit.)
+3. **Clamping the attention mask fill (`-inf` → `-1e4`) did *not* fix it** — kept
+   as a correct FP16-safety measure, but it was not the cure.
+4. **FP32 is exact on every unit** but slow — kept only as the `--fp32` fallback.
+5. **What fixed it:** `ct.EnumeratedShapes` length buckets `[128,256,512,1024,1800]`
+   (small padding) **+ running on ANE**. 0 NaN, 100% argmax, and RTFx scales with
+   audio length (5.5 s clip: bucket 128 → ~524 RTFx, bucket 1800 → ~14).
+
+> **Known limitation.** The FP16 encoder is NaN on CPU/GPU; non-ANE hardware must
+> use the `--fp32` build. Hardening FP16 for the CPU/GPU path (isolating the
+> overflowing op via selective precision) is open follow-up work.
+
+### Front-end (preprocessor)
+- A CoreML replica of FunASR's `WavFrontend`: kaldi fbank-80 + LFR(m=7,n=6) + CMVN.
+  Framing and LFR use **conv1d identity kernels** and the DFT is a **matmul against
+  a precomputed cos/sin basis** — coremltools has no FFT and rejects `unfold`/int64
+  `gather`. Kaldi's window + mel matrix are baked from torchaudio, so it's
+  bit-for-bit kaldi (torch parity max\|Δ\| ≈ 2.3e-5).
+- It runs **FP32 on CPU**: the power spectrum + log exceed the FP16 range, and the
+  large framing convs fail ANE compile. FP32 CoreML parity: max\|Δ\| ≈ 2.9e-6.
+
+### Parity metric
+- For ASR we gate on **argmax CTC-token agreement** (what governs WER), not raw
+  logit drift — FP16 logit drift on a 234M encoder is expected and benign once the
+  argmax matches.
+
+### Environment gotchas
+- `torchaudio` is a required `funasr` import dependency.
+- `ct.TensorType(dtype=…)` wants **numpy** dtypes (not `ct.converters.mil.types`).
+- Benchmark inputs must be *representative*: all-zero or N(0,1) random inputs are
+  out-of-distribution and either mask or fabricate failures.

--- a/Documentation/ASR/SenseVoice.md
+++ b/Documentation/ASR/SenseVoice.md
@@ -1,0 +1,92 @@
+# SenseVoice
+
+Non-autoregressive multilingual ASR using [SenseVoiceSmall](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) (FunASR) converted to CoreML. A SANM encoder + single CTC head produces all output tokens in one forward pass — no autoregressive decode loop.
+
+## Model
+
+**CoreML Model**: [FluidInference/sensevoice-small-coreml](https://huggingface.co/FluidInference/sensevoice-small-coreml)
+
+3-stage pipeline:
+
+| Stage | File | Precision | Compute unit |
+|-------|------|-----------|--------------|
+| Front-end | `SenseVoicePreprocessor.mlmodelc` | FP32 | CPU |
+| Encoder + CTC | `SenseVoiceSmall.mlmodelc` | FP16 | **ANE** (`CPU_AND_NE`) |
+| Encoder fallback | `SenseVoiceSmall_fp32.mlmodelc` | FP32 | any (`--fp32`) |
+
+> **Compute-unit requirement.** The FP16 encoder is numerically correct only on the Neural Engine; it produces NaN on the CPU/GPU FP16 path. The loader pins it to `.cpuAndNeuralEngine`. On hardware without an ANE, use `--fp32`.
+
+## Architecture
+
+```
+waveform → [Preprocessor FP32/CPU] → 560-d LFR features
+        → [SenseVoiceSmall FP16/ANE encoder+CTC] → logits [1, T+4, 25055]
+        → host greedy-CTC decode → text
+```
+
+- **Front-end**: kaldi fbank-80 → LFR (m=7, n=6 → 560-d) → CMVN. A CoreML replica of FunASR's `WavFrontend` (matches to max\|Δ\|≈2e-5). FP32/CPU because the power spectrum and log exceed the FP16 range and the framing convolutions do not ANE-compile.
+- **Encoder**: enumerated sequence buckets `[128, 256, 512, 1024, 1800]`; the host pads features up to the smallest bucket ≥ T. The 4 leading logit positions are the language / emotion / event / inverse-text-norm query tokens.
+- **Decode**: greedy CTC (blank = 0) → collapse repeats → SentencePiece detokenize → strip the leading `<|...|>` tags.
+
+## Supported Languages
+
+SenseVoiceSmall covers 50+ languages (strongest on zh / yue / en / ja / ko). Language is auto-detected by default (`language = 0`).
+
+## Usage
+
+### CLI
+
+```bash
+# Transcribe a file (auto language)
+swift run -c release fluidaudiocli sensevoice-transcribe audio.wav
+
+# FP32 encoder (no Neural Engine)
+swift run -c release fluidaudiocli sensevoice-transcribe audio.wav --fp32
+
+# FLEURS WER/CER benchmark (English + Chinese)
+swift run -c release fluidaudiocli sensevoice-benchmark --languages en_us,cmn_hans_cn --samples 100
+```
+
+### Swift
+
+```swift
+let manager = try await SenseVoiceManager.load()           // fp16/ANE (use useFp32Encoder: true for fallback)
+let text = try await manager.transcribe(audioURL: url)
+```
+
+## Benchmarks
+
+Measured on Apple M5 Pro with the CoreML FP16 encoder on the Neural Engine, over
+the **full** canonical test sets — directly comparable to the published
+[SenseVoice-Small results](https://github.com/FunAudioLLM/SenseVoice).
+
+### English — LibriSpeech test-clean (full, 2,620 utts)
+
+| Metric | CoreML (ANE) | Official SenseVoice-Small |
+|--------|--------------|---------------------------|
+| **WER** | **3.22%** | ~3.1% |
+| Median RTFx | 299 | — |
+
+### Chinese — AISHELL-1 test (full, ~7,176 utts)
+
+| Metric | CoreML (ANE) | Official SenseVoice-Small |
+|--------|--------------|---------------------------|
+| **CER** | **3.09%** | ~2.9% |
+| Median RTFx | 382 | — |
+
+Both reproduce the published numbers, confirming the conversion (front-end +
+encoder + decode) is faithful. Offline CoreML↔PyTorch parity was also verified on
+FLEURS (en WER Δ +0.00 pp, zh CER Δ −0.03 pp).
+
+### Reproduction
+
+English (FLEURS, in-repo) via the CLI:
+
+```bash
+swift run -c release fluidaudiocli sensevoice-benchmark \
+    --languages en_us,cmn_hans_cn --samples all
+```
+
+The canonical LibriSpeech / AISHELL-1 numbers above were measured with the same
+CoreML(ANE) model via the conversion repo's Python harness (the FLEURS CLI
+benchmark above is the in-repo, multilingual reproducible path).

--- a/Documentation/Benchmarks.md
+++ b/Documentation/Benchmarks.md
@@ -411,6 +411,40 @@ Full benchmark across all 30 languages supported by Qwen3-ASR, matching the offi
 swift run -c release fluidaudiocli qwen3-benchmark --dataset fleurs --languages all
 ```
 
+## SenseVoice
+
+Non-autoregressive multilingual ASR using SenseVoiceSmall (FunASR, ~234M) converted to CoreML — SANM encoder + single CTC head, all tokens in one forward pass. See [ASR/SenseVoice.md](ASR/SenseVoice.md) for the architecture and conversion notes.
+
+Model: [FluidInference/sensevoice-small-coreml](https://huggingface.co/FluidInference/sensevoice-small-coreml)
+
+Hardware: Apple M5 Pro, macOS 26. FP16 encoder on the Neural Engine (`CPU_AND_NE`); FP32 CPU front-end. Full canonical test sets, directly comparable to the published [SenseVoice-Small results](https://github.com/FunAudioLLM/SenseVoice).
+
+### LibriSpeech test-clean (2620 files)
+
+| Metric | CoreML (ANE) | Official SenseVoice-Small |
+|--------|--------------|---------------------------|
+| WER (Avg) | **3.22%** | ~3.1% |
+| Median RTFx | 299x | — |
+
+### AISHELL-1 Chinese (7176 files)
+
+| Metric | CoreML (ANE) | Official SenseVoice-Small |
+|--------|--------------|---------------------------|
+| CER (Avg) | **3.09%** | ~2.9% |
+| Median RTFx | 382x | — |
+
+**Methodology notes:**
+- CER (character-level, whitespace removed) is the primary metric for Chinese, matching the official SenseVoice chart (AISHELL-1 test).
+- Both numbers reproduce the published SenseVoice-Small results, confirming the CoreML conversion (front-end + encoder + decode) is faithful.
+- CoreML↔PyTorch parity additionally verified on FLEURS: en WER Δ +0.00pp, zh CER Δ −0.03pp (100 samples/lang).
+- The FP16 encoder is correct only on the Neural Engine (NaN on the CPU/GPU FP16 path); non-ANE hardware uses the `--fp32` build. See [ASR/SenseVoice.md](ASR/SenseVoice.md#conversion-notes--findings).
+- AISHELL-1 dataset: [TwinkStart/AISHELL-1](https://huggingface.co/datasets/TwinkStart/AISHELL-1).
+
+```bash
+# FLEURS WER/CER (in-repo, multilingual)
+swift run -c release fluidaudiocli sensevoice-benchmark --languages en_us,cmn_hans_cn --samples all
+```
+
 ## Streaming ASR (Parakeet EOU)
 
 Real-time streaming ASR with End-of-Utterance detection using the Parakeet EOU 120M CoreML model.

--- a/Documentation/Benchmarks.md
+++ b/Documentation/Benchmarks.md
@@ -435,14 +435,14 @@ Hardware: Apple M5 Pro, macOS 26. FP16 encoder on the Neural Engine (`CPU_AND_NE
 
 ### int8 encoder variant (`--int8`)
 
-Post-training weight quantization of the encoder — **~half the size, accuracy-neutral** vs fp16 (run on ANE):
+Post-training weight quantization of the encoder — **~half the size, accuracy-neutral** vs fp16 (run on ANE). Full canonical test sets:
 
 | | size | LibriSpeech WER | AISHELL CER | peak RAM |
 |---|------|-----------------|-------------|----------|
-| fp16 (default) | 447 MB | 3.27% | 3.40% | 0.54 GB |
-| **int8** | **225 MB** | **3.22%** | **3.43%** | **0.32 GB** |
+| fp16 (default) | 447 MB | 3.22% | 3.09% | 0.54 GB |
+| **int8** | **225 MB** | **3.25%** | **3.09%** | **0.32 GB** |
 
-(Δ ≤ 0.05 pp on 300-sample subsets, 0 NaN.) int4 per-tensor palettization wrecks accuracy (WER 31%) and is not shipped.
+(Δ +0.03 pp / 0.00 pp on the full LibriSpeech test-clean (2,620) / AISHELL-1 test (7,176), 0 NaN.) int4 per-tensor palettization wrecks accuracy (WER 31%) and is not shipped.
 
 **Methodology notes:**
 - CER (character-level, whitespace removed) is the primary metric for Chinese, matching the official SenseVoice chart (AISHELL-1 test).

--- a/Documentation/Benchmarks.md
+++ b/Documentation/Benchmarks.md
@@ -433,6 +433,17 @@ Hardware: Apple M5 Pro, macOS 26. FP16 encoder on the Neural Engine (`CPU_AND_NE
 | CER (Avg) | **3.09%** | ~2.9% |
 | Median RTFx | 382x | — |
 
+### int8 encoder variant (`--int8`)
+
+Post-training weight quantization of the encoder — **~half the size, accuracy-neutral** vs fp16 (run on ANE):
+
+| | size | LibriSpeech WER | AISHELL CER | peak RAM |
+|---|------|-----------------|-------------|----------|
+| fp16 (default) | 447 MB | 3.27% | 3.40% | 0.54 GB |
+| **int8** | **225 MB** | **3.22%** | **3.43%** | **0.32 GB** |
+
+(Δ ≤ 0.05 pp on 300-sample subsets, 0 NaN.) int4 per-tensor palettization wrecks accuracy (WER 31%) and is not shipped.
+
 **Methodology notes:**
 - CER (character-level, whitespace removed) is the primary metric for Chinese, matching the official SenseVoice chart (AISHELL-1 test).
 - Both numbers reproduce the published SenseVoice-Small results, confirming the CoreML conversion (front-end + encoder + decode) is faithful.

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceConfig.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceConfig.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Configuration constants for the SenseVoiceSmall CoreML pipeline.
+///
+/// SenseVoiceSmall is non-autoregressive: a SANM encoder + single CTC head.
+/// The CoreML export is a 3-stage pipeline (preprocessor → encoder+CTC → host
+/// greedy decode). These constants mirror the conversion in
+/// `FluidInference/sensevoice-small-coreml`.
+public enum SenseVoiceConfig {
+    /// LFR feature dimension (80-bin fbank × LFR m=7).
+    public static let featureDim = 560
+
+    /// Enumerated encoder sequence-length buckets (post-LFR frames). The host
+    /// pads the preprocessor's feature output up to the smallest bucket ≥ T.
+    public static let buckets = [128, 256, 512, 1024, 1800]
+
+    /// Number of query tokens the encoder prepends (language + 2 event/emotion
+    /// + text-norm). The first 4 logit positions are these special tokens.
+    public static let numQueryTokens = 4
+
+    /// CTC blank token id (SenseVoice uses `<unk>` = 0 as blank).
+    public static let blankId = 0
+
+    /// Default language embed index (`0` = auto-detect).
+    public static let defaultLanguage: Int32 = 0
+
+    /// Default text-norm embed index (`15` = woitn, no inverse text-norm).
+    public static let defaultTextNorm: Int32 = 15
+
+    public static let sampleRate = 16_000
+
+    /// Kaldi feeds waveforms in int16 range; AudioConverter yields [-1, 1], so
+    /// the preprocessor input is scaled by this factor.
+    public static let waveformScale: Float = 32_768.0
+
+    /// Largest feature length we can serve (= last bucket). ~108 s of audio.
+    public static var maxFrames: Int { buckets.last ?? 1800 }
+
+    /// Smallest bucket ≥ `frames` (clamped to the largest bucket).
+    public static func pickBucket(forFrames frames: Int) -> Int {
+        for b in buckets where b >= frames { return b }
+        return buckets.last ?? 1800
+    }
+}

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceManager.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceManager.swift
@@ -1,0 +1,147 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Manager for SenseVoiceSmall transcription.
+///
+/// Pipeline: waveform → [Preprocessor fp32/CPU] → 560-d features → pad to the
+/// smallest enumerated encoder bucket → [encoder+CTC fp16/ANE] → greedy CTC
+/// decode (drop blank 0, collapse) → SentencePiece detokenize → strip the
+/// leading `<|lang|><|emo|><|event|><|itn|>` tags.
+public actor SenseVoiceManager {
+
+    private let models: SenseVoiceModels
+    private let language: Int32
+    private let textNorm: Int32
+    private static let logger = AppLogger(category: "SenseVoiceManager")
+
+    public init(
+        models: SenseVoiceModels,
+        language: Int32 = SenseVoiceConfig.defaultLanguage,
+        textNorm: Int32 = SenseVoiceConfig.defaultTextNorm
+    ) {
+        self.models = models
+        self.language = language
+        self.textNorm = textNorm
+    }
+
+    /// Load models from the default cache (downloading if needed), then build a manager.
+    public static func load(
+        useFp32Encoder: Bool = false,
+        progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws -> SenseVoiceManager {
+        let models = try await SenseVoiceModels.downloadAndLoad(
+            useFp32Encoder: useFp32Encoder, progressHandler: progressHandler)
+        return SenseVoiceManager(models: models)
+    }
+
+    /// Transcribe a 16 kHz mono audio file.
+    public func transcribe(audioURL: URL) throws -> String {
+        let converter = AudioConverter(sampleRate: Double(SenseVoiceConfig.sampleRate))
+        let samples = try converter.resampleAudioFile(audioURL)
+        return try transcribe(audio: samples)
+    }
+
+    /// Transcribe 16 kHz mono float samples (in [-1, 1]).
+    public func transcribe(audio: [Float]) throws -> String {
+        let features = try runPreprocessor(audio: audio)
+        let (logits, validFrames) = try runEncoder(features: features)
+        return decode(logits: logits, validFrames: validFrames)
+    }
+
+    // MARK: - Pipeline
+
+    /// waveform [1, N] (scaled to int16 range) → features [1, T, 560].
+    private func runPreprocessor(audio: [Float]) throws -> MLMultiArray {
+        let n = audio.count
+        let waveform = try MLMultiArray(shape: [1, n as NSNumber], dataType: .float32)
+        let scale = SenseVoiceConfig.waveformScale
+        let wptr = waveform.dataPointer.assumingMemoryBound(to: Float32.self)
+        for i in 0..<n { wptr[i] = audio[i] * scale }
+
+        let input = try MLDictionaryFeatureProvider(
+            dictionary: ["waveform": MLFeatureValue(multiArray: waveform)])
+        let out = try models.preprocessor.prediction(from: input)
+        guard let features = out.featureValue(for: "features")?.multiArrayValue else {
+            throw ASRError.processingFailed("SenseVoice preprocessor produced no `features`")
+        }
+        return features
+    }
+
+    /// features [1, T, 560] → (ctc_logits [1, bucket+4, V], validFrames = 4 + T).
+    private func runEncoder(features: MLMultiArray) throws -> (MLMultiArray, Int) {
+        let dim = SenseVoiceConfig.featureDim
+        var t = features.shape[1].intValue
+        if t > SenseVoiceConfig.maxFrames {
+            Self.logger.warning("Audio exceeds max length; truncating \(t) → \(SenseVoiceConfig.maxFrames) frames")
+            t = SenseVoiceConfig.maxFrames
+        }
+        let bucket = SenseVoiceConfig.pickBucket(forFrames: t)
+
+        // Zero-padded [1, bucket, 560] with the first T feature frames copied in.
+        let speech = try MLMultiArray(shape: [1, bucket as NSNumber, dim as NSNumber], dataType: .float32)
+        let sptr = speech.dataPointer.assumingMemoryBound(to: Float32.self)
+        memset(sptr, 0, bucket * dim * MemoryLayout<Float32>.size)
+        let count = t * dim
+        if features.dataType == .float32 {
+            memcpy(sptr, features.dataPointer, count * MemoryLayout<Float32>.size)
+        } else {
+            for i in 0..<count { sptr[i] = features[i].floatValue }
+        }
+
+        let lengths = try MLMultiArray(shape: [1], dataType: .int32)
+        lengths[0] = NSNumber(value: t)
+        let lang = try MLMultiArray(shape: [1], dataType: .int32)
+        lang[0] = NSNumber(value: language)
+        let tn = try MLMultiArray(shape: [1], dataType: .int32)
+        tn[0] = NSNumber(value: textNorm)
+
+        let input = try MLDictionaryFeatureProvider(dictionary: [
+            "speech": MLFeatureValue(multiArray: speech),
+            "speech_lengths": MLFeatureValue(multiArray: lengths),
+            "language": MLFeatureValue(multiArray: lang),
+            "textnorm": MLFeatureValue(multiArray: tn),
+        ])
+        let out = try models.encoder.prediction(from: input)
+        guard let logits = out.featureValue(for: "ctc_logits")?.multiArrayValue else {
+            throw ASRError.processingFailed("SenseVoice encoder produced no `ctc_logits`")
+        }
+        return (logits, SenseVoiceConfig.numQueryTokens + t)
+    }
+
+    /// Greedy CTC over the first `validFrames` (drop blank 0, collapse repeats),
+    /// detokenize, then strip the `<|...|>` meta tags.
+    private func decode(logits: MLMultiArray, validFrames: Int) -> String {
+        let vocab = logits.shape[2].intValue
+        let frames = min(validFrames, logits.shape[1].intValue)
+        var ids: [Int] = []
+        var prev = -1
+
+        func appendArgmax(frameBase: (Int) -> Float) {
+            var best = 0
+            var bestVal = frameBase(0)
+            for v in 1..<vocab {
+                let x = frameBase(v)
+                if x > bestVal { bestVal = x; best = v }
+            }
+            if best != SenseVoiceConfig.blankId && best != prev { ids.append(best) }
+            prev = best
+        }
+
+        if logits.dataType == .float32 {
+            let p = logits.dataPointer.assumingMemoryBound(to: Float32.self)
+            for t in 0..<frames {
+                let base = t * vocab
+                appendArgmax { p[base + $0] }
+            }
+        } else {
+            for t in 0..<frames {
+                appendArgmax { logits[[0, t as NSNumber, $0 as NSNumber]].floatValue }
+            }
+        }
+
+        let raw = decodeCtcTokenIds(ids, vocabulary: models.vocabulary)
+        return raw
+            .replacingOccurrences(of: "<\\|[^|]*\\|>", with: "", options: .regularExpression)
+            .trimmingCharacters(in: .whitespaces)
+    }
+}

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceManager.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceManager.swift
@@ -121,7 +121,10 @@ public actor SenseVoiceManager {
             var bestVal = frameBase(0)
             for v in 1..<vocab {
                 let x = frameBase(v)
-                if x > bestVal { bestVal = x; best = v }
+                if x > bestVal {
+                    bestVal = x
+                    best = v
+                }
             }
             if best != SenseVoiceConfig.blankId && best != prev { ids.append(best) }
             prev = best
@@ -140,7 +143,8 @@ public actor SenseVoiceManager {
         }
 
         let raw = decodeCtcTokenIds(ids, vocabulary: models.vocabulary)
-        return raw
+        return
+            raw
             .replacingOccurrences(of: "<\\|[^|]*\\|>", with: "", options: .regularExpression)
             .trimmingCharacters(in: .whitespaces)
     }

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceManager.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceManager.swift
@@ -26,11 +26,11 @@ public actor SenseVoiceManager {
 
     /// Load models from the default cache (downloading if needed), then build a manager.
     public static func load(
-        useFp32Encoder: Bool = false,
+        precision: SenseVoiceEncoderPrecision = .fp16,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> SenseVoiceManager {
         let models = try await SenseVoiceModels.downloadAndLoad(
-            useFp32Encoder: useFp32Encoder, progressHandler: progressHandler)
+            precision: precision, progressHandler: progressHandler)
         return SenseVoiceManager(models: models)
     }
 

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
@@ -1,6 +1,26 @@
 @preconcurrency import CoreML
 import Foundation
 
+/// SenseVoice encoder weight precision. fp16 and int8 run on the Neural Engine
+/// (int8 is ~half the size, accuracy-neutral); fp32 is the non-ANE fallback.
+public enum SenseVoiceEncoderPrecision: String, Sendable {
+    case fp16
+    case int8
+    case fp32
+
+    var modelName: String {
+        switch self {
+        case .fp16: return ModelNames.SenseVoice.encoder
+        case .int8: return ModelNames.SenseVoice.encoderInt8
+        case .fp32: return ModelNames.SenseVoice.encoderFp32
+        }
+    }
+
+    var computeUnits: MLComputeUnits {
+        self == .fp32 ? .all : .cpuAndNeuralEngine
+    }
+}
+
 /// Loaded SenseVoiceSmall CoreML models + vocabulary.
 ///
 /// 3 stages from `FluidInference/sensevoice-small-coreml`:
@@ -23,15 +43,14 @@ public struct SenseVoiceModels: Sendable {
 
     /// Download (if needed) and load all SenseVoice models.
     ///
-    /// - Parameter useFp32Encoder: load the fp32 encoder fallback instead of the
-    ///   fp16/ANE encoder. Use on hardware without a Neural Engine (the fp16
-    ///   encoder is correct only on ANE).
+    /// - Parameter precision: encoder weight precision (`.fp16` default ANE,
+    ///   `.int8` ~half size on ANE, `.fp32` fallback for non-ANE hardware).
     public static func downloadAndLoad(
-        useFp32Encoder: Bool = false,
+        precision: SenseVoiceEncoderPrecision = .fp16,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> SenseVoiceModels {
         let directory = try await download(progressHandler: progressHandler)
-        return try load(from: directory, useFp32Encoder: useFp32Encoder)
+        return try load(from: directory, precision: precision)
     }
 
     /// Download the repo into the shared model cache; returns the model directory.
@@ -65,24 +84,24 @@ public struct SenseVoiceModels: Sendable {
     }
 
     /// Load models from a directory that already contains the artifacts.
-    public static func load(from directory: URL, useFp32Encoder: Bool = false) throws -> SenseVoiceModels {
+    public static func load(
+        from directory: URL, precision: SenseVoiceEncoderPrecision = .fp16
+    ) throws -> SenseVoiceModels {
         // Preprocessor must run fp32 on CPU (power-spectrum/log exceed fp16 range,
         // and the big identity convs fail ANE compile).
         let cpuConfig = MLModelConfiguration()
         cpuConfig.computeUnits = .cpuOnly
 
-        // The fp16 encoder is numerically correct only on the Neural Engine;
-        // the fp32 fallback can run anywhere.
+        // fp16/int8 encoders are correct on the Neural Engine; fp32 runs anywhere.
         let encoderConfig = MLModelConfiguration()
-        encoderConfig.computeUnits = useFp32Encoder ? .all : .cpuAndNeuralEngine
+        encoderConfig.computeUnits = precision.computeUnits
 
         let preprocessor = try loadModel(
             named: ModelNames.SenseVoice.preprocessor, from: directory, configuration: cpuConfig)
-        let encoderName = useFp32Encoder ? ModelNames.SenseVoice.encoderFp32 : ModelNames.SenseVoice.encoder
-        let encoder = try loadModel(named: encoderName, from: directory, configuration: encoderConfig)
+        let encoder = try loadModel(named: precision.modelName, from: directory, configuration: encoderConfig)
         let vocabulary = try loadVocabulary(from: directory)
 
-        logger.info("Loaded SenseVoice (encoder: \(useFp32Encoder ? "fp32" : "fp16/ANE"), vocab: \(vocabulary.count))")
+        logger.info("Loaded SenseVoice (encoder: \(precision.rawValue), vocab: \(vocabulary.count))")
         return SenseVoiceModels(preprocessor: preprocessor, encoder: encoder, vocabulary: vocabulary)
     }
 

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
@@ -49,19 +49,24 @@ public struct SenseVoiceModels: Sendable {
         precision: SenseVoiceEncoderPrecision = .fp16,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> SenseVoiceModels {
-        let directory = try await download(progressHandler: progressHandler)
+        let directory = try await download(precision: precision, progressHandler: progressHandler)
         return try load(from: directory, precision: precision)
     }
 
     /// Download the repo into the shared model cache; returns the model directory.
+    ///
+    /// `precision` ensures the requested encoder variant is present — a cache that
+    /// predates a variant (e.g. fp16-only) re-fetches just the missing file
+    /// (`DownloadUtils.downloadRepo` skips files already on disk).
     public static func download(
+        precision: SenseVoiceEncoderPrecision = .fp16,
         force: Bool = false,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> URL {
         let modelsRoot = modelsRootDirectory()
         let targetDir = modelsRoot.appendingPathComponent(Repo.senseVoiceSmall.folderName, isDirectory: true)
 
-        if !force && modelsExist(at: targetDir) {
+        if !force && modelsExist(at: targetDir, precision: precision) {
             logger.info("SenseVoice models already present at: \(targetDir.path)")
             return targetDir
         }
@@ -73,11 +78,13 @@ public struct SenseVoiceModels: Sendable {
         return targetDir
     }
 
-    public static func modelsExist(at directory: URL) -> Bool {
+    public static func modelsExist(
+        at directory: URL, precision: SenseVoiceEncoderPrecision = .fp16
+    ) -> Bool {
         let fm = FileManager.default
         let required = [
             ModelNames.SenseVoice.preprocessorFile,
-            ModelNames.SenseVoice.encoderFile,
+            precision.modelName + ".mlmodelc",
             ModelNames.SenseVoice.vocabularyFile,
         ]
         return required.allSatisfy { fm.fileExists(atPath: directory.appendingPathComponent($0).path) }

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
@@ -124,7 +124,8 @@ public struct SenseVoiceModels: Sendable {
     private static func modelsRootDirectory() -> URL {
         let fm = FileManager.default
         if let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
-            return appSupport
+            return
+                appSupport
                 .appendingPathComponent("FluidAudio", isDirectory: true)
                 .appendingPathComponent("Models", isDirectory: true)
         }

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
@@ -1,0 +1,135 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Loaded SenseVoiceSmall CoreML models + vocabulary.
+///
+/// 3 stages from `FluidInference/sensevoice-small-coreml`:
+///   - `preprocessor` (fp32, CPU): waveform → [1, T, 560] LFR features
+///   - `encoder` (fp16 on ANE, or fp32 fallback): features + lang/textnorm → CTC logits
+///   - `vocabulary`: 25055 SentencePiece tokens (id → piece)
+public final class SenseVoiceModels: @unchecked Sendable {
+
+    public let preprocessor: MLModel
+    public let encoder: MLModel
+    public let vocabulary: [Int: String]
+
+    private static let logger = AppLogger(category: "SenseVoiceModels")
+
+    public init(preprocessor: MLModel, encoder: MLModel, vocabulary: [Int: String]) {
+        self.preprocessor = preprocessor
+        self.encoder = encoder
+        self.vocabulary = vocabulary
+    }
+
+    /// Download (if needed) and load all SenseVoice models.
+    ///
+    /// - Parameter useFp32Encoder: load the fp32 encoder fallback instead of the
+    ///   fp16/ANE encoder. Use on hardware without a Neural Engine (the fp16
+    ///   encoder is correct only on ANE).
+    public static func downloadAndLoad(
+        useFp32Encoder: Bool = false,
+        progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws -> SenseVoiceModels {
+        let directory = try await download(progressHandler: progressHandler)
+        return try load(from: directory, useFp32Encoder: useFp32Encoder)
+    }
+
+    /// Download the repo into the shared model cache; returns the model directory.
+    public static func download(
+        force: Bool = false,
+        progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws -> URL {
+        let modelsRoot = modelsRootDirectory()
+        let targetDir = modelsRoot.appendingPathComponent(Repo.senseVoiceSmall.folderName, isDirectory: true)
+
+        if !force && modelsExist(at: targetDir) {
+            logger.info("SenseVoice models already present at: \(targetDir.path)")
+            return targetDir
+        }
+        if force { try? FileManager.default.removeItem(at: targetDir) }
+
+        logger.info("Downloading SenseVoice models from HuggingFace...")
+        try await DownloadUtils.downloadRepo(.senseVoiceSmall, to: modelsRoot, progressHandler: progressHandler)
+        logger.info("Successfully downloaded SenseVoice models")
+        return targetDir
+    }
+
+    public static func modelsExist(at directory: URL) -> Bool {
+        let fm = FileManager.default
+        let required = [
+            ModelNames.SenseVoice.preprocessorFile,
+            ModelNames.SenseVoice.encoderFile,
+            ModelNames.SenseVoice.vocabularyFile,
+        ]
+        return required.allSatisfy { fm.fileExists(atPath: directory.appendingPathComponent($0).path) }
+    }
+
+    /// Load models from a directory that already contains the artifacts.
+    public static func load(from directory: URL, useFp32Encoder: Bool = false) throws -> SenseVoiceModels {
+        // Preprocessor must run fp32 on CPU (power-spectrum/log exceed fp16 range,
+        // and the big identity convs fail ANE compile).
+        let cpuConfig = MLModelConfiguration()
+        cpuConfig.computeUnits = .cpuOnly
+
+        // The fp16 encoder is numerically correct only on the Neural Engine;
+        // the fp32 fallback can run anywhere.
+        let encoderConfig = MLModelConfiguration()
+        encoderConfig.computeUnits = useFp32Encoder ? .all : .cpuAndNeuralEngine
+
+        let preprocessor = try loadModel(
+            named: ModelNames.SenseVoice.preprocessor, from: directory, configuration: cpuConfig)
+        let encoderName = useFp32Encoder ? ModelNames.SenseVoice.encoderFp32 : ModelNames.SenseVoice.encoder
+        let encoder = try loadModel(named: encoderName, from: directory, configuration: encoderConfig)
+        let vocabulary = try loadVocabulary(from: directory)
+
+        logger.info("Loaded SenseVoice (encoder: \(useFp32Encoder ? "fp32" : "fp16/ANE"), vocab: \(vocabulary.count))")
+        return SenseVoiceModels(preprocessor: preprocessor, encoder: encoder, vocabulary: vocabulary)
+    }
+
+    // MARK: - Private
+
+    private static func loadModel(
+        named name: String, from directory: URL, configuration: MLModelConfiguration
+    ) throws -> MLModel {
+        let compiledPath = directory.appendingPathComponent("\(name).mlmodelc")
+        let packagePath = directory.appendingPathComponent("\(name).mlpackage")
+        let modelURL: URL
+        if FileManager.default.fileExists(atPath: compiledPath.path) {
+            modelURL = compiledPath
+        } else if FileManager.default.fileExists(atPath: packagePath.path) {
+            modelURL = try MLModel.compileModel(at: packagePath)
+        } else {
+            throw ASRError.processingFailed("SenseVoice model not found: \(name)")
+        }
+        return try MLModel(contentsOf: modelURL, configuration: configuration)
+    }
+
+    private static func loadVocabulary(from directory: URL) throws -> [Int: String] {
+        let path = directory.appendingPathComponent(ModelNames.SenseVoice.vocabularyFile)
+        let data = try Data(contentsOf: path)
+        // Canonical format: JSON array ["<unk>", "<s>", ...].
+        if let arr = try? JSONSerialization.jsonObject(with: data) as? [String] {
+            var v: [Int: String] = [:]
+            for (i, tok) in arr.enumerated() { v[i] = tok }
+            return v
+        }
+        if let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
+            var v: [Int: String] = [:]
+            for (k, tok) in dict { if let i = Int(k) { v[i] = tok } }
+            return v
+        }
+        throw ASRError.processingFailed("Failed to parse vocab.json (expected array or dict)")
+    }
+
+    private static func modelsRootDirectory() -> URL {
+        let fm = FileManager.default
+        if let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            return appSupport
+                .appendingPathComponent("FluidAudio", isDirectory: true)
+                .appendingPathComponent("Models", isDirectory: true)
+        }
+        return fm.temporaryDirectory
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+}

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
@@ -7,7 +7,7 @@ import Foundation
 ///   - `preprocessor` (fp32, CPU): waveform → [1, T, 560] LFR features
 ///   - `encoder` (fp16 on ANE, or fp32 fallback): features + lang/textnorm → CTC logits
 ///   - `vocabulary`: 25055 SentencePiece tokens (id → piece)
-public final class SenseVoiceModels: @unchecked Sendable {
+public struct SenseVoiceModels: Sendable {
 
     public let preprocessor: MLModel
     public let encoder: MLModel

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -419,17 +419,20 @@ public enum ModelNames {
     /// Plus `vocab.json` (25055 SentencePiece tokens, auto-fetched as a root file).
     public enum SenseVoice {
         public static let preprocessor = "SenseVoicePreprocessor"
-        public static let encoder = "SenseVoiceSmall"  // fp16, runs on ANE
-        public static let encoderFp32 = "SenseVoiceSmall_fp32"  // fallback
+        public static let encoder = "SenseVoiceSmall"  // fp16, runs on ANE (default)
+        public static let encoderInt8 = "SenseVoiceSmall_int8"  // int8 weights, ANE, ~half size
+        public static let encoderFp32 = "SenseVoiceSmall_fp32"  // fp32 fallback (non-ANE)
 
         public static let preprocessorFile = preprocessor + ".mlmodelc"
         public static let encoderFile = encoder + ".mlmodelc"
+        public static let encoderInt8File = encoderInt8 + ".mlmodelc"
         public static let encoderFp32File = encoderFp32 + ".mlmodelc"
         public static let vocabularyFile = "vocab.json"
 
         public static let requiredModels: Set<String> = [
             preprocessorFile,
             encoderFile,
+            encoderInt8File,
             encoderFp32File,
         ]
     }

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -8,6 +8,10 @@ public enum Repo: String, CaseIterable, Sendable {
     case parakeetCtc110m = "FluidInference/parakeet-ctc-110m-coreml"
     case parakeetCtc06b = "FluidInference/parakeet-ctc-0.6b-coreml"
     case parakeetCtcZhCn = "FluidInference/parakeet-ctc-0.6b-zh-cn-coreml"
+    /// SenseVoiceSmall (FunASR) — non-autoregressive multilingual ASR (50+ langs).
+    /// 3-stage: fp32 CPU preprocessor (waveform→560-d LFR feats) + fp16 ANE
+    /// encoder+CTC (+ fp32 fallback) + host greedy-CTC decode. See ASR/SenseVoice.
+    case senseVoiceSmall = "FluidInference/sensevoice-small-coreml"
     // Japanese hybrid TDT: INT8 CTC-trained preprocessor+encoder paired with a
     // TDT decoder+joint. CTC-only inference for Japanese was removed in
     // 846924a1d; only the preprocessor+encoder files from this repo are reused.
@@ -67,6 +71,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "parakeet-ctc-0.6b-coreml"
         case .parakeetCtcZhCn:
             return "parakeet-ctc-0.6b-zh-cn-coreml"
+        case .senseVoiceSmall:
+            return "sensevoice-small-coreml"
         case .parakeetJa:
             return "parakeet-0.6b-ja-coreml"
         case .parakeetEou160:
@@ -403,6 +409,28 @@ public enum ModelNames {
             encoderFile,  // int8 encoder
             encoderFp32File,  // fp32 encoder
             decoderFile,
+        ]
+    }
+
+    /// SenseVoiceSmall (FunASR) model names. 3-stage pipeline:
+    ///   Preprocessor (fp32, CPU): waveform → 560-d LFR features
+    ///   SenseVoiceSmall (fp16, ANE): features + lang/textnorm → CTC logits
+    ///   SenseVoiceSmall_fp32 (fp32): encoder fallback for non-ANE hardware
+    /// Plus `vocab.json` (25055 SentencePiece tokens, auto-fetched as a root file).
+    public enum SenseVoice {
+        public static let preprocessor = "SenseVoicePreprocessor"
+        public static let encoder = "SenseVoiceSmall"  // fp16, runs on ANE
+        public static let encoderFp32 = "SenseVoiceSmall_fp32"  // fallback
+
+        public static let preprocessorFile = preprocessor + ".mlmodelc"
+        public static let encoderFile = encoder + ".mlmodelc"
+        public static let encoderFp32File = encoderFp32 + ".mlmodelc"
+        public static let vocabularyFile = "vocab.json"
+
+        public static let requiredModels: Set<String> = [
+            preprocessorFile,
+            encoderFile,
+            encoderFp32File,
         ]
     }
 
@@ -1028,6 +1056,8 @@ public enum ModelNames {
             return ModelNames.CTC.requiredModels
         case .parakeetCtcZhCn:
             return ModelNames.CTCZhCn.requiredModels
+        case .senseVoiceSmall:
+            return ModelNames.SenseVoice.requiredModels
         case .parakeetJa:
             return ModelNames.TDTJa.requiredModels
         case .parakeetEou160, .parakeetEou320, .parakeetEou1280:

--- a/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceBenchmark.swift
@@ -14,7 +14,7 @@ enum SenseVoiceBenchmark {
     static func run(arguments: [String]) async {
         var languages = ["en_us", "cmn_hans_cn"]
         var samplesPerLanguage = 100
-        var useFp32 = false
+        var precision: SenseVoiceEncoderPrecision = .fp16
         var verbose = false
 
         var i = 0
@@ -31,12 +31,16 @@ enum SenseVoiceBenchmark {
                         arguments[i + 1].lowercased() == "all" ? Int.max : (Int(arguments[i + 1]) ?? 100)
                     i += 1
                 }
+            case "--int8":
+                precision = .int8
             case "--fp32":
-                useFp32 = true
+                precision = .fp32
             case "--verbose", "-v":
                 verbose = true
             case "--help", "-h":
-                print("Usage: fluidaudio sensevoice-benchmark [--languages en_us,cmn_hans_cn] [--samples N] [--fp32]")
+                print(
+                    "Usage: fluidaudio sensevoice-benchmark [--languages en_us,cmn_hans_cn] [--samples N|all] [--int8|--fp32]"
+                )
                 return
             default:
                 break
@@ -48,8 +52,8 @@ enum SenseVoiceBenchmark {
             .appendingPathComponent("Library/Application Support/FluidAudio/FLEURS").path
 
         do {
-            logger.info("Loading SenseVoice (encoder: \(useFp32 ? "fp32" : "fp16/ANE"))...")
-            let manager = try await SenseVoiceManager.load(useFp32Encoder: useFp32)
+            logger.info("Loading SenseVoice (encoder: \(precision.rawValue))...")
+            let manager = try await SenseVoiceManager.load(precision: precision)
 
             let fleurs = FLEURSBenchmark(
                 config: .init(

--- a/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceBenchmark.swift
@@ -23,7 +23,10 @@ enum SenseVoiceBenchmark {
             case "--languages":
                 if i + 1 < arguments.count { languages = arguments[i + 1].split(separator: ",").map(String.init); i += 1 }
             case "--samples", "-n":
-                if i + 1 < arguments.count { samplesPerLanguage = Int(arguments[i + 1]) ?? 100; i += 1 }
+                if i + 1 < arguments.count {
+                    samplesPerLanguage = arguments[i + 1].lowercased() == "all" ? Int.max : (Int(arguments[i + 1]) ?? 100)
+                    i += 1
+                }
             case "--fp32":
                 useFp32 = true
             case "--verbose", "-v":

--- a/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceBenchmark.swift
@@ -1,0 +1,86 @@
+#if os(macOS)
+import AVFoundation
+import FluidAudio
+import Foundation
+
+/// `sensevoice-benchmark [--languages en_us,cmn_hans_cn] [--samples 100] [--fp32]`
+///
+/// FLEURS WER/CER for SenseVoiceSmall on Apple Silicon. Reuses the shared
+/// `FLEURSBenchmark` downloader + `WERCalculator`. CoreML(ANE) vs the published
+/// numbers; cross-checks the conversion is accuracy-neutral.
+enum SenseVoiceBenchmark {
+    private static let logger = AppLogger(category: "SenseVoiceBenchmark")
+
+    static func run(arguments: [String]) async {
+        var languages = ["en_us", "cmn_hans_cn"]
+        var samplesPerLanguage = 100
+        var useFp32 = false
+        var verbose = false
+
+        var i = 0
+        while i < arguments.count {
+            switch arguments[i] {
+            case "--languages":
+                if i + 1 < arguments.count { languages = arguments[i + 1].split(separator: ",").map(String.init); i += 1 }
+            case "--samples", "-n":
+                if i + 1 < arguments.count { samplesPerLanguage = Int(arguments[i + 1]) ?? 100; i += 1 }
+            case "--fp32":
+                useFp32 = true
+            case "--verbose", "-v":
+                verbose = true
+            case "--help", "-h":
+                print("Usage: fluidaudio sensevoice-benchmark [--languages en_us,cmn_hans_cn] [--samples N] [--fp32]")
+                return
+            default:
+                break
+            }
+            i += 1
+        }
+
+        let cacheDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Application Support/FluidAudio/FLEURS").path
+
+        do {
+            logger.info("Loading SenseVoice (encoder: \(useFp32 ? "fp32" : "fp16/ANE"))...")
+            let manager = try await SenseVoiceManager.load(useFp32Encoder: useFp32)
+
+            let fleurs = FLEURSBenchmark(
+                config: .init(
+                    languages: languages, samplesPerLanguage: samplesPerLanguage,
+                    outputFile: "", cacheDir: cacheDir, debugMode: verbose))
+            logger.info("Downloading FLEURS (\(languages.joined(separator: ", ")))...")
+            try await fleurs.downloadFLEURS(languages: languages)
+            let allSamples = try fleurs.loadFLEURSSamples(languages: languages)
+
+            let converter = AudioConverter(sampleRate: 16_000)
+            for language in languages {
+                let samples = allSamples.filter { $0.language == language }.prefix(samplesPerLanguage)
+                var wordErrors = 0, totalWords = 0
+                var charErrors = 0.0, totalChars = 0
+                var audioSec = 0.0, procSec = 0.0
+                var n = 0
+                for sample in samples {
+                    guard let audio = try? converter.resampleAudioFile(path: sample.audioPath) else { continue }
+                    let t0 = Date()
+                    guard let hyp = try? await manager.transcribe(audio: audio) else { continue }
+                    procSec += Date().timeIntervalSince(t0)
+                    audioSec += Double(audio.count) / 16_000.0
+                    let m = WERCalculator.calculateWERAndCER(hypothesis: hyp, reference: sample.transcription)
+                    wordErrors += m.insertions + m.deletions + m.substitutions
+                    totalWords += m.totalWords
+                    charErrors += m.cer * Double(m.totalCharacters)
+                    totalChars += m.totalCharacters
+                    n += 1
+                }
+                let wer = totalWords > 0 ? 100.0 * Double(wordErrors) / Double(totalWords) : 0
+                let cer = totalChars > 0 ? 100.0 * charErrors / Double(totalChars) : 0
+                let rtfx = procSec > 0 ? audioSec / procSec : 0
+                logger.info(
+                    "[\(language)] n=\(n)  WER=\(String(format: "%.2f", wer))%  CER=\(String(format: "%.2f", cer))%  RTFx=\(String(format: "%.0f", rtfx))")
+            }
+        } catch {
+            logger.error("Benchmark failed: \(error)")
+        }
+    }
+}
+#endif

--- a/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceBenchmark.swift
@@ -21,10 +21,14 @@ enum SenseVoiceBenchmark {
         while i < arguments.count {
             switch arguments[i] {
             case "--languages":
-                if i + 1 < arguments.count { languages = arguments[i + 1].split(separator: ",").map(String.init); i += 1 }
+                if i + 1 < arguments.count {
+                    languages = arguments[i + 1].split(separator: ",").map(String.init)
+                    i += 1
+                }
             case "--samples", "-n":
                 if i + 1 < arguments.count {
-                    samplesPerLanguage = arguments[i + 1].lowercased() == "all" ? Int.max : (Int(arguments[i + 1]) ?? 100)
+                    samplesPerLanguage =
+                        arguments[i + 1].lowercased() == "all" ? Int.max : (Int(arguments[i + 1]) ?? 100)
                     i += 1
                 }
             case "--fp32":
@@ -58,9 +62,12 @@ enum SenseVoiceBenchmark {
             let converter = AudioConverter(sampleRate: 16_000)
             for language in languages {
                 let samples = allSamples.filter { $0.language == language }.prefix(samplesPerLanguage)
-                var wordErrors = 0, totalWords = 0
-                var charErrors = 0.0, totalChars = 0
-                var audioSec = 0.0, procSec = 0.0
+                var wordErrors = 0
+                var totalWords = 0
+                var charErrors = 0.0
+                var totalChars = 0
+                var audioSec = 0.0
+                var procSec = 0.0
                 var n = 0
                 for sample in samples {
                     guard let audio = try? converter.resampleAudioFile(path: sample.audioPath) else { continue }
@@ -79,7 +86,8 @@ enum SenseVoiceBenchmark {
                 let cer = totalChars > 0 ? 100.0 * charErrors / Double(totalChars) : 0
                 let rtfx = procSec > 0 ? audioSec / procSec : 0
                 logger.info(
-                    "[\(language)] n=\(n)  WER=\(String(format: "%.2f", wer))%  CER=\(String(format: "%.2f", cer))%  RTFx=\(String(format: "%.0f", rtfx))")
+                    "[\(language)] n=\(n)  WER=\(String(format: "%.2f", wer))%  CER=\(String(format: "%.2f", cer))%  RTFx=\(String(format: "%.0f", rtfx))"
+                )
             }
         } catch {
             logger.error("Benchmark failed: \(error)")

--- a/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceTranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceTranscribeCommand.swift
@@ -9,14 +9,16 @@ enum SenseVoiceTranscribeCommand {
 
     static func run(arguments: [String]) async {
         var audioPath: String?
-        var useFp32 = false
+        var precision: SenseVoiceEncoderPrecision = .fp16
         var verbose = false
 
         var i = 0
         while i < arguments.count {
             switch arguments[i] {
+            case "--int8":
+                precision = .int8
             case "--fp32":
-                useFp32 = true
+                precision = .fp32
             case "--verbose", "-v":
                 verbose = true
             case "--help", "-h":
@@ -40,8 +42,8 @@ enum SenseVoiceTranscribeCommand {
         }
 
         do {
-            logger.info("Loading SenseVoice models (encoder: \(useFp32 ? "fp32" : "fp16/ANE"))...")
-            let manager = try await SenseVoiceManager.load(useFp32Encoder: useFp32)
+            logger.info("Loading SenseVoice models (encoder: \(precision.rawValue))...")
+            let manager = try await SenseVoiceManager.load(precision: precision)
 
             let start = Date()
             let text = try await manager.transcribe(audioURL: audioURL)
@@ -62,6 +64,7 @@ enum SenseVoiceTranscribeCommand {
             Transcribe audio with SenseVoiceSmall (multilingual, non-autoregressive).
 
             Options:
+              --int8        Use the int8 encoder (~half size, ANE, accuracy-neutral)
               --fp32        Use the fp32 encoder (for hardware without a Neural Engine)
               --verbose,-v  Print timing
               --help,-h     Show this help

--- a/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceTranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/SenseVoiceTranscribeCommand.swift
@@ -1,0 +1,72 @@
+#if os(macOS)
+import AVFoundation
+import FluidAudio
+import Foundation
+
+/// `sensevoice-transcribe <audio> [--fp32] [--verbose]`
+enum SenseVoiceTranscribeCommand {
+    private static let logger = AppLogger(category: "SenseVoiceTranscribe")
+
+    static func run(arguments: [String]) async {
+        var audioPath: String?
+        var useFp32 = false
+        var verbose = false
+
+        var i = 0
+        while i < arguments.count {
+            switch arguments[i] {
+            case "--fp32":
+                useFp32 = true
+            case "--verbose", "-v":
+                verbose = true
+            case "--help", "-h":
+                printUsage()
+                return
+            default:
+                if audioPath == nil { audioPath = arguments[i] }
+            }
+            i += 1
+        }
+
+        guard let audioPath else {
+            logger.error("Error: No audio file specified")
+            printUsage()
+            return
+        }
+        let audioURL = URL(fileURLWithPath: audioPath)
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            logger.error("Error: Audio file not found: \(audioPath)")
+            return
+        }
+
+        do {
+            logger.info("Loading SenseVoice models (encoder: \(useFp32 ? "fp32" : "fp16/ANE"))...")
+            let manager = try await SenseVoiceManager.load(useFp32Encoder: useFp32)
+
+            let start = Date()
+            let text = try await manager.transcribe(audioURL: audioURL)
+            let elapsed = Date().timeIntervalSince(start)
+
+            if verbose { logger.info("Transcribed in \(String(format: "%.2f", elapsed))s") }
+            print(text)
+        } catch {
+            logger.error("Transcription failed: \(error)")
+        }
+    }
+
+    private static func printUsage() {
+        print(
+            """
+            Usage: fluidaudio sensevoice-transcribe <audio-file> [options]
+
+            Transcribe audio with SenseVoiceSmall (multilingual, non-autoregressive).
+
+            Options:
+              --fp32        Use the fp32 encoder (for hardware without a Neural Engine)
+              --verbose,-v  Print timing
+              --help,-h     Show this help
+            """
+        )
+    }
+}
+#endif

--- a/Sources/FluidAudioCLI/FluidAudioCLI.swift
+++ b/Sources/FluidAudioCLI/FluidAudioCLI.swift
@@ -84,6 +84,8 @@ struct FluidAudioCLI {
             await NemotronTranscribe.run(arguments: Array(arguments.dropFirst(2)))
         case "ctc-zh-cn-transcribe":
             await CtcZhCnTranscribeCommand.run(arguments: Array(arguments.dropFirst(2)))
+        case "sensevoice-transcribe":
+            await SenseVoiceTranscribeCommand.run(arguments: Array(arguments.dropFirst(2)))
         case "ctc-zh-cn-benchmark":
             await CtcZhCnBenchmark.run(arguments: Array(arguments.dropFirst(2)))
         case "ja-benchmark":

--- a/Sources/FluidAudioCLI/FluidAudioCLI.swift
+++ b/Sources/FluidAudioCLI/FluidAudioCLI.swift
@@ -86,6 +86,8 @@ struct FluidAudioCLI {
             await CtcZhCnTranscribeCommand.run(arguments: Array(arguments.dropFirst(2)))
         case "sensevoice-transcribe":
             await SenseVoiceTranscribeCommand.run(arguments: Array(arguments.dropFirst(2)))
+        case "sensevoice-benchmark":
+            await SenseVoiceBenchmark.run(arguments: Array(arguments.dropFirst(2)))
         case "ctc-zh-cn-benchmark":
             await CtcZhCnBenchmark.run(arguments: Array(arguments.dropFirst(2)))
         case "ja-benchmark":


### PR DESCRIPTION
## Summary

Adds **SenseVoiceSmall** (FunASR) as a CoreML ASR backend — non-autoregressive multilingual ASR (50+ languages, SANM encoder + single CTC head). Models live at [`FluidInference/sensevoice-small-coreml`](https://huggingface.co/FluidInference/sensevoice-small-coreml).

Tracks #645 / #646.

## Pipeline (3 stages)

```
waveform → [SenseVoicePreprocessor fp32/CPU] → 560-d LFR features
        → [SenseVoiceSmall fp16/ANE encoder+CTC] → logits
        → host greedy-CTC decode → text
```

- **Preprocessor** (fp32, CPU): kaldi fbank80 + LFR(m=7) + CMVN — a CoreML replica of FunASR's `WavFrontend` (matches to max|Δ|≈2e-5). Runs fp32/CPU because the power-spectrum/log exceed fp16 range and the framing convs don't ANE-compile.
- **Encoder+CTC** (fp16, ANE): enumerated length buckets `[128,256,512,1024,1800]`; an fp32 fallback (`--fp32`) is included for hardware without a Neural Engine. ⚠️ the fp16 encoder is numerically correct **only on `CPU_AND_NE`** (NaN on the CPU/GPU fp16 path) — the loader sets `.cpuAndNeuralEngine`.
- **Decode** (host): greedy CTC (blank=0) → reuses `CtcDecoder.decodeCtcTokenIds` → strips the leading `<|lang|><|emo|><|event|><|itn|>` tags.

## Changes

- `ModelNames`: `senseVoiceSmall` `Repo` case + `ModelNames.SenseVoice` registry.
- `Sources/FluidAudio/ASR/SenseVoice/`: `SenseVoiceConfig`, `SenseVoiceModels` (download/load), `SenseVoiceManager` (the pipeline).
- CLI: `sensevoice-transcribe` and `sensevoice-benchmark` (FLEURS WER/CER, reuses `FLEURSBenchmark` + `WERCalculator`).

## Verification

- **End-to-end on M5 Pro ANE**: `sensevoice-transcribe` on the zh sample → `欢迎大家来体验达摩院推出的语音识别模型` (correct), 0.93 s.
- **Conversion is accuracy-neutral vs the PyTorch model** (validated in the conversion repo):
  - LibriSpeech test-clean (full 2620 utts): CoreML(ANE) **WER 3.22%** vs official SenseVoice-Small ~3.1%.
  - FLEURS 100/lang: en WER 9.52%/9.52% (Δ +0.00pp), zh CER 9.60%/9.57% (Δ −0.03pp) vs torch.
- `swift build` clean; both CLI commands run.

## Notes

- Front-end conversion + parity/WER scripts live in the conversion repo (not in this PR).
- RTFx numbers here are debug-build; release + larger batches are higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
