### PR TITLE
fix(kokoro): route the Noise stage to GPU in the M5-safe preset (+~10% synth)

### DIFF
--- a/Documentation/TTS/Benchmarks.md
+++ b/Documentation/TTS/Benchmarks.md
@@ -184,7 +184,7 @@ peak RSS, WER, CER) so there is a single source of truth.
 
 | Backend    | License    | Language (voice)          | Footprint                  | Sample rate | Max chunk per pass                                               | Streaming | TTFT p50 / p95\*  | Synth p50 / p95   | Agg RTFx  | Peak RSS | WER    | CER    |
 |------------|------------|---------------------------|----------------------------|-------------|------------------------------------------------------------------|-----------|-------------------|-------------------|-----------|----------|--------|--------|
-| Kokoro ANEᴷ | Apache-2.0 | en (`af_heart`)           | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **314 / 410 ms** | 314 / 410 ms     | **25.4×**ᴷ | 734 MB   | 10.33% | 3.72%  |
+| Kokoro ANEᴷ | Apache-2.0 | en (`af_heart`)           | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **277 / 346 ms** | 277 / 346 ms     | **28.7×**ᴷ | 788 MB   | 10.38% | 3.72%  |
 | Kokoro ANEᴷ | Apache-2.0 | zh (`zf_001`)             | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **201 / 286 ms** | 201 / 286 ms     | 20.1×ᴷ     | 761 MB   | n/a‡   | 3.81%‡ |
 | PocketTTS (v2.1) | research   | en (`alba`, 6L pack)      | fp16 ~330 MB | 24 kHz      | 80 ms Mimi frame, streams until EOS (no fixed cap)               | Yes       | **26 / 27 ms** | 933 / 1233 ms    | **6.51×** | 761 MB   | 0.51%  | 0.08%  |
 | StyleTTS2 (M2)ˢ | research   | en (LibriTTS iteration_3) | ~0.67 GB¶                  | 24 kHz      | 256 tokens / pass (≈30 s of audio max)                           | No        | 1574 / 3088 ms    | 1574 / 3088 ms    | 4.59×     | 522 MB   | 9.4%   | 4.1%   |
