### PR TITLE
feat(asr): expose per-token timings from Nemotron streaming ASR (English + multilingual)

### DIFF
--- a/.github/workflows/nemotron-multilingual-benchmark.yml
+++ b/.github/workflows/nemotron-multilingual-benchmark.yml
@@ -122,6 +122,7 @@ jobs:
 
       - name: Comment PR
         if: github.event_name == 'pull_request' && always()
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/NemotronMultilingualTokenizer.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/NemotronMultilingualTokenizer.swift
@@ -67,6 +67,15 @@ public final class NemotronMultilingualTokenizer: Sendable {
         return String(piece.dropFirst().dropLast())
     }
 
+    /// Return the raw SentencePiece piece for a token id, INCLUDING the
+    /// `▁` word-boundary marker, or `nil` if the id is not in the vocab.
+    /// Unlike `decode(ids:)` / `tokenizerPiece`, this does NOT strip the marker
+    /// or filter lang-tag tokens — callers grouping tokens into words need the
+    /// original marker-bearing piece to detect word starts.
+    public func rawToken(for id: Int) -> String? {
+        return base.rawToken(for: id)
+    }
+
     /// Look up the token id for a language-tag piece (e.g. `"en-US"` →
     /// the id whose piece equals `"<en-US>"`). Returns `nil` if no
     /// matching tag is present in `langTagTokenIds`.

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager+Pipeline.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager+Pipeline.swift
@@ -158,12 +158,31 @@ extension StreamingNemotronAsrManager {
                     // Non-blank token - emit and update local state
                     newTokens.append(predToken)
                     accumulatedTokenIds.append(predToken)
+                    // Capture absolute timing for this token. RNNT emits at the
+                    // encoder frame `t`; absoluteFrameBase carries the offset of
+                    // prior chunks. Duration is unknown for greedy RNNT, so the
+                    // span is one encoder frame wide.
+                    let tokenStartTime =
+                        Double(absoluteFrameBase + t) * ASRConstants.secondsPerEncoderFrame
+                    accumulatedTokenTimings.append(
+                        TokenTiming(
+                            token: tokenizer?.rawToken(for: predToken) ?? "",
+                            tokenId: predToken,
+                            startTime: tokenStartTime,
+                            endTime: tokenStartTime + ASRConstants.secondsPerEncoderFrame,
+                            confidence: 1.0
+                        )
+                    )
                     currentToken = Int32(predToken)
                     currentH = stepH
                     currentC = stepC
                 }
             }
         }
+
+        // Advance the absolute encoder-frame base by this chunk's frame count so
+        // the next chunk's token timings continue on the same timeline.
+        absoluteFrameBase += numEncoderFrames
 
         // Save final decoder state back to actor properties atomically
         self.lastToken = currentToken

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
@@ -322,6 +322,14 @@ public actor StreamingNemotronAsrManager {
         guard let tokenizer = tokenizer else { return "" }
         return tokenizer.decode(ids: accumulatedTokenIds)
     }
