### PR TITLE
fix(download): fetch repo-root vocab.json for Cohere Transcribe (#649)

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -389,9 +389,60 @@ public class DownloadUtils {
             }
         }
 
+        // Pull root-level files whose basename is in `names`. Some subPath repos
+        // keep shared auxiliary files at the repo root rather than inside the
+        // precision subdirectory, so a subPath-only traversal misses them.
+        func listRootFiles(matching names: Set<String>) async throws {
+            let dirURL = try ModelRegistry.apiModels(repo.remotePath, "tree/main")
+            let request = authorizedRequest(url: dirURL)
+            let (dirData, response) = try await sharedSession.data(for: request)
+
+            if let httpResponse = response as? HTTPURLResponse,
+                httpResponse.statusCode == 429 || httpResponse.statusCode == 503
+            {
+                throw HuggingFaceDownloadError.rateLimited(
+                    statusCode: httpResponse.statusCode, message: "Rate limited while listing root files")
+            }
+
+            try validateJSONResponse(dirData, path: "")
+
+            guard let items = try JSONSerialization.jsonObject(with: dirData) as? [[String: Any]] else {
+                throw HuggingFaceDownloadError.invalidResponse
+            }
+
+            for item in items {
+                guard let itemPath = item["path"] as? String,
+                    item["type"] as? String == "file",
+                    names.contains((itemPath as NSString).lastPathComponent)
+                else { continue }
+                let fileSize = item["size"] as? Int ?? -1
+                filesToDownload.append((path: itemPath, size: fileSize))
+            }
+        }
+
         // Start listing from subPath if specified, otherwise from root
         progressHandler?(DownloadProgress(fractionCompleted: 0.0, phase: .listing))
         try await listDirectory(path: subPath ?? "")
+
+        // Some subPath repos keep shared auxiliary files (e.g. vocab.json) at the
+        // repo *root* rather than inside the precision subdirectory — the bundled
+        // .mlmodelc dirs live under `q8/`, but the tokenizer vocab is shared across
+        // precisions and published once at the root. The subPath traversal above
+        // never visits the root, so those files are missed and the verify pass
+        // below throws `modelNotFound` (issue #649). For any required *file*
+        // (i.e. not an .mlmodelc/.mlpackage bundle) that the subPath sweep did not
+        // already collect, fall back to grabbing a matching root-level file.
+        if subPath != nil {
+            let collected = Set(filesToDownload.map { ($0.path as NSString).lastPathComponent })
+            let missingAux = requiredModels.filter { model in
+                !model.hasSuffix(".mlmodelc") && !model.hasSuffix(".mlpackage")
+                    && !collected.contains((model as NSString).lastPathComponent)
+            }
+            if !missingAux.isEmpty {
+                try await listRootFiles(matching: Set(missingAux))
+            }
+        }
+
         logger.info("Found \(filesToDownload.count) files to download")
 
         // Compute total known bytes for byte-weighted progress.

