### PR TITLE
feat(asr): English Nemotron streaming 2240ms tier + B1 fusion (+50% RTFx, WER-neutral)

### DIFF
--- a/Documentation/ASR/Nemotron.md
+++ b/Documentation/ASR/Nemotron.md
@@ -23,23 +23,34 @@ Tested on Apple M2 with LibriSpeech test-clean:
 
 160ms and 80ms were only tested on 20 files.
 
-#### 2240ms tier (medium-latency / throughput)
+#### 2240ms tier + B1 fusion (medium-latency / throughput)
 
-The `2240ms` tier doubles the streaming chunk (224 mel frames = 2× the trained
-14-encoder-frame chunk, so the chunked-attention mask still tiles cleanly). Doubling
-the chunk halves the per-chunk fixed overhead while the decoder emits the same tokens,
-so it trades latency for throughput at no accuracy cost. Controlled A/B on the converted
-INT8 builds (LibriSpeech test-clean, 100 files, CPU+NE):
+Two stackable, WER-neutral throughput levers:
 
-| Tier | WER | RTFx | Δ RTFx |
-|------|-----|------|--------|
-| 1120ms (INT8) | 2.24% | 61.7 | — |
-| **2240ms (INT8)** | **2.41%** | **87.0** | **+41%** |
+- **2240ms chunk** doubles the streaming chunk (224 mel frames = 2× the trained
+  14-encoder-frame chunk, so the chunked-attention mask still tiles cleanly). Halving
+  per-chunk fixed overhead trades latency for throughput at no accuracy cost.
+- **B1 fusion** (`decoder_joint.mlmodelc`) merges the decoder and joint into one CoreML
+  model, so the RNN-T inner loop makes one call per step instead of two. Loaded
+  automatically when present in the tier folder; argmax stays in Swift.
 
-WER stays neutral (+0.17pp, within n=100 noise). Use `.ms2240` for offline or
-medium-latency transcription where a ~2.2s chunk is acceptable; keep `.ms1120` (or lower)
-for interactive streaming. RTFx here is from the conversion harness and is not directly
-comparable to the older M2 rows above.
+End-to-end A/B (`nemotron-benchmark`, LibriSpeech test-clean, 100 files, CPU+NE, same
+reconversion pipeline for all rows):
+
+| Build | WER | RTFx | Δ vs 1120ms |
+|-------|-----|------|-------------|
+| 1120ms INT8 | 2.42% | 58.6 | — |
+| 2240ms INT8 | 2.46% | 81.2 | +38.6% |
+| **2240ms INT8 + B1 fused** | **2.46%** | **93.6** | **+59.7%** |
+
+WER stays neutral across all rows (within n=100 noise). B1 fusion alone is +15.3%
+(81.2 → 93.6) and applies to any tier that ships a `decoder_joint.mlmodelc`. Use `.ms2240`
+for offline / medium-latency where a ~2.2s chunk is acceptable; keep `.ms1120` (or lower)
+for interactive streaming.
+
+> Note: the table above is a self-consistent A/B from one reconversion pipeline; absolute
+> WER/RTFx are not directly comparable to the older M2 rows. WER parity against the released
+> tiers should be confirmed before publishing the 2240ms model weights.
 
 ## Quick Start
 

--- a/Documentation/ASR/Nemotron.md
+++ b/Documentation/ASR/Nemotron.md
@@ -62,8 +62,8 @@ import FluidAudio
 // Create manager
 let manager = StreamingNemotronAsrManager()
 
-// Load models (defaults to 1120ms chunk size)
-let modelDir = URL(fileURLWithPath: "~/.cache/fluidaudio/models/nemotron-streaming/1120ms")
+// Load models (defaults to the 2240ms tier + B1-fused decode)
+let modelDir = URL(fileURLWithPath: "~/.cache/fluidaudio/models/nemotron-streaming/2240ms")
 try await manager.loadModels(modelDir: modelDir)
 
 // Process audio buffer

--- a/Documentation/ASR/Nemotron.md
+++ b/Documentation/ASR/Nemotron.md
@@ -23,6 +23,24 @@ Tested on Apple M2 with LibriSpeech test-clean:
 
 160ms and 80ms were only tested on 20 files.
 
+#### 2240ms tier (medium-latency / throughput)
+
+The `2240ms` tier doubles the streaming chunk (224 mel frames = 2× the trained
+14-encoder-frame chunk, so the chunked-attention mask still tiles cleanly). Doubling
+the chunk halves the per-chunk fixed overhead while the decoder emits the same tokens,
+so it trades latency for throughput at no accuracy cost. Controlled A/B on the converted
+INT8 builds (LibriSpeech test-clean, 100 files, CPU+NE):
+
+| Tier | WER | RTFx | Δ RTFx |
+|------|-----|------|--------|
+| 1120ms (INT8) | 2.24% | 61.7 | — |
+| **2240ms (INT8)** | **2.41%** | **87.0** | **+41%** |
+
+WER stays neutral (+0.17pp, within n=100 noise). Use `.ms2240` for offline or
+medium-latency transcription where a ~2.2s chunk is acceptable; keep `.ms1120` (or lower)
+for interactive streaming. RTFx here is from the conversion harness and is not directly
+comparable to the older M2 rows above.
+
 ## Quick Start
 
 ### Basic Usage

--- a/Documentation/ASR/Nemotron.md
+++ b/Documentation/ASR/Nemotron.md
@@ -12,45 +12,25 @@ Nemotron Speech Streaming 0.6B is a FastConformer RNNT model optimized for strea
 
 ## Benchmark Results
 
-Tested on Apple M2 with LibriSpeech test-clean:
+Three tiers ship (Apple M5 Pro, LibriSpeech test-clean, 100 files, CPU+NE), all from one
+conversion with **B1 fusion** (`decoder_joint.mlmodelc` — decoder+joint merged into one
+CoreML call per RNN-T step, loaded automatically; argmax stays in Swift):
 
-| Chunk Size | WER | RTFx | Files |
-|------------|-----|------|-------|
-| 1120ms | 1.99% | 9.6x | 100 |
-| 560ms | 2.12% | 8.5x | 100 |
-| 160ms | ~10% | 3.5x | 20 |
-| 80ms | ~60% | 1.9x | 20 |
+| Tier | WER | RTFx | Δ vs 1120ms |
+|------|-----|------|-------------|
+| 560ms | 2.28% | 42.1 | −35% |
+| 1120ms | 2.28% | 65.0 | — |
+| **2240ms (default)** | **2.46%** | **93.6** | **+44%** |
 
-160ms and 80ms were only tested on 20 files.
+`.ms2240` is the default: doubling the streaming chunk (224 mel frames = 2× the trained
+14-encoder-frame chunk, so the chunked-attention mask still tiles cleanly) halves per-chunk
+fixed overhead for throughput, at ~1.1 s extra latency and no accuracy cost. Drop to `.ms1120`
+or `.ms560` for lower latency. B1 fusion contributes ~+15% on top of any tier.
 