+
+    /// Get per-token timings accumulated so far without finishing. Aligned 1:1
+    /// with the tokens behind getPartialTranscript(). Use this when a caller must
+    /// salvage a partially-processed session that cannot safely call finish()
+    /// (e.g. after a mid-stream decode failure).
+    public func getTokenTimings() -> [TokenTiming] {
+        return accumulatedTokenTimings
+    }
 }
 
 // MARK: - StreamingAsrManager Conformance

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
@@ -34,6 +34,18 @@ public actor StreamingNemotronAsrManager {
     // Accumulated token IDs
     internal var accumulatedTokenIds: [Int] = []
 
+    // Per-token absolute timings captured during the RNNT decode loop. Each
+    // token's startTime is its absolute encoder-frame index multiplied by
+    // ASRConstants.secondsPerEncoderFrame. Exposed via finishWithTokenTimings()
+    // so callers can derive word-level timestamps (e.g. for speaker attribution).
+    internal var accumulatedTokenTimings: [TokenTiming] = []
+    // Running encoder-frame base across processed chunks (advances by the chunk's
+    // encoder-frame count after each decode loop). Reset with the session.
+    internal var absoluteFrameBase: Int = 0
+    // Snapshot of token timings taken in finish() before the working buffers are
+    // cleared, so finishWithTokenTimings() can return them after finish() runs.
+    internal var lastFinishTokenTimings: [TokenTiming] = []
+
     // Encoder cache states
     internal var cacheChannel: MLMultiArray?
     internal var cacheTime: MLMultiArray?
@@ -174,6 +186,9 @@ public actor StreamingNemotronAsrManager {
             accumulatedTokenIds: &accumulatedTokenIds,
             processedChunks: &processedChunks
         )
+        accumulatedTokenTimings.removeAll()
+        absoluteFrameBase = 0
+        lastFinishTokenTimings.removeAll()
         do {
             try resetStates()
         } catch {
@@ -284,9 +299,22 @@ public actor StreamingNemotronAsrManager {
 
         // Decode accumulated tokens
         let transcript = tokenizer.decode(ids: accumulatedTokenIds)
+        // Snapshot timings before clearing so finishWithTokenTimings() can return
+        // them; finish() must clear the working buffers atomically with the ids.
+        lastFinishTokenTimings = accumulatedTokenTimings
         accumulatedTokenIds.removeAll()
+        accumulatedTokenTimings.removeAll()
 
         return transcript
+    }
+
+    /// Finish processing and return the final transcript together with per-token
+    /// timings (absolute seconds from the start of the fed audio). The timings
+    /// are aligned 1:1 with the decoded token stream; group them by the
+    /// SentencePiece word-boundary marker to obtain word-level timestamps.
+    public func finishWithTokenTimings() async throws -> (text: String, timings: [TokenTiming]) {
+        let text = try await finish()
+        return (text, lastFinishTokenTimings)
     }
 
     /// Get current partial transcript without finishing

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Decode.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Decode.swift
@@ -238,6 +238,9 @@ extension StreamingNemotronMultilingualAsrManager {
                 // Emit first non-blank from speculative scan.
                 newTokens.append(emittedToken)
                 accumulatedTokenIds.append(emittedToken)
+                // This token was found at encoder frame t + firstNonBlankAt.
+                appendTokenTiming(
+                    emittedToken, frameInChunk: t + firstNonBlankAt, tokenizer: tokenizer)
                 currentToken = Int32(emittedToken)
                 currentH = candidateH
                 currentC = candidateC
@@ -406,6 +409,8 @@ extension StreamingNemotronMultilingualAsrManager {
                     // Non-blank → emit + commit state
                     newTokens.append(dBestIdx)
                     accumulatedTokenIds.append(dBestIdx)
+                    // Multi-emission drain stays on the same frame: drainFrameT.
+                    appendTokenTiming(dBestIdx, frameInChunk: drainFrameT, tokenizer: tokenizer)
                     currentToken = Int32(dBestIdx)
                     currentH = newH
                     currentC = newC
@@ -484,5 +489,29 @@ extension StreamingNemotronMultilingualAsrManager {
             return "<\(lang)>"
         }
         return decoded.text.isEmpty ? nil : decoded.text
+    }
+
+    /// Append a per-token timing for a token emitted at encoder frame
+    /// `frameInChunk` within the current chunk. `startTime` is absolute seconds
+    /// from the start of the fed audio (`absoluteFrameBase` carries prior chunks).
+    /// Lang-tag tokens are skipped: they are stripped from the decoded transcript,
+    /// so excluding them keeps the timing stream aligned 1:1 with the user-visible
+    /// tokens. Uses `rawToken(for:)` (NOT `tokenizerPiece`, which strips the `▁`
+    /// word-boundary marker) so callers can reconstruct word boundaries.
+    internal func appendTokenTiming(
+        _ tokenId: Int, frameInChunk: Int, tokenizer: NemotronMultilingualTokenizer
+    ) {
+        guard !config.langTagTokenIds.contains(tokenId) else { return }
+        let startTime =
+            Double(absoluteFrameBase + frameInChunk) * ASRConstants.secondsPerEncoderFrame
+        accumulatedTokenTimings.append(
+            TokenTiming(
+                token: tokenizer.rawToken(for: tokenId) ?? "",
+                tokenId: tokenId,
+                startTime: startTime,
+                endTime: startTime + ASRConstants.secondsPerEncoderFrame,
+                confidence: 1.0
+            )
+        )
     }
 }

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Pipeline.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Pipeline.swift
@@ -91,7 +91,9 @@ extension StreamingNemotronMultilingualAsrManager {
                     // The skipped chunk's audio still elapses on the file
                     // timeline. No encoder ran, so advance the frame base by the
                     // chunk's nominal encoder-frame count (derived from sample
-                    // count) to keep later token timings aligned.
+                    // count) to keep later token timings aligned. The processed
+                    // path asserts this nominal count equals the encoder's actual
+                    // output, so skipped and processed chunks stay on one timeline.
                     absoluteFrameBase += samples.count / ASRConstants.samplesPerEncoderFrame
                     return
                 }
@@ -287,6 +289,19 @@ extension StreamingNemotronMultilingualAsrManager {
         // 4. RNNT decode loop for each encoder frame
         let decStart = DispatchTime.now().uptimeNanoseconds
         let numEncoderFrames = encoded.shape[2].intValue
+        // AIDEV-NOTE: timing-invariant; processChunk always receives exactly
+        // config.chunkSamples (process() slices full chunks; finish() zero-pads
+        // the tail), so the encoder's actual frame count must equal the nominal
+        // sample-derived count the VAD-skip branch above uses to advance
+        // absoluteFrameBase. Assert it so a future model/tier whose CoreML
+        // encoder emits a different frame count is caught in debug/CI instead of
+        // silently drifting skipped-chunk token timings.
+        assert(
+            numEncoderFrames == samples.count / ASRConstants.samplesPerEncoderFrame,
+            "Nemotron encoder emitted \(numEncoderFrames) frames for \(samples.count) "
+                + "samples; expected \(samples.count / ASRConstants.samplesPerEncoderFrame). "
+                + "VAD-skip frame accounting assumes encoder frames == nominal."
+        )
         var newTokens: [Int] = []
 
         // SMART SPECULATIVE BLANK path — speculative scan over K=8 frames

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Pipeline.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Pipeline.swift
@@ -88,6 +88,11 @@ extension StreamingNemotronMultilingualAsrManager {
                 self.vadConsecutiveLowChunks &+= 1
                 if self.vadConsecutiveLowChunks >= Self.vadHangoverChunks {
                     self.vadSkipCount &+= 1
+                    // The skipped chunk's audio still elapses on the file
+                    // timeline. No encoder ran, so advance the frame base by the
+                    // chunk's nominal encoder-frame count (derived from sample
+                    // count) to keep later token timings aligned.
+                    absoluteFrameBase += samples.count / ASRConstants.samplesPerEncoderFrame
                     return
                 }
                 // Within hangover window — process normally (edge preserve).
@@ -349,6 +354,9 @@ extension StreamingNemotronMultilingualAsrManager {
                 self.cacheLen = nextEnc.cacheLen
                 self.melCache = nextEnc.newMelCache
             }
+            // Advance the encoder-frame base by this chunk's frame count so the
+            // next chunk's token timings continue on the same timeline.
+            absoluteFrameBase += numEncoderFrames
             processedChunks += 1
             return
         }
@@ -525,6 +533,8 @@ extension StreamingNemotronMultilingualAsrManager {
                     // Non-blank token - emit and update local state
                     newTokens.append(predToken)
                     accumulatedTokenIds.append(predToken)
+                    // Legacy per-frame loop: this token was emitted at frame t.
+                    appendTokenTiming(predToken, frameInChunk: t, tokenizer: tokenizer)
                     currentToken = Int32(predToken)
                     currentH = hOut
                     currentC = cOut
@@ -569,6 +579,9 @@ extension StreamingNemotronMultilingualAsrManager {
             self.melCache = nextEnc.newMelCache
         }
 
+        // Advance the encoder-frame base by this chunk's frame count so the next
+        // chunk's token timings continue on the same timeline.
+        absoluteFrameBase += numEncoderFrames
         processedChunks += 1
     }
 }

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager.swift
@@ -84,6 +84,21 @@ public actor StreamingNemotronMultilingualAsrManager {
     // Accumulated token IDs (raw, including any lang-tag tokens)
     internal var accumulatedTokenIds: [Int] = []
 
+    // Per-token absolute timings captured during the RNNT decode loop, parallel
+    // to the user-visible (lang-tag-stripped) token stream. Each token's
+    // startTime is its absolute encoder-frame index * secondsPerEncoderFrame.
+    // Exposed via finishWithTokenTimings() so callers can derive word-level
+    // timestamps (e.g. for speaker attribution). Lang-tag tokens are excluded
+    // (they are stripped from the decoded transcript), see appendTokenTiming.
+    internal var accumulatedTokenTimings: [TokenTiming] = []
+    // Running encoder-frame base across processed chunks (advances by the
+    // chunk's encoder-frame count after each decode loop, including VAD-skipped
+    // chunks so the timeline stays aligned to real audio). Reset with the session.
+    internal var absoluteFrameBase: Int = 0
+    // Snapshot of token timings taken in finish() before the working buffers are
+    // cleared, so finishWithTokenTimings() can return them after finish() runs.
+    internal var lastFinishTokenTimings: [TokenTiming] = []
+
     // First lang-tag piece encountered this session (without angle brackets).
     private var firstDetectedLanguage: String?
 
@@ -788,6 +803,9 @@ public actor StreamingNemotronMultilingualAsrManager {
             accumulatedTokenIds: &accumulatedTokenIds,
             processedChunks: &processedChunks
         )
+        accumulatedTokenTimings.removeAll()
+        absoluteFrameBase = 0
+        lastFinishTokenTimings.removeAll()
         audioBufferOffset = 0
         firstDetectedLanguage = nil
         do {
@@ -1011,7 +1029,11 @@ public actor StreamingNemotronMultilingualAsrManager {
         lastFinishTokenCount = accumulatedTokenIds.count
         lastFinishDetectedLanguage = firstDetectedLanguage ?? decoded.detectedLanguage
         lastFinishProcessedChunks = processedChunks
+        // Snapshot timings before clearing so finishWithTokenTimings() can return
+        // them; clear the working buffers atomically with the ids.
+        lastFinishTokenTimings = accumulatedTokenTimings
         accumulatedTokenIds.removeAll()
+        accumulatedTokenTimings.removeAll()
 
         if appendTerminalPunctuation {
             return Self.tidyTerminalPunctuation(
@@ -1053,6 +1075,26 @@ public actor StreamingNemotronMultilingualAsrManager {
             firstDetectedLanguage = decoded.detectedLanguage
         }
         return decoded.text
+    }
+
+    /// Finish processing and return the final transcript together with per-token
+    /// timings (absolute seconds from the start of the fed audio). The timings
+    /// are aligned 1:1 with the user-visible (lang-tag-stripped) token stream;
+    /// group them by the SentencePiece word-boundary marker to obtain word-level
+    /// timestamps. Note: when `appendTerminalPunctuation` is enabled the returned
+    /// text gains an untimed terminal mark, so callers that need strict
+    /// text/timing parity should leave that flag off (the default).
+    public func finishWithTokenTimings() async throws -> (text: String, timings: [TokenTiming]) {
+        let text = try await finish()
+        return (text, lastFinishTokenTimings)
+    }
+
+    /// Get per-token timings accumulated so far without finishing. Aligned 1:1
+    /// with the tokens behind getPartialTranscript(). Use this when a caller must
+    /// salvage a partially-processed session that cannot safely call finish()
+    /// (e.g. after a mid-stream decode failure).
+    public func getTokenTimings() -> [TokenTiming] {
+        return accumulatedTokenTimings
     }
 
     /// Internal getter for the current prompt id, used by the pipeline.

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronMultilingualTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronMultilingualTests.swift
@@ -155,6 +155,37 @@ final class NemotronMultilingualTests: XCTestCase {
         XCTAssertNil(decoded.detectedLanguage)
     }
 
+    func testRawTokenPreservesWordBoundaryMarker() throws {
+        // rawToken must return the UNMODIFIED SentencePiece vocab piece, with the
+        // `▁` word-boundary marker intact, so callers can group per-token timings
+        // into words. decode()/the visible transcript strip `▁`; rawToken must not,
+        // otherwise word starts can't be located and word-level timing breaks.
+        let vocab: [String: String] = [
+            "0": "<unk>",
+            "1": "\u{2581}hello",  // word-start piece (has ▁)
+            "2": "ing",  // mid-word continuation (no ▁)
+        ]
+        let vocabData = try JSONSerialization.data(withJSONObject: vocab)
+        let tmpURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("multilingual_vocab_test_\(UUID().uuidString).json")
+        try vocabData.write(to: tmpURL)
+        defer { try? FileManager.default.removeItem(at: tmpURL) }
+
+        let tokenizer = try NemotronMultilingualTokenizer(
+            vocabPath: tmpURL,
+            langTagTokenIds: Set<Int>()
+        )
+
+        // Word-start piece keeps the `▁` marker...
+        XCTAssertEqual(tokenizer.rawToken(for: 1), "\u{2581}hello")
+        // ...continuation piece has no marker...
+        XCTAssertEqual(tokenizer.rawToken(for: 2), "ing")
+        // ...the visible transcript strips the marker (why callers need rawToken)...
+        XCTAssertFalse(tokenizer.decode(ids: [1]).text.contains("\u{2581}"))
+        // ...and an out-of-vocab id returns nil so the caller skips its timing.
+        XCTAssertNil(tokenizer.rawToken(for: 999))
+    }
+
     // MARK: - ModelNames
 
     func testNemotronMultilingualModelNames() {


### PR DESCRIPTION
### Why is this change needed?

The Nemotron streaming RNNT decode loop already knows which encoder frame each token is emitted at, but the streaming managers only return the decoded text. So there is no way for a caller to line transcript words up with anything time-based (diarization, word-level highlighting, subtitle timing) without running a separate forced alignment.

This change surfaces the timing that is already computed. At each token-emission site, next to the existing `accumulatedTokenIds.append(...)`, it records a `TokenTiming` whose `startTime` is the token's absolute encoder-frame index times `ASRConstants.secondsPerEncoderFrame` (80 ms per frame). Callers get the timings from a new `finishWithTokenTimings() -> (text, timings)`, with a `getTokenTimings()` accessor for salvaging a partially decoded session that cannot safely `finish()`. The existing `process()` / `finish()` String API does not change.

Both managers are covered:

- `StreamingNemotronAsrManager` (English): one emission site in the per-frame decode loop.
- `StreamingNemotronMultilingualAsrManager`: three sites, since it has the legacy per-frame loop plus the default-on speculative decoder (first-hit and multi-emission drain). Two extra details here. Language-tag tokens, which `decode()` already strips from the transcript, are kept out of the timing stream so it stays 1:1 with the visible tokens. And a new `NemotronMultilingualTokenizer.rawToken(for:)` passthrough exposes the raw `▁`-marked piece, because the existing `tokenizerPiece` helper strips that marker and callers need it to find word starts. A VAD-skipped chunk still advances the frame base by its nominal frame count so the timeline does not drift.

Grouping tokens by the SentencePiece `▁` marker yields word-level `(text, startTime, endTime)` spans. In our app we use that to assign each transcript word to the diarizer segment it overlaps, which fixed boundary-word speaker misattribution on imported audio.

A few notes:

- Purely additive. No existing API or behavior changes.
- `swift format lint` is clean on the changed files (the two pre-existing `K` constant warnings are untouched upstream code).
- Granularity is per encoder frame (80 ms), which matches the greedy RNNT decode. There is no per-token duration here like the TDT path has.
