### PR TITLE
feat(tts/supertonic3): quantized + ANE-bucketed VectorEstimator

### DIFF
--- a/.github/workflows/pocket-tts-test.yml
+++ b/.github/workflows/pocket-tts-test.yml
@@ -1,4 +1,4 @@
-name: PocketTTS Smoke Test
+name: TTS Smoke Tests
 
 on:
   pull_request:
@@ -143,4 +143,145 @@ jobs:
         with:
           name: pocket-tts-output
           path: pocket_tts_output.wav
+          retention-days: 7
+
+  supertonic3-smoke-test:
+    name: Supertonic3 Smoke Test
+    runs-on: macos-15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.1"
+
+      - name: Cache Dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Application Support/FluidAudio/Models/supertonic-3
+          key: ${{ runner.os }}-supertonic3-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/TTS/Supertonic3/**', 'Sources/FluidAudio/ModelNames.swift') }}
+
+      - name: Build
+        run: swift build -c release
+
+      - name: Run Smoke Test
+        id: smoketest
+        run: |
+          BENCHMARK_START=$(date +%s)
+
+          echo "========================================="
+          echo "Supertonic3 smoke test (ANE-bucketed int4 VectorEstimator)"
+          echo "========================================="
+          echo ""
+          echo "NOTE: --ve-variant int4 selects the fixed-length, ANE-resident"
+          echo "VectorEstimator. CI VMs lack a physical Neural Engine, so Core ML"
+          echo "falls back to CPU here — this validates download + variant"
+          echo "resolution + the synthesis pipeline, not ANE residency itself."
+          echo ""
+
+          TEXT="The quick brown fox jumps over the lazy dog near the riverbank."
+
+          if .build/release/fluidaudiocli tts "$TEXT" \
+            --backend supertonic3 \
+            --ve-variant int4 \
+            --voice M1 \
+            --lang en \
+            --output supertonic3_output.wav 2>&1; then
+            echo "Smoke test PASSED - pipeline completed without crash"
+            echo "SMOKE_STATUS=PASSED" >> $GITHUB_OUTPUT
+          else
+            EXIT_CODE=$?
+            echo "Smoke test FAILED with exit code $EXIT_CODE"
+            echo "SMOKE_STATUS=FAILED" >> $GITHUB_OUTPUT
+          fi
+
+          if [ -f supertonic3_output.wav ]; then
+            SIZE=$(stat -f%z supertonic3_output.wav 2>/dev/null || stat -c%s supertonic3_output.wav 2>/dev/null)
+            echo "Output file size: $SIZE bytes"
+            echo "FILE_SIZE=$SIZE" >> $GITHUB_OUTPUT
+          else
+            echo "FILE_SIZE=0" >> $GITHUB_OUTPUT
+          fi
+
+          EXECUTION_TIME=$(( ($(date +%s) - BENCHMARK_START) / 60 ))m$(( ($(date +%s) - BENCHMARK_START) % 60 ))s
+          echo "EXECUTION_TIME=$EXECUTION_TIME" >> $GITHUB_OUTPUT
+
+          if [ ! -f supertonic3_output.wav ]; then
+            echo "❌ CRITICAL: Output WAV file not generated"
+            exit 1
+          fi
+
+          FILE_SIZE=$(stat -f%z supertonic3_output.wav 2>/dev/null || stat -c%s supertonic3_output.wav 2>/dev/null)
+          if [ "$FILE_SIZE" -eq 0 ]; then
+            echo "❌ CRITICAL: Output WAV file is empty (0 bytes)"
+            exit 1
+          fi
+
+      - name: Comment PR
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ steps.smoketest.outputs.SMOKE_STATUS }}';
+            const emoji = status === 'PASSED' ? '✅' : '❌';
+            const fileSize = '${{ steps.smoketest.outputs.FILE_SIZE }}';
+            const fileSizeKB = (parseInt(fileSize) / 1024).toFixed(1);
+
+            const body = `## Supertonic3 Smoke Test ${emoji}
+
+            | Check | Result |
+            |-------|--------|
+            | Build | ✅ |
+            | Model download (incl. \`VectorEstimatorVariants/\` int4 buckets) | ${emoji} |
+            | Model load | ${emoji} |
+            | Synthesis pipeline (\`--ve-variant int4\`) | ${emoji} |
+            | Output WAV | ${parseInt(fileSize) > 0 ? '✅' : '❌'} (${fileSizeKB} KB) |
+
+            <sub>Runtime: ${{ steps.smoketest.outputs.EXECUTION_TIME }}</sub>
+
+            <sub>**Note:** CI VMs lack a physical Neural Engine; the ANE-bucketed VectorEstimator falls back to CPU here. This validates download + variant resolution + synthesis, not ANE residency/perf.</sub>
+
+            <!-- fluidaudio-supertonic3-test -->`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c =>
+              c.body.includes('<!-- fluidaudio-supertonic3-test -->')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: body
+              });
+            }
+
+      - name: Upload Output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: supertonic3-output
+          path: supertonic3_output.wav
           retention-days: 7

--- a/.github/workflows/supertonic3-tts-test.yml
+++ b/.github/workflows/supertonic3-tts-test.yml
@@ -1,4 +1,4 @@
-name: PocketTTS Smoke Test
+name: Supertonic3 Smoke Test
 
 on:
   pull_request:
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  pocket-tts-smoke-test:
-    name: PocketTTS Smoke Test
+  supertonic3-smoke-test:
+    name: Supertonic3 Smoke Test
     runs-on: macos-15
     permissions:
       contents: read
@@ -27,8 +27,8 @@ jobs:
         with:
           path: |
             .build
-            ~/Library/Application Support/FluidAudio/Models/pocket-tts
-          key: ${{ runner.os }}-pocket-tts-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/TTS/PocketTTS/**', 'Sources/FluidAudio/ModelNames.swift') }}
+            ~/Library/Application Support/FluidAudio/Models/supertonic-3
+          key: ${{ runner.os }}-supertonic3-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/TTS/Supertonic3/**', 'Sources/FluidAudio/ModelNames.swift') }}
 
       - name: Build
         run: swift build -c release
@@ -39,19 +39,23 @@ jobs:
           BENCHMARK_START=$(date +%s)
 
           echo "========================================="
-          echo "PocketTTS smoke test"
+          echo "Supertonic3 smoke test (ANE-bucketed int4 VectorEstimator)"
           echo "========================================="
           echo ""
-          echo "NOTE: PocketTTS uses CoreML MLState (macOS 15) KV cache"
-          echo "and Mimi streaming state. Results on virtualized CI VMs"
-          echo "may differ from physical Apple Silicon."
+          echo "NOTE: --ve-variant int4 selects the fixed-length, ANE-resident"
+          echo "VectorEstimator. CI VMs lack a physical Neural Engine, so Core ML"
+          echo "falls back to CPU here — this validates download + variant"
+          echo "resolution + the synthesis pipeline, not ANE residency itself."
           echo ""
 
           TEXT="The quick brown fox jumps over the lazy dog near the riverbank."
 
           if .build/release/fluidaudiocli tts "$TEXT" \
-            --backend pocket \
-            --output pocket_tts_output.wav 2>&1; then
+            --backend supertonic3 \
+            --ve-variant int4 \
+            --voice M1 \
+            --lang en \
+            --output supertonic3_output.wav 2>&1; then
             echo "Smoke test PASSED - pipeline completed without crash"
             echo "SMOKE_STATUS=PASSED" >> $GITHUB_OUTPUT
           else
@@ -60,8 +64,8 @@ jobs:
             echo "SMOKE_STATUS=FAILED" >> $GITHUB_OUTPUT
           fi
 
-          if [ -f pocket_tts_output.wav ]; then
-            SIZE=$(stat -f%z pocket_tts_output.wav 2>/dev/null || stat -c%s pocket_tts_output.wav 2>/dev/null)
+          if [ -f supertonic3_output.wav ]; then
+            SIZE=$(stat -f%z supertonic3_output.wav 2>/dev/null || stat -c%s supertonic3_output.wav 2>/dev/null)
             echo "Output file size: $SIZE bytes"
             echo "FILE_SIZE=$SIZE" >> $GITHUB_OUTPUT
           else
@@ -71,14 +75,12 @@ jobs:
           EXECUTION_TIME=$(( ($(date +%s) - BENCHMARK_START) / 60 ))m$(( ($(date +%s) - BENCHMARK_START) % 60 ))s
           echo "EXECUTION_TIME=$EXECUTION_TIME" >> $GITHUB_OUTPUT
 
-          # Validate output file was generated
-          if [ ! -f pocket_tts_output.wav ]; then
+          if [ ! -f supertonic3_output.wav ]; then
             echo "❌ CRITICAL: Output WAV file not generated"
             exit 1
           fi
 
-          # Validate output file is not empty
-          FILE_SIZE=$(stat -f%z pocket_tts_output.wav 2>/dev/null || stat -c%s pocket_tts_output.wav 2>/dev/null)
+          FILE_SIZE=$(stat -f%z supertonic3_output.wav 2>/dev/null || stat -c%s supertonic3_output.wav 2>/dev/null)
           if [ "$FILE_SIZE" -eq 0 ]; then
             echo "❌ CRITICAL: Output WAV file is empty (0 bytes)"
             exit 1
@@ -95,21 +97,21 @@ jobs:
             const fileSize = '${{ steps.smoketest.outputs.FILE_SIZE }}';
             const fileSizeKB = (parseInt(fileSize) / 1024).toFixed(1);
 
-            const body = `## PocketTTS Smoke Test ${emoji}
+            const body = `## Supertonic3 Smoke Test ${emoji}
 
             | Check | Result |
             |-------|--------|
             | Build | ✅ |
-            | Model download | ${emoji} |
+            | Model download (incl. \`VectorEstimatorVariants/\` int4 buckets) | ${emoji} |
             | Model load | ${emoji} |
-            | Synthesis pipeline | ${emoji} |
+            | Synthesis pipeline (\`--ve-variant int4\`) | ${emoji} |
             | Output WAV | ${parseInt(fileSize) > 0 ? '✅' : '❌'} (${fileSizeKB} KB) |
 
             <sub>Runtime: ${{ steps.smoketest.outputs.EXECUTION_TIME }}</sub>
 
-            <sub>**Note:** PocketTTS uses CoreML MLState (macOS 15) KV cache + Mimi streaming state. CI VM lacks physical GPU — audio quality and performance may differ from Apple Silicon.</sub>
+            <sub>**Note:** CI VMs lack a physical Neural Engine; the ANE-bucketed VectorEstimator falls back to CPU here. This validates download + variant resolution + synthesis, not ANE residency/perf.</sub>
 
-            <!-- fluidaudio-pocket-tts-test -->`;
+            <!-- fluidaudio-supertonic3-test -->`;
 
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
@@ -118,7 +120,7 @@ jobs:
             });
 
             const existing = comments.find(c =>
-              c.body.includes('<!-- fluidaudio-pocket-tts-test -->')
+              c.body.includes('<!-- fluidaudio-supertonic3-test -->')
             );
 
             if (existing) {
@@ -141,6 +143,6 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pocket-tts-output
-          path: pocket_tts_output.wav
+          name: supertonic3-output
+          path: supertonic3_output.wav
           retention-days: 7

--- a/Documentation/ANE_Profiler.md
+++ b/Documentation/ANE_Profiler.md
@@ -173,7 +173,8 @@ Latency **measured on real synthesis**, warm (one short sentence; `tts --backend
 | Model | Type | ANE | GPU | CPU | ops | Size | Heavy graph → device |
 |-------|------|----:|----:|----:|----:|-----:|----------------------|
 | Kokoro ANE (7-stage) | batch (per utterance) | 75% | 0% | 25% | 1472 | 83 MB | Vocoder → ANE |
-| Supertonic | batch (8-step diffusion) | 30% | 0% | 70% | 1365 | 192 MB | VectorEstimator → **CPU** (ANE compile fails) |
+| Supertonic (default fp16) | batch (8-step diffusion) | 30% | 0% | 70% | 1365 | 192 MB | VectorEstimator → **CPU** (dynamic shapes can't use ANE) |
+| Supertonic (`--ve-variant int4`) | batch (8-step diffusion) | ~90% | 0% | ~10% | 1289 | 102 MB | VectorEstimator → **ANE** (fixed L-buckets) |
 | PocketTTS | streaming (autoregressive) | 0% | 0% | 100% | 1504 | 606 MB | all stages → CPU (mimi_encoder crashes loader) |
 
 **Component detail**
@@ -205,15 +206,24 @@ Autoregressive: stages run many steps per utterance. All on CPU.
 > unknown). Getting these onto the ANE is future work.
 
 ### Supertonic
-`VectorEstimator` runs once per denoising step (default 8). It's the heaviest stage and is stuck on
-CPU because it **fails ANE compile** (`ANECCompile() FAILED`), fp32 and int8 both.
+`VectorEstimator` runs once per denoising step (default 8) and is the heaviest stage. The **default**
+build uses dynamic (RangeDim) shapes, which Core ML **cannot place on the ANE** — so it runs on CPU.
+The opt-in **fixed-length** builds (`--ve-variant int8|int6|int4`, L = 128/256/512) land ~94% on the
+ANE (~2.7× faster end-to-end); the synthesizer pads each chunk's latent to the nearest bucket. The
+`ANECCompile() FAILED` line emitted for the dynamic build is **non-fatal noise** — the fixed builds
+compile and execute on the ANE (verified M5 Pro / macOS 26.5; see
+[Supertonic3 docs](TTS/Supertonic3.md#vectorestimator-variants)).
 
 | Component | ANE | GPU | CPU | ops | Size | Lat ms |
 |-----------|----:|----:|----:|----:|-----:|-------:|
 | TextEncoder | 98% | 0% | 2% | 308 | 18 MB | 1.2 |
 | DurationPredictor | 0% | 0% | 100% | 195 | 2 MB | 2.5 |
-| VectorEstimator | 0% | 0% | 100% | 755 | 123 / 62 MB | 89 ms (8× @ 11.1) |
+| VectorEstimator (fp16 dynamic, default) | 0% | 0% | 100% | 755 | 123 MB | 89 ms (8× @ 11.1) |
+| VectorEstimator (fixed L128, int4) | 94% | 0% | 6% | 679 | 33 MB | ~31 ms (8× @ 3.8)¹ |
 | Vocoder | 100% | 0% | 0% | 107 | 49 MB | 10.5 |
+
+¹ Fixed-build split + per-step latency from `MLComputePlan` + warm CPU-vs-NE timing at L128 (NE 3.8 ms
+vs CPU-only 14.2 ms/step). A cold first call additionally pays a one-time ANE compile.
 
 ---
 
@@ -222,8 +232,6 @@ CPU because it **fails ANE compile** (`ANECCompile() FAILED`), fp32 and int8 bot
 - [ ] **PocketTTS**: get `cond_step` (255 MB) and `flowlm_step` (291 MB) onto the ANE; file a
   loader-crash bug for `mimi_encoder` (SIGSEGV in `MLComputePlan.load`). Biggest CPU-bound graphs in
   the lineup.
-- [ ] **Supertonic `VectorEstimator`**: file ANE-compile bug (`ANECCompile() FAILED`, fp32 + int8,
-  123 MB on CPU).
 
 **profiled is based on model downloads** 
 

--- a/Documentation/TTS/Supertonic3.md
+++ b/Documentation/TTS/Supertonic3.md
@@ -48,6 +48,7 @@ Optional flags:
 | `--lang <code>` | `en` | One of the 31 supported ISO codes — see [Languages](#languages) |
 | `--total-steps <n>` | `8` | Denoising step count; lower trades quality for latency |
 | `--speed <f>` | `1.05` | Speech-rate multiplier; divides predicted duration |
+| `--ve-variant <v>` | `fp16` | VectorEstimator build — `fp16`, `int8`/`int6`/`int4` (ANE-bucketed), or `dyn-int8`/`dyn-int6`/`dyn-int4` (dynamic CPU/GPU). See [VectorEstimator variants](#vectorestimator-variants) |
 
 ### Swift
 
@@ -55,7 +56,8 @@ Optional flags:
 import FluidAudio
 
 let manager = try await Supertonic3Manager.downloadAndCreate(
-    computeUnits: .cpuAndNeuralEngine
+    computeUnits: .cpuAndNeuralEngine,
+    vectorEstimator: .aneBucketed(.int4)   // optional; default .fp16Dynamic
 )
 
 let style = try Supertonic3VoiceStyle.load(
@@ -184,7 +186,7 @@ All CoreML packages live under
 |---|---|---|
 | Text encoder | `TextEncoder.mlmodelc` | T=128 fixed, outputs `text_emb [1, 256, 128]` |
 | Duration predictor | `DurationPredictor.mlmodelc` | T=128 fixed, outputs scalar `duration` |
-| Vector estimator | `VectorEstimator.mlmodelc` | 8 denoising steps with fused CFG (W_COND = 4.0, W_UNCOND = 3.0) |
+| Vector estimator | `VectorEstimator.mlmodelc` | FP16 dynamic (RangeDim), CPU/GPU. 8 denoising steps with fused CFG (W_COND = 4.0, W_UNCOND = 3.0). See [variants](#vectorestimator-variants) for quantized / ANE builds |
 | Vocoder | `Vocoder.mlmodelc` | Outputs `wav` at 44.1 kHz mono Float32 |
 
 Companion assets:
@@ -194,6 +196,48 @@ Companion assets:
 | `tts.json` | Sample rate, chunk-compress factor, base chunk size — overrides the compile-time defaults in `Supertonic3Constants` |
 | `unicode_indexer.json` | Flat `[Int64]` array, indexed by codepoint, mapping every Unicode scalar to a model token id |
 | `assets/voice_styles/*.json` | Per-speaker `style_ttl` / `style_dp` tensors |
+
+## VectorEstimator variants
+
+`VectorEstimator` is the cost center (run once per denoising step × 8), so it
+ships in 12 weight-compressed builds under
+[`FluidInference/supertonic-3-coreml/VectorEstimatorVariants/`](https://huggingface.co/FluidInference/supertonic-3-coreml/tree/main/VectorEstimatorVariants).
+Select one via `Supertonic3Manager(vectorEstimator:)` or the `--ve-variant`
+CLI flag. Two independent axes:
+
+**Shape → compute device.** Dynamic (RangeDim) shapes cannot use the ANE
+(Core ML rejects data-dependent shapes), so they run on CPU/GPU. Fixed-length
+builds land ~94–96% on the Neural Engine (~2.7× faster end-to-end). The
+synthesizer pads each chunk's latent up to the smallest bucket ≥ its length and
+trims back before the vocoder; the bucket model is loaded lazily. Per-chunk
+length is bounded by the 110/90-char chunker, so the **L128** bucket covers the
+common case.
+
+| `Supertonic3VectorEstimator` | `--ve-variant` | shape | device | bundle |
+|---|---|---|---|---|
+| `.fp16Dynamic` (default) | `fp16` | RangeDim | CPU/GPU | `VectorEstimator.mlmodelc` (repo root) |
+| `.dynamic(q)` | `dyn-int8` / `dyn-int6` / `dyn-int4` | RangeDim | CPU/GPU | `VectorEstimatorVariants/VectorEstimator_int{8,6,4}.mlmodelc` |
+| `.aneBucketed(q)` | `int8` / `int6` / `int4` | fixed L=128/256/512 | **ANE** | `VectorEstimatorVariants/VectorEstimator_L{128,256,512}_int{8,6,4}.mlmodelc` |
+
+**Quantization → size only** (placement and latency are unchanged — ANE compute
+is precision-independent). All are post-training, weight-only:
+
+| suffix | method | size vs FP16 | quality |
+|---|---|---|---|
+| `int8` | linear, per-channel symmetric int8 | ~2.0× smaller (64.5 MB) | transparent (closest to FP16) |
+| `int6` | 6-bit k-means palettization | ~2.5× smaller (48.4 MB) | very good |
+| `int4` | 4-bit k-means palettization | ~3.9× smaller (32.5 MB) | perceptually clean in A/B listening |
+
+Only the selected build downloads (via the variant filter), so non-default
+choices add no cost to other configurations. Max audio per chunk for the fixed
+buckets is `L × 0.0697 s` (L128 ≈ 8.9 s, L256 ≈ 17.8 s, L512 ≈ 35.7 s); the
+synthesizer picks the smallest bucket that fits.
+
+> Quality note: waveform/spectral SNR of the quantized builds vs FP16 looks low,
+> but that is **diffusion trajectory divergence, not degradation** — an 8-step
+> flow-matching ODE under a slightly-perturbed vector field lands on a
+> different-but-valid sample, and sample-aligned SNR is phase-sensitive. Judge by
+> listening (or ASR), not waveform SNR.
 
 ## Known issues
 

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -999,6 +999,60 @@ public enum ModelNames {
         /// Models + companion JSON files the downloader must fetch.
         public static let requiredFiles: Set<String> =
             requiredModels.union([configFile, unicodeIndexerFile])
+
+        // MARK: VectorEstimator variants
+
+        /// The three modules shared by every VectorEstimator variant.
+        public static let sharedModelFiles: Set<String> = [
+            textEncoderFile, durationPredictorFile, vocoderFile,
+        ]
+        public static let companionFiles: Set<String> = [configFile, unicodeIndexerFile]
+
+        /// Fixed latent buckets published for ANE residency (smallest ≥ chunk
+        /// length is selected at synthesis time).
+        public static let aneBuckets: [Int] = [128, 256, 512]
+
+        /// Quantized / fixed-length VectorEstimator builds live under this repo
+        /// subdirectory; the FP16 dynamic model + the 3 shared modules sit at
+        /// the repo root.
+        public static let variantsSubdir = "VectorEstimatorVariants"
+
+        /// Bundle (dir) name of a VectorEstimator build, e.g.
+        /// `VectorEstimator`, `VectorEstimator_int4`, `VectorEstimator_L256_int8`.
+        public static func vectorEstimatorName(precisionSuffix: String?, bucket: Int?) -> String {
+            var name = vectorEstimator
+            if let bucket { name += "_L\(bucket)" }
+            if let precisionSuffix { name += "_\(precisionSuffix)" }
+            return name
+        }
+
+        /// Repo-relative `.mlmodelc` path for a VectorEstimator build. FP16
+        /// dynamic stays at the root; every quantized/bucketed variant is under
+        /// `variantsSubdir`.
+        public static func vectorEstimatorFile(precisionSuffix: String?, bucket: Int?) -> String {
+            let base = vectorEstimatorName(precisionSuffix: precisionSuffix, bucket: bucket) + ".mlmodelc"
+            if precisionSuffix == nil && bucket == nil { return base }
+            return "\(variantsSubdir)/\(base)"
+        }
+
+        /// Files to fetch for a given VectorEstimator download variant token
+        /// (see `Supertonic3VectorEstimator.downloadVariant`). `nil` ⇒ the
+        /// historical FP16 dynamic model.
+        public static func requiredFiles(veVariant: String?) -> Set<String> {
+            var set = sharedModelFiles.union(companionFiles)
+            switch veVariant {
+            case .some(let v) where v.hasPrefix("dyn-"):
+                set.insert(vectorEstimatorFile(precisionSuffix: String(v.dropFirst(4)), bucket: nil))
+            case .some(let v) where v.hasPrefix("ane-"):
+                let q = String(v.dropFirst(4))
+                for b in aneBuckets {
+                    set.insert(vectorEstimatorFile(precisionSuffix: q, bucket: b))
+                }
+            default:
+                set.insert(vectorEstimatorFile)  // fp16 dynamic
+            }
+            return set
+        }
     }
 
     /// Multilingual G2P (CharsiuG2P ByT5) model names
@@ -1211,7 +1265,7 @@ public enum ModelNames {
                 return ModelNames.StyleTTS2.requiredModels
             }
         case .supertonic3:
-            return ModelNames.Supertonic3.requiredFiles
+            return ModelNames.Supertonic3.requiredFiles(veVariant: variant)
         }
     }
 }

--- a/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ModelStore.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ModelStore.swift
@@ -20,21 +20,41 @@ public actor Supertonic3ModelStore {
 
     private let directory: URL?
     private let computeUnits: MLComputeUnits
+    private let veOption: Supertonic3VectorEstimator
 
     private var repoDirectory: URL?
     private var textEncoderModel: MLModel?
     private var durationPredictorModel: MLModel?
-    private var vectorEstimatorModel: MLModel?
     private var vocoderModel: MLModel?
+
+    /// Single VectorEstimator for the non-bucketed (`.fp16Dynamic` / `.dynamic`)
+    /// modes. `nil` in bucketed mode, where models are loaded lazily per bucket.
+    private var vectorEstimatorModel: MLModel?
+    /// Lazily-loaded fixed-length VectorEstimators keyed by latent bucket length
+    /// (used only in `.aneBucketed` mode).
+    private var bucketModels: [Int: MLModel] = [:]
 
     private(set) var config: Supertonic3Config = .defaults
 
     public init(
         directory: URL? = nil,
-        computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
+        vectorEstimator: Supertonic3VectorEstimator = .default
     ) {
         self.directory = directory
         self.computeUnits = computeUnits
+        self.veOption = vectorEstimator
+    }
+
+    /// Compute units the VectorEstimator stage should use. Dynamic-shape builds
+    /// cannot use the ANE (CoreML rejects data-dependent shapes), so they are
+    /// pinned to CPU/GPU; bucketed builds target the ANE.
+    private var veComputeUnits: MLComputeUnits {
+        switch veOption {
+        case .fp16Dynamic: return computeUnits  // preserve historical behavior
+        case .dynamic: return .cpuAndGPU
+        case .aneBucketed: return .cpuAndNeuralEngine
+        }
     }
 
     // MARK: - Public API
@@ -44,7 +64,8 @@ public actor Supertonic3ModelStore {
     public func loadIfNeeded() async throws {
         if textEncoderModel != nil { return }
 
-        let repoDir = try await Supertonic3ResourceDownloader.ensureModels(directory: directory)
+        let repoDir = try await Supertonic3ResourceDownloader.ensureModels(
+            directory: directory, veVariant: veOption.downloadVariant)
         self.repoDirectory = repoDir
 
         // tts.json — optional override of the compile-time defaults. If parsing
@@ -72,12 +93,21 @@ public actor Supertonic3ModelStore {
         durationPredictorModel = try loadModel(
             repoDir: repoDir,
             fileName: ModelNames.Supertonic3.durationPredictorFile, config: cfg)
-        vectorEstimatorModel = try loadModel(
-            repoDir: repoDir,
-            fileName: ModelNames.Supertonic3.vectorEstimatorFile, config: cfg)
         vocoderModel = try loadModel(
             repoDir: repoDir,
             fileName: ModelNames.Supertonic3.vocoderFile, config: cfg)
+
+        // VectorEstimator: dynamic builds load eagerly; bucketed builds load
+        // each fixed-length model lazily on first use (see vectorEstimator(forLatentLength:)).
+        if !veOption.isBucketed {
+            let veCfg = MLModelConfiguration()
+            veCfg.computeUnits = veComputeUnits
+            vectorEstimatorModel = try loadModel(
+                repoDir: repoDir,
+                fileName: ModelNames.Supertonic3.vectorEstimatorFile(
+                    precisionSuffix: veOption.precisionSuffix, bucket: nil),
+                config: veCfg)
+        }
 
         let elapsed = Date().timeIntervalSince(loadStart)
         logger.info(
@@ -90,8 +120,39 @@ public actor Supertonic3ModelStore {
     public func durationPredictor() throws -> MLModel {
         try unwrap(durationPredictorModel, name: "duration_predictor")
     }
-    public func vectorEstimator() throws -> MLModel {
-        try unwrap(vectorEstimatorModel, name: "vector_estimator")
+    /// Resolve the VectorEstimator for a chunk of `latentLength` TTL slots.
+    ///
+    /// Returns the model plus the latent length the caller must feed it: in
+    /// dynamic modes that equals `latentLength` (no padding); in bucketed mode
+    /// it is the smallest published bucket ≥ `latentLength`, and the caller pads
+    /// the latent/mask up to that length. Bucket models are loaded lazily and
+    /// cached.
+    public func vectorEstimator(forLatentLength latentLength: Int) throws -> (
+        model: MLModel, paddedLength: Int
+    ) {
+        guard veOption.isBucketed else {
+            return (try unwrap(vectorEstimatorModel, name: "vector_estimator"), latentLength)
+        }
+        guard let bucket = ModelNames.Supertonic3.aneBuckets.first(where: { $0 >= latentLength })
+        else {
+            throw Supertonic3Error.inferenceFailed(
+                stage: "vector_estimator",
+                underlying:
+                    "latent length \(latentLength) exceeds largest ANE bucket "
+                    + "\(ModelNames.Supertonic3.aneBuckets.last ?? 0); use a dynamic VectorEstimator")
+        }
+        if let cached = bucketModels[bucket] { return (cached, bucket) }
+
+        guard let repoDir = repoDirectory else { throw Supertonic3Error.notInitialized }
+        let veCfg = MLModelConfiguration()
+        veCfg.computeUnits = veComputeUnits
+        let model = try loadModel(
+            repoDir: repoDir,
+            fileName: ModelNames.Supertonic3.vectorEstimatorFile(
+                precisionSuffix: veOption.precisionSuffix, bucket: bucket),
+            config: veCfg)
+        bucketModels[bucket] = model
+        return (model, bucket)
     }
     public func vocoder() throws -> MLModel { try unwrap(vocoderModel, name: "vocoder") }
 
@@ -109,6 +170,7 @@ public actor Supertonic3ModelStore {
         textEncoderModel = nil
         durationPredictorModel = nil
         vectorEstimatorModel = nil
+        bucketModels.removeAll()
         vocoderModel = nil
     }
 

--- a/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ModelStore.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ModelStore.swift
@@ -50,6 +50,10 @@ public actor Supertonic3ModelStore {
     /// cannot use the ANE (CoreML rejects data-dependent shapes), so they are
     /// pinned to CPU/GPU; bucketed builds target the ANE.
     private var veComputeUnits: MLComputeUnits {
+        // An explicit .cpuOnly request always wins (it already excludes the ANE,
+        // so no override is needed). Otherwise dynamic shapes avoid the ANE
+        // (Core ML rejects them) and bucketed builds target it.
+        if computeUnits == .cpuOnly { return .cpuOnly }
         switch veOption {
         case .fp16Dynamic: return computeUnits  // preserve historical behavior
         case .dynamic: return .cpuAndGPU

--- a/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ModelStore.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ModelStore.swift
@@ -131,9 +131,7 @@ public actor Supertonic3ModelStore {
     /// it is the smallest published bucket ≥ `latentLength`, and the caller pads
     /// the latent/mask up to that length. Bucket models are loaded lazily and
     /// cached.
-    public func vectorEstimator(forLatentLength latentLength: Int) throws -> (
-        model: MLModel, paddedLength: Int
-    ) {
+    public func vectorEstimator(forLatentLength latentLength: Int) throws -> (model: MLModel, paddedLength: Int) {
         guard veOption.isBucketed else {
             return (try unwrap(vectorEstimatorModel, name: "vector_estimator"), latentLength)
         }

--- a/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ResourceDownloader.swift
@@ -16,12 +16,14 @@ public enum Supertonic3ResourceDownloader {
     @discardableResult
     public static func ensureModels(
         directory: URL? = nil,
+        veVariant: String? = nil,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> URL {
         let modelsRoot = try directory ?? defaultCacheRoot()
         let repoDir = modelsRoot.appendingPathComponent(Repo.supertonic3.folderName)
 
-        let allPresent = ModelNames.Supertonic3.requiredFiles.allSatisfy { file in
+        let required = ModelNames.Supertonic3.requiredFiles(veVariant: veVariant)
+        let allPresent = required.allSatisfy { file in
             FileManager.default.fileExists(atPath: repoDir.appendingPathComponent(file).path)
         }
 
@@ -29,7 +31,8 @@ public enum Supertonic3ResourceDownloader {
             logger.info("Downloading Supertonic-3 CoreML assets from HuggingFace…")
             do {
                 try await DownloadUtils.downloadRepo(
-                    .supertonic3, to: modelsRoot, progressHandler: progressHandler)
+                    .supertonic3, to: modelsRoot, variant: veVariant,
+                    progressHandler: progressHandler)
             } catch {
                 throw Supertonic3Error.downloadFailed("\(error)")
             }

--- a/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3Synthesizer.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Pipeline/Synthesize/Supertonic3Synthesizer.swift
@@ -136,13 +136,30 @@ struct Supertonic3Synthesizer {
                 chunkCompress: cfg.ttl.chunkCompressFactor,
                 latentDim: cfg.ttl.latentDim)
 
-        let latentShape = [latentDims.bsz, latentDims.channels, latentDims.length]
-        let latentMaskShape = [latentDims.bsz, 1, latentDims.length]
+        let trueLen = latentDims.length
+        let channels = latentDims.channels
+        let latentShape = [latentDims.bsz, channels, trueLen]
 
-        var noisyLatent = try makeFloat(values: initialLatent, shape: latentShape)
-        let latentMask = try makeFloat(values: latentMaskFlat, shape: latentMaskShape)
+        // Resolve the VectorEstimator for this chunk. In bucketed (ANE) mode the
+        // store returns a fixed-length model and the bucket length to pad up to;
+        // in dynamic mode `padLen == trueLen` and no padding happens.
+        let (vectorEstimator, padLen) = try await store.vectorEstimator(forLatentLength: trueLen)
 
-        let vectorEstimator = try await store.vectorEstimator()
+        let veLatentShape = [latentDims.bsz, channels, padLen]
+        let veMaskShape = [latentDims.bsz, 1, padLen]
+
+        let noisyFlat =
+            padLen == trueLen
+            ? initialLatent
+            : Self.padRows(initialLatent, channels: channels, fromLen: trueLen, toLen: padLen)
+        let veMaskFlat =
+            padLen == trueLen
+            ? latentMaskFlat
+            : Self.padTail(latentMaskFlat, toLen: padLen)
+
+        var noisyLatent = try makeFloat(values: noisyFlat, shape: veLatentShape)
+        let latentMask = try makeFloat(values: veMaskFlat, shape: veMaskShape)
+
         for step in 0..<totalSteps {
             let currentStep = try makeFloat(values: [Float(step)], shape: [1])
             let totalStep = try makeFloat(values: [Float(totalSteps)], shape: [1])
@@ -166,14 +183,26 @@ struct Supertonic3Synthesizer {
                     stage: "vector_estimator", underlying: "missing 'denoised_latent' output")
             }
             // Rebind without recopying when the shape and dtype already match.
-            noisyLatent = try reshape(denoised, to: latentShape)
+            noisyLatent = try reshape(denoised, to: veLatentShape)
+        }
+
+        // Trim the padded bucket output back to the true latent length before the
+        // vocoder (which accepts a RangeDim latent length).
+        let vocoderLatent: MLMultiArray
+        if padLen == trueLen {
+            vocoderLatent = noisyLatent
+        } else {
+            let denoisedFlat = Supertonic3MultiArray.extractFloats(noisyLatent)
+            let trimmed = Self.trimRows(
+                denoisedFlat, channels: channels, fromLen: padLen, toLen: trueLen)
+            vocoderLatent = try makeFloat(values: trimmed, shape: latentShape)
         }
 
         // --- Stage 4: vocoder --- //
         let vocoderOut = try predict(
             stage: "vocoder",
             model: await store.vocoder(),
-            inputs: ["latent": MLFeatureValue(multiArray: noisyLatent)])
+            inputs: ["latent": MLFeatureValue(multiArray: vocoderLatent)])
         guard let wavArray = vocoderOut.featureValue(for: "wav")?.multiArrayValue else {
             throw Supertonic3Error.inferenceFailed(
                 stage: "vocoder", underlying: "missing 'wav' output")
@@ -213,6 +242,39 @@ struct Supertonic3Synthesizer {
                 stage: "tensor", expected: "\(shape)",
                 got: "len=\(values.count) (\(error))")
         }
+    }
+
+    // MARK: - Bucket padding helpers (channel-major [1, C, L] flattened)
+
+    /// Right-pad each channel row from `fromLen` to `toLen` with zeros.
+    /// Input/output are row-major `[1, channels, len]` flattened (`c*len + t`).
+    static func padRows(_ flat: [Float], channels: Int, fromLen: Int, toLen: Int) -> [Float] {
+        guard toLen > fromLen else { return flat }
+        var out = [Float](repeating: 0, count: channels * toLen)
+        for c in 0..<channels {
+            let src = c * fromLen
+            let dst = c * toLen
+            for t in 0..<fromLen { out[dst + t] = flat[src + t] }
+        }
+        return out
+    }
+
+    /// Trim each channel row from `fromLen` down to `toLen` (drops the padding).
+    static func trimRows(_ flat: [Float], channels: Int, fromLen: Int, toLen: Int) -> [Float] {
+        guard fromLen > toLen else { return flat }
+        var out = [Float](repeating: 0, count: channels * toLen)
+        for c in 0..<channels {
+            let src = c * fromLen
+            let dst = c * toLen
+            for t in 0..<toLen { out[dst + t] = flat[src + t] }
+        }
+        return out
+    }
+
+    /// Right-pad a single `[1, 1, L]` mask row with zeros up to `toLen`.
+    static func padTail(_ flat: [Float], toLen: Int) -> [Float] {
+        guard toLen > flat.count else { return flat }
+        return flat + [Float](repeating: 0, count: toLen - flat.count)
     }
 
     private func makeInt32(values: [Int32], shape: [Int]) throws -> MLMultiArray {

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Manager.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Manager.swift
@@ -39,16 +39,23 @@ public actor Supertonic3Manager {
 
     private let directory: URL?
     private let computeUnits: MLComputeUnits
+    private let vectorEstimatorOption: Supertonic3VectorEstimator
 
     private var store: Supertonic3ModelStore?
     private var synthesizer: Supertonic3Synthesizer?
 
+    /// - Parameters:
+    ///   - vectorEstimator: which VectorEstimator build to download/run. Default
+    ///     `.fp16Dynamic` preserves prior behavior; `.aneBucketed(.int4)` etc.
+    ///     opt into the smaller, ANE-resident fixed-length builds.
     public init(
         directory: URL? = nil,
-        computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
+        vectorEstimator: Supertonic3VectorEstimator = .default
     ) {
         self.directory = directory
         self.computeUnits = computeUnits
+        self.vectorEstimatorOption = vectorEstimator
     }
 
     public var isAvailable: Bool { synthesizer != nil }
@@ -56,11 +63,13 @@ public actor Supertonic3Manager {
     /// Convenience factory: download assets and return a ready-to-use manager.
     public static func downloadAndCreate(
         cacheDirectory: URL? = nil,
-        computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
+        vectorEstimator: Supertonic3VectorEstimator = .default
     ) async throws -> Supertonic3Manager {
         let manager = Supertonic3Manager(
             directory: cacheDirectory,
-            computeUnits: computeUnits)
+            computeUnits: computeUnits,
+            vectorEstimator: vectorEstimator)
         try await manager.initialize()
         return manager
     }
@@ -70,7 +79,8 @@ public actor Supertonic3Manager {
         if synthesizer != nil { return }
 
         let store = Supertonic3ModelStore(
-            directory: directory, computeUnits: computeUnits)
+            directory: directory, computeUnits: computeUnits,
+            vectorEstimator: vectorEstimatorOption)
         try await store.loadIfNeeded()
         let indexerURL = try await store.unicodeIndexerURL()
         let processor = try Supertonic3UnicodeProcessor(unicodeIndexerURL: indexerURL)

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
@@ -58,6 +58,64 @@ public struct Supertonic3Config: Codable, Sendable {
             latentDim: Supertonic3Constants.latentDim))
 }
 
+/// Weight-quantization level for the VectorEstimator stage. All three are
+/// post-training, weight-only compressions that leave placement and speed
+/// unchanged — they only shrink the on-disk / in-memory model:
+///   - `.int8` — linear per-channel symmetric int8 (≈64 MB, transparent).
+///   - `.int6` — 6-bit k-means palettization (≈48 MB, very good).
+///   - `.int4` — 4-bit k-means palettization (≈32 MB, perceptually clean).
+public enum Supertonic3Quantization: String, Sendable, Equatable, CaseIterable {
+    case int8
+    case int6
+    case int4
+}
+
+/// Selects which VectorEstimator build the pipeline downloads and runs.
+///
+/// VectorEstimator is the heaviest stage (run `totalSteps`× per utterance).
+/// Two independent axes — weight precision (size) and shape mode (compute
+/// device):
+///
+/// - `.fp16Dynamic` (default): the original FP16 RangeDim model. Dynamic
+///   shapes ⇒ CPU/GPU; preserves pre-existing behavior.
+/// - `.dynamic(q)`: a weight-quantized RangeDim model. Smaller download, same
+///   placement (dynamic shapes cannot use the ANE).
+/// - `.aneBucketed(q)`: fixed-length L∈{128,256,512} models that land ~94% on
+///   the Neural Engine (~2.7× faster end-to-end). The synthesizer pads each
+///   chunk's latent up to the smallest bucket ≥ its length. Per-chunk length is
+///   bounded by the text chunker, so the 128 bucket covers the common case.
+public enum Supertonic3VectorEstimator: Sendable, Equatable {
+    case fp16Dynamic
+    case dynamic(Supertonic3Quantization)
+    case aneBucketed(Supertonic3Quantization)
+
+    /// Default preserves the historical FP16 dynamic VectorEstimator.
+    public static let `default`: Supertonic3VectorEstimator = .fp16Dynamic
+
+    /// `nil` for FP16; the rawValue (`"int8"`/`"int6"`/`"int4"`) otherwise.
+    var precisionSuffix: String? {
+        switch self {
+        case .fp16Dynamic: return nil
+        case .dynamic(let q), .aneBucketed(let q): return q.rawValue
+        }
+    }
+
+    var isBucketed: Bool {
+        if case .aneBucketed = self { return true }
+        return false
+    }
+
+    /// Variant token passed to `DownloadUtils.downloadRepo` / `getRequiredModelNames`
+    /// so only the selected VectorEstimator file(s) are fetched.
+    var downloadVariant: String? {
+        switch self {
+        case .fp16Dynamic: return nil
+        case .dynamic(let q): return "dyn-\(q.rawValue)"
+        case .aneBucketed(let q): return "ane-\(q.rawValue)"
+        }
+    }
+}
+
 /// The 10 built-in Supertonic-3 voice styles published at
 /// `FluidInference/supertonic-3-coreml/voice_styles/`: female `f1`-`f5`,
 /// male `m1`-`m5`. Fetch one with

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -86,6 +86,9 @@ public struct TTS {
         var supertonicVoiceStylePath: String? = nil
         var supertonicTotalSteps: Int = Supertonic3Constants.defaultTotalSteps
         var supertonicSpeed: Float = Supertonic3Constants.defaultSpeed
+        // VectorEstimator build: fp16 | int8/int6/int4 (ANE-bucketed) |
+        // dyn-int8/dyn-int6/dyn-int4 (dynamic CPU/GPU). Default fp16.
+        var supertonicVE: Supertonic3VectorEstimator = .fp16Dynamic
 
         var i = 0
         while i < arguments.count {
@@ -152,6 +155,18 @@ public struct TTS {
             case "--voice-style":
                 if i + 1 < arguments.count {
                     supertonicVoiceStylePath = arguments[i + 1]
+                    i += 1
+                }
+            case "--ve-variant", "--vector-estimator":
+                if i + 1 < arguments.count {
+                    let raw = arguments[i + 1].lowercased()
+                    if let v = Self.parseSupertonicVE(raw) {
+                        supertonicVE = v
+                    } else {
+                        logger.warning(
+                            "Unknown --ve-variant '\(raw)'; using fp16. "
+                                + "Valid: fp16, int8/int6/int4 (ANE), dyn-int8/dyn-int6/dyn-int4.")
+                    }
                     i += 1
                 }
             case "--total-steps":
@@ -274,6 +289,7 @@ public struct TTS {
                 text: text, output: output, language: supertonicLanguage,
                 voiceStylePath: supertonicVoiceStylePath, voiceName: voice,
                 totalSteps: supertonicTotalSteps, speed: supertonicSpeed,
+                vectorEstimator: supertonicVE,
                 metricsPath: metricsPath, cpuOnly: cpuOnly)
         }
     }
@@ -734,16 +750,31 @@ public struct TTS {
     /// Run Supertonic-3 multilingual TTS. Voice comes from a built-in style
     /// (`--voice F1`..`M5`, downloaded on demand, default `M1`) or an explicit
     /// `--voice-style <file.json>`, which overrides `--voice`.
+    /// Map a `--ve-variant` token to a `Supertonic3VectorEstimator`.
+    private static func parseSupertonicVE(_ raw: String) -> Supertonic3VectorEstimator? {
+        func q(_ s: String) -> Supertonic3Quantization? { Supertonic3Quantization(rawValue: s) }
+        switch raw {
+        case "fp16", "fp16dynamic", "default", "": return .fp16Dynamic
+        case "int8", "int6", "int4", "ane-int8", "ane-int6", "ane-int4":
+            return q(String(raw.split(separator: "-").last!)).map { .aneBucketed($0) }
+        case "dyn-int8", "dyn-int6", "dyn-int4", "dynamic-int8", "dynamic-int6", "dynamic-int4":
+            return q("int" + String(raw.suffix(1))).map { .dynamic($0) }
+        default: return nil
+        }
+    }
+
     private static func runSupertonic3(
         text: String, output: String, language: String,
         voiceStylePath: String?, voiceName: String,
         totalSteps: Int, speed: Float,
+        vectorEstimator: Supertonic3VectorEstimator,
         metricsPath: String?, cpuOnly: Bool
     ) async {
         do {
             let tStart = Date()
             let computeUnits: MLComputeUnits = cpuOnly ? .cpuOnly : .cpuAndNeuralEngine
-            let manager = Supertonic3Manager(computeUnits: computeUnits)
+            let manager = Supertonic3Manager(
+                computeUnits: computeUnits, vectorEstimator: vectorEstimator)
 
             let tLoad0 = Date()
             try await manager.initialize()

--- a/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3BucketPaddingTests.swift
+++ b/Tests/FluidAudioTests/TTS/Supertonic3/Supertonic3BucketPaddingTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Verifies the channel-major pad/trim helpers used to fit a dynamic-length
+/// latent into a fixed ANE bucket and trim it back for the vocoder.
+final class Supertonic3BucketPaddingTests: XCTestCase {
+
+    func testPadRowsZeroFillsEachChannelTail() {
+        // 2 channels, length 3 → length 5. Layout is row-major [c*len + t].
+        let flat: [Float] = [1, 2, 3, 4, 5, 6]  // c0:[1,2,3] c1:[4,5,6]
+        let out = Supertonic3Synthesizer.padRows(flat, channels: 2, fromLen: 3, toLen: 5)
+        XCTAssertEqual(out, [1, 2, 3, 0, 0, 4, 5, 6, 0, 0])
+    }
+
+    func testTrimRowsDropsEachChannelTail() {
+        // 2 channels, length 5 → length 3.
+        let flat: [Float] = [1, 2, 3, 9, 9, 4, 5, 6, 9, 9]
+        let out = Supertonic3Synthesizer.trimRows(flat, channels: 2, fromLen: 5, toLen: 3)
+        XCTAssertEqual(out, [1, 2, 3, 4, 5, 6])
+    }
+
+    func testPadThenTrimRoundTrips() {
+        let channels = 4
+        let trueLen = 7
+        let bucket = 16
+        let flat = (0..<(channels * trueLen)).map { Float($0) }
+        let padded = Supertonic3Synthesizer.padRows(
+            flat, channels: channels, fromLen: trueLen, toLen: bucket)
+        XCTAssertEqual(padded.count, channels * bucket)
+        let restored = Supertonic3Synthesizer.trimRows(
+            padded, channels: channels, fromLen: bucket, toLen: trueLen)
+        XCTAssertEqual(restored, flat)
+    }
+
+    func testPadRowsNoopWhenLengthsEqual() {
+        let flat: [Float] = [1, 2, 3, 4]
+        XCTAssertEqual(
+            Supertonic3Synthesizer.padRows(flat, channels: 2, fromLen: 2, toLen: 2), flat)
+    }
+
+    func testPadTailZeroFillsMask() {
+        let mask: [Float] = [1, 1, 1]
+        XCTAssertEqual(Supertonic3Synthesizer.padTail(mask, toLen: 6), [1, 1, 1, 0, 0, 0])
+        XCTAssertEqual(Supertonic3Synthesizer.padTail(mask, toLen: 3), [1, 1, 1])
+    }
+
+    func testVariantFileNaming() {
+        // FP16 dynamic stays at repo root; variants live under the subdir.
+        XCTAssertEqual(
+            ModelNames.Supertonic3.vectorEstimatorFile(precisionSuffix: nil, bucket: nil),
+            "VectorEstimator.mlmodelc")
+        XCTAssertEqual(
+            ModelNames.Supertonic3.vectorEstimatorFile(precisionSuffix: "int4", bucket: nil),
+            "VectorEstimatorVariants/VectorEstimator_int4.mlmodelc")
+        XCTAssertEqual(
+            ModelNames.Supertonic3.vectorEstimatorFile(precisionSuffix: "int8", bucket: 256),
+            "VectorEstimatorVariants/VectorEstimator_L256_int8.mlmodelc")
+    }
+
+    func testRequiredFilesPerVariant() {
+        let ane = ModelNames.Supertonic3.requiredFiles(veVariant: "ane-int4")
+        XCTAssertTrue(ane.contains("VectorEstimatorVariants/VectorEstimator_L128_int4.mlmodelc"))
+        XCTAssertTrue(ane.contains("VectorEstimatorVariants/VectorEstimator_L256_int4.mlmodelc"))
+        XCTAssertTrue(ane.contains("VectorEstimatorVariants/VectorEstimator_L512_int4.mlmodelc"))
+        XCTAssertFalse(ane.contains("VectorEstimator.mlmodelc"))
+        XCTAssertTrue(ane.contains("TextEncoder.mlmodelc"))  // shared module stays at root
+
+        let dyn = ModelNames.Supertonic3.requiredFiles(veVariant: "dyn-int8")
+        XCTAssertTrue(dyn.contains("VectorEstimatorVariants/VectorEstimator_int8.mlmodelc"))
+        XCTAssertFalse(dyn.contains("VectorEstimator.mlmodelc"))
+
+        let def = ModelNames.Supertonic3.requiredFiles(veVariant: nil)
+        XCTAssertTrue(def.contains("VectorEstimator.mlmodelc"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in **VectorEstimator** selector to the Supertonic-3 TTS pipeline. VectorEstimator is the heaviest stage (run once per denoising step × 8); this lets callers trade size and choose the compute device. Default behavior is unchanged.

Two independent axes:
- **Shape** → compute device. Dynamic (RangeDim) shapes can't use the ANE, so they stay on CPU/GPU. **Fixed-length** builds (L=128/256/512) land ~94–96% on the Neural Engine.
- **Quantization** → size only (placement/latency unchanged). int8 (linear per-channel), int6/int4 (k-means palettization).

```swift
let tts = try await Supertonic3Manager.downloadAndCreate(
    vectorEstimator: .aneBucketed(.int4))   // smallest + ANE
```

| option | model | device | size vs fp16 |
| --- | --- | --- | --- |
| `.fp16Dynamic` (default) | `VectorEstimator` | CPU/GPU | 1× |
| `.dynamic(.int8/.int6/.int4)` | `VectorEstimatorVariants/VectorEstimator_int*` | CPU/GPU | 2× / 2.5× / 3.9× |
| `.aneBucketed(.int8/.int6/.int4)` | `VectorEstimatorVariants/VectorEstimator_L{128,256,512}_int*` | **ANE** | 2× / 2.5× / 3.9× |

## How it works
- `Supertonic3Types`: `Supertonic3VectorEstimator` + `Supertonic3Quantization` enums.
- `ModelNames`: variant filename builder + `requiredFiles(veVariant:)`; variants live under the `VectorEstimatorVariants/` repo subdir, shared modules stay at root. Only the selected file(s) download via the existing variant filter — no cost to the default path.
- `Supertonic3ModelStore`: routes VE compute units (dynamic→CPU/GPU, bucketed→ANE), lazily loads + caches bucket models, `vectorEstimator(forLatentLength:)` picks the smallest bucket ≥ chunk length.
- `Supertonic3Synthesizer`: pads the latent to the bucket before the denoise loop, trims back before the vocoder.
- `TTSCommand`: `--ve-variant fp16|int8|int6|int4|dyn-int8|…` flag.

## Validation
- `swift build` clean; added `Supertonic3BucketPaddingTests` (pad/trim round-trip + variant naming).
- **End-to-end on Apple M5 Pro / macOS 26.5**: `fluidaudiocli tts --backend supertonic3 --ve-variant int4` downloaded the variant files (subfolder layout resolved), lazy-loaded the L128 bucket on `cpuAndNeuralEngine`, and produced valid 3.63 s audio.
- Models published at `FluidInference/supertonic-3-coreml` under `VectorEstimatorVariants/` (manifest updated).

## Notes
- Per-chunk latent length is bounded by the text chunker, so the L128 bucket covers the common case; longer chunks pick 256/512.
- Quality: human A/B listening found int8 closest to fp16 and int4 still perceptually clean (the low waveform SNR vs fp16 is diffusion trajectory divergence, not degradation).