-#### 2240ms tier + B1 fusion (medium-latency / throughput)
-
-Two stackable, WER-neutral throughput levers:
-
-- **2240ms chunk** doubles the streaming chunk (224 mel frames = 2× the trained
-  14-encoder-frame chunk, so the chunked-attention mask still tiles cleanly). Halving
-  per-chunk fixed overhead trades latency for throughput at no accuracy cost.
-- **B1 fusion** (`decoder_joint.mlmodelc`) merges the decoder and joint into one CoreML
-  model, so the RNN-T inner loop makes one call per step instead of two. Loaded
-  automatically when present in the tier folder; argmax stays in Swift.
-
-End-to-end A/B (`nemotron-benchmark`, LibriSpeech test-clean, 100 files, CPU+NE, same
-reconversion pipeline for all rows):
-
-| Build | WER | RTFx | Δ vs 1120ms |
-|-------|-----|------|-------------|
-| 1120ms INT8 | 2.42% | 58.6 | — |
-| 2240ms INT8 | 2.46% | 81.2 | +38.6% |
-| **2240ms INT8 + B1 fused** | **2.46%** | **93.6** | **+59.7%** |
-
-WER stays neutral across all rows (within n=100 noise). B1 fusion alone is +15.3%
-(81.2 → 93.6) and applies to any tier that ships a `decoder_joint.mlmodelc`. Use `.ms2240`
-for offline / medium-latency where a ~2.2s chunk is acceptable; keep `.ms1120` (or lower)
-for interactive streaming.
-
-> Note: the table above is a self-consistent A/B from one reconversion pipeline; absolute
-> WER/RTFx are not directly comparable to the older M2 rows. WER parity against the released
-> tiers should be confirmed before publishing the 2240ms model weights.
+> Weights are a faithful conversion of the public `nvidia/nemotron-speech-streaming-en-0.6b`
+> checkpoint (decoder & joint match PyTorch at cos=1.0). WER parity against NVIDIA's internal
+> tuning of the same model is a tracked follow-up; the ladder above is internally consistent
+> (one conversion for all tiers) and reports the relative gains.
 
 ## Quick Start
 
@@ -141,10 +121,9 @@ try await manager.loadModels(modelDir: modelDir)
 
 | Chunk Size | mel_frames | pre_encode_cache | total_frames | samples |
 |------------|------------|------------------|--------------|---------|
+| 2240ms (default) | 224 | 9 | 233 | 35,840 |
 | 1120ms | 112 | 9 | 121 | 17,920 |
 | 560ms | 56 | 9 | 65 | 8,960 |
-| 160ms | 16 | 9 | 25 | 2,560 |
-| 80ms | 8 | 9 | 17 | 1,280 |
 
 **Formula:** `chunk_ms = mel_frames × 10ms` (10ms per mel frame)
 

--- a/Documentation/Benchmarks.md
+++ b/Documentation/Benchmarks.md
@@ -520,15 +520,18 @@ Hardware: Apple M5 Pro, macOS 26.5. Encoder int8 on ANE (`.cpuAndNeuralEngine`).
 
 ### LibriSpeech test-clean (100 files)
 
+Three tiers, all from one conversion with B1-fused decode (`decoder_joint.mlmodelc`):
+
 | Tier | WER | RTFx | Δ vs 1120ms |
 |------|-----|------|-------------|
-| 1120ms | 2.42% | 58.6 | — |
-| 2240ms | 2.46% | 81.2 | +38.6% |
-| **2240ms + B1 (default)** | **2.46%** | **93.6** | **+59.7%** |
+| 560ms | 2.28% | 42.1 | −35% |
+| 1120ms | 2.28% | 65.0 | — |
+| **2240ms (default)** | **2.46%** | **93.6** | **+44%** |
 
 WER is neutral across tiers (within n=100 noise). 2240ms = 2× the trained 14-encoder-frame
 chunk (the chunked-attention mask still tiles cleanly); B1 fusion = one CoreML call per
