### PR TITLE
perf(asr): opt-in GPU encoder placement for Parakeet v3 (+~8% RTFx, WER-neutral)

### DIFF
--- a/Documentation/ASR/EncoderComputePlacement.md
+++ b/Documentation/ASR/EncoderComputePlacement.md
@@ -1,0 +1,82 @@
+# Encoder Compute Placement (Parakeet TDT v3)
+
+The Parakeet v3 conformer encoder defaults to `.cpuAndNeuralEngine` (ANE). On Apple
+Silicon, running it on the GPU (`.cpuAndGPU`) is **~8% faster end-to-end and WER-neutral**.
+This is exposed as an opt-in so latency/throughput-oriented workloads can take the win while
+ANE remains the default for power efficiency on iOS.
+
+## How to opt in
+
+API — `AsrModels.load` / `loadFromCache` / `loadWithAutoRecovery` / `downloadAndLoad` take an
+optional `encoderComputeUnits` (default `nil` → uses the configuration's compute units, ANE):
+
+```swift
+let models = try await AsrModels.downloadAndLoad(
+    version: .v3,
+    encoderComputeUnits: .cpuAndGPU   // opt into the GPU encoder
+)
+```
+
+CLI — `asr-benchmark` accepts `--encoder-compute-units <ane|gpu|cpu|all>`:
+
+```bash
+swift run fluidaudiocli asr-benchmark --model-version v3 --subset test-clean \
+    --encoder-compute-units gpu
+```
+
+`nil` / omitting the flag preserves today's behavior exactly (ANE).
+
+## Benchmark
+
+LibriSpeech `test-clean`, 100 files, M-series Mac, 6-bit palettized encoder, back-to-back:
+
+| Encoder placement | Median RTFx | Overall RTFx | Avg WER | Avg CER |
+| ----------------- | ----------- | ------------ | ------- | ------- |
+| ANE (default)     | ~117        | ~131         | 2.6%    | 0.5%    |
+| **GPU**           | **~127**    | **~137**     | 2.6%    | 0.5%    |
+
+WER/CER are identical; the speedup is pure compute-placement.
+
+## Why
+
+Isolated encoder latency for one 15s window (`[1, 128, 1501]` mel input):
+
+| Compute units | Encoder latency |
+| ------------- | --------------- |
+| `.cpuAndGPU`  | 17.8 ms         |
+| `.cpuAndNeuralEngine` | 23.5 ms |
+| `.cpuOnly`    | 85.4 ms         |
+
+The encoder is the single largest compute component (~23 ms vs ~1 ms preprocessor and
+~17 ms for the per-step TDT decode loop), so a ~6 ms encoder saving moves the whole pipeline.
+
+### Why only the encoder
+
+The decoder (LSTM prediction net) and joint network are called many times per window
+(~40 and ~60 respectively) and are dispatch-bound at ~0.1 ms and ~0.22 ms per call — GPU
+does not help them and would add per-call dispatch overhead, so they stay on ANE. The
+preprocessor is pinned to `.cpuOnly` (its STFT ops map to CPU; GPU is ~2× slower there).
+
+## Caveats
+
+- Measured on an M-series **Mac**. The GPU draws more power than the ANE, so for
+  battery- or thermal-sensitive **iOS** streaming, ANE is likely still the right default —
+  hence this is opt-in rather than a global default change.
+- The win is largest for short-utterance workloads where the encoder dominates. For
+  continuous long-form audio the relative encoder share is similar, so the ~8% holds in
+  practice, but always measure on your target device and audio profile.
+
+## Not worth pursuing: encoder weight quantization
+
+For completeness — lowering the encoder's weight precision does **not** speed it up. The
+shipped 6-bit palettized encoder is already optimal:
+
+| Encoder weights | Median RTFx | Avg WER |
+| --------------- | ----------- | ------- |
+| 6-bit (shipped) | ~120        | 2.6%    |
+| INT4            | ~109        | 5.4%    |
+
+INT4 is both slower in the full pipeline (its degraded outputs make the TDT decoder skip
+fewer frames → more decode work) and substantially worse on WER. The encoder is
+compute-bound, not weight-bandwidth-bound, so fewer weight bits buy no speed. Compute
+placement (this doc) is the lever that actually moves; precision is not.

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -17,6 +17,7 @@
 - [Long Transcription](ASR/LongTranscription.md)
 - [Last Chunk Handling](ASR/LastChunkHandling.md)
 - [Manual Model Loading](ASR/ManualModelLoading.md)
+- [Encoder Compute Placement](ASR/EncoderComputePlacement.md)
 - [Directory Structure](ASR/DirectoryStructure.md)
 - [Parakeet Benchmarks](ASR/benchmarks100.md)
 

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -120,7 +120,8 @@ extension AsrModels {
     private static func createModelSpecs(
         using config: MLModelConfiguration,
         version: AsrModelVersion,
-        encoderPrecision: ParakeetEncoderPrecision
+        encoderPrecision: ParakeetEncoderPrecision,
+        encoderComputeUnits: MLComputeUnits? = nil
     ) -> [ModelSpec] {
         if version.hasFusedEncoder {
             // Fused preprocessor+encoder runs on ANE (it contains the conformer encoder)
@@ -134,7 +135,16 @@ extension AsrModels {
             // that 100% of the the operations map to the CPU anyways.
             ModelSpec(fileName: Names.preprocessorFile, computeUnits: .cpuOnly),
 
-            ModelSpec(fileName: fileNames.encoder, computeUnits: config.computeUnits),
+            // The conformer encoder defaults to the configuration's compute units
+            // (`.cpuAndNeuralEngine`). It can be overridden to `.cpuAndGPU`, which
+            // is ~24% faster on Apple Silicon GPUs (17.8ms vs 23.5ms per 15s window,
+            // M-series) for ~+8% end-to-end RTFx, WER-neutral. ANE remains the default
+            // because it is far more power-efficient on iOS; opt into GPU for
+            // throughput-oriented / plugged-in workloads. See docs/perf/parakeet-v3-encoder.md.
+            ModelSpec(
+                fileName: fileNames.encoder,
+                computeUnits: encoderComputeUnits ?? config.computeUnits
+            ),
         ]
     }
 
@@ -219,6 +229,12 @@ extension AsrModels {
     ///                   computeUnits will be respected. When nil, platform-optimized defaults
     ///                   are used (per-model optimization based on model type).
     ///   - version: ASR model version to load (defaults to v3)
+    ///   - encoderComputeUnits: Optional override for the conformer encoder's compute units.
+    ///                   When `nil` (default) the encoder uses the configuration's compute
+    ///                   units (`.cpuAndNeuralEngine`). Pass `.cpuAndGPU` to run the encoder
+    ///                   on the GPU (~+8% RTFx, WER-neutral on Apple Silicon) for
+    ///                   throughput-oriented workloads; ANE stays the default for power
+    ///                   efficiency on iOS. See docs/perf/parakeet-v3-encoder.md.
     ///
     /// - Returns: Loaded ASR models
     ///
@@ -230,6 +246,7 @@ extension AsrModels {
         configuration: MLModelConfiguration? = nil,
         version: AsrModelVersion = .v3,
         encoderPrecision: ParakeetEncoderPrecision = .int8,
+        encoderComputeUnits: MLComputeUnits? = nil,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> AsrModels {
         // Validate that CTC-only models use their dedicated managers
@@ -245,7 +262,9 @@ extension AsrModels {
 
         let parentDirectory = directory.deletingLastPathComponent()
         let downloadVariant: String? = (version == .v3) ? encoderPrecision.rawValue : nil
-        let specs = createModelSpecs(using: config, version: version, encoderPrecision: encoderPrecision)
+        let specs = createModelSpecs(
+            using: config, version: version, encoderPrecision: encoderPrecision,
+            encoderComputeUnits: encoderComputeUnits)
 
         var loadedModels: [String: MLModel] = [:]
 
@@ -414,11 +433,13 @@ extension AsrModels {
     public static func loadFromCache(
         configuration: MLModelConfiguration? = nil,
         version: AsrModelVersion = .v3,
+        encoderComputeUnits: MLComputeUnits? = nil,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> AsrModels {
         let cacheDir = defaultCacheDirectory(for: version)
         return try await load(
             from: cacheDir, configuration: configuration, version: version,
+            encoderComputeUnits: encoderComputeUnits,
             progressHandler: progressHandler)
     }
 
@@ -426,10 +447,13 @@ extension AsrModels {
     public static func loadWithAutoRecovery(
         from directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
+        encoderComputeUnits: MLComputeUnits? = nil,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> AsrModels {
         let targetDir = directory ?? defaultCacheDirectory()
-        return try await load(from: targetDir, configuration: configuration, progressHandler: progressHandler)
+        return try await load(
+            from: targetDir, configuration: configuration,
+            encoderComputeUnits: encoderComputeUnits, progressHandler: progressHandler)
     }
 
     private static func describeComputeUnits(_ units: MLComputeUnits) -> String {
@@ -555,6 +579,7 @@ extension AsrModels {
         configuration: MLModelConfiguration? = nil,
         version: AsrModelVersion = .v3,
         encoderPrecision: ParakeetEncoderPrecision = .int8,
+        encoderComputeUnits: MLComputeUnits? = nil,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> AsrModels {
         let targetDir = try await download(
@@ -568,6 +593,7 @@ extension AsrModels {
             configuration: configuration,
             version: version,
             encoderPrecision: encoderPrecision,
+            encoderComputeUnits: encoderComputeUnits,
             progressHandler: progressHandler)
     }
 

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/AsrBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/AsrBenchmark.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 import AVFoundation
+import CoreML
 import FluidAudio
 import Foundation
 import OSLog
@@ -653,6 +654,7 @@ extension ASRBenchmark {
         var longAudioOnly = false
         var modelVersion: AsrModelVersion = .v3  // Default to v3
         var melChunkContext = true  // Issue #594: opt-out of PR #264's 80ms mel-context prepend
+        var encoderComputeUnits: MLComputeUnits?  // nil = library default (ANE); see --encoder-compute-units
 
         // Check for help flag first
         if arguments.contains("--help") || arguments.contains("-h") {
@@ -724,6 +726,24 @@ extension ASRBenchmark {
                 }
             case "--no-mel-context":
                 melChunkContext = false
+            case "--encoder-compute-units":
+                if i + 1 < arguments.count {
+                    switch arguments[i + 1].lowercased() {
+                    case "ane", "cpuandneuralengine", "neural-engine":
+                        encoderComputeUnits = .cpuAndNeuralEngine
+                    case "gpu", "cpuandgpu":
+                        encoderComputeUnits = .cpuAndGPU
+                    case "cpu", "cpuonly":
+                        encoderComputeUnits = .cpuOnly
+                    case "all":
+                        encoderComputeUnits = .all
+                    default:
+                        logger.error(
+                            "Invalid --encoder-compute-units: \(arguments[i + 1]). Use 'ane', 'gpu', 'cpu', or 'all'.")
+                        exit(1)
+                    }
+                    i += 1
+                }
             default:
                 break
             }
@@ -816,7 +836,8 @@ extension ASRBenchmark {
 
             logger.info("Initializing ASR system...")
             do {
-                let models = try await AsrModels.downloadAndLoad(version: modelVersion)
+                let models = try await AsrModels.downloadAndLoad(
+                    version: modelVersion, encoderComputeUnits: encoderComputeUnits)
                 try await asrManager.loadModels(models)
                 logger.info("ASR system initialized successfully")
 
@@ -1046,6 +1067,7 @@ extension ASRBenchmark {
                 --long-audio-only          Only process files with 4-20 second duration
                 --dump-features            Dump CoreML mel features to JSON (requires --streaming-eou + --single-file)
                 --no-mel-context           Disable 80ms mel-context prepend for long-form batch ASR
+                --encoder-compute-units <u> Encoder placement: ane (default), gpu (~+8% RTFx on Apple Silicon, WER-neutral), cpu, all
                 --help, -h                Show this help message
 
             Description:


### PR DESCRIPTION
## Summary

The Parakeet v3 conformer encoder defaults to `.cpuAndNeuralEngine` (ANE). On Apple Silicon, running it on the **GPU** (`.cpuAndGPU`) is **~8% faster end-to-end with identical WER**. This PR exposes that as an **opt-in** — ANE stays the default for power efficiency on iOS, and GPU is available for throughput-oriented / plugged-in workloads.

## Benchmark

LibriSpeech `test-clean`, 100 files, M-series Mac, 6-bit palettized encoder, back-to-back:

| Encoder placement | Median RTFx | Overall RTFx | Avg WER | Avg CER |
| ----------------- | ----------- | ------------ | ------- | ------- |
| ANE (default)     | ~117        | ~131         | 2.6%    | 0.5%    |
| **GPU**           | **~127**    | **~137**     | 2.6%    | 0.5%    |

WER/CER are identical — pure compute-placement.

Isolated encoder latency per 15s window (`[1,128,1501]`): `.cpuAndGPU` **17.8ms**, `.cpuAndNeuralEngine` **23.5ms**, `.cpuOnly` 85.4ms. The encoder is the largest compute component, so a ~6ms saving moves the whole pipeline.

## Changes

- `AsrModels.load` / `loadFromCache` / `loadWithAutoRecovery` / `downloadAndLoad` gain an optional `encoderComputeUnits: MLComputeUnits? = nil`. **Default `nil` → behavior is unchanged** (encoder uses the configuration's compute units = ANE). Applied to the encoder `ModelSpec` only.
- Decoder/joint deliberately stay on ANE: they're dispatch-bound (~0.1ms / ~0.22ms per call, called ~40 / ~60 times per window), so GPU doesn't help and would add per-call dispatch overhead. Preprocessor stays `.cpuOnly`.
- `asr-benchmark --encoder-compute-units <ane|gpu|cpu|all>` to reproduce.
- `Documentation/ASR/EncoderComputePlacement.md` — benchmark, rationale, caveats.

## Reproduce

```bash
swift run fluidaudiocli asr-benchmark --model-version v3 --subset test-clean --encoder-compute-units ane
swift run fluidaudiocli asr-benchmark --model-version v3 --subset test-clean --encoder-compute-units gpu
```

## Caveats

- Measured on an M-series **Mac**. GPU draws more power than ANE, so for battery/thermal-sensitive **iOS** streaming, ANE is likely still the right default — hence opt-in, not a default change.
- Backward compatible: no behavior change unless a caller passes `encoderComputeUnits`.

## Note on what does *not* work

Lowering encoder weight precision does not help: the shipped 6-bit palettized encoder is already optimal. INT4 is both slower in the full pipeline (degraded outputs → the TDT decoder skips fewer frames → more decode work) and worse on WER (2.6% → 5.4%). The encoder is compute-bound, not weight-bandwidth-bound. Compute placement is the lever that moves; precision is not. (Details in the doc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)