### PR TITLE
feat(tts): M5 benchmark re-baseline + Kokoro ane-tail-gpu (M5 fix) + Supertonic int4 default + PocketTTS v2.1 ANE docs

### DIFF
--- a/Documentation/ANE_Profiler.md
+++ b/Documentation/ANE_Profiler.md
@@ -173,8 +173,8 @@ Latency **measured on real synthesis**, warm (one short sentence; `tts --backend
 | Model | Type | ANE | GPU | CPU | ops | Size | Heavy graph → device |
 |-------|------|----:|----:|----:|----:|-----:|----------------------|
 | Kokoro ANE (7-stage) | batch (per utterance) | 75% | 0% | 25% | 1472 | 83 MB | Vocoder → ANE |
-| Supertonic (default fp16) | batch (8-step diffusion) | 30% | 0% | 70% | 1365 | 192 MB | VectorEstimator → **CPU** (dynamic shapes can't use ANE) |
-| Supertonic (`--ve-variant int4`) | batch (8-step diffusion) | ~90% | 0% | ~10% | 1289 | 102 MB | VectorEstimator → **ANE** (fixed L-buckets) |
+| Supertonic (`--ve-variant fp16`, legacy) | batch (8-step diffusion) | 30% | 0% | 70% | 1365 | 192 MB | VectorEstimator → **CPU** (dynamic shapes can't use ANE) |
+| Supertonic (default, int4 L-bucketed) | batch (8-step diffusion) | ~90% | 0% | ~10% | 1289 | 102 MB | VectorEstimator → **ANE** (fixed L-buckets) |
 | PocketTTS (v2.1) | streaming (autoregressive) | ~9% | ~31% | ~60% | — | ~330 MB | flow_decoder_fused → **ANE**; flowlm/cond → GPU; mimi → CPU |
 
 **Component detail**
@@ -199,15 +199,16 @@ feedback produces audible artifacts on the ANE, and it is compute-bound anyway).
 
 | Component | ANE | GPU | CPU | ops | Size | Lat ms |
 |-----------|----:|----:|----:|----:|-----:|-------:|
-| cond_prefill | 0% | 100% | 0% | n/a¹ | 127 MB | ~5 ms (1× @ 4.8) |
-| flowlm_step (fp16) | 0% | 100% | 0% | 540 | 145 MB | 149 ms (43× @ 3.46) |
+| cond_prefill | 0% | 100% | 0% | 550¹ | 127 MB | ~5 ms (1× @ 4.8) |
+| flowlm_step (fp16) | 0% | 100% | 0% | 556 | 145 MB | 149 ms (43× @ 3.46) |
 | flow_decoder_fused | **100%** | 0% | 0% | 1252 | 18 MB | 46 ms (42× @ 1.09) |
-| mimi_decoder | 0% | 0% | 100% | n/a¹ | 41 MB | 302 ms (42× @ 7.2) |
+| mimi_decoder | 0% | 0% | 100% | 271¹ | 41 MB | 302 ms (42× @ 7.2) |
 | mimi_encoder | _crash_ | n/a | n/a | n/a | 70 MB | voice-clone only |
 
 ¹ `MLComputePlan` crashes on `cond_prefill` (ANE compile) and `mimi_decoder`
-(streaming state), so the per-op split is unavailable; they still run cleanly on
-GPU / CPU respectively.
+(streaming state), so their device split is inferred from the runtime config
+(GPU / CPU) and the op counts are from `model.mil` (non-const ops, the same
+metric MLComputePlan reports — verified equal on the fused decoder: 1252).
 
 > v2.1 cut the per-utterance pipeline ~905 ms → ~452–520 ms (**~1.8× RTFx**),
 > device-verified end-to-end (Whisper exact). Wins: **fused flow decoder** — the
@@ -220,23 +221,23 @@ GPU / CPU respectively.
 > marshalling is only ~0.5 ms/call). `mimi_encoder` still crashes the loader.
 
 ### Supertonic
-`VectorEstimator` runs once per denoising step (default 8) and is the heaviest stage. The **default**
-build uses dynamic (RangeDim) shapes, which Core ML **cannot place on the ANE** — so it runs on CPU.
-The opt-in **fixed-length** builds (`--ve-variant int8|int6|int4`, L = 128/256/512) land ~94% on the
-ANE (~2.7× faster end-to-end); the synthesizer pads each chunk's latent to the nearest bucket. The
-`ANECCompile() FAILED` line emitted for the dynamic build is **non-fatal noise** — the fixed builds
-compile and execute on the ANE (verified M5 Pro / macOS 26.5; see
-[Supertonic3 docs](TTS/Supertonic3.md#vectorestimator-variants)).
+`VectorEstimator` runs once per denoising step (default 8) and is the heaviest stage. The **default is
+now the fixed-length int4 (L-bucketed) build** (`.aneBucketed(.int4)`): ~94% on the ANE, ~2.7× faster
+end-to-end, with 4-bit k-means palettization that is perceptually clean. The synthesizer pads each
+chunk's latent up to the smallest bucket ≥ its length (L ∈ {128, 256, 512}; 128 covers the common
+case). The legacy **fp16 dynamic** build (`--ve-variant fp16`) uses RangeDim shapes Core ML **cannot
+place on the ANE**, so it stays on CPU; the `ANECCompile() FAILED` line it emits is non-fatal noise.
+Verified M5 Pro / macOS 26.5; see [Supertonic3 docs](TTS/Supertonic3.md#vectorestimator-variants).
 
 | Component | ANE | GPU | CPU | ops | Size | Lat ms |
 |-----------|----:|----:|----:|----:|-----:|-------:|
 | TextEncoder | 98% | 0% | 2% | 308 | 18 MB | 1.2 |
 | DurationPredictor | 0% | 0% | 100% | 195 | 2 MB | 2.5 |
-| VectorEstimator (fp16 dynamic, default) | 0% | 0% | 100% | 755 | 123 MB | 89 ms (8× @ 11.1) |
-| VectorEstimator (fixed L128, int4) | 94% | 0% | 6% | 679 | 33 MB | ~31 ms (8× @ 3.8)¹ |
+| VectorEstimator (fp16 dynamic, legacy) | 0% | 0% | 100% | 755 | 123 MB | 89 ms (8× @ 11.1) |
+| VectorEstimator (fixed L128, int4, **default**) | 94% | 0% | 6% | 679 | 33 MB | ~31 ms (8× @ 3.8)² |
 | Vocoder | 100% | 0% | 0% | 107 | 49 MB | 10.5 |
 
-¹ Fixed-build split + per-step latency from `MLComputePlan` + warm CPU-vs-NE timing at L128 (NE 3.8 ms
+² Fixed-build split + per-step latency from `MLComputePlan` + warm CPU-vs-NE timing at L128 (NE 3.8 ms
 vs CPU-only 14.2 ms/step). A cold first call additionally pays a one-time ANE compile.
 
 ---

--- a/Documentation/ANE_Profiler.md
+++ b/Documentation/ANE_Profiler.md
@@ -175,7 +175,7 @@ Latency **measured on real synthesis**, warm (one short sentence; `tts --backend
 | Kokoro ANE (7-stage) | batch (per utterance) | 75% | 0% | 25% | 1472 | 83 MB | Vocoder → ANE |
 | Supertonic (default fp16) | batch (8-step diffusion) | 30% | 0% | 70% | 1365 | 192 MB | VectorEstimator → **CPU** (dynamic shapes can't use ANE) |
 | Supertonic (`--ve-variant int4`) | batch (8-step diffusion) | ~90% | 0% | ~10% | 1289 | 102 MB | VectorEstimator → **ANE** (fixed L-buckets) |
-| PocketTTS | streaming (autoregressive) | 0% | 0% | 100% | 1504 | 606 MB | all stages → CPU (mimi_encoder crashes loader) |
+| PocketTTS (v2.1) | streaming (autoregressive) | ~9% | ~31% | ~60% | — | ~330 MB | flow_decoder_fused → **ANE**; flowlm/cond → GPU; mimi → CPU |
 
 **Component detail**
 
@@ -190,20 +190,34 @@ Latency **measured on real synthesis**, warm (one short sentence; `tts --backend
 | Vocoder | 99% | 0% | 1% | 655 | 47 MB | 71.8 |
 | Tail | 0% | 0% | 100% | 13 | 1 MB | 9.6 |
 
-### PocketTTS
-Autoregressive: stages run many steps per utterance. All on CPU.
+### PocketTTS (v2.1)
+Autoregressive: stages run many steps per utterance. Measured on M-series /
+macOS 26 with the v2.1 optimized packs. Only the fused flow decoder reaches the
+ANE; flowlm/cond run on GPU (the rank-5 KV-cache `scatter` is rejected by the
+ANE compiler at **any** precision), and mimi is CPU (fp16 streaming-state
+feedback produces audible artifacts on the ANE, and it is compute-bound anyway).
 
 | Component | ANE | GPU | CPU | ops | Size | Lat ms |
 |-----------|----:|----:|----:|----:|-----:|-------:|
-| cond_step | 0% | 0% | 100% | 492 | 255 MB | 122 ms (18× @ 6.8) |
-| flowlm_step | 0% | 0% | 100% | 540 | 291 MB | 231 ms (43× @ 5.4) |
-| flow_decoder | 0% | 0% | 100% | 165 | 38 MB | 249 ms (336× @ 0.74) |
-| mimi_decoder | 0% | 0% | 100% | 307 | 22 MB | 302 ms (42× @ 7.2) |
+| cond_prefill | 0% | 100% | 0% | n/a¹ | 127 MB | ~5 ms (1× @ 4.8) |
+| flowlm_step (fp16) | 0% | 100% | 0% | 540 | 145 MB | 149 ms (43× @ 3.46) |
+| flow_decoder_fused | **100%** | 0% | 0% | 1252 | 18 MB | 46 ms (42× @ 1.09) |
+| mimi_decoder | 0% | 0% | 100% | n/a¹ | 41 MB | 302 ms (42× @ 7.2) |
 | mimi_encoder | _crash_ | n/a | n/a | n/a | 70 MB | voice-clone only |
 
-> PocketTTS is an outlier, ~900 ms of CPU work per utterance across four stages, all 100% CPU.
-> `mimi_encoder` runs only for voice cloning (and crashes `MLComputePlan.load`, so its split is
-> unknown). Getting these onto the ANE is future work.
+¹ `MLComputePlan` crashes on `cond_prefill` (ANE compile) and `mimi_decoder`
+(streaming state), so the per-op split is unavailable; they still run cleanly on
+GPU / CPU respectively.
+
+> v2.1 cut the per-utterance pipeline ~905 ms → ~452–520 ms (**~1.8× RTFx**),
+> device-verified end-to-end (Whisper exact). Wins: **fused flow decoder** — the
+> 8-step LSD Euler loop unrolled into one call (336→42 dispatches/utt), and the
+> fat scatter-free fp16 graph flips **0% → 100% ANE** (the single-step kernel was
+> always rejected); **cond_prefill** — whole conditioning block in one call
+> (18→1); **fp16 flowlm**. The earlier "flowlm 1.97× on ANE" claim did **not**
+> reproduce — flowlm is GPU. mimi is the remaining floor (~60% of wall-time),
+> compute-bound (not overhead-bound — an MLState micro-bench showed state
+> marshalling is only ~0.5 ms/call). `mimi_encoder` still crashes the loader.
 
 ### Supertonic
 `VectorEstimator` runs once per denoising step (default 8) and is the heaviest stage. The **default**
@@ -229,9 +243,12 @@ vs CPU-only 14.2 ms/step). A cold first call additionally pays a one-time ANE co
 
 ## Todos 
 
-- [ ] **PocketTTS**: get `cond_step` (255 MB) and `flowlm_step` (291 MB) onto the ANE; file a
-  loader-crash bug for `mimi_encoder` (SIGSEGV in `MLComputePlan.load`). Biggest CPU-bound graphs in
-  the lineup.
+- [x] **PocketTTS (v2.1)**: fused flow decoder is now **100% ANE**. `flowlm`/`cond`
+  **cannot** reach the ANE — the rank-5 KV-cache `scatter` is rejected by the ANE
+  compiler at any precision (verified: fp32/fp16/int8 and a rank-4 split all fail;
+  it's the scatter op, not the shape). mimi is compute-bound on CPU. The remaining
+  lever is **cross-engine pipelining** (overlap mimi-CPU with flowlm-GPU/flow-ANE),
+  not ANE placement. Still open: `mimi_encoder` loader crash (`MLComputePlan.load`).
 
 **profiled is based on model downloads** 
 

--- a/Documentation/ANE_Profiler.md
+++ b/Documentation/ANE_Profiler.md
@@ -203,7 +203,6 @@ feedback produces audible artifacts on the ANE, and it is compute-bound anyway).
 | flowlm_step (fp16) | 0% | 100% | 0% | 556 | 145 MB | 149 ms (43× @ 3.46) |
 | flow_decoder_fused | **100%** | 0% | 0% | 1252 | 18 MB | 46 ms (42× @ 1.09) |
 | mimi_decoder | 0% | 0% | 100% | 271¹ | 41 MB | 302 ms (42× @ 7.2) |
-| mimi_encoder | _crash_ | n/a | n/a | n/a | 70 MB | voice-clone only |
 
 ¹ `MLComputePlan` crashes on `cond_prefill` (ANE compile) and `mimi_decoder`
 (streaming state), so their device split is inferred from the runtime config
@@ -218,7 +217,9 @@ metric MLComputePlan reports — verified equal on the fused decoder: 1252).
 > (18→1); **fp16 flowlm**. The earlier "flowlm 1.97× on ANE" claim did **not**
 > reproduce — flowlm is GPU. mimi is the remaining floor (~60% of wall-time),
 > compute-bound (not overhead-bound — an MLState micro-bench showed state
-> marshalling is only ~0.5 ms/call). `mimi_encoder` still crashes the loader.
+> marshalling is only ~0.5 ms/call). Voice cloning uses the unchanged v2
+> `mimi_encoder` (repo-root, language-agnostic; still crashes
+> `MLComputePlan.load`) — not part of the v2.1 synthesis path.
 
 ### Supertonic
 `VectorEstimator` runs once per denoising step (default 8) and is the heaviest stage. The **default is
@@ -241,12 +242,6 @@ vs CPU-only 14.2 ms/step). A cold first call additionally pays a one-time ANE co
 
 ---
 
-## Todos 
-
-
-**profiled is based on model downloads** 
-
----
 
 ## How to measure
 

--- a/Documentation/ANE_Profiler.md
+++ b/Documentation/ANE_Profiler.md
@@ -175,7 +175,7 @@ Latency **measured on real synthesis**, warm (one short sentence; `tts --backend
 | Kokoro ANE (7-stage) | batch (per utterance) | 75% | 0% | 25% | 1472 | 83 MB | Vocoder → ANE |
 | Supertonic (`--ve-variant fp16`, legacy) | batch (8-step diffusion) | 30% | 0% | 70% | 1365 | 192 MB | VectorEstimator → **CPU** (dynamic shapes can't use ANE) |
 | Supertonic (default, int4 L-bucketed) | batch (8-step diffusion) | ~90% | 0% | ~10% | 1289 | 102 MB | VectorEstimator → **ANE** (fixed L-buckets) |
-| PocketTTS (v2.1) | streaming (autoregressive) | ~9% | ~31% | ~60% | — | ~330 MB | flow_decoder_fused → **ANE**; flowlm/cond → GPU; mimi → CPU |
+| PocketTTS (v2.1) | streaming (autoregressive) | ~9% | ~31% | ~60% | 2629 | ~330 MB | flow_decoder_fused → **ANE**; flowlm/cond → GPU; mimi → CPU |
 
 **Component detail**
 

--- a/Documentation/ANE_Profiler.md
+++ b/Documentation/ANE_Profiler.md
@@ -233,7 +233,6 @@ Verified M5 Pro / macOS 26.5; see [Supertonic3 docs](TTS/Supertonic3.md#vectores
 |-----------|----:|----:|----:|----:|-----:|-------:|
 | TextEncoder | 98% | 0% | 2% | 308 | 18 MB | 1.2 |
 | DurationPredictor | 0% | 0% | 100% | 195 | 2 MB | 2.5 |
-| VectorEstimator (fp16 dynamic, legacy) | 0% | 0% | 100% | 755 | 123 MB | 89 ms (8× @ 11.1) |
 | VectorEstimator (fixed L128, int4, **default**) | 94% | 0% | 6% | 679 | 33 MB | ~31 ms (8× @ 3.8)² |
 | Vocoder | 100% | 0% | 0% | 107 | 49 MB | 10.5 |
 
@@ -244,12 +243,6 @@ vs CPU-only 14.2 ms/step). A cold first call additionally pays a one-time ANE co
 
 ## Todos 
 
-- [x] **PocketTTS (v2.1)**: fused flow decoder is now **100% ANE**. `flowlm`/`cond`
-  **cannot** reach the ANE — the rank-5 KV-cache `scatter` is rejected by the ANE
-  compiler at any precision (verified: fp32/fp16/int8 and a rank-4 split all fail;
-  it's the scatter op, not the shape). mimi is compute-bound on CPU. The remaining
-  lever is **cross-engine pipelining** (overlap mimi-CPU with flowlm-GPU/flow-ANE),
-  not ANE placement. Still open: `mimi_encoder` loader crash (`MLComputePlan.load`).
 
 **profiled is based on model downloads** 
 

--- a/Documentation/TTS/Benchmarks.md
+++ b/Documentation/TTS/Benchmarks.md
@@ -1,19 +1,19 @@
 # TTS Benchmarks
 
 > **Setup:** Apple M5 Pro, 24 GB, macOS 26.5 (25F71), on AC.
-> Kokoro ANE and StyleTTS2 rows are carried from the M2 reference
-> (MacBook Air M2, 16 GB) — they cannot run on this M5 host (see the
-> Kokoro libBNNS and StyleTTS2 asset footnotes below).
+> Kokoro ANE runs on M5 with `--compute-units ane-tail-gpu` (the
+> `default`/`all-ane` paths crash — see the ᴷ footnote). Only the
+> StyleTTS2 row is carried from the M2 reference (MacBook Air M2,
+> 16 GB), pending a HF asset fix (see the ˢ footnote below).
 > **Corpus:** [MiniMax Multilingual TTS Test Set][minimax] (100
 > phrases / language, CC-BY-SA-4.0) — the same public corpus used
 > by [MiniMax-Speech][mms], seed-tts-eval, and Gradium, so numbers
 > here are directly paper-comparable.
-> **Status:** PocketTTS (English), Magpie (English), and Supertonic-3
-> (English) complete the full 100-phrase MiniMax run on **M5 Pro**.
-> Kokoro ANE (English + Mandarin) and StyleTTS2 (English, zero-shot)
-> are **M2-only** here — Kokoro segfaults inside Apple's `libBNNS`
-> on M5/macOS 26.5 and StyleTTS2's bucketed BERT assets ship without
-> `model.mil`; both rows carry their M2 numbers.
+> **Status:** Kokoro ANE (English + Mandarin), PocketTTS (English),
+> Magpie (English), and Supertonic-3 (English) all complete the full
+> 100-phrase MiniMax run on **M5 Pro** (Kokoro via the `ane-tail-gpu`
+> preset). Only **StyleTTS2** is **M2-only** here — its bucketed BERT
+> assets ship without `model.mil`; that row carries its M2 numbers.
 >
 > [minimax]: https://huggingface.co/datasets/MiniMaxAI/TTS-Multilingual-Test-Set
 > [mms]: https://arxiv.org/abs/2505.07916
@@ -165,19 +165,18 @@ Mandarin (or any of the 14 Cohere languages) against
 ### Per-backend top-line
 
 Reference machine: **Apple M5 Pro, 24 GB unified memory, macOS 26.5
-(`25F71`), on AC** for the PocketTTS, Magpie, and Supertonic-3 rows.
-The **Kokoro ANE** (en + zh) and **StyleTTS2** rows are carried from
-the prior **MacBook Air, Apple M2 (2022), 8-core CPU / 8-core GPU /
-16-core Neural Engine, 16 GB, macOS 26** (`Mac14,2`) reference —
-they do not run on the M5 host (Kokoro: Apple `libBNNS` SIGSEGV on
-longer phrases in every compute mode; StyleTTS2: missing `model.mil`
-in the shipped bucketed BERT graphs — see footnotes ᴷ / ˢ). M5
-rows use `--compute-units default`; M2 rows used `--compute-units
-default` on M2. 100 phrases per language. Voices are backend defaults
-(`af_heart` for Kokoro ANE en, `zf_001` for Kokoro ANE zh,
-`alba` for PocketTTS, `John` for Magpie, LibriTTS iteration_3 for
-StyleTTS2). English WER / CER via Parakeet TDT roundtrip; Mandarin
-CER via `whisper-large-v3`.
+(`25F71`), on AC** for the Kokoro ANE, PocketTTS, Magpie, and
+Supertonic-3 rows. Only the **StyleTTS2** row is carried from the
+prior **MacBook Air, Apple M2 (2022), 8-core CPU / 8-core GPU /
+16-core Neural Engine, 16 GB, macOS 26** (`Mac14,2`) reference — it
+does not run on the M5 host (missing `model.mil` in the shipped
+bucketed BERT graphs — see footnote ˢ). M5 rows use `--compute-units
+default`, **except Kokoro ANE which uses `ane-tail-gpu`** (the only
+preset that runs on M5/macOS 26.5 — see footnote ᴷ). 100 phrases per
+language. Voices are backend defaults (`af_heart` for Kokoro ANE en,
+`zf_001` for Kokoro ANE zh, `alba` for PocketTTS, `John` for Magpie,
+LibriTTS iteration_3 for StyleTTS2). English WER / CER via Parakeet
+TDT roundtrip; Mandarin CER via `whisper-large-v3-turbo`.
 
 One consolidated table per backend × language. **Basic info**
 (license, language, footprint, sample rate, max chunk per pass,
@@ -186,26 +185,26 @@ peak RSS, WER, CER) so there is a single source of truth.
 
 | Backend    | License    | Language (voice)          | Footprint                  | Sample rate | Max chunk per pass                                               | Streaming | TTFT p50 / p95\*  | Synth p50 / p95   | Agg RTFx  | Peak RSS | WER    | CER    |
 |------------|------------|---------------------------|----------------------------|-------------|------------------------------------------------------------------|-----------|-------------------|-------------------|-----------|----------|--------|--------|
-| Kokoro ANE (M2)ᴷ | Apache-2.0 | en (`af_heart`)           | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **988 / 2068 ms** | 988 / 2068 ms     | **7.47×** | 1027 MB  | 10.8%  | 4.0%   |
-| Kokoro ANE (M2)ᴷ | Apache-2.0 | zh (`zf_001`)             | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **956 / 1802 ms** | 956 / 1802 ms     | 6.37×     | 685 MB   | n/a‡   | 4.0%‡  |
+| Kokoro ANEᴷ | Apache-2.0 | en (`af_heart`)           | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **314 / 410 ms** | 314 / 410 ms     | **25.4×**ᴷ | 734 MB   | 10.33% | 3.72%  |
+| Kokoro ANEᴷ | Apache-2.0 | zh (`zf_001`)             | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **201 / 286 ms** | 201 / 286 ms     | 20.1×ᴷ     | 761 MB   | n/a‡   | 3.81%‡ |
 | PocketTTS (v2.1) | research   | en (`alba`, 6L pack)      | fp16 ~330 MB | 24 kHz      | 80 ms Mimi frame, streams until EOS (no fixed cap)               | Yes       | **26 / 27 ms** | 933 / 1233 ms    | **6.51×** | 761 MB   | 0.51%  | 0.08%  |
 | Magpie     | research   | en (`John`)               | ~1.3 GB                    | 22.05 kHz   | 256 NanoCodec frames / pass (≈11.9 s); sentence-split for longer | No        | 3765 / 12110 ms∥ | 3765 / 12110 ms∥ | 2.34×∥    | 832 MB∥  | 3.98%  | 2.44%  |
 | StyleTTS2 (M2)ˢ | research   | en (LibriTTS iteration_3) | ~0.67 GB¶                  | 24 kHz      | 256 tokens / pass (≈30 s of audio max)                           | No        | 1574 / 3088 ms    | 1574 / 3088 ms    | 4.59×     | 522 MB   | 9.4%   | 4.1%   |
 | Supertonic-3 (int4) | Apache-2.0 | en (`M1`, 31-lang)        | int4 ~0.10 GB                   | 44.1 kHz    | 128 codepoints / pass (chunker splits ≥110 char Latin / 90 CJK)  | No        | **80 / 86 ms** | 80 / 86 ms     | **118×** | 201 MB   | 6.86%ᶜ | 4.08%ᶜ |
 
-ᴷ **Kokoro ANE (M2)** — numbers carried from the M2 reference. Kokoro
-**cannot be benchmarked on this M5 Pro / macOS 26.5 host**: a *single*
-synthesis works (verified, correct audio, en + zh), but the **2nd+
-prediction in a process crashes** — even for the identical short
-phrase. The mode depends on routing: `--compute-units default` hits a
-GPU `MetalPerformanceShadersGraph GPURNNOps … 'JIT not supported'`
-assert (SIGABRT) on the prosody RNN; `all-ane` / `cpu-only` segfault in
-`libBNNS.dylib` (`BnnsCpuInferenceOperation::ExecuteSync`, SIGSEGV,
-nondeterministic). It is not phrase-length, not ASR contention, and no
-compute-unit routing avoids it — an Apple-framework instability on
-repeated dynamic-shape predictions, not fixable from FluidAudio.
-Tracked in [#667][i667]. Re-baseline once Apple ships a fix (or the
-Kokoro graphs are re-exported with bucketed shapes).
+ᴷ **Kokoro ANE on M5** is measured with **`--compute-units
+ane-tail-gpu`**, which is required on M5 / macOS 26.5: the stock
+routings crash on the 2nd+ prediction in a process (`default` → GPU
+`MetalPerformanceShadersGraph GPURNNOps … 'JIT not supported'` on the
+prosody RNN; `all-ane`/`cpu-only` → `libBNNS` SIGSEGV on the tail
+iSTFT). The `ane-tail-gpu` preset pins every stage to
+`.cpuAndNeuralEngine` **except the tail (iSTFT) → `.cpuAndGPU`**,
+keeping the RNN off the GPU while keeping the iSTFT off BNNS — which
+dodges both crashes with dynamic shapes. Quality matches the prior M2
+baseline (en WER 10.33% vs 10.8%; zh CER 3.81% vs 4.01%), confirming
+the routing change is numerically faithful. The underlying Apple bug
+(stock routings) is tracked in [#667][i667]; the preset shipped in
+`TtsComputeUnitPreset.aneTailGpu`.
 
 ᶜ **Supertonic-3 (int4)** is measured on **M5 Pro / macOS 26.5** with
 the default **int4 L-bucketed (ANE) VectorEstimator**. The int4-ANE
@@ -229,17 +228,14 @@ one-shot per phrase (no streaming yield on `main`), so for those
 rows `ttft_ms == synth_ms == time-to-complete-wav`.
 
 ‡ Kokoro ANE Mandarin CER measured on the **full 100-phrase**
-`minimax-chinese` corpus via `whisper-large-v3` (Python CPU FP32,
-[`Scripts/whisper_zh_cer.py`](../../Scripts/whisper_zh_cer.py))
+`minimax-chinese` corpus via `mlx-community/whisper-large-v3-turbo`
 against the WAVs rendered by `tts-benchmark --backend kokoro-ane
 --variant mandarin --voice zf_001 --corpus minimax-chinese
---skip-asr`: **macro CER 4.01% (0.0401)**, **micro CER 4.14%
-(0.0414)** across 100 phrases (table reports the macro figure).
-WER is omitted because Mandarin has no word boundaries and
-`WERCalculator` splits on whitespace — word-level WER reads near
-100% and is meaningless. Cohere Transcribe q8 hit a
-`MILCompilerForANE` cache failure on this M2 host, so whisper is
-the local source of truth for Mandarin CER.
+--compute-units ane-tail-gpu --skip-asr`: **macro CER 3.81% (M5 Pro /
+macOS 26.5)**, in line with the prior M2 baseline (4.01%). WER is
+omitted because Mandarin has no word boundaries and `WERCalculator`
+splits on whitespace — word-level WER reads near 100% and is
+meaningless.
 
 ∥ Magpie: batch-only. `synthesize(...)` returns one
 `MagpieSynthesisResult` after the full AR + codec pipeline completes,
@@ -271,8 +267,11 @@ files are re-uploaded.
 ### Kokoro ANE — per-stage breakdown (default preset, MiniMax-English)
 
 Means across 100 `minimax-english` phrases on M2 (`af_heart`,
-post-laishere 7-graph chain). Stages map to the 7-CoreML-graph split
-documented in [KokoroAne.md](KokoroAne.md). Vocoder + noise together
+post-laishere 7-graph chain, `default` preset). On M5 / macOS 26.5 the
+main table uses the `ane-tail-gpu` preset (tail iSTFT on GPU instead of
+the default routing — see footnote ᴷ), so the per-stage split there
+differs. Stages map to the 7-CoreML-graph split documented in
+[KokoroAne.md](KokoroAne.md). Vocoder + noise together
 account for ~90% of synth time, which is the natural target for any
 further per-stage compute-unit re-tuning.
 

--- a/Documentation/TTS/Benchmarks.md
+++ b/Documentation/TTS/Benchmarks.md
@@ -176,10 +176,20 @@ peak RSS, WER, CER) so there is a single source of truth.
 |------------|------------|---------------------------|----------------------------|-------------|------------------------------------------------------------------|-----------|-------------------|-------------------|-----------|----------|--------|--------|
 | Kokoro ANE | Apache-2.0 | en (`af_heart`)           | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **988 / 2068 ms** | 988 / 2068 ms     | **7.47×** | 1027 MB  | 10.8%  | 4.0%   |
 | Kokoro ANE | Apache-2.0 | zh (`zf_001`)             | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **956 / 1802 ms** | 956 / 1802 ms     | 6.37×     | 685 MB   | n/a‡   | 4.0%‡  |
-| PocketTTS  | research   | en (`alba`, 6L pack)      | int8 ~0.55 GB | 24 kHz      | 80 ms Mimi frame, streams until EOS (no fixed cap)               | Yes       | **710 / 1496 ms** | 5160 / 9801 ms    | 1.10×     | 1167 MB  | 1.0%   | 0.4%   |
+| PocketTTS (v2.1)◆ | research   | en (`alba`, 6L pack)      | fp16 ~330 MB | 24 kHz      | 80 ms Mimi frame, streams until EOS (no fixed cap)               | Yes       | **22 / 27 ms** | 987 / 1343 ms    | **6.18×**◆ | 696 MB◆  | 1.0%◆  | 0.4%◆  |
 | Magpie     | research   | en (`John`)               | ~1.3 GB                    | 22.05 kHz   | 256 NanoCodec frames / pass (≈11.9 s); sentence-split for longer | No        | 11470 / 26042 ms∥ | 11470 / 26042 ms∥ | 0.87×∥    | 543 MB∥  | 3.8%   | 2.6%   |
 | StyleTTS2  | research   | en (LibriTTS iteration_3) | ~0.67 GB¶                  | 24 kHz      | 256 tokens / pass (≈30 s of audio max)                           | No        | 1574 / 3088 ms    | 1574 / 3088 ms    | 4.59×     | 522 MB   | 9.4%   | 4.1%   |
 | Supertonic-3 | Apache-2.0 | en (`M1`, 31-lang)        | ~0.40 GB                   | 44.1 kHz    | 128 codepoints / pass (chunker splits ≥110 char Latin / 90 CJK)  | No        | **479 / 6491 ms** | 479 / 6491 ms     | 5.55×     | 679 MB   | 0.8%   | 0.3%   |
+
+◆ **PocketTTS (v2.1)** is the only row measured on **M5 Pro / macOS 26** with
+the optimized v2.1 packs (fused flow decoder on the ANE + one-shot cond_prefill
++ fp16 flowlm) — **not** the M2 reference, so its TTFT / synth / RTFx are **not
+directly comparable** to the M2 rows above (chip *and* code differ). On M5 Pro,
+cond_prefill collapses TTFT from ~710 ms (v2) to ~22 ms and agg RTFx is 6.18×
+(100 phrases). WER/CER are carried from the v2 run (identical weights; fp16
+intelligibility device-verified via Whisper, e.g. "Hello, this is a
+text-to-speech system." exact) and were **not** re-scored with ASR here. Re-run
+on the M2 reference for a row comparable to the others.
 
 \* TTFT for **PocketTTS** is first-frame emit through the streaming
 API (perceptual TTFA). **Kokoro ANE / Magpie / StyleTTS2** all run

--- a/Documentation/TTS/Benchmarks.md
+++ b/Documentation/TTS/Benchmarks.md
@@ -179,7 +179,7 @@ peak RSS, WER, CER) so there is a single source of truth.
 | PocketTTS (v2.1)◆ | research   | en (`alba`, 6L pack)      | fp16 ~330 MB | 24 kHz      | 80 ms Mimi frame, streams until EOS (no fixed cap)               | Yes       | **22 / 27 ms** | 987 / 1343 ms    | **6.18×**◆ | 696 MB◆  | 1.0%◆  | 0.4%◆  |
 | Magpie     | research   | en (`John`)               | ~1.3 GB                    | 22.05 kHz   | 256 NanoCodec frames / pass (≈11.9 s); sentence-split for longer | No        | 11470 / 26042 ms∥ | 11470 / 26042 ms∥ | 0.87×∥    | 543 MB∥  | 3.8%   | 2.6%   |
 | StyleTTS2  | research   | en (LibriTTS iteration_3) | ~0.67 GB¶                  | 24 kHz      | 256 tokens / pass (≈30 s of audio max)                           | No        | 1574 / 3088 ms    | 1574 / 3088 ms    | 4.59×     | 522 MB   | 9.4%   | 4.1%   |
-| Supertonic-3 | Apache-2.0 | en (`M1`, 31-lang)        | ~0.40 GB                   | 44.1 kHz    | 128 codepoints / pass (chunker splits ≥110 char Latin / 90 CJK)  | No        | **479 / 6491 ms** | 479 / 6491 ms     | 5.55×     | 679 MB   | 0.8%   | 0.3%   |
+| Supertonic-3 (int4)✦ | Apache-2.0 | en (`M1`, 31-lang)        | int4 ~0.10 GB                   | 44.1 kHz    | 128 codepoints / pass (chunker splits ≥110 char Latin / 90 CJK)  | No        | **79 / 84 ms** | 79 / 84 ms     | **119×**✦ | 297 MB✦  | 0.8%✦  | 0.3%✦  |
 
 ◆ **PocketTTS (v2.1)** is the only row measured on **M5 Pro / macOS 26** with
 the optimized v2.1 packs (fused flow decoder on the ANE + one-shot cond_prefill
@@ -190,6 +190,15 @@ cond_prefill collapses TTFT from ~710 ms (v2) to ~22 ms and agg RTFx is 6.18×
 intelligibility device-verified via Whisper, e.g. "Hello, this is a
 text-to-speech system." exact) and were **not** re-scored with ASR here. Re-run
 on the M2 reference for a row comparable to the others.
+
+✦ **Supertonic-3 (int4)** uses the new default **int4 L-bucketed (ANE)
+VectorEstimator** and is measured on **M5 Pro / macOS 26**, not the M2 reference
+— **not directly comparable** to the M2 rows above. On M5 Pro the int4-ANE
+VectorEstimator drops per-phrase synth to ~79 ms (agg RTFx 119× over 100
+phrases) vs the prior fp16-dynamic-on-CPU path (5.55× on M2). WER/CER shown are
+the prior **fp16** figures (0.8% / 0.3%); the int4 build was **not** re-scored
+with ASR here (4-bit k-means palettization is documented perceptually clean).
+Re-run on the M2 reference for a row comparable to the others.
 
 \* TTFT for **PocketTTS** is first-frame emit through the streaming
 API (perceptual TTFA). **Kokoro ANE / Magpie / StyleTTS2** all run

--- a/Documentation/TTS/Benchmarks.md
+++ b/Documentation/TTS/Benchmarks.md
@@ -190,7 +190,7 @@ peak RSS, WER, CER) so there is a single source of truth.
 | PocketTTS (v2.1) | research   | en (`alba`, 6L pack)      | fp16 ~330 MB | 24 kHz      | 80 ms Mimi frame, streams until EOS (no fixed cap)               | Yes       | **26 / 27 ms** | 933 / 1233 ms    | **6.51×** | 761 MB   | 0.51%  | 0.08%  |
 | Magpie     | research   | en (`John`)               | ~1.3 GB                    | 22.05 kHz   | 256 NanoCodec frames / pass (≈11.9 s); sentence-split for longer | No        | 3765 / 12110 ms∥ | 3765 / 12110 ms∥ | 2.34×∥    | 832 MB∥  | 3.98%  | 2.44%  |
 | StyleTTS2 (M2)ˢ | research   | en (LibriTTS iteration_3) | ~0.67 GB¶                  | 24 kHz      | 256 tokens / pass (≈30 s of audio max)                           | No        | 1574 / 3088 ms    | 1574 / 3088 ms    | 4.59×     | 522 MB   | 9.4%   | 4.1%   |
-| Supertonic-3 (int4) | Apache-2.0 | en (`M1`, 31-lang)        | int4 ~0.10 GB                   | 44.1 kHz    | 128 codepoints / pass (chunker splits ≥110 char Latin / 90 CJK)  | No        | **80 / 86 ms** | 80 / 86 ms     | **118×** | 201 MB   | 6.86%ᶜ | 4.08%ᶜ |
+| Supertonic-3 (int4) | Apache-2.0 | en (`M1`, 31-lang)        | int4 ~0.10 GB                   | 44.1 kHz    | 128 codepoints / pass (chunker splits ≥70 char Latin / 90 CJK)   | No        | **81 / 120 ms** | 81 / 120 ms     | **94×** | 197 MB   | 1.02%ᶜ | 0.31%ᶜ |
 
 ᴷ **Kokoro ANE on M5** is measured with **`--compute-units
 ane-tail-gpu`**, which is required on M5 / macOS 26.5: the stock
@@ -208,19 +208,18 @@ the routing change is numerically faithful. The underlying Apple bug
 
 ᶜ **Supertonic-3 (int4)** is measured on **M5 Pro / macOS 26.5** with
 the default **int4 L-bucketed (ANE) VectorEstimator**. The int4-ANE
-path drops per-phrase synth to ~80 ms (agg RTFx 118× over 100 phrases)
-vs the prior fp16-dynamic-on-CPU path (5.55× on M2 — the speedup is the
-elimination of per-length MPSGraph recompiles, not a chip effect). The
-**6.86% WER / 4.08% CER are the actual M5 Parakeet roundtrip** on
-`minimax-english` — a regression from the **0.84% measured on M2**
-(see the per-language table below, same corpus, long phrases present).
-**int4 is not the cause**: on M5, fp16 (7.02%), int8 (6.15%), int6
-(6.36%), and int4 (6.86%) all land in the same band. The error is
-concentrated in the **chunker**: single-chunk phrases (<110 char) score
-**3.88% WER** while multi-chunk phrases (≥110 char) score **8.77%**,
-with garbling at chunk seams ("hot air"→"Hudir"). Whether the M2→M5
-regression is an Apple-framework numerical change or a chunker code
-change since the M2 run is under investigation in [#669][i669].
+path drops per-phrase synth to ~80 ms vs the prior fp16-dynamic-on-CPU
+path (5.55× on M2 — the speedup is the elimination of per-length
+MPSGraph recompiles, not a chip effect). **WER 1.02% / CER 0.31%** —
+restored to the M2 baseline (~0.84% / 0.3%) by the chunker fix in
+[#669][i669]: the model degrades as a chunk approaches the 110-char /
+128-token window (a 105-char *single* chunk scored 17.6% WER; a 71-char
+chunk scored 0%), so `maxChunkLengthLatin` was lowered 110 → 70, keeping
+every chunk in the clean regime. This cost ~20% RTFx (118× → 94×) but
+cut macro WER from 6.86% to 1.02% — and confirmed the earlier "6.86%"
+was chunk length, **not** an M2→M5 regression and **not** the int4
+quantization (fp16/int8/int6 all scored the same 6–7% band at maxLen
+110).
 
 \* TTFT for **PocketTTS** is first-frame emit through the streaming
 API (perceptual TTFA). **Kokoro ANE / Magpie / StyleTTS2** all run
@@ -303,11 +302,13 @@ Same harness, same `M1.json` voice style, same default
 (`--total-steps 8 --speed 1.05 --compute-units default`). All 10
 languages complete the full 100-phrase `minimax-<lang>` run.
 
-> **Note (M2 vs M5):** this breakdown is the **M2** run. On **M5 Pro /
-> macOS 26.5** the English WER regresses to **6.86%** (vs **0.84%**
-> here) — concentrated in chunker-split phrases and independent of
-> VectorEstimator precision. See the ᶜ footnote and [#669][i669]
-> before treating the per-language WER/CER as current on M5.
+> **Note (M2 vs M5):** this breakdown is the **M2** run at the old
+> 110-char chunk cap. On **M5 Pro / macOS 26.5** with the int4 default
+> and the [#669][i669] chunker fix (`maxChunkLengthLatin` 110 → 70),
+> English scores **WER 1.02% / CER 0.31%** — in line with the 0.84% /
+> 0.32% here. The per-language non-English rows below have **not** been
+> re-measured with the shorter chunk cap; expect a similar improvement
+> on the longer-phrase languages.
 
 WER / CER for English is from the in-process Parakeet TDT
 roundtrip. The nine non-English rows were synthesized with

--- a/Documentation/TTS/Benchmarks.md
+++ b/Documentation/TTS/Benchmarks.md
@@ -1,13 +1,19 @@
 # TTS Benchmarks
 
-> **Setup:** MacBook Air M2 (2022), 16 GB, macOS 26, on AC.
+> **Setup:** Apple M5 Pro, 24 GB, macOS 26.5 (25F71), on AC.
+> Kokoro ANE and StyleTTS2 rows are carried from the M2 reference
+> (MacBook Air M2, 16 GB) — they cannot run on this M5 host (see the
+> Kokoro libBNNS and StyleTTS2 asset footnotes below).
 > **Corpus:** [MiniMax Multilingual TTS Test Set][minimax] (100
 > phrases / language, CC-BY-SA-4.0) — the same public corpus used
 > by [MiniMax-Speech][mms], seed-tts-eval, and Gradium, so numbers
 > here are directly paper-comparable.
-> **Status:** Kokoro ANE (English + Mandarin), PocketTTS (English),
-> Magpie (English), StyleTTS2 (English, zero-shot), and Supertonic-3
-> (English) all complete the full 100-phrase MiniMax run.
+> **Status:** PocketTTS (English), Magpie (English), and Supertonic-3
+> (English) complete the full 100-phrase MiniMax run on **M5 Pro**.
+> Kokoro ANE (English + Mandarin) and StyleTTS2 (English, zero-shot)
+> are **M2-only** here — Kokoro segfaults inside Apple's `libBNNS`
+> on M5/macOS 26.5 and StyleTTS2's bucketed BERT assets ship without
+> `model.mil`; both rows carry their M2 numbers.
 >
 > [minimax]: https://huggingface.co/datasets/MiniMaxAI/TTS-Multilingual-Test-Set
 > [mms]: https://arxiv.org/abs/2505.07916
@@ -158,10 +164,16 @@ Mandarin (or any of the 14 Cohere languages) against
 
 ### Per-backend top-line
 
-Reference machine: **MacBook Air, Apple M2 (2022), 8-core CPU /
-8-core GPU / 16-core Neural Engine, 16 GB unified memory, macOS 26**
-(`Mac14,2`, on AC). All runs use `--compute-units default`, 100
-phrases per language. Voices are backend defaults
+Reference machine: **Apple M5 Pro, 24 GB unified memory, macOS 26.5
+(`25F71`), on AC** for the PocketTTS, Magpie, and Supertonic-3 rows.
+The **Kokoro ANE** (en + zh) and **StyleTTS2** rows are carried from
+the prior **MacBook Air, Apple M2 (2022), 8-core CPU / 8-core GPU /
+16-core Neural Engine, 16 GB, macOS 26** (`Mac14,2`) reference —
+they do not run on the M5 host (Kokoro: Apple `libBNNS` SIGSEGV on
+longer phrases in every compute mode; StyleTTS2: missing `model.mil`
+in the shipped bucketed BERT graphs — see footnotes ᴷ / ˢ). M5
+rows use `--compute-units default`; M2 rows used `--compute-units
+default` on M2. 100 phrases per language. Voices are backend defaults
 (`af_heart` for Kokoro ANE en, `zf_001` for Kokoro ANE zh,
 `alba` for PocketTTS, `John` for Magpie, LibriTTS iteration_3 for
 StyleTTS2). English WER / CER via Parakeet TDT roundtrip; Mandarin
@@ -174,31 +186,38 @@ peak RSS, WER, CER) so there is a single source of truth.
 
 | Backend    | License    | Language (voice)          | Footprint                  | Sample rate | Max chunk per pass                                               | Streaming | TTFT p50 / p95\*  | Synth p50 / p95   | Agg RTFx  | Peak RSS | WER    | CER    |
 |------------|------------|---------------------------|----------------------------|-------------|------------------------------------------------------------------|-----------|-------------------|-------------------|-----------|----------|--------|--------|
-| Kokoro ANE | Apache-2.0 | en (`af_heart`)           | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **988 / 2068 ms** | 988 / 2068 ms     | **7.47×** | 1027 MB  | 10.8%  | 4.0%   |
-| Kokoro ANE | Apache-2.0 | zh (`zf_001`)             | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **956 / 1802 ms** | 956 / 1802 ms     | 6.37×     | 685 MB   | n/a‡   | 4.0%‡  |
-| PocketTTS (v2.1)◆ | research   | en (`alba`, 6L pack)      | fp16 ~330 MB | 24 kHz      | 80 ms Mimi frame, streams until EOS (no fixed cap)               | Yes       | **22 / 27 ms** | 987 / 1343 ms    | **6.18×**◆ | 696 MB◆  | 1.0%◆  | 0.4%◆  |
-| Magpie     | research   | en (`John`)               | ~1.3 GB                    | 22.05 kHz   | 256 NanoCodec frames / pass (≈11.9 s); sentence-split for longer | No        | 11470 / 26042 ms∥ | 11470 / 26042 ms∥ | 0.87×∥    | 543 MB∥  | 3.8%   | 2.6%   |
-| StyleTTS2  | research   | en (LibriTTS iteration_3) | ~0.67 GB¶                  | 24 kHz      | 256 tokens / pass (≈30 s of audio max)                           | No        | 1574 / 3088 ms    | 1574 / 3088 ms    | 4.59×     | 522 MB   | 9.4%   | 4.1%   |
-| Supertonic-3 (int4)✦ | Apache-2.0 | en (`M1`, 31-lang)        | int4 ~0.10 GB                   | 44.1 kHz    | 128 codepoints / pass (chunker splits ≥110 char Latin / 90 CJK)  | No        | **79 / 84 ms** | 79 / 84 ms     | **119×**✦ | 297 MB✦  | 0.8%✦  | 0.3%✦  |
+| Kokoro ANE (M2)ᴷ | Apache-2.0 | en (`af_heart`)           | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **988 / 2068 ms** | 988 / 2068 ms     | **7.47×** | 1027 MB  | 10.8%  | 4.0%   |
+| Kokoro ANE (M2)ᴷ | Apache-2.0 | zh (`zf_001`)             | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **956 / 1802 ms** | 956 / 1802 ms     | 6.37×     | 685 MB   | n/a‡   | 4.0%‡  |
+| PocketTTS (v2.1) | research   | en (`alba`, 6L pack)      | fp16 ~330 MB | 24 kHz      | 80 ms Mimi frame, streams until EOS (no fixed cap)               | Yes       | **26 / 27 ms** | 933 / 1233 ms    | **6.51×** | 761 MB   | 0.51%  | 0.08%  |
+| Magpie     | research   | en (`John`)               | ~1.3 GB                    | 22.05 kHz   | 256 NanoCodec frames / pass (≈11.9 s); sentence-split for longer | No        | 3765 / 12110 ms∥ | 3765 / 12110 ms∥ | 2.34×∥    | 832 MB∥  | 3.98%  | 2.44%  |
+| StyleTTS2 (M2)ˢ | research   | en (LibriTTS iteration_3) | ~0.67 GB¶                  | 24 kHz      | 256 tokens / pass (≈30 s of audio max)                           | No        | 1574 / 3088 ms    | 1574 / 3088 ms    | 4.59×     | 522 MB   | 9.4%   | 4.1%   |
+| Supertonic-3 (int4) | Apache-2.0 | en (`M1`, 31-lang)        | int4 ~0.10 GB                   | 44.1 kHz    | 128 codepoints / pass (chunker splits ≥110 char Latin / 90 CJK)  | No        | **80 / 86 ms** | 80 / 86 ms     | **118×** | 201 MB   | 6.86%ᶜ | 4.08%ᶜ |
 
-◆ **PocketTTS (v2.1)** is the only row measured on **M5 Pro / macOS 26** with
-the optimized v2.1 packs (fused flow decoder on the ANE + one-shot cond_prefill
-+ fp16 flowlm) — **not** the M2 reference, so its TTFT / synth / RTFx are **not
-directly comparable** to the M2 rows above (chip *and* code differ). On M5 Pro,
-cond_prefill collapses TTFT from ~710 ms (v2) to ~22 ms and agg RTFx is 6.18×
-(100 phrases). WER/CER are carried from the v2 run (identical weights; fp16
-intelligibility device-verified via Whisper, e.g. "Hello, this is a
-text-to-speech system." exact) and were **not** re-scored with ASR here. Re-run
-on the M2 reference for a row comparable to the others.
+ᴷ **Kokoro ANE (M2)** — numbers carried from the M2 reference. Kokoro
+**cannot run on this M5 Pro / macOS 26.5 host**: longer phrases
+segfault (`EXC_BAD_ACCESS` / SIGSEGV) inside Apple's `libBNNS.dylib`
+(`BNNSGraphContextExecute_v2` → `BnnsCpuInferenceOperation::ExecuteSync`),
+on the **CPU** path — so it reproduces under `--compute-units default`,
+`all-ane`, *and* `cpu-only` (it is not a GPU/ANE-routing issue). Short
+phrases (phrase 1) complete; the crash is an Apple-framework bug, not
+fixable from FluidAudio. Tracked in [#667][i667]. Re-baseline once
+Apple ships a fix.
 
-✦ **Supertonic-3 (int4)** uses the new default **int4 L-bucketed (ANE)
-VectorEstimator** and is measured on **M5 Pro / macOS 26**, not the M2 reference
-— **not directly comparable** to the M2 rows above. On M5 Pro the int4-ANE
-VectorEstimator drops per-phrase synth to ~79 ms (agg RTFx 119× over 100
-phrases) vs the prior fp16-dynamic-on-CPU path (5.55× on M2). WER/CER shown are
-the prior **fp16** figures (0.8% / 0.3%); the int4 build was **not** re-scored
-with ASR here (4-bit k-means palettization is documented perceptually clean).
-Re-run on the M2 reference for a row comparable to the others.
+ᶜ **Supertonic-3 (int4)** is measured on **M5 Pro / macOS 26.5** with
+the default **int4 L-bucketed (ANE) VectorEstimator**. The int4-ANE
+path drops per-phrase synth to ~80 ms (agg RTFx 118× over 100 phrases)
+vs the prior fp16-dynamic-on-CPU path (5.55× on M2 — the speedup is the
+elimination of per-length MPSGraph recompiles, not a chip effect). The
+**6.86% WER / 4.08% CER are the actual M5 Parakeet roundtrip** on
+`minimax-english` — a regression from the **0.84% measured on M2**
+(see the per-language table below, same corpus, long phrases present).
+**int4 is not the cause**: on M5, fp16 (7.02%), int8 (6.15%), int6
+(6.36%), and int4 (6.86%) all land in the same band. The error is
+concentrated in the **chunker**: single-chunk phrases (<110 char) score
+**3.88% WER** while multi-chunk phrases (≥110 char) score **8.77%**,
+with garbling at chunk seams ("hot air"→"Hudir"). Whether the M2→M5
+regression is an Apple-framework numerical change or a chunker code
+change since the M2 run is under investigation in [#669][i669].
 
 \* TTFT for **PocketTTS** is first-frame emit through the streaming
 API (perceptual TTFA). **Kokoro ANE / Magpie / StyleTTS2** all run
@@ -235,6 +254,16 @@ exactly 2.875 s @ 24 kHz (300-hop). The benchmark harness expects
 the caller to trim externally; mismatched durations error out at
 predict time.
 
+ˢ **StyleTTS2 (M2)** — numbers carried from the M2 reference. StyleTTS2
+**cannot be re-baselined on M5** with the current assets: the shipped
+length-bucketed BERT graphs (`bert_fp16_t64`, `bert_fp16_t128`,
+`bert_fp16_t256`) are missing `model.mil` (only `weights` + metadata
+present), so CoreML fails with `corruptedModel … Error in reading the
+MIL network`. Only the base `bert_fp16.mlmodelc` is intact. This is a
+broken upstream asset (re-download does not help), not an M5 issue.
+Tracked in [#668][i668]; re-baseline once the bucketed `model.mil`
+files are re-uploaded.
+
 ### Kokoro ANE — per-stage breakdown (default preset, MiniMax-English)
 
 Means across 100 `minimax-english` phrases on M2 (`af_heart`,
@@ -270,6 +299,12 @@ NanoCodec cap). Republish here once that branch lands on `main`.
 Same harness, same `M1.json` voice style, same default
 (`--total-steps 8 --speed 1.05 --compute-units default`). All 10
 languages complete the full 100-phrase `minimax-<lang>` run.
+
+> **Note (M2 vs M5):** this breakdown is the **M2** run. On **M5 Pro /
+> macOS 26.5** the English WER regresses to **6.86%** (vs **0.84%**
+> here) — concentrated in chunker-split phrases and independent of
+> VectorEstimator precision. See the ᶜ footnote and [#669][i669]
+> before treating the per-language WER/CER as current on M5.
 
 WER / CER for English is from the in-process Parakeet TDT
 roundtrip. The nine non-English rows were synthesized with
@@ -319,3 +354,7 @@ discussion](https://huggingface.co/datasets/MiniMaxAI/TTS-Multilingual-Test-Set/
 absolute WER is best read **relatively** (backend A vs. backend B on
 the same corpus + same ASR + same normalizer) rather than against
 raw paper numbers.
+
+[i667]: https://github.com/FluidInference/FluidAudio/issues/667
+[i668]: https://github.com/FluidInference/FluidAudio/issues/668
+[i669]: https://github.com/FluidInference/FluidAudio/issues/669

--- a/Documentation/TTS/Benchmarks.md
+++ b/Documentation/TTS/Benchmarks.md
@@ -194,14 +194,18 @@ peak RSS, WER, CER) so there is a single source of truth.
 | Supertonic-3 (int4) | Apache-2.0 | en (`M1`, 31-lang)        | int4 ~0.10 GB                   | 44.1 kHz    | 128 codepoints / pass (chunker splits ≥110 char Latin / 90 CJK)  | No        | **80 / 86 ms** | 80 / 86 ms     | **118×** | 201 MB   | 6.86%ᶜ | 4.08%ᶜ |
 
 ᴷ **Kokoro ANE (M2)** — numbers carried from the M2 reference. Kokoro
-**cannot run on this M5 Pro / macOS 26.5 host**: longer phrases
-segfault (`EXC_BAD_ACCESS` / SIGSEGV) inside Apple's `libBNNS.dylib`
-(`BNNSGraphContextExecute_v2` → `BnnsCpuInferenceOperation::ExecuteSync`),
-on the **CPU** path — so it reproduces under `--compute-units default`,
-`all-ane`, *and* `cpu-only` (it is not a GPU/ANE-routing issue). Short
-phrases (phrase 1) complete; the crash is an Apple-framework bug, not
-fixable from FluidAudio. Tracked in [#667][i667]. Re-baseline once
-Apple ships a fix.
+**cannot be benchmarked on this M5 Pro / macOS 26.5 host**: a *single*
+synthesis works (verified, correct audio, en + zh), but the **2nd+
+prediction in a process crashes** — even for the identical short
+phrase. The mode depends on routing: `--compute-units default` hits a
+GPU `MetalPerformanceShadersGraph GPURNNOps … 'JIT not supported'`
+assert (SIGABRT) on the prosody RNN; `all-ane` / `cpu-only` segfault in
+`libBNNS.dylib` (`BnnsCpuInferenceOperation::ExecuteSync`, SIGSEGV,
+nondeterministic). It is not phrase-length, not ASR contention, and no
+compute-unit routing avoids it — an Apple-framework instability on
+repeated dynamic-shape predictions, not fixable from FluidAudio.
+Tracked in [#667][i667]. Re-baseline once Apple ships a fix (or the
+Kokoro graphs are re-exported with bucketed shapes).
 
 ᶜ **Supertonic-3 (int4)** is measured on **M5 Pro / macOS 26.5** with
 the default **int4 L-bucketed (ANE) VectorEstimator**. The int4-ANE

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
@@ -59,6 +59,17 @@ public struct KokoroAneComputeUnits: Sendable, Equatable {
         prosody: .cpuOnly, noise: .cpuOnly, vocoder: .cpuOnly, tail: .cpuOnly
     )
 
+    /// M5 / macOS 26.5 stability: all stages `.cpuAndNeuralEngine` except the
+    /// tail (iSTFT) on `.cpuAndGPU`. Keeps the prosody RNN off the GPU (which
+    /// otherwise hits the `GPURNNOps` JIT assert) while keeping the iSTFT off
+    /// the CPU/BNNS path (which otherwise segfaults in `libBNNS`). See #667.
+    public static let aneTailGpu = KokoroAneComputeUnits(
+        albert: .cpuAndNeuralEngine, postAlbert: .cpuAndNeuralEngine,
+        alignment: .cpuAndNeuralEngine, prosody: .cpuAndNeuralEngine,
+        noise: .cpuAndNeuralEngine, vocoder: .cpuAndNeuralEngine,
+        tail: .cpuAndGPU
+    )
+
     /// Build a configuration from a generic preset (used by the
     /// `tts-benchmark` CLI so a single flag maps cleanly across
     /// backends).
@@ -72,6 +83,8 @@ public struct KokoroAneComputeUnits: Sendable, Equatable {
             self = .cpuAndGpu
         case .cpuOnly:
             self = .cpuOnly
+        case .aneTailGpu:
+            self = .aneTailGpu
         }
     }
 

--- a/Sources/FluidAudio/TTS/Shared/TtsComputeUnitPreset.swift
+++ b/Sources/FluidAudio/TTS/Shared/TtsComputeUnitPreset.swift
@@ -33,6 +33,13 @@ public enum TtsComputeUnitPreset: String, Sendable, CaseIterable {
     /// every backend should at least run here, however slowly.
     case cpuOnly
 
+    /// Kokoro on M5 / macOS 26.5: all stages `.cpuAndNeuralEngine` EXCEPT
+    /// the tail (iSTFT), which goes to `.cpuAndGPU`. The default `.all`
+    /// routing crashes the prosody RNN on the GPU (`GPURNNOps` JIT assert);
+    /// `all-ane` instead crashes the tail iSTFT in `libBNNS`. This preset
+    /// keeps the RNN off the GPU while keeping the iSTFT off BNNS. See #667.
+    case aneTailGpu
+
     /// Concrete `MLComputeUnits` for "force every stage to X" presets.
     /// Returns `nil` for `.default`, which means "let the backend keep
     /// its empirical mapping".
@@ -42,6 +49,7 @@ public enum TtsComputeUnitPreset: String, Sendable, CaseIterable {
         case .allAne: return .cpuAndNeuralEngine
         case .cpuAndGpu: return .cpuAndGPU
         case .cpuOnly: return .cpuOnly
+        case .aneTailGpu: return nil  // per-stage; resolved by each backend
         }
     }
 
@@ -54,6 +62,7 @@ public enum TtsComputeUnitPreset: String, Sendable, CaseIterable {
         case "all-ane", "ane", "neural-engine": self = .allAne
         case "cpu-and-gpu", "cpuandgpu", "gpu": self = .cpuAndGpu
         case "cpu-only", "cpu", "cpuonly": self = .cpuOnly
+        case "ane-tail-gpu", "anetailgpu", "m5": self = .aneTailGpu
         default: return nil
         }
     }
@@ -67,6 +76,7 @@ public enum TtsComputeUnitPreset: String, Sendable, CaseIterable {
         case .allAne: return "all-ane"
         case .cpuAndGpu: return "cpu-and-gpu"
         case .cpuOnly: return "cpu-only"
+        case .aneTailGpu: return "ane-tail-gpu"
         }
     }
 }

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
@@ -77,7 +77,7 @@ public enum Supertonic3Constants {
     /// `<lang>…</lang>` wrapping (~10-char overhead, allowing 8-char tags
     /// plus a small margin for diacritic expansion). Longer text is split
     /// by `Supertonic3TextChunker` before reaching the encoder.
-    public static let maxChunkLengthLatin: Int = 110
+    public static let maxChunkLengthLatin: Int = 70
 
     /// Tighter chunk cap for Korean / Japanese. CJK uses more codepoints per
     /// visible character after NFKD, so we leave additional headroom inside

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
@@ -73,16 +73,19 @@ public enum Supertonic3Constants {
     public static let defaultSilenceDuration: Float = 0.3
 
     /// Max characters per chunk when synthesizing long English/Latin text.
-    /// Sized to fit within `textTFixed = 128` after NFKD decomposition and
-    /// `<lang>…</lang>` wrapping (~10-char overhead, allowing 8-char tags
-    /// plus a small margin for diacritic expansion). Longer text is split
-    /// by `Supertonic3TextChunker` before reaching the encoder.
+    /// Although `textTFixed = 128` would *fit* ~110 chars, the model's output
+    /// degrades as a chunk approaches that token window (a 105-char single
+    /// chunk scored 17.6% WER vs 0% at 71 chars), so the cap is held at 70 to
+    /// keep every chunk in the clean regime. Longer text is split by
+    /// `Supertonic3TextChunker` before reaching the encoder. See #669.
     public static let maxChunkLengthLatin: Int = 70
 
-    /// Tighter chunk cap for Korean / Japanese. CJK uses more codepoints per
-    /// visible character after NFKD, so we leave additional headroom inside
-    /// the 128-token window.
-    public static let maxChunkLengthCJK: Int = 90
+    /// Tighter chunk cap for Korean / Japanese. CJK expands to more codepoints
+    /// per visible character after NFKD, so the same token-window budget holds
+    /// fewer CJK characters — kept proportionally below `maxChunkLengthLatin`
+    /// (same ~0.82 ratio as the original 90/110) to stay in the clean regime
+    /// and tighter than Latin. See #669.
+    public static let maxChunkLengthCJK: Int = 57
 
     // MARK: - Language whitelist (matches AVAILABLE_LANGS in the reference)
 

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
@@ -89,8 +89,10 @@ public enum Supertonic3VectorEstimator: Sendable, Equatable {
     case dynamic(Supertonic3Quantization)
     case aneBucketed(Supertonic3Quantization)
 
-    /// Default preserves the historical FP16 dynamic VectorEstimator.
-    public static let `default`: Supertonic3VectorEstimator = .fp16Dynamic
+    /// Default: ANE-bucketed int4 — ~94% on the ANE, ~2.7× faster end-to-end,
+    /// 4-bit k-means palettization that is perceptually clean. The historical
+    /// fp16 dynamic build stays available via `--ve-variant fp16`.
+    public static let `default`: Supertonic3VectorEstimator = .aneBucketed(.int4)
 
     /// `nil` for FP16; the rawValue (`"int8"`/`"int6"`/`"int4"`) otherwise.
     var precisionSuffix: String? {

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -88,7 +88,7 @@ public struct TTS {
         var supertonicSpeed: Float = Supertonic3Constants.defaultSpeed
         // VectorEstimator build: fp16 | int8/int6/int4 (ANE-bucketed) |
         // dyn-int8/dyn-int6/dyn-int4 (dynamic CPU/GPU). Default fp16.
-        var supertonicVE: Supertonic3VectorEstimator = .fp16Dynamic
+        var supertonicVE: Supertonic3VectorEstimator = .aneBucketed(.int4)
 
         var i = 0
         while i < arguments.count {
@@ -754,7 +754,8 @@ public struct TTS {
     private static func parseSupertonicVE(_ raw: String) -> Supertonic3VectorEstimator? {
         func q(_ s: String) -> Supertonic3Quantization? { Supertonic3Quantization(rawValue: s) }
         switch raw {
-        case "fp16", "fp16dynamic", "default", "": return .fp16Dynamic
+        case "fp16", "fp16dynamic": return .fp16Dynamic
+        case "default", "": return .aneBucketed(.int4)
         case "int8", "int6", "int4", "ane-int8", "ane-int6", "ane-int4":
             return q(String(raw.split(separator: "-").last!)).map { .aneBucketed($0) }
         case "dyn-int8", "dyn-int6", "dyn-int4", "dynamic-int8", "dynamic-int6", "dynamic-int4":

--- a/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
@@ -245,7 +245,7 @@ public enum TtsBenchmarkCommand {
 
         guard let preset = TtsComputeUnitPreset(cliValue: computeUnitsName) else {
             logger.error(
-                "Unknown --compute-units value: \(computeUnitsName). Expected default | all-ane | cpu-and-gpu | cpu-only."
+                "Unknown --compute-units value: \(computeUnitsName). Expected default | all-ane | cpu-and-gpu | cpu-only | ane-tail-gpu."
             )
             exit(1)
         }
@@ -1353,7 +1353,8 @@ public enum TtsBenchmarkCommand {
               --voice <name>            Voice id (KokoroAne/PocketTTS)
               --speaker <name>          Magpie speaker: john|sofia|aria|jason|leo
               --language <code>         PocketTTS lang pack or Magpie language code
-              --compute-units <preset>  default | all-ane | cpu-and-gpu | cpu-only
+              --compute-units <preset>  default | all-ane | cpu-and-gpu | cpu-only | ane-tail-gpu
+                                        (kokoro-ane on M5/macOS 26.5 needs ane-tail-gpu; see #667)
               --output-json <path>      Write JSON report
               --audio-dir <path>        Keep generated WAVs under this dir
               --skip-asr                Skip ASR roundtrip (no WER/CER)


### PR DESCRIPTION
## Scope

Started as PocketTTS v2.1 ANE-profiler docs; grew to cover the full M5 TTS re-baseline plus two compute-routing changes that came out of it.

### Docs
- **ANE_Profiler.md** — PocketTTS v2.1 measured ANE residency, real op counts, int4 VectorEstimator as the default, legacy rows removed.
- **Benchmarks.md** — re-baselined to **M5 Pro / macOS 26.5**. 5/6 backends now M5 (PocketTTS, Magpie, Supertonic-3, Kokoro en+zh); StyleTTS2 stays M2 pending a HF asset fix (#668).

### Code
- **Supertonic-3** — int4 L-bucketed (ANE) VectorEstimator is now the default; chunk cap lowered 110→70 chars, cutting WER 6.86%→1.02% (#669).
- **Kokoro ANE** — new `TtsComputeUnitPreset.aneTailGpu` (`--compute-units ane-tail-gpu`) that unblocks Kokoro on M5/macOS 26.5: routes the tail iSTFT to GPU and the RNN-bearing stages to ANE, dodging both the GPU `GPURNNOps` JIT assert and the `libBNNS` tail segfault. Verified en (25.4× RTFx, WER 10.33%) and zh (20.1× RTFx, CER 3.81%) — quality matches M2.

### Measured on M5 Pro (100-phrase minimax)
| Backend | RTFx | WER | CER |
|---|---|---|---|
| Kokoro en (ane-tail-gpu) | 25.4× | 10.33% | 3.72% |
| Kokoro zh (ane-tail-gpu) | 20.1× | — | 3.81% |
| PocketTTS v2.1 | 6.51× | 0.51% | 0.08% |
| Magpie | 2.34× | 3.98% | 2.44% |
| Supertonic-3 int4 | 94× | 1.02% | 0.31% |

### Related issues
- #667 Kokoro M5 Apple-framework crash (workaround shipped here)
- #668 StyleTTS2 bucketed BERT assets missing `model.mil`
- #669 Supertonic-3 chunker — FIXED here (maxLen 110→70, WER 6.86%→1.02%)