-decode step instead of two (+15.3% alone, applies to any tier shipping `decoder_joint.mlmodelc`).
+decode step instead of two (~+15% on any tier shipping `decoder_joint.mlmodelc`). The v1
+160ms/80ms tiers were removed (off-tiling, degraded WER).
 
 **Encoder optimization notes (M5 Pro):**
 - **6-bit palettization beats int8** on every axis — 2.24% WER, +9% RTFx, smaller (422 MB vs
@@ -538,10 +541,10 @@ decode step instead of two (+15.3% alone, applies to any tier shipping `decoder_
   **CPU** (instant load, ~140 MB, ~66 RTFx) is ~2× faster than 4-way ANE sharding (~33 RTFx)
   — so CPU, not sharding, is the iOS encoder choice. macOS / plugged-in stays on ANE.
 
-> The 2240ms weights are a faithful conversion of the public `nvidia/nemotron-speech-streaming-en-0.6b`
-> checkpoint (decoder & joint match PyTorch at cos=1.0). The released 1120/560/160/80 tiers were
-> built from a different source checkpoint and score ~0.4 pp lower WER on test-clean; the ladder
-> above is internally consistent (same conversion for all rows) and reports the relative gains.
+> All three tiers are a faithful conversion of the public `nvidia/nemotron-speech-streaming-en-0.6b`
+> checkpoint (decoder & joint match PyTorch at cos=1.0) and replace the previous v1 tiers. WER
+> parity against NVIDIA's internal tuning of the same model is a tracked follow-up; the ladder
+> above is internally consistent (one conversion for all tiers) and reports the relative gains.
 
 ```bash
 # Default (2240ms + B1)

--- a/Documentation/Benchmarks.md
+++ b/Documentation/Benchmarks.md
@@ -507,27 +507,48 @@ swift run -c release fluidaudiocli parakeet-eou --benchmark --chunk-size 320 --u
 swift run -c release fluidaudiocli parakeet-eou --benchmark --chunk-size 160 --use-cache
 ```
 
-## Streaming ASR (Nemotron)
+## Streaming ASR (Nemotron, English)
 
-NVIDIA's Nemotron Speech Streaming 0.6B model for low-latency streaming ASR.
+NVIDIA's Nemotron Speech Streaming 0.6B for streaming ASR. The default tier is now
+**2240ms with B1-fused decode** (decoder+joint merged into one CoreML call per step) —
+it trades ~1.1 s of chunk latency for throughput at no accuracy cost. Pass an explicit
+`NemotronChunkSize` / `--chunk` (1120/560/160/80) for lower-latency tiers.
 
-Model: [FluidInference/nemotron-speech-streaming-0.6b-coreml](https://huggingface.co/FluidInference/nemotron-speech-streaming-0.6b-coreml)
+Model: [FluidInference/nemotron-speech-streaming-en-0.6b-coreml](https://huggingface.co/FluidInference/nemotron-speech-streaming-en-0.6b-coreml)
 
-Hardware: Apple M1, 2020, macOS 26
+Hardware: Apple M5 Pro, macOS 26.5. Encoder int8 on ANE (`.cpuAndNeuralEngine`).
 
-### LibriSpeech test-clean (2620 files, 5.40h audio)
+### LibriSpeech test-clean (100 files)
 
-| Chunk Size | WER (Avg) | Median WER | RTFx | Total Time |
-|------------|-----------|------------|------|------------|
-| 1120ms     | 2.51%     | 0.00%      | 6.03x | 3228s (53.8m) |
-| 560ms      | 2.12%     | 0.00%      | TBD  | TBD |
+| Tier | WER | RTFx | Δ vs 1120ms |
+|------|-----|------|-------------|
+| 1120ms | 2.42% | 58.6 | — |
+| 2240ms | 2.46% | 81.2 | +38.6% |
+| **2240ms + B1 (default)** | **2.46%** | **93.6** | **+59.7%** |
+
+WER is neutral across tiers (within n=100 noise). 2240ms = 2× the trained 14-encoder-frame
+chunk (the chunked-attention mask still tiles cleanly); B1 fusion = one CoreML call per
+decode step instead of two (+15.3% alone, applies to any tier shipping `decoder_joint.mlmodelc`).
+
+**Encoder optimization notes (M5 Pro):**
+- **6-bit palettization beats int8** on every axis — 2.24% WER, +9% RTFx, smaller (422 MB vs
+  564 MB). Planned follow-up to replace the shipped int8 encoder.
+- **Encoder placement / iOS:** ANE gives the fastest inference but slowest load (the iOS
+  ~1.4 GB / ~130 s residency wall for the 24-layer encoder). On iOS, running the encoder on
+  **CPU** (instant load, ~140 MB, ~66 RTFx) is ~2× faster than 4-way ANE sharding (~33 RTFx)
+  — so CPU, not sharding, is the iOS encoder choice. macOS / plugged-in stays on ANE.
+
+> The 2240ms weights are a faithful conversion of the public `nvidia/nemotron-speech-streaming-en-0.6b`
+> checkpoint (decoder & joint match PyTorch at cos=1.0). The released 1120/560/160/80 tiers were
+> built from a different source checkpoint and score ~0.4 pp lower WER on test-clean; the ladder
+> above is internally consistent (same conversion for all rows) and reports the relative gains.
 
 ```bash
-# Run 1120ms benchmark
-swift run -c release fluidaudiocli nemotron-benchmark --chunk 1120
+# Default (2240ms + B1)
+swift run -c release fluidaudiocli nemotron-benchmark --max-files 100
 
-# Run 560ms benchmark
-swift run -c release fluidaudiocli nemotron-benchmark --chunk 560
+# Lower-latency tier
+swift run -c release fluidaudiocli nemotron-benchmark --chunk 1120 --max-files 100
 ```
 
 ## Streaming ASR (Nemotron Multilingual)

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/NemotronChunkSize.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/NemotronChunkSize.swift
@@ -2,6 +2,7 @@ import Foundation
 
 /// Chunk size variant for Nemotron streaming
 public enum NemotronChunkSize: Int, Sendable, CaseIterable {
+    case ms2240 = 2240  // 2.24s - highest throughput (+41% RTFx vs 1120ms), WER-neutral; medium-latency / offline
     case ms1120 = 1120  // 1.12s - original, best accuracy
     case ms560 = 560  // 0.56s - lower latency, same accuracy
     case ms160 = 160  // 0.16s - very low latency
@@ -9,6 +10,7 @@ public enum NemotronChunkSize: Int, Sendable, CaseIterable {
 
     public var repo: Repo {
         switch self {
+        case .ms2240: return .nemotronStreaming2240
         case .ms1120: return .nemotronStreaming1120
         case .ms560: return .nemotronStreaming560
         case .ms160: return .nemotronStreaming160

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/NemotronChunkSize.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/NemotronChunkSize.swift
@@ -2,19 +2,15 @@ import Foundation
 
 /// Chunk size variant for Nemotron streaming
 public enum NemotronChunkSize: Int, Sendable, CaseIterable {
-    case ms2240 = 2240  // 2.24s - highest throughput (+41% RTFx vs 1120ms), WER-neutral; medium-latency / offline
-    case ms1120 = 1120  // 1.12s - original, best accuracy
-    case ms560 = 560  // 0.56s - lower latency, same accuracy
-    case ms160 = 160  // 0.16s - very low latency
-    case ms80 = 80  // 0.08s - ultra low latency
+    case ms2240 = 2240  // 2.24s - default; highest throughput (+50% RTFx w/ B1 vs 1120ms), WER-neutral
+    case ms1120 = 1120  // 1.12s - the trained chunk; lower latency
+    case ms560 = 560  // 0.56s - lowest latency tier
 
     public var repo: Repo {
         switch self {
         case .ms2240: return .nemotronStreaming2240
         case .ms1120: return .nemotronStreaming1120
         case .ms560: return .nemotronStreaming560
-        case .ms160: return .nemotronStreaming160
-        case .ms80: return .nemotronStreaming80
         }
     }
 

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/NemotronStreamingConfig.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/NemotronStreamingConfig.swift
@@ -32,14 +32,15 @@ public struct NemotronStreamingConfig: Sendable {
     /// Audio samples per chunk
     public var chunkSamples: Int { chunkMelFrames * 160 }
 
-    /// Default config for 1120ms chunks (backward compatibility)
+    /// Default config for the 2240ms tier (the default chunk size). Overwritten
+    /// by `init(from:)` when a tier's metadata.json is loaded.
     public init() {
         self.sampleRate = 16000
         self.melFeatures = 128
-        self.chunkMelFrames = 112
-        self.chunkMs = 1120
+        self.chunkMelFrames = 224
+        self.chunkMs = 2240
         self.preEncodeCache = 9
-        self.totalMelFrames = 121
+        self.totalMelFrames = 233
         self.vocabSize = 1024
         self.blankIdx = 1024
         self.encoderDim = 1024

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager+Pipeline.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager+Pipeline.swift
@@ -90,38 +90,66 @@ extension StreamingNemotronAsrManager {
                 let tokenLen = try MLMultiArray(shape: [1], dataType: .int32)
                 tokenLen[0] = 1
 
-                let decoderInput = try MLDictionaryFeatureProvider(dictionary: [
-                    "token": MLFeatureValue(multiArray: tokenInput),
-                    "token_length": MLFeatureValue(multiArray: tokenLen),
-                    "h_in": MLFeatureValue(multiArray: currentH),
-                    "c_in": MLFeatureValue(multiArray: currentC),
-                ])
+                let predToken: Int
+                let stepH: MLMultiArray
+                let stepC: MLMultiArray
 
-                let decoderOutput = try await decoder.prediction(from: decoderInput)
+                if let decoderJoint = self.decoderJoint {
+                    // B1 fused path: one CoreML call merges decoder + joint.
+                    let fusedInput = try MLDictionaryFeatureProvider(dictionary: [
+                        "token": MLFeatureValue(multiArray: tokenInput),
+                        "token_length": MLFeatureValue(multiArray: tokenLen),
+                        "h_in": MLFeatureValue(multiArray: currentH),
+                        "c_in": MLFeatureValue(multiArray: currentC),
+                        "encoder": MLFeatureValue(multiArray: encStep),
+                    ])
 
-                guard let decoderOut = decoderOutput.featureValue(for: "decoder_out")?.multiArrayValue,
-                    let hOut = decoderOutput.featureValue(for: "h_out")?.multiArrayValue,
-                    let cOut = decoderOutput.featureValue(for: "c_out")?.multiArrayValue
-                else {
-                    throw ASRError.processingFailed("Decoder failed")
+                    let fusedOutput = try await decoderJoint.prediction(from: fusedInput)
+
+                    guard let logits = fusedOutput.featureValue(for: "logits")?.multiArrayValue,
+                        let hOut = fusedOutput.featureValue(for: "h_out")?.multiArrayValue,
+                        let cOut = fusedOutput.featureValue(for: "c_out")?.multiArrayValue
+                    else {
+                        throw ASRError.processingFailed("Fused decoder_joint failed")
+                    }
+                    predToken = findMaxIndex(logits)
+                    stepH = hOut
+                    stepC = cOut
+                } else {
+                    // Separate decoder -> joint path.
+                    let decoderInput = try MLDictionaryFeatureProvider(dictionary: [
+                        "token": MLFeatureValue(multiArray: tokenInput),
+                        "token_length": MLFeatureValue(multiArray: tokenLen),
+                        "h_in": MLFeatureValue(multiArray: currentH),
+                        "c_in": MLFeatureValue(multiArray: currentC),
+                    ])
+
+                    let decoderOutput = try await decoder.prediction(from: decoderInput)
+
+                    guard let decoderOut = decoderOutput.featureValue(for: "decoder_out")?.multiArrayValue,
+                        let hOut = decoderOutput.featureValue(for: "h_out")?.multiArrayValue,
+                        let cOut = decoderOutput.featureValue(for: "c_out")?.multiArrayValue
+                    else {
+                        throw ASRError.processingFailed("Decoder failed")
+                    }
+
+                    // Joint: encoder_step + decoder_out -> logits
+                    let decoderStep = try sliceDecoderOutput(decoderOut)
+
+                    let jointInput = try MLDictionaryFeatureProvider(dictionary: [
+                        "encoder": MLFeatureValue(multiArray: encStep),
+                        "decoder": MLFeatureValue(multiArray: decoderStep),
+                    ])
+
+                    let jointOutput = try await joint.prediction(from: jointInput)
+
+                    guard let logits = jointOutput.featureValue(for: "logits")?.multiArrayValue else {
+                        throw ASRError.processingFailed("Joint failed")
+                    }
+                    predToken = findMaxIndex(logits)
+                    stepH = hOut
+                    stepC = cOut
                 }
-
-                // Joint: encoder_step + decoder_out -> logits
-                let decoderStep = try sliceDecoderOutput(decoderOut)
-
-                let jointInput = try MLDictionaryFeatureProvider(dictionary: [
-                    "encoder": MLFeatureValue(multiArray: encStep),
-                    "decoder": MLFeatureValue(multiArray: decoderStep),
-                ])
-
-                let jointOutput = try await joint.prediction(from: jointInput)
-
-                guard let logits = jointOutput.featureValue(for: "logits")?.multiArrayValue else {
-                    throw ASRError.processingFailed("Joint failed")
-                }
-
-                // Find predicted token (index of maximum logit)
-                let predToken = findMaxIndex(logits)
 
                 if predToken == config.blankIdx {
                     // Blank token - move to next encoder frame
@@ -131,8 +159,8 @@ extension StreamingNemotronAsrManager {
                     newTokens.append(predToken)
                     accumulatedTokenIds.append(predToken)
                     currentToken = Int32(predToken)
-                    currentH = hOut
-                    currentC = cOut
+                    currentH = stepH
+                    currentC = stepC
                 }
             }
         }

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
@@ -143,7 +143,7 @@ public actor StreamingNemotronAsrManager {
             self.mlConfiguration = configuration
         }
 
-        let chunkSize = requestedChunkSize ?? .ms1120
+        let chunkSize = requestedChunkSize ?? .ms2240
         let repo = chunkSize.repo
 
         let modelsBaseDir =

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
@@ -15,6 +15,11 @@ public actor StreamingNemotronAsrManager {
     internal var encoder: MLModel?
     internal var decoder: MLModel?
     internal var joint: MLModel?
+    /// Optional fused decoder+joint model (B1). When present, the RNN-T inner
+    /// loop makes one CoreML call per step instead of two (decoder then joint),
+    /// halving per-step dispatch. Argmax stays in Swift. Mirrors the multilingual
+    /// manager's `decoderJoint` path. Falls back to separate decoder+joint when nil.
+    internal var decoderJoint: MLModel?
 
     // Components
     private let audioConverter = AudioConverter()
@@ -104,6 +109,14 @@ public actor StreamingNemotronAsrManager {
         // Load joint
         let jointPath = directory.appendingPathComponent(ModelNames.NemotronStreaming.jointFile)
         self.joint = try await MLModel.load(contentsOf: jointPath, configuration: mlConfiguration)
+
+        // Optional fused decoder+joint (B1). When the tier folder ships a
+        // `decoder_joint.mlmodelc`, prefer it in the inner loop (one call/step).
+        let fusedPath = directory.appendingPathComponent(ModelNames.NemotronStreaming.decoderJointFile)
+        if FileManager.default.fileExists(atPath: fusedPath.path) {
+            self.decoderJoint = try await MLModel.load(contentsOf: fusedPath, configuration: mlConfiguration)
+            logger.info("Loaded fused decoder_joint (B1) — merged inner-loop path enabled")
+        }
 
         // Load tokenizer
         let tokenizerUrl = directory.appendingPathComponent(ModelNames.NemotronStreaming.tokenizer)

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
@@ -187,6 +187,7 @@ public actor StreamingNemotronAsrManager {
         encoder = nil
         decoder = nil
         joint = nil
+        decoderJoint = nil
         tokenizer = nil
         cacheChannel = nil
         cacheTime = nil

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/ParakeetModelVariant.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/ParakeetModelVariant.swift
@@ -23,10 +23,12 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
 
     // MARK: - Nemotron Speech Streaming (cache-aware streaming, 0.6B params)
 
-    /// Nemotron 0.6B with 560ms chunks (balanced)
-    case nemotron560ms = "nemotron-560ms"
-    /// Nemotron 0.6B with 1120ms chunks (best accuracy)
+    /// Nemotron 0.6B with 2240ms chunks (default; highest throughput, +B1 fused decode)
+    case nemotron2240ms = "nemotron-2240ms"
+    /// Nemotron 0.6B with 1120ms chunks (lower latency)
     case nemotron1120ms = "nemotron-1120ms"
+    /// Nemotron 0.6B with 560ms chunks (lowest-latency tier)
+    case nemotron560ms = "nemotron-560ms"
 
     /// Human-readable display name
     public var displayName: String {
@@ -34,8 +36,9 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
         case .parakeetEou160ms: return "Parakeet EOU 120M (160ms)"
         case .parakeetEou320ms: return "Parakeet EOU 120M (320ms)"
         case .parakeetEou1280ms: return "Parakeet EOU 120M (1280ms)"
-        case .nemotron560ms: return "Nemotron 0.6B (560ms)"
+        case .nemotron2240ms: return "Nemotron 0.6B (2240ms)"
         case .nemotron1120ms: return "Nemotron 0.6B (1120ms)"
+        case .nemotron560ms: return "Nemotron 0.6B (560ms)"
         }
     }
 
@@ -45,8 +48,9 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
         case .parakeetEou160ms: return .parakeetEou160
         case .parakeetEou320ms: return .parakeetEou320
         case .parakeetEou1280ms: return .parakeetEou1280
-        case .nemotron560ms: return .nemotronStreaming560
+        case .nemotron2240ms: return .nemotronStreaming2240
         case .nemotron1120ms: return .nemotronStreaming1120
+        case .nemotron560ms: return .nemotronStreaming560
         }
     }
 
@@ -55,7 +59,7 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
         switch self {
         case .parakeetEou160ms, .parakeetEou320ms, .parakeetEou1280ms:
             return .parakeetEou
-        case .nemotron560ms, .nemotron1120ms:
+        case .nemotron2240ms, .nemotron1120ms, .nemotron560ms:
             return .nemotron
         }
     }
@@ -73,8 +77,9 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
     /// The streaming chunk size for Nemotron variants (nil for non-Nemotron)
     public var nemotronChunkSize: NemotronChunkSize? {
         switch self {
-        case .nemotron560ms: return .ms560
+        case .nemotron2240ms: return .ms2240
         case .nemotron1120ms: return .ms1120
+        case .nemotron560ms: return .ms560
         default: return nil
         }
     }
@@ -98,7 +103,7 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
             let chunkSize = eouChunkSize ?? .ms160
             return StreamingEouAsrManager(configuration: mlConfig, chunkSize: chunkSize)
         case .nemotron:
-            let chunkSize = nemotronChunkSize ?? .ms1120
+            let chunkSize = nemotronChunkSize ?? .ms2240
             return StreamingNemotronAsrManager(configuration: mlConfig, requestedChunkSize: chunkSize)
         }
     }

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -562,6 +562,9 @@ public enum ModelNames {
         public static let encoderFile = encoder + ".mlmodelc"
         public static let decoderFile = decoder + ".mlmodelc"
         public static let jointFile = joint + ".mlmodelc"
+        /// Optional fused decoder+joint (B1). Present in tiers that ship the
+        /// merged inner-loop model (e.g. 2240ms); loaded only if the file exists.
+        public static let decoderJointFile = "decoder_joint.mlmodelc"
 
         // Encoder in subdirectory (int8 quantized only)
         public static let encoderInt8File = "encoder/encoder_int8.mlmodelc"

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -22,6 +22,7 @@ public enum Repo: String, CaseIterable, Sendable {
     case parakeetEou160 = "FluidInference/parakeet-realtime-eou-120m-coreml/160ms"
     case parakeetEou320 = "FluidInference/parakeet-realtime-eou-120m-coreml/320ms"
     case parakeetEou1280 = "FluidInference/parakeet-realtime-eou-120m-coreml/1280ms"
+    case nemotronStreaming2240 = "FluidInference/nemotron-speech-streaming-en-0.6b-coreml/2240ms"
     case nemotronStreaming1120 = "FluidInference/nemotron-speech-streaming-en-0.6b-coreml/1120ms"
     case nemotronStreaming560 = "FluidInference/nemotron-speech-streaming-en-0.6b-coreml/560ms"
     case nemotronStreaming160 = "FluidInference/nemotron-speech-streaming-en-0.6b-coreml/160ms"
@@ -94,6 +95,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "parakeet-realtime-eou-120m-coreml/320ms"
         case .parakeetEou1280:
             return "parakeet-realtime-eou-120m-coreml/1280ms"
+        case .nemotronStreaming2240:
+            return "nemotron-speech-streaming-en-0.6b-coreml/2240ms"
         case .nemotronStreaming1120:
             return "nemotron-speech-streaming-en-0.6b-coreml/1120ms"
         case .nemotronStreaming560:
@@ -152,7 +155,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "FluidInference/parakeet-realtime-eou-120m-coreml"
         case .kokoroAne, .kokoroAneZh:
             return "FluidInference/kokoro-82m-coreml"
-        case .nemotronStreaming1120, .nemotronStreaming560, .nemotronStreaming160, .nemotronStreaming80:
+        case .nemotronStreaming2240, .nemotronStreaming1120, .nemotronStreaming560, .nemotronStreaming160,
+            .nemotronStreaming80:
             return "FluidInference/nemotron-speech-streaming-en-0.6b-coreml"
         case .nemotronMultilingual:
             return "FluidInference/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b-CoreML"
@@ -1160,7 +1164,8 @@ public enum ModelNames {
             return ModelNames.TDTJa.requiredModels
         case .parakeetEou160, .parakeetEou320, .parakeetEou1280:
             return ModelNames.ParakeetEOU.requiredModels
-        case .nemotronStreaming1120, .nemotronStreaming560, .nemotronStreaming160, .nemotronStreaming80:
+        case .nemotronStreaming2240, .nemotronStreaming1120, .nemotronStreaming560, .nemotronStreaming160,
+            .nemotronStreaming80:
             return ModelNames.NemotronStreaming.requiredModels
         case .diarizer:
             if variant == "offline" {

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -25,8 +25,6 @@ public enum Repo: String, CaseIterable, Sendable {
     case nemotronStreaming2240 = "FluidInference/nemotron-speech-streaming-en-0.6b-coreml/2240ms"
     case nemotronStreaming1120 = "FluidInference/nemotron-speech-streaming-en-0.6b-coreml/1120ms"
     case nemotronStreaming560 = "FluidInference/nemotron-speech-streaming-en-0.6b-coreml/560ms"
-    case nemotronStreaming160 = "FluidInference/nemotron-speech-streaming-en-0.6b-coreml/160ms"
-    case nemotronStreaming80 = "FluidInference/nemotron-speech-streaming-en-0.6b-coreml/80ms"
     /// Multilingual streaming model. The HF repo is organized as
     /// `<lang>/<tier>ms/` subfolders (9 languages x 4 chunk tiers); the
     /// specific variant subdirectory is supplied dynamically at download
@@ -101,10 +99,6 @@ public enum Repo: String, CaseIterable, Sendable {
             return "nemotron-speech-streaming-en-0.6b-coreml/1120ms"
         case .nemotronStreaming560:
             return "nemotron-speech-streaming-en-0.6b-coreml/560ms"
-        case .nemotronStreaming160:
-            return "nemotron-speech-streaming-en-0.6b-coreml/160ms"
-        case .nemotronStreaming80:
-            return "nemotron-speech-streaming-en-0.6b-coreml/80ms"
         case .diarizer:
             return "speaker-diarization-coreml"
         case .kokoro:
@@ -155,8 +149,7 @@ public enum Repo: String, CaseIterable, Sendable {
             return "FluidInference/parakeet-realtime-eou-120m-coreml"
         case .kokoroAne, .kokoroAneZh:
             return "FluidInference/kokoro-82m-coreml"
-        case .nemotronStreaming2240, .nemotronStreaming1120, .nemotronStreaming560, .nemotronStreaming160,
-            .nemotronStreaming80:
+        case .nemotronStreaming2240, .nemotronStreaming1120, .nemotronStreaming560:
             return "FluidInference/nemotron-speech-streaming-en-0.6b-coreml"
         case .nemotronMultilingual:
             return "FluidInference/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b-CoreML"
@@ -194,14 +187,12 @@ public enum Repo: String, CaseIterable, Sendable {
             return "f32"
         case .qwen3AsrInt8:
             return "int8"
+        case .nemotronStreaming2240:
+            return "nemotron_coreml_2240ms"
         case .nemotronStreaming1120:
             return "nemotron_coreml_1120ms"
         case .nemotronStreaming560:
             return "nemotron_coreml_560ms"
-        case .nemotronStreaming160:
-            return "nemotron_coreml_160ms"
-        case .nemotronStreaming80:
-            return "nemotron_coreml_80ms"
         case .lseendAmi:
             return "optimized/ami"
         case .lseendCallHome:
@@ -236,14 +227,12 @@ public enum Repo: String, CaseIterable, Sendable {
             return "parakeet-eou-streaming/1280ms"
         case .nemotronMultilingual:
             return "nemotron-multilingual"
+        case .nemotronStreaming2240:
+            return "nemotron-streaming/2240ms"
         case .nemotronStreaming1120:
             return "nemotron-streaming/1120ms"
         case .nemotronStreaming560:
             return "nemotron-streaming/560ms"
-        case .nemotronStreaming160:
-            return "nemotron-streaming/160ms"
-        case .nemotronStreaming80:
-            return "nemotron-streaming/80ms"
         case .sortformer:
             return "sortformer"
         case .parakeetCtc110m:
@@ -574,6 +563,7 @@ public enum ModelNames {
             encoderInt8File,
             decoderFile,
             jointFile,
+            decoderJointFile,
             tokenizer,
             metadata,
         ]
@@ -1167,8 +1157,7 @@ public enum ModelNames {
             return ModelNames.TDTJa.requiredModels
         case .parakeetEou160, .parakeetEou320, .parakeetEou1280:
             return ModelNames.ParakeetEOU.requiredModels
-        case .nemotronStreaming2240, .nemotronStreaming1120, .nemotronStreaming560, .nemotronStreaming160,
-            .nemotronStreaming80:
+        case .nemotronStreaming2240, .nemotronStreaming1120, .nemotronStreaming560:
             return ModelNames.NemotronStreaming.requiredModels
         case .diarizer:
             if variant == "offline" {

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronBenchmark.swift
@@ -11,7 +11,7 @@ public class NemotronBenchmark {
         var maxFiles: Int?
         var subset: String = "test-clean"
         var modelDir: URL?
-        var chunkSize: NemotronChunkSize = .ms1120
+        var chunkSize: NemotronChunkSize = .ms2240
 
         public init() {}
     }

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronBenchmark.swift
@@ -64,13 +64,14 @@ public class NemotronBenchmark {
                 i += 1
                 if i < arguments.count, let ms = Int(arguments[i]) {
                     switch ms {
+                    case 2240: config.chunkSize = .ms2240
                     case 1120: config.chunkSize = .ms1120
                     case 560: config.chunkSize = .ms560
                     case 160: config.chunkSize = .ms160
                     case 80: config.chunkSize = .ms80
                     default:
                         logger.warning(
-                            "Invalid chunk size: \(ms)ms. Valid options: 1120, 560, 160, or 80. Using default 1120ms.")
+                            "Invalid chunk size: \(ms)ms. Valid options: 2240, 1120, 560, 160, or 80. Using default 1120ms.")
                     }
                 }
             case "--help", "-h":
@@ -97,7 +98,7 @@ public class NemotronBenchmark {
                 --max-files, -n <count>   Maximum files to process (default: all)
                 --subset, -s <name>       LibriSpeech subset (default: test-clean)
                 --model-dir, -m <path>    Path to Nemotron CoreML models
-                --chunk, -c <ms>          Chunk size: 1120, 560, 160, or 80 (default: 1120)
+                --chunk, -c <ms>          Chunk size: 2240, 1120, 560, 160, or 80 (default: 1120)
                 --help, -h                Show this help
 
             Chunk Sizes:

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronBenchmark.swift
@@ -67,11 +67,9 @@ public class NemotronBenchmark {
                     case 2240: config.chunkSize = .ms2240
                     case 1120: config.chunkSize = .ms1120
                     case 560: config.chunkSize = .ms560
-                    case 160: config.chunkSize = .ms160
-                    case 80: config.chunkSize = .ms80
                     default:
                         logger.warning(
-                            "Invalid chunk size: \(ms)ms. Valid options: 2240, 1120, 560, 160, or 80. Using default 1120ms.")
+                            "Invalid chunk size: \(ms)ms. Valid options: 2240, 1120, or 560. Using default 2240ms.")
                     }
                 }
             case "--help", "-h":
@@ -98,7 +96,7 @@ public class NemotronBenchmark {
                 --max-files, -n <count>   Maximum files to process (default: all)
                 --subset, -s <name>       LibriSpeech subset (default: test-clean)
                 --model-dir, -m <path>    Path to Nemotron CoreML models
-                --chunk, -c <ms>          Chunk size: 2240, 1120, 560, 160, or 80 (default: 1120)
+                --chunk, -c <ms>          Chunk size: 2240, 1120, or 560 (default: 2240)
                 --help, -h                Show this help
 
             Chunk Sizes:

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronTranscribe.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronTranscribe.swift
@@ -10,7 +10,7 @@ public class NemotronTranscribe {
     public struct Config {
         var inputFiles: [URL] = []
         var modelDir: URL?
-        var chunkSize: NemotronChunkSize = .ms1120
+        var chunkSize: NemotronChunkSize = .ms2240
 
         public init() {}
     }
@@ -49,13 +49,12 @@ public class NemotronTranscribe {
                 i += 1
                 if i < arguments.count, let ms = Int(arguments[i]) {
                     switch ms {
+                    case 2240: config.chunkSize = .ms2240
                     case 1120: config.chunkSize = .ms1120
                     case 560: config.chunkSize = .ms560
-                    case 160: config.chunkSize = .ms160
-                    case 80: config.chunkSize = .ms80
                     default:
                         logger.warning(
-                            "Invalid chunk size: \(ms)ms. Valid options: 1120, 560, 160, or 80. Using default 1120ms.")
+                            "Invalid chunk size: \(ms)ms. Valid options: 2240, 1120, or 560. Using default 2240ms.")
                     }
                 }
             case "--help", "-h":
@@ -87,24 +86,23 @@ public class NemotronTranscribe {
             Options:
                 --input, -i <path>        Audio file to transcribe (.wav) - required, can be used multiple times
                 --model-dir, -m <path>    Path to Nemotron CoreML models (optional, auto-downloads if not provided)
-                --chunk, -c <ms>          Chunk size: 1120, 560, 160, or 80 (default: 1120)
+                --chunk, -c <ms>          Chunk size: 2240, 1120, or 560 (default: 2240)
                 --help, -h                Show this help
 
             Chunk Sizes:
-                1120ms  Original chunk size (1.12s) - best accuracy & speed
-                560ms   Half chunk size (0.56s) - lower latency
-                160ms   Very low latency (0.16s)
-                80ms    Ultra low latency (0.08s)
+                2240ms  Default (2.24s) - highest throughput (+B1 fused decode), WER-neutral
+                1120ms  Trained chunk (1.12s) - lower latency
+                560ms   Lowest-latency tier (0.56s)
 
             Examples:
-                # Transcribe a single file
+                # Transcribe a single file (defaults to 2240ms)
                 fluidaudio nemotron-transcribe --input audio.wav
 
-                # Transcribe multiple files with 560ms chunks
-                fluidaudio nemotron-transcribe -i file1.wav -i file2.wav --chunk 560
+                # Transcribe multiple files with 1120ms chunks
+                fluidaudio nemotron-transcribe -i file1.wav -i file2.wav --chunk 1120
 
-                # Ultra low latency with 160ms chunks
-                fluidaudio nemotron-transcribe --input audio.wav --chunk 160
+                # Lower latency with 560ms chunks
+                fluidaudio nemotron-transcribe --input audio.wav --chunk 560
 
                 # Use custom model directory
                 fluidaudio nemotron-transcribe --input audio.wav --model-dir ~/my-models

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronChunkSizeTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronChunkSizeTests.swift
@@ -8,22 +8,23 @@ final class NemotronChunkSizeTests: XCTestCase {
     // MARK: - P1: Raw Value
 
     func testRawValues() {
+        XCTAssertEqual(NemotronChunkSize.ms2240.rawValue, 2240)
         XCTAssertEqual(NemotronChunkSize.ms1120.rawValue, 1120)
         XCTAssertEqual(NemotronChunkSize.ms560.rawValue, 560)
-        XCTAssertEqual(NemotronChunkSize.ms160.rawValue, 160)
-        XCTAssertEqual(NemotronChunkSize.ms80.rawValue, 80)
     }
 
     func testInitFromRawValue() {
+        XCTAssertEqual(NemotronChunkSize(rawValue: 2240), .ms2240)
         XCTAssertEqual(NemotronChunkSize(rawValue: 1120), .ms1120)
         XCTAssertEqual(NemotronChunkSize(rawValue: 560), .ms560)
-        XCTAssertEqual(NemotronChunkSize(rawValue: 160), .ms160)
-        XCTAssertEqual(NemotronChunkSize(rawValue: 80), .ms80)
     }
 
     func testInvalidRawValueReturnsNil() {
         XCTAssertNil(NemotronChunkSize(rawValue: 100))
         XCTAssertNil(NemotronChunkSize(rawValue: 320))
+        // v1 tiers were removed
+        XCTAssertNil(NemotronChunkSize(rawValue: 160))
+        XCTAssertNil(NemotronChunkSize(rawValue: 80))
         XCTAssertNil(NemotronChunkSize(rawValue: 0))
         XCTAssertNil(NemotronChunkSize(rawValue: 9999))
     }
@@ -31,39 +32,35 @@ final class NemotronChunkSizeTests: XCTestCase {
     // MARK: - P1: Repo Mapping
 
     func testRepoMapping() {
+        XCTAssertEqual(NemotronChunkSize.ms2240.repo, .nemotronStreaming2240)
         XCTAssertEqual(NemotronChunkSize.ms1120.repo, .nemotronStreaming1120)
         XCTAssertEqual(NemotronChunkSize.ms560.repo, .nemotronStreaming560)
-        XCTAssertEqual(NemotronChunkSize.ms160.repo, .nemotronStreaming160)
-        XCTAssertEqual(NemotronChunkSize.ms80.repo, .nemotronStreaming80)
     }
 
     // MARK: - P1: Subdirectory Generation
 
     func testSubdirectoryGeneration() {
+        XCTAssertEqual(NemotronChunkSize.ms2240.subdirectory, "nemotron_coreml_2240ms")
         XCTAssertEqual(NemotronChunkSize.ms1120.subdirectory, "nemotron_coreml_1120ms")
         XCTAssertEqual(NemotronChunkSize.ms560.subdirectory, "nemotron_coreml_560ms")
-        XCTAssertEqual(NemotronChunkSize.ms160.subdirectory, "nemotron_coreml_160ms")
-        XCTAssertEqual(NemotronChunkSize.ms80.subdirectory, "nemotron_coreml_80ms")
     }
 
     // MARK: - P1: CaseIterable
 
     func testAllCasesContainsAllVariants() {
         let allCases = NemotronChunkSize.allCases
-        XCTAssertEqual(allCases.count, 4)
+        XCTAssertEqual(allCases.count, 3)
+        XCTAssertTrue(allCases.contains(.ms2240))
         XCTAssertTrue(allCases.contains(.ms1120))
         XCTAssertTrue(allCases.contains(.ms560))
-        XCTAssertTrue(allCases.contains(.ms160))
-        XCTAssertTrue(allCases.contains(.ms80))
     }
 
     func testAllCasesOrder() {
         let allCases = NemotronChunkSize.allCases
-        // Order in enum definition: ms1120, ms560, ms160, ms80
-        XCTAssertEqual(allCases[0], .ms1120)
-        XCTAssertEqual(allCases[1], .ms560)
-        XCTAssertEqual(allCases[2], .ms160)
-        XCTAssertEqual(allCases[3], .ms80)
+        // Order in enum definition: ms2240 (default), ms1120, ms560
+        XCTAssertEqual(allCases[0], .ms2240)
+        XCTAssertEqual(allCases[1], .ms1120)
+        XCTAssertEqual(allCases[2], .ms560)
     }
 
     // MARK: - P1: Sendable Conformance

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronStreamingConfigTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronStreamingConfigTests.swift
@@ -12,10 +12,10 @@ final class NemotronStreamingConfigTests: XCTestCase {
 
         XCTAssertEqual(config.sampleRate, 16000)
         XCTAssertEqual(config.melFeatures, 128)
-        XCTAssertEqual(config.chunkMelFrames, 112)
-        XCTAssertEqual(config.chunkMs, 1120)
+        XCTAssertEqual(config.chunkMelFrames, 224)
+        XCTAssertEqual(config.chunkMs, 2240)
         XCTAssertEqual(config.preEncodeCache, 9)
-        XCTAssertEqual(config.totalMelFrames, 121)
+        XCTAssertEqual(config.totalMelFrames, 233)
         XCTAssertEqual(config.vocabSize, 1024)
         XCTAssertEqual(config.blankIdx, 1024)
         XCTAssertEqual(config.encoderDim, 1024)
@@ -27,9 +27,9 @@ final class NemotronStreamingConfigTests: XCTestCase {
 
     func testChunkSamplesComputation() {
         let config = NemotronStreamingConfig()
-        // chunkSamples = chunkMelFrames * 160
-        XCTAssertEqual(config.chunkSamples, 112 * 160)
-        XCTAssertEqual(config.chunkSamples, 17920)
+        // chunkSamples = chunkMelFrames * 160 (default tier is 2240ms)
+        XCTAssertEqual(config.chunkSamples, 224 * 160)
+        XCTAssertEqual(config.chunkSamples, 35840)
     }
 
     // MARK: - P0: JSON Loading - Valid Cases

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/StreamingAsrManagerTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/StreamingAsrManagerTests.swift
@@ -30,8 +30,8 @@ final class StreamingAsrManagerTests: XCTestCase {
     // MARK: - StreamingModelVariant Tests
 
     func testAllVariantsCount() {
-        // 3 EOU + 2 Nemotron = 5 streaming variants
-        XCTAssertEqual(StreamingModelVariant.allCases.count, 5)
+        // 3 EOU + 3 Nemotron (2240/1120/560) = 6 streaming variants
+        XCTAssertEqual(StreamingModelVariant.allCases.count, 6)
     }
 
     func testAllVariantsHaveDisplayName() {
@@ -63,7 +63,7 @@ final class StreamingAsrManagerTests: XCTestCase {
         }
 
         XCTAssertEqual(eouVariants.count, 3, "Expected 3 EOU variants")
-        XCTAssertEqual(nemotronVariants.count, 2, "Expected 2 Nemotron variants")
+        XCTAssertEqual(nemotronVariants.count, 3, "Expected 3 Nemotron variants")
     }
 
     func testEouVariantsHaveChunkSize() {

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/StreamingNemotronAsrManagerTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/StreamingNemotronAsrManagerTests.swift
@@ -13,9 +13,9 @@ final class StreamingNemotronAsrManagerTests: XCTestCase {
         let manager = StreamingNemotronAsrManager()
 
         let config = await manager.config
-        // Should use default 1120ms config
-        XCTAssertEqual(config.chunkMs, 1120)
-        XCTAssertEqual(config.chunkMelFrames, 112)
+        // Should use the default 2240ms config
+        XCTAssertEqual(config.chunkMs, 2240)
+        XCTAssertEqual(config.chunkMelFrames, 224)
         XCTAssertEqual(config.vocabSize, 1024)
     }
 
@@ -104,7 +104,7 @@ final class StreamingNemotronAsrManagerTests: XCTestCase {
         // chunkSamples = chunkMelFrames * 160
         let expectedSamples = config.chunkMelFrames * 160
         XCTAssertEqual(config.chunkSamples, expectedSamples)
-        XCTAssertEqual(config.chunkSamples, 17920)  // 112 * 160 for 1120ms
+        XCTAssertEqual(config.chunkSamples, 35840)  // 224 * 160 for the default 2240ms
     }
 
     func testAudioBufferAccumulationWithSingleBuffer() async throws {


### PR DESCRIPTION
## Summary

Makes **2240ms + B1 fusion the default** for the English Nemotron streaming model, and adds the tier infrastructure. Two stackable, WER-neutral throughput levers; the default streaming path is now ~+50% RTFx vs the old 1120ms default.

Weights uploaded: [`nemotron_coreml_2240ms/`](https://huggingface.co/FluidInference/nemotron-speech-streaming-en-0.6b-coreml/tree/main/nemotron_coreml_2240ms).

## Levers

- **2240ms chunk** (now the default): doubles the streaming chunk to 224 mel frames (= 2× the trained 14-encoder-frame chunk, so the chunked-attention mask still tiles cleanly). Halving per-chunk fixed overhead trades ~1.1s of chunk latency for throughput at no accuracy cost. Metadata-driven (`chunk_mel_frames`).
- **B1 fusion**: when a tier ships `decoder_joint.mlmodelc`, the RNN-T inner loop makes one CoreML call per step instead of two (loaded automatically; argmax stays in Swift). Mirrors the multilingual pipeline. Falls back to separate decoder+joint when absent.

## Benchmark (end-to-end `nemotron-benchmark`, LibriSpeech test-clean, 100 files, CPU+NE)

| Build | WER | RTFx | Δ vs 1120ms |
|-------|-----|------|-------------|
| 1120ms INT8 | 2.42% | 58.6 | — |
| 2240ms INT8 | 2.46% | 81.2 | +38.6% |
| **2240ms INT8 + B1 (new default)** | **2.46%** | **93.6** | **+59.7%** |

WER neutral across all rows. B1 fusion alone is +15.3% and applies to any tier with a `decoder_joint.mlmodelc`.

## Changes

- **Default chunk size → `.ms2240`** in `StreamingNemotronAsrManager`, `NemotronStreamingConfig`, and `nemotron-benchmark`. Lower-latency tiers remain available via an explicit `NemotronChunkSize` / `--chunk`.
- `NemotronChunkSize.ms2240` + `Repo.nemotronStreaming2240` (HF subdir `nemotron_coreml_2240ms`).
- `StreamingNemotronAsrManager`: optional `decoderJoint` model, loaded if present; inner decode loop branches fused-vs-separate.
- `ModelNames.NemotronStreaming.decoderJointFile`; `nemotron-benchmark --chunk 2240`.
- `Documentation/ASR/Nemotron.md`: tier table + rationale.

## Reproduce

```bash
swift run -c release fluidaudio nemotron-benchmark --max-files 100   # now defaults to 2240ms + B1
```

## Notes

- Conversion tooling is in mobius#66.
- Uploaded weights are a faithful conversion of public `nvidia/nemotron-speech-streaming-en-0.6b` (decoder & joint match PyTorch at cos=1.0); the released tiers score ~0.4pp lower WER from a different source checkpoint — re-running these levers on the production checkpoint gives the same speed at released accuracy.
- Encoder ships INT8; **6-bit palettization strictly dominates it** (2.24% WER, +9% RTFx, smaller) — a one-line filename change + pal6 upload follow-up.