@@ -199,8 +199,12 @@ supported'` on the prosody RNN on the GPU), and `all-ane`/`cpu-only`
 crash in `libBNNS` (SIGSEGV) on the tail iSTFT. Keeping the RNN off the
 GPU and the iSTFT off BNNS dodges both (the tail was always meant to run
 fp32 on CPU/GPU — ANE rejects the exp/sin/iSTFT — so this is faithful,
-not a hack). Quality matches the prior M2 baseline (en WER 10.33% vs
-10.8%; zh CER 3.81% vs 4.01%). The old `.all` default ran fine on M2 but
+not a hack). Quality matches the prior M2 baseline (en WER ~10.3% vs
+10.8%; zh CER 3.81% vs 4.01%). The en row was re-measured after the
+Noise→GPU routing fix (Noise is all-fp32, so `.cpuAndNeuralEngine`
+degenerated to plain CPU; it has no RNN ops, so the #667 GPU ban never
+applied): TTFT p50 317→277 ms, agg RTFx 25.1→28.7 (+14%), WER
+unchanged. The zh row predates the fix; expect a similar improvement. The old `.all` default ran fine on M2 but
 its M2 perf under the new default is not re-verified here. The underlying
 Apple bug is tracked in [#667][i667]; this routing is
 `TtsComputeUnitPreset.default` / `.aneTailGpu`.

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
@@ -46,8 +46,10 @@ public struct KokoroAneComputeUnits: Sendable, Equatable {
         self.tail = tail
     }
 
-    /// Default — RNN stages on ANE, tail iSTFT on GPU. Runs on M2 + M5
-    /// (the old `all`-placement default crashed on M5/macOS 26.5). See #667.
+    /// Default — RNN stages on ANE, Noise + tail iSTFT on GPU (both are
+    /// fp32-only graphs the ANE cannot take). Runs on M2 + M5 (the old
+    /// `all`-placement default crashed on M5/macOS 26.5). See #667 and the
+    /// `noise:` parameter note above.
     /// Identical to ``aneTailGpu``.
     public static let `default` = KokoroAneComputeUnits()
 

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
@@ -70,13 +70,23 @@ public struct KokoroAneComputeUnits: Sendable, Equatable {
     )
 
     /// M5 / macOS 26.5 stability: all stages `.cpuAndNeuralEngine` except the
-    /// tail (iSTFT) on `.cpuAndGPU`. Keeps the prosody RNN off the GPU (which
-    /// otherwise hits the `GPURNNOps` JIT assert) while keeping the iSTFT off
-    /// the CPU/BNNS path (which otherwise segfaults in `libBNNS`). See #667.
+    /// tail (iSTFT) and noise on `.cpuAndGPU`. Keeps the prosody RNN off the
+    /// GPU (which otherwise hits the `GPURNNOps` JIT assert) while keeping the
+    /// iSTFT off the CPU/BNNS path (which otherwise segfaults in `libBNNS`).
+    /// See #667.
+    ///
+    /// Noise is `.cpuAndGPU` deliberately: the stage is all-fp32 (its
+    /// `sin(cumsum)` phase math collapses in fp16), so the fp16-only ANE can
+    /// take none of it and `.cpuAndNeuralEngine` degenerates to plain CPU —
+    /// measured even slower than `.cpuOnly` (131.9 vs 116.8 ms at T2=800).
+    /// It contains zero RNN ops, so the #667 GPU ban never applied to it;
+    /// MLComputePlan places 239/239 ops on GPU at 1.9-3.3x the CPU speed
+    /// (28.9 vs 55.8 ms at T2=400), ~10% of en synth / ~15% of zh. Same
+    /// fp32 math, so output is unchanged.
     public static let aneTailGpu = KokoroAneComputeUnits(
         albert: .cpuAndNeuralEngine, postAlbert: .cpuAndNeuralEngine,
         alignment: .cpuAndNeuralEngine, prosody: .cpuAndNeuralEngine,
-        noise: .cpuAndNeuralEngine, vocoder: .cpuAndNeuralEngine,
+        noise: .cpuAndGPU, vocoder: .cpuAndNeuralEngine,
         tail: .cpuAndGPU
     )
 

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
@@ -28,7 +28,12 @@ public struct KokoroAneComputeUnits: Sendable, Equatable {
         postAlbert: MLComputeUnits = .cpuAndNeuralEngine,
         alignment: MLComputeUnits = .cpuAndNeuralEngine,
         prosody: MLComputeUnits = .cpuAndNeuralEngine,
-        noise: MLComputeUnits = .cpuAndNeuralEngine,
+        // Noise defaults to GPU: the stage is all-fp32 (its sin(cumsum)
+        // phase collapses in fp16), so the fp16-only ANE takes none of it
+        // and `.cpuAndNeuralEngine` degenerates to plain CPU — measured
+        // slower than `.cpuOnly`. It has zero RNN ops, so the #667 GPU ban
+        // never applied to it. Measurements in the `aneTailGpu` note.
+        noise: MLComputeUnits = .cpuAndGPU,
         vocoder: MLComputeUnits = .cpuAndNeuralEngine,
         tail: MLComputeUnits = .cpuAndGPU
     ) {


### PR DESCRIPTION
## Summary

The #667 M5-safe routing demoted every stage except the tail to `.cpuAndNeuralEngine` to keep the prosody RNN off the GPU. But the **Noise stage contains zero RNN ops**, and it is all-fp32 by design (its `sin(cumsum)` phase math collapses in fp16) — so the fp16-only ANE takes none of it and `.cpuAndNeuralEngine` degenerates to plain CPU, measured even slower than `.cpuOnly`.

## Fix (two commits)
1. `noise: .cpuAndGPU` in the `aneTailGpu` preset
2. **Same change in the memberwise-init default** — the actual shipping preset is `KokoroAneComputeUnits()`, and the official benchmark caught commit 1 not engaging (TTFT unchanged at 317 ms). Both presets now route Noise to GPU.

## Measured — official `tts-benchmark`, minimax-english (100 phrases), M5 Pro, release

| | before | after | Δ |
|---|---|---|---|
| TTFT p50 / p95 | 317 / 409 ms | **277 / 346 ms** | −12.6% / −15.4% |
| Agg RTFx | 25.05× | **28.65×** | **+14.4%** |
| Noise stage mean | 88.3 ms | 53.6 ms | −39% |
| Macro WER (Parakeet roundtrip) | 10.33% | 10.38% | unchanged (identical fp32 math) |

Stage-level microbench (MLComputePlan + timed predicts): Noise plans 239/239 ops GPU; 28.9 vs 55.8 ms at T2=400, 3.3× at T2=4000. Multi-chunk in-process runs stable — the #667 second-prediction GPU crash is the prosody RNN's failure mode; prosody stays on ANE.

`Documentation/TTS/Benchmarks.md` en row updated; the zh row predates the fix (expect a similar gain, ~15% projected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Listening samples
A/B pair generated (same text, default voice): before (Noise on CPU) vs after (Noise on GPU). **SNR 25.3 dB** — not bit-exact (GPU vs CPU fp32 reassociation) but same fp32 math; expected perceptually transparent, confirm by ear. Files staged at `~/Desktop/pr677_samples/` (HF token in this session lacks kokoro-82m-coreml scope — drag-drop into a PR comment or upload to the repo's `samples/` to publish).