### PR TITLE
feat(asr): Paraformer-large (zh) CoreML backend (non-autoregressive, CIF)

### DIFF
--- a/Documentation/ASR/Paraformer.md
+++ b/Documentation/ASR/Paraformer.md
@@ -1,0 +1,85 @@
+# Paraformer
+
+Non-autoregressive Mandarin (zh) ASR using FunASR's **Paraformer-large**, converted
+to CoreML. A SANM encoder + a CIF predictor (one acoustic-embedding token per output
+character) + a single-pass parallel decoder.
+
+## Model
+
+**CoreML Model**: [FluidInference/paraformer-large-zh-coreml](https://huggingface.co/FluidInference/paraformer-large-zh-coreml)
+
+4 CoreML stages + a host-side CIF:
+
+| File | Precision | Compute unit | Role |
+|------|-----------|--------------|------|
+| `ParaformerPreprocessor.mlmodelc` | FP32 | CPU | waveform → 560-d LFR features |
+| `ParaformerEncoder.mlmodelc` / `_int8` | FP16 / INT8 | **ANE** | SANM encoder (enumerated buckets) |
+| `ParaformerCifAlphas.mlmodelc` | FP16 | **ANE** | enc_out → per-frame alphas |
+| `ParaformerDecoder.mlmodelc` / `_int8` | FP16 / INT8 | **ANE** | parallel decoder → token logits |
+| `vocab.json` | — | — | 8404 CharTokenizer tokens |
+
+The **CIF predictor** emits a *dynamic* token count, so it can't be a fixed-shape
+graph: its conv1d+linear+sigmoid (→ alphas) is the `CifAlphas` model, and the host
+does only the integrate-and-fire loop (`ParaformerCif`, ported bit-exact from FunASR).
+
+## Architecture
+
+```
+waveform → [Preprocessor fp32/CPU] → features [1,T,560]
+        → [Encoder fp16/ANE] → enc_out [1,T,512]
+        → [CifAlphas fp16/ANE] → alphas → [host integrate-and-fire] → acoustic_embeds, L
+        → [Decoder fp16/ANE] → logits [1,L,8404]
+        → argmax per token → drop sos(1)/eos(2)/blank(0) → CharTokenizer
+```
+
+Run encoder/CifAlphas/decoder on `.cpuAndNeuralEngine`; the preprocessor is FP32/CPU
+(power-spectrum + log exceed the FP16 range).
+
+## Audio length
+
+Offline / whole-utterance (not streaming). ~60 ms per feature frame (fbank 10 ms ×
+LFR n=6). The encoder enumerates `[128,256,512,1024,1800]` frames, but the **decoder
+is fixed at 512 frames / 128 tokens**, so the effective ceiling is **~30 s of audio /
+~128 characters** per call (`ParaformerManager` truncates longer audio). Segment with
+VAD for long-form input.
+
+## Usage
+
+### CLI
+
+```bash
+# Transcribe (fp16, default)
+swift run -c release fluidaudiocli paraformer-transcribe audio.wav
+
+# int8 encoder/decoder (~half size, accuracy-neutral)
+swift run -c release fluidaudiocli paraformer-transcribe audio.wav --int8
+```
+
+### Swift
+
+```swift
+let manager = try await ParaformerManager.load()            // .fp16 default; .int8 for half size
+let text = try await manager.transcribe(audioURL: url)
+```
+
+## Benchmarks
+
+Full canonical set on Apple M5 Pro (CoreML on ANE) — see
+[Benchmarks.md#paraformer](../Benchmarks.md#paraformer) for the full table.
+
+| Precision | size (enc+dec) | AISHELL-1 CER (7,176) | RTFx | peak RAM |
+|-----------|----------------|------------------------|------|----------|
+| fp16 | 411 MB | 2.12% | 85× | 0.38 GB |
+| int8 | 207 MB | 2.12% | 84× | 0.24 GB |
+
+Official Paraformer-large AISHELL-1 ≈ 1.95% (the ~0.17 pp gap is fp16 + the
+fixed-shape decoder padding). int8 is accuracy-neutral.
+
+## Conversion notes
+
+Two SANM-specific fixes were required for fp16/ANE under bucket padding (shared with
+SenseVoice): a fp16-safe attention mask fill (`-inf` → `-1e4`), and building the
+encoder/decoder pad-masks from the **input tensor's seq dim** (so `EnumeratedShapes`
+generalize on ANE) rather than `lengths.max()`. The decoder is currently fixed-shape
+(enc 512 / tokens 128); an enumerated-shape decoder would raise RTFx on short clips
+and lift the ~30 s ceiling.

--- a/Documentation/Benchmarks.md
+++ b/Documentation/Benchmarks.md
@@ -456,6 +456,33 @@ Post-training weight quantization of the encoder — **~half the size, accuracy-
 swift run -c release fluidaudiocli sensevoice-benchmark --languages en_us,cmn_hans_cn --samples all
 ```
 
+## Paraformer
+
+Non-autoregressive Mandarin (zh) ASR: SANM encoder + CIF predictor (host
+integrate-and-fire) + parallel decoder. See [ASR/Paraformer.md](ASR/Paraformer.md).
+
+Model: [FluidInference/paraformer-large-zh-coreml](https://huggingface.co/FluidInference/paraformer-large-zh-coreml)
+
+Hardware: Apple M5 Pro, macOS 26. Encoder/CifAlphas/decoder on ANE; FP32 CPU front-end.
+
+### AISHELL-1 Chinese (7176 files, full test, full-CoreML pipeline)
+
+| Precision | size (enc+dec) | CER | median RTFx | peak RAM | Official |
+|-----------|----------------|-----|-------------|----------|----------|
+| fp16 (default) | 411 MB | **2.12%** | 85× | 0.38 GB | ~1.95% |
+| int8 | 207 MB | **2.12%** | 84× | 0.24 GB | ~1.95% |
+
+**Methodology notes:**
+- CER (character-level, whitespace removed) is the primary metric for Chinese, matching the official Paraformer-large AISHELL-1 number.
+- int8 weight quantization (encoder + decoder) is accuracy-neutral (CER unchanged on the full set), ~half the size/memory.
+- The ~0.17 pp gap vs official is fp16 + the fixed-shape decoder (enc 512 / tokens 128). RTFx (~85×) is lower than SenseVoice (~400×) because Paraformer runs 3 CoreML predicts/clip + the decoder pads short clips to 512 frames — an enumerated decoder would raise it.
+- AISHELL-1 dataset: [TwinkStart/AISHELL-1](https://huggingface.co/datasets/TwinkStart/AISHELL-1).
+
+```bash
+swift run -c release fluidaudiocli paraformer-transcribe audio.wav         # fp16
+swift run -c release fluidaudiocli paraformer-transcribe audio.wav --int8  # half size
+```
+
 ## Streaming ASR (Parakeet EOU)
 
 Real-time streaming ASR with End-of-Utterance detection using the Parakeet EOU 120M CoreML model.

--- a/Sources/FluidAudio/ASR/Paraformer/ParaformerCif.swift
+++ b/Sources/FluidAudio/ASR/Paraformer/ParaformerCif.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Host-side CIF (Continuous Integrate-and-Fire) for Paraformer.
+///
+/// The conv1d+linear+sigmoid that produces per-frame `alphas` is the CoreML
+/// `ParaformerCifAlphas` model; this does only the integrate-and-fire that turns
+/// (encoder rows, alphas) into a dynamic number of acoustic-embedding tokens.
+/// Port of the numpy reference (`cif_numpy.py`), bit-exact vs FunASR.
+enum ParaformerCif {
+
+    /// - Parameters:
+    ///   - encRows: encoder output rows `[T][D]` (real frames only).
+    ///   - alphas: per-frame weights `[T]` from the CifAlphas model.
+    /// - Returns: acoustic embeddings `[L][D]`.
+    static func integrateAndFire(encRows: [[Float]], alphas: [Float]) -> [[Float]] {
+        let threshold = ParaformerConfig.cifThreshold
+        let tail = ParaformerConfig.cifTailThreshold
+        let T = encRows.count
+        let dim = encRows.first?.count ?? ParaformerConfig.encoderDim
+
+        var embeds: [[Float]] = []
+        var integrate: Float = 0
+        var frame = [Float](repeating: 0, count: dim)
+
+        // T real frames + 1 tail frame (alpha = tail_threshold, hidden = zeros)
+        for t in 0...T {
+            let alpha = (t < T) ? alphas[t] : tail
+            let hidden = (t < T) ? encRows[t] : [Float](repeating: 0, count: dim)
+            integrate += alpha
+            if integrate < threshold {
+                for d in 0..<dim { frame[d] += alpha * hidden[d] }
+            } else {
+                let used = alpha - (integrate - threshold)  // portion to reach threshold
+                for d in 0..<dim { frame[d] += used * hidden[d] }
+                embeds.append(frame)
+                integrate -= threshold
+                let leftover = alpha - used
+                frame = hidden.map { $0 * leftover }  // leftover seeds next token
+            }
+        }
+        return embeds
+    }
+}

--- a/Sources/FluidAudio/ASR/Paraformer/ParaformerConfig.swift
+++ b/Sources/FluidAudio/ASR/Paraformer/ParaformerConfig.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Configuration for the Paraformer-large (zh) CoreML pipeline.
+///
+/// Non-autoregressive: SANM encoder -> CIF predictor (host integrate-and-fire on
+/// alphas from `ParaformerCifAlphas`) -> parallel decoder. Mirrors the conversion
+/// in `FluidInference/paraformer-large-zh-coreml`.
+public enum ParaformerConfig {
+    /// LFR feature dim (80-bin fbank x LFR m=7).
+    public static let featureDim = 560
+    /// Encoder hidden dim.
+    public static let encoderDim = 512
+
+    /// Encoder enumerated sequence-length buckets (post-LFR frames). Host pads
+    /// features up to the smallest bucket >= T.
+    public static let encoderBuckets = [128, 256, 512, 1024, 1800]
+
+    /// Decoder fixed shapes: cross-attention memory length and token budget.
+    public static let decoderEncFrames = 512
+    public static let decoderMaxTokens = 128
+
+    /// Special token ids (CharTokenizer): <blank>=0, <s>=1, </s>=2.
+    public static let blankId = 0
+    public static let sosId = 1
+    public static let eosId = 2
+
+    /// CIF hyperparameters (CifPredictorV2).
+    public static let cifThreshold: Float = 1.0
+    public static let cifTailThreshold: Float = 0.45
+
+    public static let sampleRate = 16_000
+    /// Kaldi feeds int16-range waveforms; AudioConverter yields [-1, 1].
+    public static let waveformScale: Float = 32_768.0
+
+    public static func pickEncoderBucket(forFrames frames: Int) -> Int {
+        for b in encoderBuckets where b >= frames { return b }
+        return encoderBuckets.last ?? 1800
+    }
+}

--- a/Sources/FluidAudio/ASR/Paraformer/ParaformerManager.swift
+++ b/Sources/FluidAudio/ASR/Paraformer/ParaformerManager.swift
@@ -16,8 +16,11 @@ public actor ParaformerManager {
         self.models = models
     }
 
-    public static func load(progressHandler: DownloadUtils.ProgressHandler? = nil) async throws -> ParaformerManager {
-        ParaformerManager(models: try await ParaformerModels.downloadAndLoad(progressHandler: progressHandler))
+    public static func load(
+        precision: ParaformerPrecision = .fp16, progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws -> ParaformerManager {
+        ParaformerManager(
+            models: try await ParaformerModels.downloadAndLoad(precision: precision, progressHandler: progressHandler))
     }
 
     public func transcribe(audioURL: URL) throws -> String {

--- a/Sources/FluidAudio/ASR/Paraformer/ParaformerManager.swift
+++ b/Sources/FluidAudio/ASR/Paraformer/ParaformerManager.swift
@@ -1,0 +1,187 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Manager for Paraformer-large (zh) transcription.
+///
+/// Pipeline: waveform -> [Preprocessor fp32/CPU] -> features
+///   -> [Encoder fp16/ANE] -> enc_out
+///   -> [CifAlphas fp16/ANE] -> alphas -> [host integrate-and-fire] -> acoustic_embeds, L
+///   -> [Decoder fp16/ANE] -> logits -> argmax -> drop sos/eos/blank -> CharTokenizer.
+public actor ParaformerManager {
+
+    private let models: ParaformerModels
+    private static let logger = AppLogger(category: "ParaformerManager")
+
+    public init(models: ParaformerModels) {
+        self.models = models
+    }
+
+    public static func load(progressHandler: DownloadUtils.ProgressHandler? = nil) async throws -> ParaformerManager {
+        ParaformerManager(models: try await ParaformerModels.downloadAndLoad(progressHandler: progressHandler))
+    }
+
+    public func transcribe(audioURL: URL) throws -> String {
+        let converter = AudioConverter(sampleRate: Double(ParaformerConfig.sampleRate))
+        return try transcribe(audio: try converter.resampleAudioFile(audioURL))
+    }
+
+    public func transcribe(audio: [Float]) throws -> String {
+        let dim = ParaformerConfig.encoderDim
+        // 1) preprocessor: waveform -> features [1, T, 560]
+        let features = try runPreprocessor(audio: audio)
+        var T = features.shape[1].intValue
+        if T > ParaformerConfig.decoderEncFrames {
+            Self.logger.warning("audio too long (\(T) frames); truncating to \(ParaformerConfig.decoderEncFrames)")
+            T = ParaformerConfig.decoderEncFrames
+        }
+
+        // 2) encoder (padded to bucket) -> enc_out
+        let bucket = ParaformerConfig.pickEncoderBucket(forFrames: T)
+        let encOut = try runEncoder(features: features, validLen: T, bucket: bucket)
+
+        // 3) CIF alphas (CoreML) + host integrate-and-fire
+        let alphas = try runCifAlphas(encOut: encOut, validLen: T)
+        let encRows = rows(of: encOut, count: T, dim: dim)
+        let embeds = ParaformerCif.integrateAndFire(encRows: encRows, alphas: alphas)
+        let L = min(embeds.count, ParaformerConfig.decoderMaxTokens)
+        if L == 0 { return "" }
+
+        // 4) decoder -> logits, then greedy decode
+        let logits = try runDecoder(encRows: encRows, validLen: T, embeds: embeds, tokenCount: L)
+        return decode(logits: logits, tokenCount: L, dim: dim)
+    }
+
+    // MARK: - Stages
+
+    private func runPreprocessor(audio: [Float]) throws -> MLMultiArray {
+        let n = audio.count
+        let wav = try MLMultiArray(shape: [1, n as NSNumber], dataType: .float32)
+        let p = wav.dataPointer.assumingMemoryBound(to: Float32.self)
+        let scale = ParaformerConfig.waveformScale
+        for i in 0..<n { p[i] = audio[i] * scale }
+        let out = try models.preprocessor.prediction(
+            from: MLDictionaryFeatureProvider(dictionary: ["waveform": MLFeatureValue(multiArray: wav)]))
+        guard let f = out.featureValue(for: "features")?.multiArrayValue else {
+            throw ASRError.processingFailed("Paraformer preprocessor produced no `features`")
+        }
+        return f
+    }
+
+    private func runEncoder(features: MLMultiArray, validLen: Int, bucket: Int) throws -> MLMultiArray {
+        let dim = ParaformerConfig.featureDim
+        let speech = try MLMultiArray(shape: [1, bucket as NSNumber, dim as NSNumber], dataType: .float32)
+        let sp = speech.dataPointer.assumingMemoryBound(to: Float32.self)
+        memset(sp, 0, bucket * dim * MemoryLayout<Float32>.size)
+        let count = validLen * dim
+        if features.dataType == .float32 {
+            memcpy(sp, features.dataPointer, count * MemoryLayout<Float32>.size)
+        } else {
+            for i in 0..<count { sp[i] = features[i].floatValue }
+        }
+        let len = try MLMultiArray(shape: [1], dataType: .int32)
+        len[0] = NSNumber(value: validLen)
+        let out = try models.encoder.prediction(
+            from: MLDictionaryFeatureProvider(dictionary: [
+                "speech": MLFeatureValue(multiArray: speech),
+                "speech_lengths": MLFeatureValue(multiArray: len),
+            ]))
+        guard let e = out.featureValue(for: "enc_out")?.multiArrayValue else {
+            throw ASRError.processingFailed("Paraformer encoder produced no `enc_out`")
+        }
+        return e
+    }
+
+    private func runCifAlphas(encOut: MLMultiArray, validLen: Int) throws -> [Float] {
+        let out = try models.cifAlphas.prediction(
+            from: MLDictionaryFeatureProvider(dictionary: ["enc_out": MLFeatureValue(multiArray: encOut)]))
+        guard let a = out.featureValue(for: "alphas")?.multiArrayValue else {
+            throw ASRError.processingFailed("Paraformer CifAlphas produced no `alphas`")
+        }
+        var alphas = [Float](repeating: 0, count: validLen)
+        if a.dataType == .float32 {
+            let p = a.dataPointer.assumingMemoryBound(to: Float32.self)
+            for t in 0..<validLen { alphas[t] = p[t] }
+        } else {
+            for t in 0..<validLen { alphas[t] = a[[0, t as NSNumber]].floatValue }
+        }
+        return alphas
+    }
+
+    private func runDecoder(
+        encRows: [[Float]], validLen: Int, embeds: [[Float]], tokenCount: Int
+    ) throws -> MLMultiArray {
+        let dim = ParaformerConfig.encoderDim
+        let Tb = ParaformerConfig.decoderEncFrames
+        let Lb = ParaformerConfig.decoderMaxTokens
+
+        let enc = try MLMultiArray(shape: [1, Tb as NSNumber, dim as NSNumber], dataType: .float32)
+        let ep = enc.dataPointer.assumingMemoryBound(to: Float32.self)
+        memset(ep, 0, Tb * dim * MemoryLayout<Float32>.size)
+        for t in 0..<validLen { for d in 0..<dim { ep[t * dim + d] = encRows[t][d] } }
+
+        let ac = try MLMultiArray(shape: [1, Lb as NSNumber, dim as NSNumber], dataType: .float32)
+        let ap = ac.dataPointer.assumingMemoryBound(to: Float32.self)
+        memset(ap, 0, Lb * dim * MemoryLayout<Float32>.size)
+        for l in 0..<tokenCount { for d in 0..<dim { ap[l * dim + d] = embeds[l][d] } }
+
+        let elen = try MLMultiArray(shape: [1], dataType: .int32)
+        elen[0] = NSNumber(value: validLen)
+        let tn = try MLMultiArray(shape: [1], dataType: .int32)
+        tn[0] = NSNumber(value: tokenCount)
+        let out = try models.decoder.prediction(
+            from: MLDictionaryFeatureProvider(dictionary: [
+                "enc": MLFeatureValue(multiArray: enc),
+                "elen": MLFeatureValue(multiArray: elen),
+                "ac": MLFeatureValue(multiArray: ac),
+                "tn": MLFeatureValue(multiArray: tn),
+            ]))
+        guard let logits = out.featureValue(for: "logits")?.multiArrayValue else {
+            throw ASRError.processingFailed("Paraformer decoder produced no `logits`")
+        }
+        return logits
+    }
+
+    private func decode(logits: MLMultiArray, tokenCount: Int, dim: Int) -> String {
+        let vocab = logits.shape[2].intValue
+        var pieces: [String] = []
+        let useFast = logits.dataType == .float32
+        let p = useFast ? logits.dataPointer.assumingMemoryBound(to: Float32.self) : nil
+        for t in 0..<tokenCount {
+            var best = 0
+            var bestVal: Float = -.infinity
+            for v in 0..<vocab {
+                let x = useFast ? p![t * vocab + v] : logits[[0, t as NSNumber, v as NSNumber]].floatValue
+                if x > bestVal {
+                    bestVal = x
+                    best = v
+                }
+            }
+            if best == ParaformerConfig.blankId || best == ParaformerConfig.sosId || best == ParaformerConfig.eosId {
+                continue
+            }
+            if let tok = models.vocabulary[best] { pieces.append(tok) }
+        }
+        // CharTokenizer: join chars; SentencePiece word-boundary -> space if present.
+        return pieces.joined()
+            .replacingOccurrences(of: ASRConstants.sentencePieceWordBoundary, with: " ")
+            .trimmingCharacters(in: .whitespaces)
+    }
+
+    private func rows(of arr: MLMultiArray, count: Int, dim: Int) -> [[Float]] {
+        var out: [[Float]] = []
+        out.reserveCapacity(count)
+        if arr.dataType == .float32 {
+            let p = arr.dataPointer.assumingMemoryBound(to: Float32.self)
+            for t in 0..<count {
+                out.append(Array(UnsafeBufferPointer(start: p + t * dim, count: dim)))
+            }
+        } else {
+            for t in 0..<count {
+                var r = [Float](repeating: 0, count: dim)
+                for d in 0..<dim { r[d] = arr[[0, t as NSNumber, d as NSNumber]].floatValue }
+                out.append(r)
+            }
+        }
+        return out
+    }
+}

--- a/Sources/FluidAudio/ASR/Paraformer/ParaformerModels.swift
+++ b/Sources/FluidAudio/ASR/Paraformer/ParaformerModels.swift
@@ -1,6 +1,20 @@
 @preconcurrency import CoreML
 import Foundation
 
+/// Encoder/decoder weight precision. Both fp16 and int8 run on the Neural Engine;
+/// int8 is ~half the size and accuracy-neutral (AISHELL CER unchanged).
+public enum ParaformerPrecision: String, Sendable {
+    case fp16
+    case int8
+
+    var encoderName: String {
+        self == .int8 ? ModelNames.ParaformerZh.encoderInt8 : ModelNames.ParaformerZh.encoder
+    }
+    var decoderName: String {
+        self == .int8 ? ModelNames.ParaformerZh.decoderInt8 : ModelNames.ParaformerZh.decoder
+    }
+}
+
 /// Loaded Paraformer-large (zh) CoreML models + vocabulary.
 ///
 /// 4 stages from `FluidInference/paraformer-large-zh-coreml`:
@@ -30,18 +44,20 @@ public struct ParaformerModels: Sendable {
     }
 
     public static func downloadAndLoad(
+        precision: ParaformerPrecision = .fp16,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> ParaformerModels {
-        let directory = try await download(progressHandler: progressHandler)
-        return try load(from: directory)
+        let directory = try await download(precision: precision, progressHandler: progressHandler)
+        return try load(from: directory, precision: precision)
     }
 
     public static func download(
+        precision: ParaformerPrecision = .fp16,
         force: Bool = false, progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> URL {
         let modelsRoot = modelsRootDirectory()
         let targetDir = modelsRoot.appendingPathComponent(Repo.paraformerLargeZh.folderName, isDirectory: true)
-        if !force && modelsExist(at: targetDir) {
+        if !force && modelsExist(at: targetDir, precision: precision) {
             logger.info("Paraformer models already present at: \(targetDir.path)")
             return targetDir
         }
@@ -52,30 +68,30 @@ public struct ParaformerModels: Sendable {
         return targetDir
     }
 
-    public static func modelsExist(at directory: URL) -> Bool {
+    public static func modelsExist(at directory: URL, precision: ParaformerPrecision = .fp16) -> Bool {
         let fm = FileManager.default
         let required = [
             ModelNames.ParaformerZh.preprocessorFile,
-            ModelNames.ParaformerZh.encoderFile,
+            precision.encoderName + ".mlmodelc",
             ModelNames.ParaformerZh.cifAlphasFile,
-            ModelNames.ParaformerZh.decoderFile,
+            precision.decoderName + ".mlmodelc",
             ModelNames.ParaformerZh.vocabularyFile,
         ]
         return required.allSatisfy { fm.fileExists(atPath: directory.appendingPathComponent($0).path) }
     }
 
-    public static func load(from directory: URL) throws -> ParaformerModels {
+    public static func load(from directory: URL, precision: ParaformerPrecision = .fp16) throws -> ParaformerModels {
         let cpu = MLModelConfiguration()
         cpu.computeUnits = .cpuOnly
         let ane = MLModelConfiguration()
         ane.computeUnits = .cpuAndNeuralEngine
 
         let pre = try loadModel(named: ModelNames.ParaformerZh.preprocessor, from: directory, configuration: cpu)
-        let enc = try loadModel(named: ModelNames.ParaformerZh.encoder, from: directory, configuration: ane)
+        let enc = try loadModel(named: precision.encoderName, from: directory, configuration: ane)
         let cif = try loadModel(named: ModelNames.ParaformerZh.cifAlphas, from: directory, configuration: ane)
-        let dec = try loadModel(named: ModelNames.ParaformerZh.decoder, from: directory, configuration: ane)
+        let dec = try loadModel(named: precision.decoderName, from: directory, configuration: ane)
         let vocab = try loadVocabulary(from: directory)
-        logger.info("Loaded Paraformer (vocab: \(vocab.count))")
+        logger.info("Loaded Paraformer (encoder/decoder: \(precision.rawValue), vocab: \(vocab.count))")
         return ParaformerModels(preprocessor: pre, encoder: enc, cifAlphas: cif, decoder: dec, vocabulary: vocab)
     }
 

--- a/Sources/FluidAudio/ASR/Paraformer/ParaformerModels.swift
+++ b/Sources/FluidAudio/ASR/Paraformer/ParaformerModels.swift
@@ -1,0 +1,128 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Loaded Paraformer-large (zh) CoreML models + vocabulary.
+///
+/// 4 stages from `FluidInference/paraformer-large-zh-coreml`:
+///   - `preprocessor` (fp32, CPU): waveform -> [1,T,560] LFR features
+///   - `encoder` (fp16, ANE): SANM encoder
+///   - `cifAlphas` (fp16, ANE): enc_out -> per-frame alphas (host integrate-and-fire)
+///   - `decoder` (fp16, ANE): parallel decoder -> token logits
+///   - `vocabulary`: 8404 CharTokenizer tokens (id -> char)
+public struct ParaformerModels: Sendable {
+
+    public let preprocessor: MLModel
+    public let encoder: MLModel
+    public let cifAlphas: MLModel
+    public let decoder: MLModel
+    public let vocabulary: [Int: String]
+
+    private static let logger = AppLogger(category: "ParaformerModels")
+
+    public init(
+        preprocessor: MLModel, encoder: MLModel, cifAlphas: MLModel, decoder: MLModel, vocabulary: [Int: String]
+    ) {
+        self.preprocessor = preprocessor
+        self.encoder = encoder
+        self.cifAlphas = cifAlphas
+        self.decoder = decoder
+        self.vocabulary = vocabulary
+    }
+
+    public static func downloadAndLoad(
+        progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws -> ParaformerModels {
+        let directory = try await download(progressHandler: progressHandler)
+        return try load(from: directory)
+    }
+
+    public static func download(
+        force: Bool = false, progressHandler: DownloadUtils.ProgressHandler? = nil
+    ) async throws -> URL {
+        let modelsRoot = modelsRootDirectory()
+        let targetDir = modelsRoot.appendingPathComponent(Repo.paraformerLargeZh.folderName, isDirectory: true)
+        if !force && modelsExist(at: targetDir) {
+            logger.info("Paraformer models already present at: \(targetDir.path)")
+            return targetDir
+        }
+        if force { try? FileManager.default.removeItem(at: targetDir) }
+        logger.info("Downloading Paraformer models from HuggingFace...")
+        try await DownloadUtils.downloadRepo(.paraformerLargeZh, to: modelsRoot, progressHandler: progressHandler)
+        logger.info("Successfully downloaded Paraformer models")
+        return targetDir
+    }
+
+    public static func modelsExist(at directory: URL) -> Bool {
+        let fm = FileManager.default
+        let required = [
+            ModelNames.ParaformerZh.preprocessorFile,
+            ModelNames.ParaformerZh.encoderFile,
+            ModelNames.ParaformerZh.cifAlphasFile,
+            ModelNames.ParaformerZh.decoderFile,
+            ModelNames.ParaformerZh.vocabularyFile,
+        ]
+        return required.allSatisfy { fm.fileExists(atPath: directory.appendingPathComponent($0).path) }
+    }
+
+    public static func load(from directory: URL) throws -> ParaformerModels {
+        let cpu = MLModelConfiguration()
+        cpu.computeUnits = .cpuOnly
+        let ane = MLModelConfiguration()
+        ane.computeUnits = .cpuAndNeuralEngine
+
+        let pre = try loadModel(named: ModelNames.ParaformerZh.preprocessor, from: directory, configuration: cpu)
+        let enc = try loadModel(named: ModelNames.ParaformerZh.encoder, from: directory, configuration: ane)
+        let cif = try loadModel(named: ModelNames.ParaformerZh.cifAlphas, from: directory, configuration: ane)
+        let dec = try loadModel(named: ModelNames.ParaformerZh.decoder, from: directory, configuration: ane)
+        let vocab = try loadVocabulary(from: directory)
+        logger.info("Loaded Paraformer (vocab: \(vocab.count))")
+        return ParaformerModels(preprocessor: pre, encoder: enc, cifAlphas: cif, decoder: dec, vocabulary: vocab)
+    }
+
+    // MARK: - Private
+
+    private static func loadModel(
+        named name: String, from directory: URL, configuration: MLModelConfiguration
+    ) throws -> MLModel {
+        let compiled = directory.appendingPathComponent("\(name).mlmodelc")
+        let pkg = directory.appendingPathComponent("\(name).mlpackage")
+        let url: URL
+        if FileManager.default.fileExists(atPath: compiled.path) {
+            url = compiled
+        } else if FileManager.default.fileExists(atPath: pkg.path) {
+            url = try MLModel.compileModel(at: pkg)
+        } else {
+            throw ASRError.processingFailed("Paraformer model not found: \(name)")
+        }
+        return try MLModel(contentsOf: url, configuration: configuration)
+    }
+
+    private static func loadVocabulary(from directory: URL) throws -> [Int: String] {
+        let path = directory.appendingPathComponent(ModelNames.ParaformerZh.vocabularyFile)
+        let data = try Data(contentsOf: path)
+        if let arr = try? JSONSerialization.jsonObject(with: data) as? [String] {
+            var v: [Int: String] = [:]
+            for (i, tok) in arr.enumerated() { v[i] = tok }
+            return v
+        }
+        if let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
+            var v: [Int: String] = [:]
+            for (k, tok) in dict { if let i = Int(k) { v[i] = tok } }
+            return v
+        }
+        throw ASRError.processingFailed("Failed to parse vocab.json (expected array or dict)")
+    }
+
+    private static func modelsRootDirectory() -> URL {
+        let fm = FileManager.default
+        if let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            return
+                appSupport
+                .appendingPathComponent("FluidAudio", isDirectory: true)
+                .appendingPathComponent("Models", isDirectory: true)
+        }
+        return fm.temporaryDirectory
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+}

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -451,20 +451,26 @@ public enum ModelNames {
     public enum ParaformerZh {
         public static let preprocessor = "ParaformerPreprocessor"
         public static let encoder = "ParaformerEncoder"
+        public static let encoderInt8 = "ParaformerEncoder_int8"  // ~half size, ANE
         public static let cifAlphas = "ParaformerCifAlphas"
         public static let decoder = "ParaformerDecoder"
+        public static let decoderInt8 = "ParaformerDecoder_int8"  // ~half size, ANE
 
         public static let preprocessorFile = preprocessor + ".mlmodelc"
         public static let encoderFile = encoder + ".mlmodelc"
+        public static let encoderInt8File = encoderInt8 + ".mlmodelc"
         public static let cifAlphasFile = cifAlphas + ".mlmodelc"
         public static let decoderFile = decoder + ".mlmodelc"
+        public static let decoderInt8File = decoderInt8 + ".mlmodelc"
         public static let vocabularyFile = "vocab.json"
 
         public static let requiredModels: Set<String> = [
             preprocessorFile,
             encoderFile,
+            encoderInt8File,
             cifAlphasFile,
             decoderFile,
+            decoderInt8File,
         ]
     }
 

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -12,6 +12,9 @@ public enum Repo: String, CaseIterable, Sendable {
     /// 3-stage: fp32 CPU preprocessor (waveform→560-d LFR feats) + fp16 ANE
     /// encoder+CTC (+ fp32 fallback) + host greedy-CTC decode. See ASR/SenseVoice.
     case senseVoiceSmall = "FluidInference/sensevoice-small-coreml"
+    /// Paraformer-large (zh) — non-autoregressive ASR: SANM encoder + CIF
+    /// predictor (host-side integrate-and-fire) + parallel decoder. See ASR/Paraformer.
+    case paraformerLargeZh = "FluidInference/paraformer-large-zh-coreml"
     // Japanese hybrid TDT: INT8 CTC-trained preprocessor+encoder paired with a
     // TDT decoder+joint. CTC-only inference for Japanese was removed in
     // 846924a1d; only the preprocessor+encoder files from this repo are reused.
@@ -73,6 +76,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "parakeet-ctc-0.6b-zh-cn-coreml"
         case .senseVoiceSmall:
             return "sensevoice-small-coreml"
+        case .paraformerLargeZh:
+            return "paraformer-large-zh-coreml"
         case .parakeetJa:
             return "parakeet-0.6b-ja-coreml"
         case .parakeetEou160:
@@ -434,6 +439,32 @@ public enum ModelNames {
             encoderFile,
             encoderInt8File,
             encoderFp32File,
+        ]
+    }
+
+    /// Paraformer-large (zh) model names. 4 CoreML stages + host CIF:
+    ///   Preprocessor (fp32/CPU): waveform -> 560-d LFR features
+    ///   Encoder (fp16/ANE): SANM encoder (enumerated buckets)
+    ///   CifAlphas (fp16/ANE): enc_out -> per-frame alphas (host does integrate-and-fire)
+    ///   Decoder (fp16/ANE): parallel decoder -> token logits
+    /// Plus `vocab.json` (8404 CharTokenizer tokens, auto-fetched as a root file).
+    public enum ParaformerZh {
+        public static let preprocessor = "ParaformerPreprocessor"
+        public static let encoder = "ParaformerEncoder"
+        public static let cifAlphas = "ParaformerCifAlphas"
+        public static let decoder = "ParaformerDecoder"
+
+        public static let preprocessorFile = preprocessor + ".mlmodelc"
+        public static let encoderFile = encoder + ".mlmodelc"
+        public static let cifAlphasFile = cifAlphas + ".mlmodelc"
+        public static let decoderFile = decoder + ".mlmodelc"
+        public static let vocabularyFile = "vocab.json"
+
+        public static let requiredModels: Set<String> = [
+            preprocessorFile,
+            encoderFile,
+            cifAlphasFile,
+            decoderFile,
         ]
     }
 
@@ -1061,6 +1092,8 @@ public enum ModelNames {
             return ModelNames.CTCZhCn.requiredModels
         case .senseVoiceSmall:
             return ModelNames.SenseVoice.requiredModels
+        case .paraformerLargeZh:
+            return ModelNames.ParaformerZh.requiredModels
         case .parakeetJa:
             return ModelNames.TDTJa.requiredModels
         case .parakeetEou160, .parakeetEou320, .parakeetEou1280:

--- a/Sources/FluidAudioCLI/Commands/ASR/ParaformerTranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/ParaformerTranscribeCommand.swift
@@ -1,0 +1,45 @@
+#if os(macOS)
+import AVFoundation
+import FluidAudio
+import Foundation
+
+/// `paraformer-transcribe <audio> [--verbose]`
+enum ParaformerTranscribeCommand {
+    private static let logger = AppLogger(category: "ParaformerTranscribe")
+
+    static func run(arguments: [String]) async {
+        var audioPath: String?
+        var verbose = false
+        var i = 0
+        while i < arguments.count {
+            switch arguments[i] {
+            case "--verbose", "-v": verbose = true
+            case "--help", "-h":
+                print("Usage: fluidaudio paraformer-transcribe <audio-file> [--verbose]")
+                return
+            default: if audioPath == nil { audioPath = arguments[i] }
+            }
+            i += 1
+        }
+        guard let audioPath else {
+            logger.error("Error: No audio file specified")
+            return
+        }
+        let url = URL(fileURLWithPath: audioPath)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            logger.error("Error: Audio file not found: \(audioPath)")
+            return
+        }
+        do {
+            logger.info("Loading Paraformer-large (zh) models...")
+            let manager = try await ParaformerManager.load()
+            let start = Date()
+            let text = try await manager.transcribe(audioURL: url)
+            if verbose { logger.info("Transcribed in \(String(format: "%.2f", Date().timeIntervalSince(start)))s") }
+            print(text)
+        } catch {
+            logger.error("Transcription failed: \(error)")
+        }
+    }
+}
+#endif

--- a/Sources/FluidAudioCLI/Commands/ASR/ParaformerTranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/ParaformerTranscribeCommand.swift
@@ -10,12 +10,14 @@ enum ParaformerTranscribeCommand {
     static func run(arguments: [String]) async {
         var audioPath: String?
         var verbose = false
+        var precision: ParaformerPrecision = .fp16
         var i = 0
         while i < arguments.count {
             switch arguments[i] {
+            case "--int8": precision = .int8
             case "--verbose", "-v": verbose = true
             case "--help", "-h":
-                print("Usage: fluidaudio paraformer-transcribe <audio-file> [--verbose]")
+                print("Usage: fluidaudio paraformer-transcribe <audio-file> [--int8] [--verbose]")
                 return
             default: if audioPath == nil { audioPath = arguments[i] }
             }
@@ -31,8 +33,8 @@ enum ParaformerTranscribeCommand {
             return
         }
         do {
-            logger.info("Loading Paraformer-large (zh) models...")
-            let manager = try await ParaformerManager.load()
+            logger.info("Loading Paraformer-large (zh) models (\(precision.rawValue))...")
+            let manager = try await ParaformerManager.load(precision: precision)
             let start = Date()
             let text = try await manager.transcribe(audioURL: url)
             if verbose { logger.info("Transcribed in \(String(format: "%.2f", Date().timeIntervalSince(start)))s") }

--- a/Sources/FluidAudioCLI/FluidAudioCLI.swift
+++ b/Sources/FluidAudioCLI/FluidAudioCLI.swift
@@ -88,6 +88,8 @@ struct FluidAudioCLI {
             await SenseVoiceTranscribeCommand.run(arguments: Array(arguments.dropFirst(2)))
         case "sensevoice-benchmark":
             await SenseVoiceBenchmark.run(arguments: Array(arguments.dropFirst(2)))
+        case "paraformer-transcribe":
+            await ParaformerTranscribeCommand.run(arguments: Array(arguments.dropFirst(2)))
         case "ctc-zh-cn-benchmark":
             await CtcZhCnBenchmark.run(arguments: Array(arguments.dropFirst(2)))
         case "ja-benchmark":


### PR DESCRIPTION
## Summary

Adds **Paraformer-large (zh)** as a CoreML ASR backend — FunASR's non-autoregressive Mandarin model (SANM encoder + CIF predictor + parallel decoder). Models: [`FluidInference/paraformer-large-zh-coreml`](https://huggingface.co/FluidInference/paraformer-large-zh-coreml).

## Pipeline (4 CoreML stages + host CIF)

```
waveform → [Preprocessor fp32/CPU] → features [1,T,560]
        → [Encoder fp16/ANE, enum buckets] → enc_out [1,T,512]
        → [CifAlphas fp16/ANE] → alphas → [host integrate-and-fire] → acoustic_embeds, L
        → [Decoder fp16/ANE] → logits → argmax → drop sos/eos/blank → CharTokenizer
```

The CIF predictor emits a *dynamic* token count, so it can't be a fixed-shape graph. Its conv1d+linear+sigmoid (→ alphas) is shipped as the tiny `ParaformerCifAlphas` CoreML model; the host (`ParaformerCif`) does only the integrate-and-fire scalar loop (ported bit-exact from the FunASR reference).

## Changes

- `ModelNames`: `paraformerLargeZh` `Repo` + `ParaformerZh` registry
- `Sources/FluidAudio/ASR/Paraformer/`: `ParaformerConfig`, `ParaformerModels`, `ParaformerCif` (integrate-and-fire), `ParaformerManager`
- CLI: `paraformer-transcribe`

## Conversion notes (same SANM fixes as SenseVoice + one more)

- FP16-safe attention mask fill (`-inf` → `-1e4`).
- Encoder/decoder pad-masks built from the **input tensor's seq dim** (not `lengths.max()`) so `EnumeratedShapes` generalize on ANE. (Decoder masks via `sequence_mask`; encoder via `make_pad_mask`.)

## Verification

- **End-to-end on M5 Pro ANE:** `paraformer-transcribe` on the zh sample → `欢迎大家来体验达摩院推出的语音识别模型` (correct), 0.15 s, 0.38 GB peak.
- **AISHELL-1 test (full, 7,176), full-CoreML pipeline: CER 2.12%** vs official Paraformer-large ~1.95% (the ~0.17 pp gap is fp16 + the fixed-shape decoder padding).
- `swift build` clean.

## Notes

- Conversion scripts (`patches.py`, `convert_pipeline.py`, `cif_numpy.py`, `aishell_pipeline_bench.py`) live in the conversion repo, not this PR.