--- a/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
@@ -257,7 +257,7 @@ public enum TtsBenchmarkCommand {
         //   no flag, otherwise               → .parakeet
         let asrChoice: AsrChoice
         do {
-            asrChoice = try resolveAsrChoice(
+            asrChoice = try await resolveAsrChoice(
                 skipAsrFlag: skipAsr,
                 backendName: asrBackendName,
                 cohereModelDir: cohereModelDirArg,
@@ -1122,14 +1122,14 @@ public enum TtsBenchmarkCommand {
         cohereComputeUnits: String?,
         corpusLabel: String,
         ttsBackend: Backend
-    ) throws -> AsrChoice {
+    ) async throws -> AsrChoice {
         let normalized = backendName?.lowercased()
         if skipAsrFlag || normalized == "none" {
             return .skip
         }
         switch normalized {
         case "cohere":
-            let dir = try resolveCohereModelDir(cohereModelDir)
+            let dir = try await resolveCohereModelDir(cohereModelDir)
             let language = inferCohereLanguage(
                 explicit: asrLanguage, corpus: corpusLabel)
             let units = try resolveCohereComputeUnits(cohereComputeUnits)
@@ -1153,34 +1153,39 @@ public enum TtsBenchmarkCommand {
     ///   1. Explicit `--cohere-model-dir <path>`.
     ///   2. The default cache location at
     ///      `~/Library/Application Support/FluidAudio/Models/cohere-transcribe/q8`,
-    ///      matching `Repo.cohereTranscribeCoreml.folderName`.
+    ///      matching `Repo.cohereTranscribeCoreml.folderName`. Auto-downloaded
+    ///      from HuggingFace if missing.
     ///
-    /// Auto-download is intentionally not wired here: the upstream
-    /// `Repo.cohereTranscribeCoreml` registration ships `vocab.json` in
-    /// `requiredModels`, but the file lives at the repo root rather than
-    /// under the `q8/` subPath, so `DownloadUtils.downloadRepo` would fail
-    /// the post-download verify. Fix this when the registry learns about
-    /// repo-root files; until then, callers must pre-populate the cache
-    /// (e.g. via `fluidaudio cohere-transcribe ... --model-dir <dir>`).
-    private static func resolveCohereModelDir(_ override: String?) throws -> URL {
+    /// `Repo.cohereTranscribeCoreml` ships `vocab.json` in `requiredModels`, and
+    /// that file lives at the repo root rather than under the `q8/` subPath.
+    /// `DownloadUtils.downloadRepo` now sweeps the repo root for required
+    /// auxiliary files (issue #649), so auto-download resolves it correctly.
+    private static func resolveCohereModelDir(_ override: String?) async throws -> URL {
         if let override {
             return resolveURL(override, isDirectory: true)
         }
         let appSupport = try FileManager.default.url(
             for: .applicationSupportDirectory,
             in: .userDomainMask, appropriateFor: nil, create: true)
-        let target =
-            appSupport
-            .appendingPathComponent("FluidAudio/Models/cohere-transcribe/q8")
+        // `downloadRepo` appends `repo.folderName` (cohere-transcribe/q8), so
+        // pass the Models base dir and let it land the bundle at `target`.
+        let modelsBase = appSupport.appendingPathComponent("FluidAudio/Models")
+        let target = modelsBase.appendingPathComponent("cohere-transcribe/q8")
         let needed = [
             ModelNames.CohereTranscribe.encoderCompiledFile,
             ModelNames.CohereTranscribe.decoderCacheExternalV2CompiledFile,
             "vocab.json",
         ]
-        let missing = needed.filter { name in
-            !FileManager.default.fileExists(
-                atPath: target.appendingPathComponent(name).path)
+        func missingFiles() -> [String] {
+            needed.filter { name in
+                !FileManager.default.fileExists(
+                    atPath: target.appendingPathComponent(name).path)
+            }
         }
+        if !missingFiles().isEmpty {
+            try await DownloadUtils.downloadRepo(.cohereTranscribeCoreml, to: modelsBase)
+        }
+        let missing = missingFiles()
         guard missing.isEmpty else {
             throw NSError(
                 domain: "TtsBenchmark", code: 1,


### PR DESCRIPTION
Fixes #649.

## Problem

Downloading Cohere Transcribe fails:

```
[INFO] [FluidAudio.DownloadUtils] Downloading cohere-transcribe/q8 from HuggingFace...
[INFO] [FluidAudio.DownloadUtils] Found 20 files to download
Download failed for Cohere Transcribe: modelNotFound(path: "vocab.json")
```

`Repo.cohereTranscribeCoreml` uses subPath `q8`, and the CoreML bundles live under `q8/`. But the repo's `vocab.json` is published once at the **repo root** (it's shared across precisions), not inside `q8/`. `DownloadUtils.downloadRepo` starts its tree walk at the subPath and only includes files whose path is prefixed with `q8/`, so root-level `vocab.json` is never fetched. The post-download verify loop then throws `modelNotFound(path: "vocab.json")`.

## Fix

After the subPath sweep, `downloadRepo` now also sweeps the repo root for any **required plain file** (i.e. not an `.mlmodelc`/`.mlpackage` bundle) that the subPath sweep didn't already collect, and pulls a matching root-level file.

This is conservative — the root sweep only runs when a required plain file is still missing after the subPath sweep, so subPath repos whose auxiliary files already live inside the subPath (e.g. Qwen3's `qwen3_asr_embeddings.bin`) trigger no extra request and are unaffected.

Also re-enables auto-download in the Cohere TTS-benchmark path (`resolveCohereModelDir`), which was previously disabled with a comment pointing at this exact limitation.

## Verification

`swift build` is clean. I replicated the exact listing + matcher logic against the live HuggingFace API:

- **Before:** subPath sweep collects exactly 20 files (matching the issue's "Found 20 files to download"), `vocab.json` absent → verify would throw.
- **After:** root sweep adds `vocab.json`; final verify resolves all three required files (`cohere_encoder.mlmodelc`, `cohere_decoder_cache_external_v2.mlmodelc`, `vocab.json`) → no `modelNotFound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)