### PR TITLE
docs(supertonic): fix stale maxChunkLengthCJK comment (90→57)

### DIFF
--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
@@ -96,6 +96,6 @@ public enum Supertonic3Constants {
         "ru", "sk", "sl", "sv", "tr", "uk", "vi", "na",
     ]
 
-    /// Languages that should use the tighter `maxChunkLengthCJK` (90-char) chunker.
+    /// Languages that should use the tighter `maxChunkLengthCJK` (57-char) chunker.
     public static let cjkLanguages: Set<String> = ["ko", "ja"]
 }


### PR DESCRIPTION
Comment-only follow-up to #669 / #666. The CJK chunk cap dropped 90→57 (to match the Latin 110→70 fix and keep CJK tighter), but a doc comment in `Supertonic3Constants.swift` still read `(90-char)`. Corrects it to `(57-char)`. No behavior change.