### PR TITLE
feat(tts/pocket): ANE placements — rank-4 split-KV models (.ane) + MLState pipeline (.aneState)

### DIFF
--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -810,8 +810,20 @@ public enum ModelNames {
         public static let flowlmStepAne = "flowlm_step_ane"
         /// Rank-4 ANE-eligible conditioning prefill (mobius Trial 20).
         public static let condPrefillAne = "cond_prefill_ane"
+        /// MLState multifunction package (mobius Trial 23): `write_state` /
+        /// `prefill` / `generate` functions over a shared fp16 KV state.
+        /// Replaces BOTH the conditioner and the FlowLM+flow-decoder pair
+        /// for `PocketTtsModelPlacement.aneState`. Requires macOS 15+/iOS 18+.
+        public static let pocketState = "pocket_state"
         public static let mimiDecoder = "mimi_decoder"
         public static let mimiEncoder = "mimi_encoderv2"
+
+        /// Function names inside the `pocket_state` multifunction package.
+        public enum StateFunction {
+            public static let writeState = "write_state"
+            public static let prefill = "prefill"
+            public static let generate = "generate"
+        }
 
         public static let condStepFile = condStep + ".mlmodelc"
         public static let condPrefillFile = condPrefill + ".mlmodelc"
@@ -821,6 +833,7 @@ public enum ModelNames {
         public static let flowDecoderFusedFile = flowDecoderFused + ".mlmodelc"
         public static let flowlmStepAneFile = flowlmStepAne + ".mlmodelc"
         public static let condPrefillAneFile = condPrefillAne + ".mlmodelc"
+        public static let pocketStateFile = pocketState + ".mlmodelc"
         public static let mimiDecoderFile = mimiDecoder + ".mlmodelc"
         public static let mimiEncoderFile = mimiEncoder + ".mlmodelc"
 
@@ -865,6 +878,14 @@ public enum ModelNames {
                     condPrefillAneFile,
                     flowlmStepAneFile,
                     flowDecoderFusedFile,
+                    mimiDecoderFile,
+                    constantsBinDir,
+                ]
+            case .aneState:
+                // The multifunction package fuses conditioner + FlowLM +
+                // flow decoder; only mimi stays a separate model.
+                return [
+                    pocketStateFile,
                     mimiDecoderFile,
                     constantsBinDir,
                 ]

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -804,6 +804,12 @@ public enum ModelNames {
         /// v2.1 fused flow decoder (8-step LSD unrolled, 100% ANE). Replaces
         /// the per-step `flow_decoder` in v2.1 packs.
         public static let flowDecoderFused = "flow_decoder_fused"
+        /// Rank-4 ANE-eligible FlowLM step (mobius Trial 19): 100% ANE under
+        /// `.cpuAndNeuralEngine`; split k/v cache I/O with explicit output
+        /// names. Selected by `PocketTtsModelPlacement.ane`.
+        public static let flowlmStepAne = "flowlm_step_ane"
+        /// Rank-4 ANE-eligible conditioning prefill (mobius Trial 20).
+        public static let condPrefillAne = "cond_prefill_ane"
         public static let mimiDecoder = "mimi_decoder"
         public static let mimiEncoder = "mimi_encoderv2"
 
@@ -813,6 +819,8 @@ public enum ModelNames {
         public static let flowlmStepV2File = flowlmStepV2 + ".mlmodelc"
         public static let flowDecoderFile = flowDecoder + ".mlmodelc"
         public static let flowDecoderFusedFile = flowDecoderFused + ".mlmodelc"
+        public static let flowlmStepAneFile = flowlmStepAne + ".mlmodelc"
+        public static let condPrefillAneFile = condPrefillAne + ".mlmodelc"
         public static let mimiDecoderFile = mimiDecoder + ".mlmodelc"
         public static let mimiEncoderFile = mimiEncoder + ".mlmodelc"
 
@@ -833,13 +841,34 @@ public enum ModelNames {
         /// Required files inside any language's `v2/<lang>/` pack for the
         /// given precision. The set differs only in the FlowLM filename.
         public static func requiredModels(precision: PocketTtsPrecision) -> Set<String> {
-            [
-                condPrefillFile,
-                flowlmStepFile(precision: precision),
-                flowDecoderFusedFile,
-                mimiDecoderFile,
-                constantsBinDir,
-            ]
+            requiredModels(precision: precision, placement: .gpu)
+        }
+
+        /// Required files for a precision + placement combination. `.ane`
+        /// swaps the rank-5 conditioner/FlowLM for the rank-4 ANE-eligible
+        /// variants (fp16 only — `precision` does not affect the ANE set).
+        public static func requiredModels(
+            precision: PocketTtsPrecision,
+            placement: PocketTtsModelPlacement
+        ) -> Set<String> {
+            switch placement {
+            case .gpu:
+                return [
+                    condPrefillFile,
+                    flowlmStepFile(precision: precision),
+                    flowDecoderFusedFile,
+                    mimiDecoderFile,
+                    constantsBinDir,
+                ]
+            case .ane:
+                return [
+                    condPrefillAneFile,
+                    flowlmStepAneFile,
+                    flowDecoderFusedFile,
+                    mimiDecoderFile,
+                    constantsBinDir,
+                ]
+            }
         }
 
         /// Required files for the default precision. Kept for callers that

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -95,6 +95,23 @@ public enum PocketTtsResourceDownloader {
         // don't need so disk usage matches the loaded models.
         removeUnusedFlowlmVariant(at: languageRoot, keeping: precision)
 
+        // The Trial 23 multifunction state package is not published on
+        // HuggingFace yet, so the subdir download above cannot provide it.
+        // Fail loudly with install instructions instead of letting the
+        // model load die with a bare file-not-found.
+        if placement == .aneState {
+            let statePath = languageRoot.appendingPathComponent(
+                ModelNames.PocketTTS.pocketStateFile)
+            guard FileManager.default.fileExists(atPath: statePath.path) else {
+                throw PocketTTSError.modelNotFound(
+                    "\(ModelNames.PocketTTS.pocketStateFile) is required for the "
+                        + "`.aneState` placement but is not published upstream. Install the "
+                        + "Trial 23 multifunction artifact (mobius bench_pipeline_mlstate.py, "
+                        + "pocket_flowlm_mf_state.mlmodelc) at \(statePath.path)."
+                )
+            }
+        }
+
         return languageRoot
     }
 

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -38,6 +38,7 @@ public enum PocketTtsResourceDownloader {
         language: PocketTtsLanguage,
         directory: URL? = nil,
         precision: PocketTtsPrecision = .fp16,
+        placement: PocketTtsModelPlacement = .gpu,
         progressHandler: DownloadUtils.ProgressHandler? = nil
     ) async throws -> URL {
         let targetDir = try directory ?? cacheDirectory()
@@ -48,7 +49,8 @@ public enum PocketTtsResourceDownloader {
         let subdir = language.repoSubdirectory
         let languageRoot = repoDir.appendingPathComponent(subdir)
 
-        let required = ModelNames.PocketTTS.requiredModels(precision: precision)
+        let required = ModelNames.PocketTTS.requiredModels(
+            precision: precision, placement: placement)
         let allPresent = required.allSatisfy { model in
             FileManager.default.fileExists(
                 atPath: languageRoot.appendingPathComponent(model).path)

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsLayerKeys.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsLayerKeys.swift
@@ -21,7 +21,11 @@ import Foundation
 /// strides that nevertheless increase monotonically per layer.
 struct PocketTtsLayerKeys: Sendable {
     /// One cache output name per transformer layer, ordered by layer index.
+    /// For split-KV (rank-4 `_ane`) models this holds the K cache names.
     let cacheKeys: [String]
+    /// V cache output names for split-KV (rank-4 `_ane`) models, ordered by
+    /// layer index. `nil` for the rank-5 packs (K+V share one tensor).
+    let vCacheKeys: [String]?
     /// One position output name per transformer layer, ordered by layer index.
     let positionKeys: [String]
     /// Hidden-state output name (flowlm_step only). `nil` for cond_step.
@@ -30,6 +34,23 @@ struct PocketTtsLayerKeys: Sendable {
     let eosLogit: String?
 
     var layerCount: Int { cacheKeys.count }
+    /// Whether the model uses rank-4 split k/v cache I/O.
+    var isSplitKV: Bool { vCacheKeys != nil }
+
+    /// Keys for the rank-4 `_ane` models, which ship EXPLICIT output names
+    /// (the k/v caches share a shape, so shape-bucket discovery can't tell
+    /// them apart — see mobius convert_flowlm_step_ane.py). No discovery:
+    /// names are `new_k_cache{i}` / `new_v_cache{i}` / `new_position{i}`,
+    /// plus `transformer_out` / `is_eos` for the FlowLM step.
+    static func aneKeys(layers: Int, kind: ModelKind) -> PocketTtsLayerKeys {
+        PocketTtsLayerKeys(
+            cacheKeys: (0..<layers).map { "new_k_cache\($0)" },
+            vCacheKeys: (0..<layers).map { "new_v_cache\($0)" },
+            positionKeys: (0..<layers).map { "new_position\($0)" },
+            transformerOut: kind == .flowlmStep ? "transformer_out" : nil,
+            eosLogit: kind == .flowlmStep ? "is_eos" : nil
+        )
+    }
 
     enum DiscoveryError: Error, LocalizedError {
         case shapeMismatch(modelName: String, expectedLayers: Int, actualCaches: Int)
@@ -131,6 +152,7 @@ struct PocketTtsLayerKeys: Sendable {
         case .condStep:
             return PocketTtsLayerKeys(
                 cacheKeys: cacheCandidates,
+                vCacheKeys: nil,
                 positionKeys: positionCandidates,
                 transformerOut: nil,
                 eosLogit: nil
@@ -145,6 +167,7 @@ struct PocketTtsLayerKeys: Sendable {
             }
             return PocketTtsLayerKeys(
                 cacheKeys: cacheCandidates,
+                vCacheKeys: nil,
                 positionKeys: positionCandidates,
                 transformerOut: transformerOut,
                 eosLogit: eosLogit

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -29,6 +29,7 @@ public actor PocketTtsModelStore {
     private let directory: URL?
     public let language: PocketTtsLanguage
     public let precision: PocketTtsPrecision
+    public let placement: PocketTtsModelPlacement
 
     /// - Parameters:
     ///   - language: Which upstream language pack to load. Defaults to
@@ -40,14 +41,20 @@ public actor PocketTtsModelStore {
     ///     `flowlm_step.mlmodelc` for `flowlm_stepv2.mlmodelc` from the
     ///     same upstream `v2/<lang>/` directory; the other three submodels
     ///     stay at fp16.
+    /// - Parameter placement: `.gpu` (default) loads the v2.1 rank-5 models;
+    ///   `.ane` loads the rank-4 `_ane` variants with the FlowLM pinned to
+    ///   `.cpuAndNeuralEngine` (see `PocketTtsModelPlacement`). `.ane`
+    ///   ignores `precision` for the FlowLM (fp16 only).
     public init(
         language: PocketTtsLanguage = .english,
         directory: URL? = nil,
-        precision: PocketTtsPrecision = .fp16
+        precision: PocketTtsPrecision = .fp16,
+        placement: PocketTtsModelPlacement = .gpu
     ) {
         self.language = language
         self.directory = directory
         self.precision = precision
+        self.placement = placement
     }
 
     /// Load all four CoreML models and the constants bundle.
@@ -57,7 +64,8 @@ public actor PocketTtsModelStore {
         let languageRoot = try await PocketTtsResourceDownloader.ensureModels(
             language: language,
             directory: directory,
-            precision: precision
+            precision: precision,
+            placement: placement
         )
         self.languageRootDirectory = languageRoot
 
@@ -86,18 +94,32 @@ public actor PocketTtsModelStore {
             c.computeUnits = units
             return c
         }
+        // `.ane` placement (rank-4 models, mobius Trials 19/20): the FlowLM
+        // plans 100% ANE under `.cpuAndNeuralEngine` (3.68 ms vs 3.04 GPU on
+        // M-series — the trade buys a GPU-free decode loop). cond_prefill_ane
+        // is 92% ANE-capable but its single fat T=256 call is ~2x faster on
+        // GPU, so it stays `.all` and lets the scheduler pick.
         let condConfig = config(.all)
-        let flowlmConfig = config(.all)
+        let flowlmConfig = config(placement == .ane ? .cpuAndNeuralEngine : .all)
         let flowDecoderConfig = config(.all)
         let mimiConfig = config(.cpuOnly)
 
         let loadStart = Date()
 
         // v2.1 required set: cond_prefill (one-shot conditioner) + fused flow
-        // decoder replace v2's cond_step + per-step flow_decoder.
+        // decoder replace v2's cond_step + per-step flow_decoder. `.ane`
+        // placement swaps in the rank-4 conditioner/FlowLM.
+        let condFile =
+            placement == .ane
+            ? ModelNames.PocketTTS.condPrefillAneFile
+            : ModelNames.PocketTTS.condPrefillFile
+        let flowlmFile =
+            placement == .ane
+            ? ModelNames.PocketTTS.flowlmStepAneFile
+            : ModelNames.PocketTTS.flowlmStepFile(precision: precision)
         let modelSpecs: [(file: String, config: MLModelConfiguration)] = [
-            (ModelNames.PocketTTS.condPrefillFile, condConfig),
-            (ModelNames.PocketTTS.flowlmStepFile(precision: precision), flowlmConfig),
+            (condFile, condConfig),
+            (flowlmFile, flowlmConfig),
             (ModelNames.PocketTTS.flowDecoderFusedFile, flowDecoderConfig),
             (ModelNames.PocketTTS.mimiDecoderFile, mimiConfig),
         ]
@@ -120,21 +142,29 @@ public actor PocketTtsModelStore {
         flowDecoderModel = loadedModels[2]  // flow_decoder_fused
         mimiDecoderModel = loadedModels[3]
 
-        // Discover per-model output names. Names differ between 6L and 24L
-        // packs because CoreML auto-generates them during tracing.
+        // Per-model output names. The rank-5 packs need shape-bucket
+        // discovery (CoreML auto-generates their names during tracing); the
+        // rank-4 `_ane` models ship explicit names, so the keys are static.
         let expectedLayers = language.transformerLayers
-        condLayerKeys = try PocketTtsLayerKeys.discover(
-            from: loadedModels[0],
-            kind: .condStep,  // cond_prefill shares cond_step's output schema
-            expectedLayers: expectedLayers,
-            modelName: "cond_prefill"
-        )
-        flowlmLayerKeys = try PocketTtsLayerKeys.discover(
-            from: loadedModels[1],
-            kind: .flowlmStep,
-            expectedLayers: expectedLayers,
-            modelName: "flowlm_step"
-        )
+        if placement == .ane {
+            condLayerKeys = PocketTtsLayerKeys.aneKeys(
+                layers: expectedLayers, kind: .condStep)
+            flowlmLayerKeys = PocketTtsLayerKeys.aneKeys(
+                layers: expectedLayers, kind: .flowlmStep)
+        } else {
+            condLayerKeys = try PocketTtsLayerKeys.discover(
+                from: loadedModels[0],
+                kind: .condStep,  // cond_prefill shares cond_step's output schema
+                expectedLayers: expectedLayers,
+                modelName: "cond_prefill"
+            )
+            flowlmLayerKeys = try PocketTtsLayerKeys.discover(
+                from: loadedModels[1],
+                kind: .flowlmStep,
+                expectedLayers: expectedLayers,
+                modelName: "flowlm_step"
+            )
+        }
 
         // cond_prefill is the required v2.1 conditioner (loaded above as
         // loadedModels[0]); its layer keys match cond_step's schema.

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -19,6 +19,9 @@ public actor PocketTtsModelStore {
     private var flowDecoderModel: MLModel?
     private var mimiDecoderModel: MLModel?
     private var mimiEncoderModel: MLModel?
+    /// `.aneState` only: the prefill/generate function instances loaded from
+    /// the `pocket_state.mlmodelc` multifunction package (mobius Trial 23).
+    private var stateModelsStore: PocketTtsStateModels?
     private var constantsBundle: PocketTtsConstantsBundle?
     private var voiceCache: [String: PocketTtsVoiceData] = [:]
     private var languageRootDirectory: URL?
@@ -44,7 +47,9 @@ public actor PocketTtsModelStore {
     /// - Parameter placement: `.gpu` (default) loads the v2.1 rank-5 models;
     ///   `.ane` loads the rank-4 `_ane` variants with the FlowLM pinned to
     ///   `.cpuAndNeuralEngine` (see `PocketTtsModelPlacement`). `.ane`
-    ///   ignores `precision` for the FlowLM (fp16 only).
+    ///   ignores `precision` for the FlowLM (fp16 only). `.aneState` loads
+    ///   the Trial 23 `pocket_state.mlmodelc` multifunction package (MLState
+    ///   KV cache; macOS 15+/iOS 18+ at runtime, fp16 only).
     public init(
         language: PocketTtsLanguage = .english,
         directory: URL? = nil,
@@ -59,7 +64,7 @@ public actor PocketTtsModelStore {
 
     /// Load all four CoreML models and the constants bundle.
     public func loadIfNeeded() async throws {
-        guard condStepModel == nil else { return }
+        guard condStepModel == nil && stateModelsStore == nil else { return }
 
         let languageRoot = try await PocketTtsResourceDownloader.ensureModels(
             language: language,
@@ -72,6 +77,22 @@ public actor PocketTtsModelStore {
         logger.info(
             "Loading PocketTTS CoreML models (language=\(self.language.rawValue), precision=\(self.precision))..."
         )
+
+        if placement == .aneState {
+            // MLState + multifunction models need the macOS 15 / iOS 18
+            // CoreML runtime; the package itself still targets macOS 14, so
+            // this is a runtime gate rather than a compile-time one.
+            guard #available(macOS 15.0, iOS 18.0, *) else {
+                throw PocketTTSError.processingFailed(
+                    "PocketTTS `.aneState` placement requires macOS 15+/iOS 18+ "
+                        + "(MLState and multifunction CoreML models)."
+                )
+            }
+            try loadStatePipeline(languageRoot: languageRoot)
+            constantsBundle = try PocketTtsConstantsLoader.load(from: languageRoot)
+            logger.info("PocketTTS constants loaded")
+            return
+        }
 
         // Per-model compute units. The global `.cpuAndGPU` hammer was set to
         // stop the Mimi decoder beeping (its streaming-state fp16 feedback loop
@@ -181,6 +202,60 @@ public actor PocketTtsModelStore {
         // Load constants
         constantsBundle = try PocketTtsConstantsLoader.load(from: languageRoot)
         logger.info("PocketTTS constants loaded")
+    }
+
+    /// Load the `.aneState` model set: the prefill + generate function
+    /// instances of the ONE `pocket_state.mlmodelc` multifunction package,
+    /// plus the regular Mimi decoder.
+    ///
+    /// Compute units follow Trial 23's host recommendation: everything at
+    /// `.cpuAndNeuralEngine` — `generate` plans 100% ANE, and the stateful
+    /// prefill no longer round-trips ~100 MB of cache I/O so it doesn't need
+    /// the GPU escape hatch that the IO `cond_prefill` uses. Mimi stays
+    /// `.cpuOnly` (ANE fp16 feedback beep, mobius IOS_COREML_ISSUES.md #7).
+    @available(macOS 15.0, iOS 18.0, *)
+    private func loadStatePipeline(languageRoot: URL) throws {
+        let loadStart = Date()
+        let stateURL = languageRoot.appendingPathComponent(
+            ModelNames.PocketTTS.pocketStateFile)
+
+        func functionConfig(_ functionName: String) -> MLModelConfiguration {
+            let c = MLModelConfiguration()
+            c.computeUnits = .cpuAndNeuralEngine
+            c.functionName = functionName
+            return c
+        }
+
+        let prefill = try MLModel(
+            contentsOf: stateURL,
+            configuration: functionConfig(ModelNames.PocketTTS.StateFunction.prefill))
+        let generate = try MLModel(
+            contentsOf: stateURL,
+            configuration: functionConfig(ModelNames.PocketTTS.StateFunction.generate))
+        stateModelsStore = PocketTtsStateModels(prefill: prefill, generate: generate)
+        logger.info(
+            "Loaded \(ModelNames.PocketTTS.pocketStateFile) (functions: prefill, generate; computeUnits=cpuAndNeuralEngine)"
+        )
+
+        let mimiConfig = MLModelConfiguration()
+        mimiConfig.computeUnits = .cpuOnly
+        let mimiURL = languageRoot.appendingPathComponent(ModelNames.PocketTTS.mimiDecoderFile)
+        let mimi = try MLModel(contentsOf: mimiURL, configuration: mimiConfig)
+        mimiDecoderModel = mimi
+        mimiDecoderKeysCache = try PocketTtsMimiKeys.discover(from: mimi)
+        logger.info("Loaded \(ModelNames.PocketTTS.mimiDecoderFile) (computeUnits=cpuOnly)")
+
+        let elapsed = Date().timeIntervalSince(loadStart)
+        logger.info("PocketTTS state-pipeline models loaded in \(String(format: "%.2f", elapsed))s")
+    }
+
+    /// The `.aneState` multifunction model handles. Throws for other
+    /// placements (gate with `placement == .aneState`).
+    func stateModels() throws -> PocketTtsStateModels {
+        guard let models = stateModelsStore else {
+            throw PocketTTSError.modelNotFound("PocketTTS state models not loaded")
+        }
+        return models
     }
 
     /// The conditioning step model (KV cache prefill).

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
@@ -205,7 +205,9 @@ public actor PocketTtsSession {
         // Generation loop
         let maxGenLen = PocketTtsSynthesizer.estimateMaxFrames(text: text)
         var eosStep: Int?
-        var sequence = try PocketTtsSynthesizer.createNaNSequence()
+        var sequence = try PocketTtsSynthesizer.createBosStartSequence(
+            bosEmbedding: constants.bosEmbedding,
+            splitKV: flowlmLayerKeys.isSplitKV)
         let totalFramesAfterEos = framesAfterEos + PocketTtsConstants.extraFramesAfterDetection
 
         for step in 0..<maxGenLen {

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSession.swift
@@ -53,26 +53,38 @@ public actor PocketTtsSession {
     private let frameContinuation: AsyncThrowingStream<PocketTtsSynthesizer.AudioFrame, Error>.Continuation
     private var generationTask: Task<Void, Never>?
 
-    // Models
-    private let condModel: MLModel
-    private let condPrefillModel: MLModel
+    // Models (IO placements: `.gpu` / `.ane`). All `nil` for `.aneState`
+    // sessions, which run on the multifunction state pipeline instead.
+    private let condModel: MLModel?
+    private let condPrefillModel: MLModel?
     private let useCondPrefill: Bool
-    private let stepModel: MLModel
-    private let flowModel: MLModel
+    private let stepModel: MLModel?
+    private let flowModel: MLModel?
     private let mimiModel: MLModel
-    private let condLayerKeys: PocketTtsLayerKeys
+    private let condLayerKeys: PocketTtsLayerKeys?
     private let condPrefillLayerKeys: PocketTtsLayerKeys?
-    private let flowlmLayerKeys: PocketTtsLayerKeys
+    private let flowlmLayerKeys: PocketTtsLayerKeys?
     private let mimiKeys: PocketTtsMimiKeys
 
-    // Persistent state
-    private let voiceKVSnapshot: PocketTtsSynthesizer.KVCacheState
+    // Persistent state (IO placements). `nil` for `.aneState`.
+    private let voiceKVSnapshot: PocketTtsSynthesizer.KVCacheState?
     private let constants: PocketTtsConstantsBundle
     private let bosEmb: MLMultiArray
     private let temperature: Float
     private let language: PocketTtsLanguage
+    private let maxTokensPerChunk: Int
     private var mimiState: PocketTtsSynthesizer.MimiState
     private var rng: SeededRNG
+
+    // Stateful (`.aneState`) path — mobius Trial 23 MLState pipeline.
+    // `stateEngineRef` / `stateVoiceSnapshotRef` are lazily created on the
+    // first chunk and stored type-erased because `PocketTtsStateEngine` (and
+    // its snapshot struct) are only available on macOS 15+/iOS 18+ while
+    // this actor compiles for macOS 14; use sites downcast under #available.
+    private let stateModels: PocketTtsStateModels?
+    private let stateVoiceData: PocketTtsVoiceData?
+    private var stateEngineRef: AnyObject?
+    private var stateVoiceSnapshotRef: Any?
 
     // MARK: - Initialization
 
@@ -96,7 +108,8 @@ public actor PocketTtsSession {
         bosEmb: MLMultiArray,
         temperature: Float,
         seed: UInt64,
-        language: PocketTtsLanguage = .english
+        language: PocketTtsLanguage = .english,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk
     ) {
         self.voiceKVSnapshot = voiceKVSnapshot
         self.mimiState = mimiState
@@ -114,7 +127,64 @@ public actor PocketTtsSession {
         self.bosEmb = bosEmb
         self.temperature = temperature
         self.language = language
+        self.maxTokensPerChunk = maxTokensPerChunk
         self.rng = SeededRNG(seed: seed)
+        self.stateModels = nil
+        self.stateVoiceData = nil
+
+        // Text queue channel
+        let (textStream, textContinuation) = AsyncStream.makeStream(of: String.self)
+        self.textStream = textStream
+        self.textContinuation = textContinuation
+
+        // Frame output stream
+        let (frames, frameContinuation) = AsyncThrowingStream.makeStream(
+            of: PocketTtsSynthesizer.AudioFrame.self
+        )
+        self.frames = frames
+        self.frameContinuation = frameContinuation
+    }
+
+    /// Create a stateful (`.aneState`) session over the Trial 23 MLState
+    /// multifunction pipeline. The voice KV is injected straight into the
+    /// shared `MLState` per chunk (fp16 snapshot write = utterance reset),
+    /// so none of the IO models/keys are needed.
+    ///
+    /// This initializer is internal — use `PocketTtsManager.makeSession()`
+    /// with a `PocketTtsModelStore` configured for `.aneState`.
+    init(
+        stateModels: PocketTtsStateModels,
+        voiceData: PocketTtsVoiceData,
+        mimiState: PocketTtsSynthesizer.MimiState,
+        constants: PocketTtsConstantsBundle,
+        mimiModel: MLModel,
+        mimiKeys: PocketTtsMimiKeys,
+        bosEmb: MLMultiArray,
+        temperature: Float,
+        seed: UInt64,
+        language: PocketTtsLanguage = .english,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk
+    ) {
+        self.voiceKVSnapshot = nil
+        self.mimiState = mimiState
+        self.constants = constants
+        self.condModel = nil
+        self.condPrefillModel = nil
+        self.useCondPrefill = false
+        self.stepModel = nil
+        self.flowModel = nil
+        self.mimiModel = mimiModel
+        self.condLayerKeys = nil
+        self.condPrefillLayerKeys = nil
+        self.flowlmLayerKeys = nil
+        self.mimiKeys = mimiKeys
+        self.bosEmb = bosEmb
+        self.temperature = temperature
+        self.language = language
+        self.maxTokensPerChunk = maxTokensPerChunk
+        self.rng = SeededRNG(seed: seed)
+        self.stateModels = stateModels
+        self.stateVoiceData = voiceData
 
         // Text queue channel
         let (textStream, textContinuation) = AsyncStream.makeStream(of: String.self)
@@ -154,7 +224,8 @@ public actor PocketTtsSession {
                 guard !trimmed.isEmpty else { continue }
 
                 let chunks = PocketTtsSynthesizer.chunkTextWithMetadata(
-                    trimmed, tokenizer: constants.tokenizer, language: language
+                    trimmed, tokenizer: constants.tokenizer,
+                    maxTokens: maxTokensPerChunk, language: language
                 )
                 Self.logger.info(
                     "Session enqueued '\(trimmed)', \(chunks.count) chunk(s)")
@@ -185,6 +256,28 @@ public actor PocketTtsSession {
         chunkCount: Int,
         utteranceIndex: Int
     ) async throws {
+        if stateModels != nil {
+            // `.aneState`: MLState multifunction pipeline. The store refuses
+            // to load these models on pre-15/18 OSes, so this gate is
+            // unreachable in practice — it exists for the compiler.
+            guard #available(macOS 15.0, iOS 18.0, *) else {
+                throw PocketTTSError.processingFailed(
+                    "PocketTTS `.aneState` placement requires macOS 15+/iOS 18+")
+            }
+            try await generateChunkStateful(
+                text: text, isMidSentence: isMidSentence,
+                chunkIndex: chunkIndex, chunkCount: chunkCount,
+                utteranceIndex: utteranceIndex)
+            return
+        }
+
+        guard let condModel, let stepModel, let flowModel,
+            let condLayerKeys, let flowlmLayerKeys, let voiceKVSnapshot
+        else {
+            throw PocketTTSError.processingFailed(
+                "PocketTTS session misconfigured: IO models missing")
+        }
+
         let (normalizedChunk, framesAfterEos) = PocketTtsSynthesizer.normalizeText(
             text, isMidSentence: isMidSentence, language: language)
         Self.logger.info("Session chunk \(chunkIndex): '\(normalizedChunk)'")
@@ -198,7 +291,7 @@ public actor PocketTtsSession {
         kvState = try await PocketTtsSynthesizer.prefillKVCacheText(
             state: kvState, textEmbeddings: textEmbeddings, model: condModel,
             layerKeys: condLayerKeys,
-            prefillModel: condPrefillModel, prefillLayerKeys: condPrefillLayerKeys,
+            prefillModel: condPrefillModel ?? condModel, prefillLayerKeys: condPrefillLayerKeys,
             useFastPrefill: useCondPrefill
         )
 
@@ -265,6 +358,169 @@ public actor PocketTtsSession {
 
             // Autoregressive feedback
             sequence = try PocketTtsSynthesizer.createSequenceFromLatent(latent)
+        }
+    }
+
+    // MARK: - Stateful (`.aneState`) Generation — mobius Trial 23
+
+    /// The lazily-created `PocketTtsStateEngine` for this session. One engine
+    /// (and one underlying `MLState`) per session, reused across utterances.
+    @available(macOS 15.0, iOS 18.0, *)
+    private func stateEngine() throws -> PocketTtsStateEngine {
+        if let engine = stateEngineRef as? PocketTtsStateEngine {
+            return engine
+        }
+        guard let stateModels else {
+            throw PocketTTSError.processingFailed(
+                "PocketTTS state session missing multifunction models")
+        }
+        let engine = PocketTtsStateEngine(
+            models: stateModels, layers: language.transformerLayers)
+        stateEngineRef = engine
+        return engine
+    }
+
+    /// The session voice's KV snapshot in the state's fp16 at-rest format.
+    /// Computed once: shipped voices convert their pre-baked snapshot
+    /// directly; cloned voices run the `[bos_before_voice, voice...]` block
+    /// through the stateful prefill once and capture the resulting state.
+    @available(macOS 15.0, iOS 18.0, *)
+    private func stateVoiceFp16Snapshot(
+        engine: PocketTtsStateEngine
+    ) async throws -> PocketTtsStateEngine.Fp16Snapshot {
+        if let cached = stateVoiceSnapshotRef as? PocketTtsStateEngine.Fp16Snapshot {
+            return cached
+        }
+        guard let voiceData = stateVoiceData else {
+            throw PocketTTSError.processingFailed(
+                "PocketTTS state session missing voice data")
+        }
+
+        let snapshot: PocketTtsStateEngine.Fp16Snapshot
+        if let baked = voiceData.cacheSnapshot {
+            snapshot = try PocketTtsStateEngine.fp16Snapshot(
+                from: baked, layers: language.transformerLayers)
+        } else if voiceData.promptLength > 0 {
+            guard let bosBeforeVoice = constants.bosBeforeVoice else {
+                throw PocketTTSError.processingFailed(
+                    "PocketTTS cloned-voice prefill requires bos_before_voice constant. "
+                        + "Re-download the language pack (FluidAudio #592 fix).")
+            }
+            let dim = PocketTtsConstants.embeddingDim
+            var flat = [Float]()
+            flat.reserveCapacity((1 + voiceData.promptLength) * dim)
+            flat.append(contentsOf: bosBeforeVoice)
+            flat.append(contentsOf: voiceData.audioPrompt[0..<(voiceData.promptLength * dim)])
+            try await engine.resetToZero()
+            try await engine.prefill(
+                flatConditioning: flat, tokenCount: 1 + voiceData.promptLength)
+            snapshot = try await engine.captureSnapshot()
+        } else {
+            // Empty voice prompt: chunks start from a zeroed cache.
+            try await engine.resetToZero()
+            snapshot = try await engine.captureSnapshot()
+        }
+        stateVoiceSnapshotRef = snapshot
+        Self.logger.info(
+            "Session state voice snapshot ready at position \(Int(snapshot.position))")
+        return snapshot
+    }
+
+    /// Stateful counterpart of `generateChunk`: voice injection (= cache
+    /// reset) + ONE prefill call + one fused `generate` dispatch per frame.
+    /// Mimi decoding, EOS handling, and frame emission are identical to the
+    /// IO path. The flow-decoder noise comes from the same seeded RNG so
+    /// `--seed` reproducibility holds (note: the fused step consumes its 32
+    /// noise draws BEFORE the post-EOS break is evaluated, so the draw
+    /// stream differs from the IO placements after the final frame — seeds
+    /// are reproducible within a placement, not across placements).
+    @available(macOS 15.0, iOS 18.0, *)
+    private func generateChunkStateful(
+        text: String,
+        isMidSentence: Bool,
+        chunkIndex: Int,
+        chunkCount: Int,
+        utteranceIndex: Int
+    ) async throws {
+        let engine = try stateEngine()
+        let voiceSnapshot = try await stateVoiceFp16Snapshot(engine: engine)
+
+        let (normalizedChunk, framesAfterEos) = PocketTtsSynthesizer.normalizeText(
+            text, isMidSentence: isMidSentence, language: language)
+        Self.logger.info("Session chunk \(chunkIndex) (state): '\(normalizedChunk)'")
+
+        // Tokenize and embed
+        let tokenIds = constants.tokenizer.encode(normalizedChunk)
+        let textEmbeddings = PocketTtsSynthesizer.embedTokens(tokenIds, constants: constants)
+        let dim = PocketTtsConstants.embeddingDim
+        var flatText = [Float]()
+        flatText.reserveCapacity(textEmbeddings.count * dim)
+        for embedding in textEmbeddings { flatText.append(contentsOf: embedding) }
+
+        // Voice injection doubles as the per-chunk cache reset (it
+        // overwrites all 512 slots), then one prefill call for the text.
+        try await engine.reset(with: voiceSnapshot)
+        try await engine.prefill(
+            flatConditioning: flatText, tokenCount: textEmbeddings.count)
+        let prefilledPosition = await engine.position
+        Self.logger.info("State KV prefilled to position \(Int(prefilledPosition))")
+
+        // Generation loop. BOS = the BOS latent passed as `sequence`
+        // (the fused graph has no NaN-BOS protocol — same contract as the
+        // rank-4 `.ane` models).
+        let maxGenLen = PocketTtsSynthesizer.estimateMaxFrames(text: text)
+        var eosStep: Int?
+        var sequence = constants.bosEmbedding
+        let totalFramesAfterEos = framesAfterEos + PocketTtsConstants.extraFramesAfterDetection
+
+        for step in 0..<maxGenLen {
+            if Task.isCancelled { break }
+
+            // z_0 noise from the session RNG (same draw count and scaling
+            // as the IO path's flowDecode).
+            var localRng = rng
+            let scale = sqrtf(temperature)
+            var noise = [Float](repeating: 0, count: PocketTtsConstants.latentDim)
+            for i in 0..<noise.count {
+                noise[i] = Float.gaussianRandom(using: &localRng) * scale
+            }
+            rng = localRng
+
+            let (latent, eosLogit) = try await engine.generateFrame(
+                sequence: sequence, noise: noise)
+
+            // EOS detection
+            if eosLogit > PocketTtsConstants.eosThreshold && eosStep == nil {
+                eosStep = step
+                Self.logger.info("Session chunk \(chunkIndex) (state) EOS at step \(step)")
+            }
+            if let eos = eosStep, step >= eos + totalFramesAfterEos {
+                break
+            }
+
+            // Mimi decode with actor-isolated state
+            var localMimi = mimiState
+            let frameSamples = try await PocketTtsSynthesizer.runMimiDecoder(
+                latent: latent,
+                state: &localMimi,
+                model: mimiModel,
+                mimiKeys: mimiKeys
+            )
+            mimiState = localMimi
+
+            // Yield frame
+            frameContinuation.yield(
+                PocketTtsSynthesizer.AudioFrame(
+                    samples: frameSamples,
+                    frameIndex: step,
+                    chunkIndex: chunkIndex,
+                    chunkCount: chunkCount,
+                    utteranceIndex: utteranceIndex
+                )
+            )
+
+            // Autoregressive feedback
+            sequence = latent
         }
     }
 }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsStateEngine.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsStateEngine.swift
@@ -1,0 +1,395 @@
+import Accelerate
+@preconcurrency import CoreML
+import Foundation
+
+/// The `MLModel` handles loaded from the ONE compiled `pocket_state.mlmodelc`
+/// multifunction package (mobius Trial 23), one instance per CoreML function
+/// (`MLModelConfiguration.functionName`).
+///
+/// The package also ships a third `write_state` function (12 fp16 inputs that
+/// overwrite the whole state) as the contract-explicit voice-injection
+/// fallback. The host does NOT load it: Trial 23 measured the host-side
+/// `MLState.withMultiArray(for:)` write as both bit-exact and faster
+/// (1.56 ms vs 2.18 ms for the function call), so `PocketTtsStateEngine`
+/// writes the state directly.
+struct PocketTtsStateModels: Sendable {
+    /// `prefill` function: `conditioning` `[1, 256, 1024]` + `valid_len` +
+    /// `position` → `new_position`, writing the KV state in place.
+    let prefill: MLModel
+    /// `generate` function: `sequence` `[1, 1, 32]` + `latent_init` `[1, 32]`
+    /// + `position` → `latent_final` + `is_eos`, fusing flowlm_step and the
+    /// 8-step LSD flow decoder into one dispatch over the shared KV state.
+    let generate: MLModel
+}
+
+/// Drives the Trial 23 MLState pipeline: one shared 12-buffer fp16 KV state
+/// (`k_cache0..5` / `v_cache0..5`, each `[1, 512, 16, 64]`) that stays
+/// resident across `prefill` and `generate` calls, replacing the 24-tensor
+/// cache I/O of the `.gpu`/`.ane` placements.
+///
+/// An actor: the `MLState` is mutable shared state that every prediction
+/// writes, so access must be serialized. One engine per session; the state
+/// is reset per chunk by re-injecting the fp16 voice snapshot (which
+/// overwrites every slot, so no `makeState()` per utterance is needed).
+@available(macOS 15.0, iOS 18.0, *)
+actor PocketTtsStateEngine {
+
+    /// A voice KV snapshot converted to the state's at-rest format: fp16 bit
+    /// patterns, zero-padded to the full `[1, 512, 16, 64]` buffer so that
+    /// injecting it doubles as the utterance reset.
+    struct Fp16Snapshot: Sendable {
+        /// Per-layer K buffers, each `kvCacheMaxLen * 16 * 64` fp16 values.
+        let kBuffers: [[UInt16]]
+        /// Per-layer V buffers, same element count as `kBuffers`.
+        let vBuffers: [[UInt16]]
+        /// KV position right after the snapshot (number of valid slots).
+        let position: Float
+    }
+
+    enum StateError: Error {
+        case stateBufferMismatch(name: String, expected: Int, actual: Int)
+        case unsupportedStateLayout(name: String)
+        case missingOutput(String)
+    }
+
+    private let models: PocketTtsStateModels
+    private let mlState: MLState
+    private let layers: Int
+    /// Next KV write slot. Advanced by `prefill` (via the model's
+    /// `new_position` output) and by 1 per `generateFrame` call.
+    private(set) var position: Float = 0
+
+    /// Elements per state buffer: `1 * kvCacheMaxLen * 16 * 64`.
+    private static var bufferElementCount: Int {
+        PocketTtsConstants.kvCacheMaxLen * 16 * 64
+    }
+
+    init(models: PocketTtsStateModels, layers: Int) {
+        self.models = models
+        self.layers = layers
+        // Trial 23: `makeState()` from ANY function instance of the
+        // multifunction package is accepted by the others.
+        self.mlState = models.generate.makeState()
+    }
+
+    // MARK: - Voice injection / reset
+
+    /// Overwrite the ENTIRE state with the fp16 voice snapshot. Because the
+    /// snapshot buffers are full-length (zero-padded), one call is both the
+    /// per-chunk cache reset and the voice injection.
+    func reset(with snapshot: Fp16Snapshot) throws {
+        for i in 0..<layers {
+            try writeStateBuffer(snapshot.kBuffers[i], name: "k_cache\(i)")
+            try writeStateBuffer(snapshot.vBuffers[i], name: "v_cache\(i)")
+        }
+        position = snapshot.position
+    }
+
+    /// Zero the whole state (cloned-voice prefill starts from scratch).
+    func resetToZero() throws {
+        let zeros = [UInt16](repeating: 0, count: Self.bufferElementCount)
+        for i in 0..<layers {
+            try writeStateBuffer(zeros, name: "k_cache\(i)")
+            try writeStateBuffer(zeros, name: "v_cache\(i)")
+        }
+        position = 0
+    }
+
+    /// Read the current state back into an `Fp16Snapshot`. Used to capture a
+    /// cloned voice's prefilled KV once so later chunks re-inject it instead
+    /// of re-running the ~126-token voice prefill.
+    func captureSnapshot() throws -> Fp16Snapshot {
+        var kBuffers: [[UInt16]] = []
+        var vBuffers: [[UInt16]] = []
+        kBuffers.reserveCapacity(layers)
+        vBuffers.reserveCapacity(layers)
+        for i in 0..<layers {
+            kBuffers.append(try readStateBuffer(name: "k_cache\(i)"))
+            vBuffers.append(try readStateBuffer(name: "v_cache\(i)"))
+        }
+        return Fp16Snapshot(kBuffers: kBuffers, vBuffers: vBuffers, position: position)
+    }
+
+    // MARK: - Prefill
+
+    /// One-shot conditioning prefill over the shared state. Mirrors
+    /// `runCondPrefill`'s ≤ T_max windowing (the KV position carries across
+    /// windows inside the state), but with a single shared `position` scalar
+    /// instead of 6 per-layer ones and NO cache tensors marshalled.
+    func prefill(flatConditioning: [Float], tokenCount: Int) async throws {
+        guard tokenCount > 0 else { return }
+        let dim = PocketTtsConstants.embeddingDim
+        let tMax = PocketTtsConstants.condPrefillMaxTokens
+
+        var processed = 0
+        while processed < tokenCount {
+            let n = min(tMax, tokenCount - processed)
+
+            let conditioning = try MLMultiArray(
+                shape: [1, NSNumber(value: tMax), NSNumber(value: dim)], dataType: .float32)
+            let condPtr = conditioning.dataPointer.bindMemory(
+                to: Float.self, capacity: tMax * dim)
+            condPtr.initialize(repeating: 0, count: tMax * dim)
+            let srcOffset = processed * dim
+            let copyCount = min(n * dim, max(0, flatConditioning.count - srcOffset))
+            if copyCount > 0 {
+                flatConditioning.withUnsafeBufferPointer { buffer in
+                    guard let base = buffer.baseAddress else { return }
+                    condPtr.update(from: base.advanced(by: srcOffset), count: copyCount)
+                }
+            }
+
+            let validLen = try MLMultiArray(shape: [1], dataType: .float32)
+            validLen[0] = NSNumber(value: Float(n))
+            let positionArray = try MLMultiArray(shape: [1], dataType: .float32)
+            positionArray[0] = NSNumber(value: position)
+
+            let input = try MLDictionaryFeatureProvider(dictionary: [
+                "conditioning": conditioning,
+                "valid_len": validLen,
+                "position": positionArray,
+            ])
+            let output = try await models.prefill.prediction(
+                from: input, using: mlState, options: MLPredictionOptions())
+
+            if let newPosition = output.featureValue(for: "new_position")?.multiArrayValue {
+                position = newPosition[0].floatValue
+            } else {
+                position += Float(n)
+            }
+            processed += n
+        }
+    }
+
+    // MARK: - Generation
+
+    /// One fused generation step: flowlm_step + flow decode in a single
+    /// dispatch. `sequence` is the previous frame's latent (or the BOS
+    /// latent on the first step — the fused graph has no NaN-BOS protocol).
+    /// `noise` is the host-provided z_0, already scaled by sqrt(temperature)
+    /// from the seeded RNG so `--seed` reproducibility holds. The package's
+    /// `transformer_out` debug output is ignored.
+    func generateFrame(
+        sequence: [Float], noise: [Float]
+    ) async throws -> (latent: [Float], eosLogit: Float) {
+        let latentDim = PocketTtsConstants.latentDim
+
+        let sequenceArray = try MLMultiArray(
+            shape: [1, 1, NSNumber(value: latentDim)], dataType: .float32)
+        let sequencePtr = sequenceArray.dataPointer.bindMemory(
+            to: Float.self, capacity: latentDim)
+        sequence.withUnsafeBufferPointer { buffer in
+            guard let base = buffer.baseAddress else { return }
+            sequencePtr.update(from: base, count: min(sequence.count, latentDim))
+        }
+
+        let latentInit = try MLMultiArray(
+            shape: [1, NSNumber(value: latentDim)], dataType: .float32)
+        let latentPtr = latentInit.dataPointer.bindMemory(to: Float.self, capacity: latentDim)
+        noise.withUnsafeBufferPointer { buffer in
+            guard let base = buffer.baseAddress else { return }
+            latentPtr.update(from: base, count: min(noise.count, latentDim))
+        }
+
+        let positionArray = try MLMultiArray(shape: [1], dataType: .float32)
+        positionArray[0] = NSNumber(value: position)
+
+        let input = try MLDictionaryFeatureProvider(dictionary: [
+            "sequence": sequenceArray,
+            "latent_init": latentInit,
+            "position": positionArray,
+        ])
+        let output = try await models.generate.prediction(
+            from: input, using: mlState, options: MLPredictionOptions())
+
+        guard let latentArray = output.featureValue(for: "latent_final")?.multiArrayValue else {
+            throw StateError.missingOutput("latent_final")
+        }
+        guard let eosArray = output.featureValue(for: "is_eos")?.multiArrayValue else {
+            throw StateError.missingOutput("is_eos")
+        }
+
+        position += 1
+        return (
+            latent: Self.readFloats(latentArray, count: latentDim),
+            eosLogit: eosArray[0].floatValue
+        )
+    }
+
+    // MARK: - Snapshot conversion
+
+    /// Convert a pre-baked v2 voice snapshot (fp32, K-then-V per layer) to
+    /// the state's fp16 at-rest format, zero-padded to full buffers.
+    ///
+    /// fp16 rounding here (vImage, IEEE round-to-nearest-even) matches the
+    /// in-state representation exactly, so re-injection is a pure bit copy —
+    /// the same property Trial 23 proved for the python host-side write.
+    static func fp16Snapshot(
+        from snapshot: PocketTtsVoiceCacheSnapshot, layers: Int
+    ) throws -> Fp16Snapshot {
+        guard snapshot.layers.count == layers else {
+            throw PocketTTSError.processingFailed(
+                "voice snapshot layer count \(snapshot.layers.count) != model layer count \(layers)"
+            )
+        }
+        let srcSeq = snapshot.cacheSeqLen
+        guard srcSeq <= PocketTtsConstants.kvCacheMaxLen else {
+            throw PocketTTSError.processingFailed(
+                "voice snapshot seqLen \(srcSeq) exceeds capacity \(PocketTtsConstants.kvCacheMaxLen)"
+            )
+        }
+        let perKV = srcSeq * 16 * 64
+
+        var kBuffers: [[UInt16]] = []
+        var vBuffers: [[UInt16]] = []
+        kBuffers.reserveCapacity(layers)
+        vBuffers.reserveCapacity(layers)
+        for layerIdx in 0..<layers {
+            let source = snapshot.layers[layerIdx]
+            guard source.cache.count == 2 * perKV else {
+                throw PocketTTSError.processingFailed(
+                    "voice snapshot layer \(layerIdx) has \(source.cache.count) floats, expected \(2 * perKV)"
+                )
+            }
+            kBuffers.append(fp16Buffer(from: source.cache, offset: 0, count: perKV))
+            vBuffers.append(fp16Buffer(from: source.cache, offset: perKV, count: perKV))
+        }
+        return Fp16Snapshot(
+            kBuffers: kBuffers,
+            vBuffers: vBuffers,
+            position: Float(snapshot.layers[0].offset)
+        )
+    }
+
+    /// Convert `count` floats starting at `offset` into a full-length,
+    /// zero-padded fp16 state buffer (IEEE round-to-nearest-even via vImage).
+    static func fp16Buffer(from source: [Float], offset: Int, count: Int) -> [UInt16] {
+        var dst = [UInt16](repeating: 0, count: bufferElementCount)
+        guard count > 0 else { return dst }
+        source.withUnsafeBufferPointer { src in
+            guard let srcBase = src.baseAddress else { return }
+            dst.withUnsafeMutableBufferPointer { dstBuf in
+                guard let dstBase = dstBuf.baseAddress else { return }
+                var srcVImage = vImage_Buffer(
+                    data: UnsafeMutableRawPointer(mutating: srcBase.advanced(by: offset)),
+                    height: 1,
+                    width: vImagePixelCount(count),
+                    rowBytes: count * MemoryLayout<Float>.size
+                )
+                var dstVImage = vImage_Buffer(
+                    data: dstBase,
+                    height: 1,
+                    width: vImagePixelCount(count),
+                    rowBytes: count * MemoryLayout<UInt16>.size
+                )
+                vImageConvert_PlanarFtoPlanar16F(
+                    &srcVImage, &dstVImage, vImage_Flags(kvImageNoFlags))
+            }
+        }
+        return dst
+    }
+
+    // MARK: - State buffer access
+
+    /// Write fp16 bit patterns over an entire state buffer via the mutable
+    /// `MLState.withMultiArray(for:)` accessor (read-write on iOS 18+).
+    private func writeStateBuffer(_ bits: [UInt16], name: String) throws {
+        try mlState.withMultiArray(for: name) { array in
+            try Self.validateBuffer(array, name: name, expectedCount: bits.count)
+            array.withUnsafeMutableBytes { rawBuffer, strides in
+                guard let base = rawBuffer.baseAddress else { return }
+                let dst = base.assumingMemoryBound(to: UInt16.self)
+                if Self.isContiguous(shape: array.shape.map(\.intValue), strides: strides) {
+                    bits.withUnsafeBufferPointer { src in
+                        guard let srcBase = src.baseAddress else { return }
+                        dst.update(from: srcBase, count: bits.count)
+                    }
+                } else {
+                    Self.stridedVisit(
+                        shape: array.shape.map(\.intValue), strides: strides
+                    ) { flatIndex, storageIndex in
+                        dst[storageIndex] = bits[flatIndex]
+                    }
+                }
+            }
+        }
+    }
+
+    /// Read an entire state buffer's fp16 bit patterns.
+    private func readStateBuffer(name: String) throws -> [UInt16] {
+        try mlState.withMultiArray(for: name) { array in
+            let count = array.count
+            try Self.validateBuffer(array, name: name, expectedCount: count)
+            var bits = [UInt16](repeating: 0, count: count)
+            array.withUnsafeMutableBytes { rawBuffer, strides in
+                guard let base = rawBuffer.baseAddress else { return }
+                let src = base.assumingMemoryBound(to: UInt16.self)
+                if Self.isContiguous(shape: array.shape.map(\.intValue), strides: strides) {
+                    bits.withUnsafeMutableBufferPointer { dst in
+                        guard let dstBase = dst.baseAddress else { return }
+                        dstBase.update(from: src, count: count)
+                    }
+                } else {
+                    Self.stridedVisit(
+                        shape: array.shape.map(\.intValue), strides: strides
+                    ) { flatIndex, storageIndex in
+                        bits[flatIndex] = src[storageIndex]
+                    }
+                }
+            }
+            return bits
+        }
+    }
+
+    private static func validateBuffer(
+        _ array: MLMultiArray, name: String, expectedCount: Int
+    ) throws {
+        guard array.dataType == .float16 else {
+            throw StateError.unsupportedStateLayout(name: name)
+        }
+        guard array.count == expectedCount else {
+            throw StateError.stateBufferMismatch(
+                name: name, expected: expectedCount, actual: array.count)
+        }
+    }
+
+    static func isContiguous(shape: [Int], strides: [Int]) -> Bool {
+        guard shape.count == strides.count else { return false }
+        var expected = 1
+        for axis in stride(from: shape.count - 1, through: 0, by: -1) {
+            if strides[axis] != expected { return false }
+            expected *= shape[axis]
+        }
+        return true
+    }
+
+    /// Visit every element of a rank-4 buffer in flat row-major order,
+    /// yielding the matching strided storage index. Fallback path for
+    /// non-contiguous state buffers (not observed in practice).
+    private static func stridedVisit(
+        shape: [Int], strides: [Int], _ visit: (_ flatIndex: Int, _ storageIndex: Int) -> Void
+    ) {
+        precondition(shape.count == 4 && strides.count == 4, "state buffers are rank 4")
+        var flat = 0
+        for a in 0..<shape[0] {
+            for b in 0..<shape[1] {
+                for c in 0..<shape[2] {
+                    let rowBase = a * strides[0] + b * strides[1] + c * strides[2]
+                    for d in 0..<shape[3] {
+                        visit(flat, rowBase + d * strides[3])
+                        flat += 1
+                    }
+                }
+            }
+        }
+    }
+
+    /// Read `count` floats from a (fp32 or fp16) output array.
+    private static func readFloats(_ array: MLMultiArray, count: Int) -> [Float] {
+        if array.dataType == .float16 {
+            return (0..<count).map { array[$0].floatValue }
+        }
+        let ptr = array.dataPointer.bindMemory(to: Float.self, capacity: count)
+        return Array(UnsafeBufferPointer(start: ptr, count: count))
+    }
+}

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+KVCache.swift
@@ -18,42 +18,63 @@ extension PocketTtsSynthesizer {
         ///  - `64`: dims per head (16 × 64 = 1024 total)
         ///
         /// `N` is 6 for 6L packs and 24 for `*_24l` packs.
+        ///
+        /// **Split-KV (rank-4 `_ane`) layout:** `caches` holds the K caches,
+        /// each `[1, kvCacheMaxLen, 16, 64]`, and `vCaches` holds the V
+        /// caches with the same shape. For the rank-5 packs `vCaches` is nil
+        /// and `caches` holds the combined `[2, 1, L, 16, 64]` tensors.
         var caches: [MLMultiArray]
+        /// V caches for split-KV models; `nil` for rank-5 packs.
+        var vCaches: [MLMultiArray]?
         /// `N` position counters (one per layer) tracking the next write slot
         /// in each cache.
         var positions: [MLMultiArray]
+
+        var isSplitKV: Bool { vCaches != nil }
     }
 
     /// Create an empty KV cache state (all zeros, positions at 0).
-    static func emptyKVCacheState(layers: Int) throws -> KVCacheState {
-        let shape: [NSNumber] = [
-            2, 1, NSNumber(value: PocketTtsConstants.kvCacheMaxLen), 16, 64,
-        ]
+    ///
+    /// The rank-4 `_ane` models REQUIRE zero-filled caches: their traces drop
+    /// the rank-5 packs' NaN scrub (unwritten slots must be 0, never NaN).
+    /// This allocator zero-fills for both layouts, satisfying that contract.
+    static func emptyKVCacheState(layers: Int, splitKV: Bool = false) throws -> KVCacheState {
+        let maxLen = NSNumber(value: PocketTtsConstants.kvCacheMaxLen)
+        let shape: [NSNumber] =
+            splitKV ? [1, maxLen, 16, 64] : [2, 1, maxLen, 16, 64]
+
+        func zeroArray() throws -> MLMultiArray {
+            let cache = try MLMultiArray(shape: shape, dataType: .float32)
+            let cachePtr = cache.dataPointer.bindMemory(
+                to: Float.self, capacity: cache.count)
+            cachePtr.initialize(repeating: 0, count: cache.count)
+            return cache
+        }
 
         var caches: [MLMultiArray] = []
+        var vCaches: [MLMultiArray] = []
         var positions: [MLMultiArray] = []
         caches.reserveCapacity(layers)
         positions.reserveCapacity(layers)
 
         for _ in 0..<layers {
-            let cache = try MLMultiArray(shape: shape, dataType: .float32)
-            let cachePtr = cache.dataPointer.bindMemory(
-                to: Float.self, capacity: cache.count)
-            cachePtr.initialize(repeating: 0, count: cache.count)
-            caches.append(cache)
+            caches.append(try zeroArray())
+            if splitKV { vCaches.append(try zeroArray()) }
 
             let pos = try MLMultiArray(shape: [1], dataType: .float32)
             pos[0] = NSNumber(value: Float(0))
             positions.append(pos)
         }
 
-        return KVCacheState(caches: caches, positions: positions)
+        return KVCacheState(
+            caches: caches, vCaches: splitKV ? vCaches : nil, positions: positions)
     }
 
     /// Clone a KV cache state for independent use.
     static func cloneKVCacheState(_ state: KVCacheState) throws -> KVCacheState {
         KVCacheState(
             caches: try state.caches.map(deepCopy),
+            vCaches: try state.vCaches.map { try $0.map(deepCopy) },
             positions: try state.positions.map(deepCopy)
         )
     }
@@ -78,6 +99,60 @@ extension PocketTtsSynthesizer {
         return copy
     }
 
+    /// Add the per-layer cache/position inputs for either cache layout.
+    ///
+    /// Rank-5 packs: `cache{i}` (combined K+V) + `position{i}`.
+    /// Rank-4 `_ane` models: `k_cache{i}` + `v_cache{i}` + `position{i}`.
+    private static func addCacheInputs(
+        _ inputDict: inout [String: Any], state: KVCacheState, layers: Int
+    ) {
+        if let vCaches = state.vCaches {
+            for i in 0..<layers {
+                inputDict["k_cache\(i)"] = state.caches[i]
+                inputDict["v_cache\(i)"] = vCaches[i]
+                inputDict["position\(i)"] = state.positions[i]
+            }
+        } else {
+            for i in 0..<layers {
+                inputDict["cache\(i)"] = state.caches[i]
+                inputDict["position\(i)"] = state.positions[i]
+            }
+        }
+    }
+
+    /// Read the per-layer cache/position outputs back into `state` for either
+    /// cache layout (`layerKeys.cacheKeys` holds K names when split).
+    private static func extractCacheOutputs(
+        _ output: MLFeatureProvider,
+        state: inout KVCacheState,
+        layerKeys: PocketTtsLayerKeys,
+        modelLabel: String
+    ) throws {
+        let layers = layerKeys.layerCount
+        for i in 0..<layers {
+            guard let newCache = output.featureValue(for: layerKeys.cacheKeys[i])?.multiArrayValue
+            else {
+                throw PocketTTSError.processingFailed(
+                    "Missing \(modelLabel) cache output: \(layerKeys.cacheKeys[i])")
+            }
+            guard let newPos = output.featureValue(for: layerKeys.positionKeys[i])?.multiArrayValue
+            else {
+                throw PocketTTSError.processingFailed(
+                    "Missing \(modelLabel) position output: \(layerKeys.positionKeys[i])")
+            }
+            state.caches[i] = newCache
+            state.positions[i] = newPos
+
+            if let vKeys = layerKeys.vCacheKeys {
+                guard let newV = output.featureValue(for: vKeys[i])?.multiArrayValue else {
+                    throw PocketTTSError.processingFailed(
+                        "Missing \(modelLabel) v-cache output: \(vKeys[i])")
+                }
+                state.vCaches?[i] = newV
+            }
+        }
+    }
+
     /// Run the conditioning step model for a single token, updating the KV cache in place.
     ///
     /// `cond_step` and `flowlm_step` share the same transformer weights. This function
@@ -94,29 +169,13 @@ extension PocketTtsSynthesizer {
         var inputDict: [String: Any] = [
             "conditioning": conditioning
         ]
-
-        for i in 0..<layers {
-            inputDict["cache\(i)"] = state.caches[i]
-            inputDict["position\(i)"] = state.positions[i]
-        }
+        addCacheInputs(&inputDict, state: state, layers: layers)
 
         let input = try MLDictionaryFeatureProvider(dictionary: inputDict)
         let output = try await model.compatPrediction(from: input, options: MLPredictionOptions())
 
-        for i in 0..<layers {
-            guard let newCache = output.featureValue(for: layerKeys.cacheKeys[i])?.multiArrayValue
-            else {
-                throw PocketTTSError.processingFailed(
-                    "Missing cond_step cache output: \(layerKeys.cacheKeys[i])")
-            }
-            guard let newPos = output.featureValue(for: layerKeys.positionKeys[i])?.multiArrayValue
-            else {
-                throw PocketTTSError.processingFailed(
-                    "Missing cond_step position output: \(layerKeys.positionKeys[i])")
-            }
-            state.caches[i] = newCache
-            state.positions[i] = newPos
-        }
+        try extractCacheOutputs(
+            output, state: &state, layerKeys: layerKeys, modelLabel: "cond_step")
     }
 
     /// Run the one-shot conditioning prefill model: fill the whole voice or
@@ -168,33 +227,14 @@ extension PocketTtsSynthesizer {
                 "conditioning": conditioning,
                 "valid_len": validLen,
             ]
-            for i in 0..<layers {
-                inputDict["cache\(i)"] = state.caches[i]
-                inputDict["position\(i)"] = state.positions[i]
-            }
+            addCacheInputs(&inputDict, state: state, layers: layers)
 
             let input = try MLDictionaryFeatureProvider(dictionary: inputDict)
             let output = try await model.compatPrediction(
                 from: input, options: MLPredictionOptions())
 
-            for i in 0..<layers {
-                guard
-                    let newCache = output.featureValue(for: layerKeys.cacheKeys[i])?
-                        .multiArrayValue
-                else {
-                    throw PocketTTSError.processingFailed(
-                        "Missing cond_prefill cache output: \(layerKeys.cacheKeys[i])")
-                }
-                guard
-                    let newPos = output.featureValue(for: layerKeys.positionKeys[i])?
-                        .multiArrayValue
-                else {
-                    throw PocketTTSError.processingFailed(
-                        "Missing cond_prefill position output: \(layerKeys.positionKeys[i])")
-                }
-                state.caches[i] = newCache
-                state.positions[i] = newPos
-            }
+            try extractCacheOutputs(
+                output, state: &state, layerKeys: layerKeys, modelLabel: "cond_prefill")
             processed += n
         }
     }
@@ -327,7 +367,8 @@ extension PocketTtsSynthesizer {
     /// (typically equal to `seqLen`).
     static func kvCacheStateFromSnapshot(
         _ snapshot: PocketTtsVoiceCacheSnapshot,
-        layers: Int
+        layers: Int,
+        splitKV: Bool = false
     ) throws -> KVCacheState {
         guard snapshot.layers.count == layers else {
             throw PocketTTSError.processingFailed(
@@ -349,11 +390,22 @@ extension PocketTtsSynthesizer {
         let destPerKVFloats = 1 * destSeq * 16 * 64
         let copyBytes = perKVFloats * MemoryLayout<Float>.size
 
-        let shape: [NSNumber] = [
+        let combinedShape: [NSNumber] = [
             2, 1, NSNumber(value: destSeq), 16, 64,
         ]
+        let splitShape: [NSNumber] = [
+            1, NSNumber(value: destSeq), 16, 64,
+        ]
+
+        func zeroArray(_ shape: [NSNumber]) throws -> (MLMultiArray, UnsafeMutablePointer<Float>) {
+            let array = try MLMultiArray(shape: shape, dataType: .float32)
+            let ptr = array.dataPointer.bindMemory(to: Float.self, capacity: array.count)
+            ptr.initialize(repeating: 0, count: array.count)
+            return (array, ptr)
+        }
 
         var caches: [MLMultiArray] = []
+        var vCaches: [MLMultiArray] = []
         var positions: [MLMultiArray] = []
         caches.reserveCapacity(layers)
         positions.reserveCapacity(layers)
@@ -367,28 +419,39 @@ extension PocketTtsSynthesizer {
                 )
             }
 
-            let cache = try MLMultiArray(shape: shape, dataType: .float32)
-            let cachePtr = cache.dataPointer.bindMemory(to: Float.self, capacity: cache.count)
-            cachePtr.initialize(repeating: 0, count: cache.count)
-
-            // Copy K (source[0..perKVFloats) → dest[0..perKVFloats))
-            // Copy V (source[perKVFloats..2*perKVFloats) → dest[destPerKVFloats..destPerKVFloats+perKVFloats))
-            source.cache.withUnsafeBufferPointer { src in
-                guard let srcBase = src.baseAddress else { return }
-                memcpy(cachePtr, srcBase, copyBytes)
-                memcpy(
-                    cachePtr.advanced(by: destPerKVFloats),
-                    srcBase.advanced(by: perKVFloats),
-                    copyBytes)
+            // Snapshot layout: K block then V block, each `perKVFloats`.
+            if splitKV {
+                let (kCache, kPtr) = try zeroArray(splitShape)
+                let (vCache, vPtr) = try zeroArray(splitShape)
+                source.cache.withUnsafeBufferPointer { src in
+                    guard let srcBase = src.baseAddress else { return }
+                    memcpy(kPtr, srcBase, copyBytes)
+                    memcpy(vPtr, srcBase.advanced(by: perKVFloats), copyBytes)
+                }
+                caches.append(kCache)
+                vCaches.append(vCache)
+            } else {
+                let (cache, cachePtr) = try zeroArray(combinedShape)
+                // Copy K (source[0..perKVFloats) → dest[0..perKVFloats))
+                // Copy V (source[perKVFloats..2*perKVFloats) → dest[destPerKVFloats..destPerKVFloats+perKVFloats))
+                source.cache.withUnsafeBufferPointer { src in
+                    guard let srcBase = src.baseAddress else { return }
+                    memcpy(cachePtr, srcBase, copyBytes)
+                    memcpy(
+                        cachePtr.advanced(by: destPerKVFloats),
+                        srcBase.advanced(by: perKVFloats),
+                        copyBytes)
+                }
+                caches.append(cache)
             }
-            caches.append(cache)
 
             let pos = try MLMultiArray(shape: [1], dataType: .float32)
             pos[0] = NSNumber(value: Float(source.offset))
             positions.append(pos)
         }
 
-        return KVCacheState(caches: caches, positions: positions)
+        return KVCacheState(
+            caches: caches, vCaches: splitKV ? vCaches : nil, positions: positions)
     }
 
     /// Prefill the KV cache with voice and text conditioning tokens.
@@ -417,9 +480,11 @@ extension PocketTtsSynthesizer {
     ) async throws -> KVCacheState {
         var state: KVCacheState
         if let snapshot = voiceData.cacheSnapshot {
-            state = try kvCacheStateFromSnapshot(snapshot, layers: layerKeys.layerCount)
+            state = try kvCacheStateFromSnapshot(
+                snapshot, layers: layerKeys.layerCount, splitKV: layerKeys.isSplitKV)
         } else {
-            let emptyState = try emptyKVCacheState(layers: layerKeys.layerCount)
+            let emptyState = try emptyKVCacheState(
+                layers: layerKeys.layerCount, splitKV: layerKeys.isSplitKV)
             state = try await prefillKVCacheVoice(
                 state: emptyState, voiceData: voiceData,
                 bosBeforeVoice: bosBeforeVoice,
@@ -477,15 +542,15 @@ extension PocketTtsSynthesizer {
         }
 
         let layers = layerKeys.layerCount
-        var inputDict: [String: Any] = [
-            "sequence": sequence,
-            "bos_emb": bosEmb,
-        ]
-
-        for i in 0..<layers {
-            inputDict["cache\(i)"] = state.caches[i]
-            inputDict["position\(i)"] = state.positions[i]
+        // The rank-4 `_ane` FlowLM has no `bos_emb` input (and no NaN-BOS
+        // protocol — the ANE mangles NaN before isnan evaluates). For it the
+        // caller passes the BOS latent as `sequence` on the first step; an
+        // unexpected extra input key would fail the predict call.
+        var inputDict: [String: Any] = ["sequence": sequence]
+        if !layerKeys.isSplitKV {
+            inputDict["bos_emb"] = bosEmb
         }
+        addCacheInputs(&inputDict, state: state, layers: layers)
 
         let input = try MLDictionaryFeatureProvider(dictionary: inputDict)
         let output = try await model.compatPrediction(from: input, options: MLPredictionOptions())
@@ -504,21 +569,8 @@ extension PocketTtsSynthesizer {
         let eosLogit = eosArray[0].floatValue
 
         // Update caches and positions
-        for i in 0..<layers {
-            guard
-                let newCache = output.featureValue(for: layerKeys.cacheKeys[i])?.multiArrayValue
-            else {
-                throw PocketTTSError.processingFailed(
-                    "Missing flowlm_step cache output: \(layerKeys.cacheKeys[i])")
-            }
-            guard let newPos = output.featureValue(for: layerKeys.positionKeys[i])?.multiArrayValue
-            else {
-                throw PocketTTSError.processingFailed(
-                    "Missing flowlm_step position output: \(layerKeys.positionKeys[i])")
-            }
-            state.caches[i] = newCache
-            state.positions[i] = newPos
-        }
+        try extractCacheOutputs(
+            output, state: &state, layerKeys: layerKeys, modelLabel: "flowlm_step")
 
         return (transformerOut: transformerOut, eosLogit: eosLogit)
     }

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+State.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer+State.swift
@@ -1,0 +1,91 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// `.aneState` (mobius Trial 23) entry points. Both public synthesis APIs
+/// route through a stateful `PocketTtsSession`: the MLState pipeline is
+/// session-shaped by construction (one shared KV state, reset per chunk by
+/// the voice-snapshot write), so the streaming API simply runs a one-shot
+/// session instead of duplicating the frame loop a fourth time.
+extension PocketTtsSynthesizer {
+
+    /// Whether the current OS can run the `.aneState` placement.
+    static var isStatePlacementAvailable: Bool {
+        if #available(macOS 15.0, iOS 18.0, *) {
+            return true
+        }
+        return false
+    }
+
+    /// Stateful counterpart of `synthesizeStreaming(text:voiceData:...)`.
+    ///
+    /// Frame metadata matches the session API (`utteranceIndex` is `0`
+    /// rather than `nil`); samples, chunking, and EOS behavior are otherwise
+    /// identical to the IO streaming path.
+    static func synthesizeStreamingStateful(
+        text: String,
+        voiceData: PocketTtsVoiceData,
+        temperature: Float,
+        seed: UInt64?,
+        maxTokensPerChunk: Int,
+        language: PocketTtsLanguage
+    ) async throws -> AsyncThrowingStream<AudioFrame, Error> {
+        let session = try await makeStateSession(
+            voiceData: voiceData,
+            temperature: temperature,
+            seed: seed,
+            language: language,
+            maxTokensPerChunk: maxTokensPerChunk
+        )
+        session.enqueue(text)
+        session.finish()
+        return session.frames
+    }
+
+    /// Build a `.aneState` session: only the multifunction state models,
+    /// the Mimi decoder, and the constants bundle are needed — no IO
+    /// models, layer keys, or host-side KV cache.
+    ///
+    /// The voice prefill/injection happens lazily on the first chunk (the
+    /// fp16 snapshot conversion is a few ms; cloned voices pay one stateful
+    /// prefill and are then captured from the state).
+    static func makeStateSession(
+        voiceData: PocketTtsVoiceData,
+        temperature: Float = PocketTtsConstants.temperature,
+        seed: UInt64? = nil,
+        language: PocketTtsLanguage = .english,
+        maxTokensPerChunk: Int = PocketTtsConstants.maxTokensPerChunk
+    ) async throws -> PocketTtsSession {
+        let store = try currentModelStore()
+        guard isStatePlacementAvailable else {
+            throw PocketTTSError.processingFailed(
+                "PocketTTS `.aneState` placement requires macOS 15+/iOS 18+ "
+                    + "(MLState and multifunction CoreML models)."
+            )
+        }
+
+        let constants = try await store.constants()
+        let stateModels = try await store.stateModels()
+        let mimiModel = try await store.mimiDecoder()
+        let mimiKeys = try await store.mimiDecoderKeys()
+        let repoDir = try await store.repoDir()
+        let mimiState = try loadMimiInitialState(from: repoDir, mimiKeys: mimiKeys)
+        let bosEmb = try createBosEmbedding(constants.bosEmbedding)
+        let seedValue = seed ?? UInt64.random(in: 0...UInt64.max)
+
+        let session = PocketTtsSession(
+            stateModels: stateModels,
+            voiceData: voiceData,
+            mimiState: mimiState,
+            constants: constants,
+            mimiModel: mimiModel,
+            mimiKeys: mimiKeys,
+            bosEmb: bosEmb,
+            temperature: temperature,
+            seed: seedValue,
+            language: language,
+            maxTokensPerChunk: maxTokensPerChunk
+        )
+        await session.start()
+        return session
+    }
+}

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -310,9 +310,10 @@ public struct PocketTtsSynthesizer {
         let voiceKVSnapshot: KVCacheState
         if let snapshot = voiceData.cacheSnapshot {
             voiceKVSnapshot = try kvCacheStateFromSnapshot(
-                snapshot, layers: condLayerKeys.layerCount)
+                snapshot, layers: condLayerKeys.layerCount, splitKV: condLayerKeys.isSplitKV)
         } else {
-            let emptyState = try emptyKVCacheState(layers: condLayerKeys.layerCount)
+            let emptyState = try emptyKVCacheState(
+                layers: condLayerKeys.layerCount, splitKV: condLayerKeys.isSplitKV)
             voiceKVSnapshot = try await prefillKVCacheVoice(
                 state: emptyState, voiceData: voiceData,
                 bosBeforeVoice: constants.bosBeforeVoice,
@@ -501,7 +502,9 @@ public struct PocketTtsSynthesizer {
 
                     let maxGenLen = PocketTtsSynthesizer.estimateMaxFrames(text: chunk.text)
                     var eosStep: Int?
-                    var sequence = try PocketTtsSynthesizer.createNaNSequence()
+                    var sequence = try PocketTtsSynthesizer.createBosStartSequence(
+                        bosEmbedding: constants.bosEmbedding,
+                        splitKV: flowlmLayerKeys.isSplitKV)
                     let totalFramesAfterEos =
                         framesAfterEos + PocketTtsConstants.extraFramesAfterDetection
 
@@ -613,7 +616,9 @@ public struct PocketTtsSynthesizer {
 
                     let maxGenLen = PocketTtsSynthesizer.estimateMaxFrames(text: chunk.text)
                     var eosStep: Int?
-                    var sequence = try PocketTtsSynthesizer.createNaNSequence()
+                    var sequence = try PocketTtsSynthesizer.createBosStartSequence(
+                        bosEmbedding: constants.bosEmbedding,
+                        splitKV: flowlmLayerKeys.isSplitKV)
                     let totalFramesAfterEos =
                         framesAfterEos + PocketTtsConstants.extraFramesAfterDetection
 
@@ -663,8 +668,16 @@ public struct PocketTtsSynthesizer {
         }
     }
 
-    /// Opt-in cross-engine pipelining (mimi overlaps flowlm/flow). UNVERIFIED on
-    /// device — leave `false` until timing + audio ordering are confirmed.
+    /// Opt-in cross-engine pipelining (mimi overlaps flowlm/flow).
+    ///
+    /// MEASURED on-device (M5 Pro, macOS 26.5, release, 3-sentence utterance,
+    /// seed 42, 3 runs each): NO win over the serial loop on either placement
+    /// — serial `.ane` 1.108 s vs pipelined 1.124 s; serial `.gpu` ~1.33 s vs
+    /// pipelined ~1.33 s (WER 0 everywhere). The Phase 7 projection assumed
+    /// mimi(CPU) dominates and overlaps flowlm/flow; in the real host the
+    /// stages don't overlap as scheduled (producer-bound and/or predictions
+    /// not actually concurrent through `compatPrediction`). Keep `false`;
+    /// re-evaluate with per-stage timers before retrying.
     static let useCrossEnginePipeline = false
 
     /// Create the AsyncThrowingStream and spawn the generation task.
@@ -1207,6 +1220,21 @@ public struct PocketTtsSynthesizer {
             ptr.update(from: base, count: dim)
         }
         return array
+    }
+
+    /// Create the first-step `sequence` input for a generation loop.
+    ///
+    /// Rank-5 packs use the NaN-BOS protocol (the graph substitutes
+    /// `bos_emb` for NaN via `isnan`). The rank-4 `_ane` FlowLM has no such
+    /// path — the ANE mangles NaN inputs before `isnan` evaluates — so for
+    /// split-KV models the BOS latent embedding is passed directly.
+    static func createBosStartSequence(
+        bosEmbedding: [Float], splitKV: Bool
+    ) throws -> MLMultiArray {
+        if splitKV {
+            return try createSequenceFromLatent(bosEmbedding)
+        }
+        return try createNaNSequence()
     }
 
     /// Create a NaN-filled sequence `[1, 1, 32]` to signal beginning-of-sequence.

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsSynthesizer.swift
@@ -222,6 +222,19 @@ public struct PocketTtsSynthesizer {
 
         logger.info("PocketTTS streaming synthesis with custom voice: '\(text)'")
 
+        // `.aneState` runs on the Trial 23 MLState pipeline (one shared KV
+        // state instead of 24-tensor cache I/O) via a one-shot session.
+        if store.placement == .aneState {
+            return try await synthesizeStreamingStateful(
+                text: text,
+                voiceData: voiceData,
+                temperature: temperature,
+                seed: seed,
+                maxTokensPerChunk: maxTokensPerChunk,
+                language: language
+            )
+        }
+
         let constants = try await store.constants()
         let chunks = chunkTextWithMetadata(
             text, tokenizer: constants.tokenizer,
@@ -283,6 +296,17 @@ public struct PocketTtsSynthesizer {
         language: PocketTtsLanguage = .english
     ) async throws -> PocketTtsSession {
         let store = try currentModelStore()
+
+        // `.aneState` sessions run on the Trial 23 MLState pipeline; none of
+        // the IO models below exist in that configuration.
+        if store.placement == .aneState {
+            return try await makeStateSession(
+                voiceData: voiceData,
+                temperature: temperature,
+                seed: seed,
+                language: language
+            )
+        }
 
         let constants = try await store.constants()
         let condModel = try await store.condStep()

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
@@ -150,3 +150,25 @@ public enum PocketTtsPrecision: Sendable, Hashable {
     case fp16
     case int8
 }
+
+/// Which transformer-model formulation (and compute-unit policy) to load.
+///
+/// The v2.1 packs ship rank-5 KV-cache graphs that the ANE compiler rejects
+/// outright (`ANECCompile FAILED`), so they run on GPU. The rank-4
+/// scatter-free rewrites (mobius Trials 19/20) are ANE-eligible:
+/// `flowlm_step_ane` plans 100% ANE and `cond_prefill_ane` 92% under
+/// `.cpuAndNeuralEngine`, bit-identical math to the rank-5 graphs.
+///
+/// On M-series Macs the GPU is slightly faster per call (flowlm 3.04 ms GPU
+/// vs 3.68 ms ANE), so `.gpu` stays the default. `.ane` removes the GPU
+/// from the synthesis path entirely — the per-frame loop becomes
+/// ANE (flowlm) → ANE (flow decoder) → CPU (mimi) — for power, engine
+/// parallelism with `useCrossEnginePipeline`, and iOS placement.
+public enum PocketTtsModelPlacement: String, Sendable, Hashable {
+    /// v2.1 rank-5 models, GPU-placed (default).
+    case gpu
+    /// Rank-4 ANE-eligible models (`flowlm_step_ane` + `cond_prefill_ane`).
+    /// Requires the `*_ane.mlmodelc` files in the language pack (fp16 only;
+    /// `precision` is ignored for the FlowLM when this is selected).
+    case ane
+}

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsConstants.swift
@@ -171,4 +171,17 @@ public enum PocketTtsModelPlacement: String, Sendable, Hashable {
     /// Requires the `*_ane.mlmodelc` files in the language pack (fp16 only;
     /// `precision` is ignored for the FlowLM when this is selected).
     case ane
+    /// MLState multifunction pipeline (mobius Trial 23): ONE
+    /// `pocket_state.mlmodelc` package exposing `write_state` / `prefill` /
+    /// `generate` functions over a shared 12-buffer fp16 KV state that stays
+    /// resident on the ANE — the 24-tensor cache I/O of `.gpu`/`.ane` is
+    /// bypassed entirely, and the per-frame `generate` call fuses
+    /// flowlm_step + flow_decoder into one dispatch.
+    ///
+    /// Requires macOS 15+/iOS 18+ at RUNTIME (both `MLState` and
+    /// multifunction models); `loadIfNeeded` throws on older OSes. fp16 only
+    /// (`precision` is ignored). Python-measured −35.8%/utterance on the
+    /// flowlm+flow share vs the `.ane` IO pipeline (mobius TRIALS.md,
+    /// Trial 23); mimi decode is unchanged.
+    case aneState = "ane-state"
 }

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsManager.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsManager.swift
@@ -36,16 +36,21 @@ public actor PocketTtsManager {
     ///     matching upstream's on-disk weight format). `.int8` swaps
     ///     `flowlm_step` for the upstream `flowlm_stepv2` int8-quantized
     ///     variant per kyutai-labs/pocket-tts#147.
+    ///   - placement: `.gpu` (default) loads the v2.1 rank-5 models;
+    ///     `.ane` loads the rank-4 ANE-eligible variants (`flowlm_step_ane`,
+    ///     `cond_prefill_ane`) with the FlowLM pinned to the Neural Engine.
     public init(
         defaultVoice: String = PocketTtsConstants.defaultVoice,
         language: PocketTtsLanguage = .english,
         directory: URL? = nil,
-        precision: PocketTtsPrecision = .fp16
+        precision: PocketTtsPrecision = .fp16,
+        placement: PocketTtsModelPlacement = .gpu
     ) {
         self.modelStore = PocketTtsModelStore(
             language: language,
             directory: directory,
-            precision: precision
+            precision: precision,
+            placement: placement
         )
         self.defaultVoice = defaultVoice
         self.language = language

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -241,7 +241,7 @@ public struct TTS {
                         pocketPlacement = parsed
                     } else {
                         logger.error(
-                            "Unknown PocketTTS placement '\(arguments[i + 1])'. Supported: gpu, ane"
+                            "Unknown PocketTTS placement '\(arguments[i + 1])'. Supported: gpu, ane, ane-state"
                         )
                         return
                     }
@@ -938,6 +938,9 @@ public struct TTS {
                                    portuguese, portuguese_24l, spanish, spanish_24l
                                    Note: French is 24-layer only (no 6-layer pack upstream)
               --seed N             Deterministic-mode seed (uses session API for fixed RNG)
+              --placement P        Model placement: gpu (default), ane (rank-4 ANE models),
+                                   ane-state (Trial 23 MLState multifunction pipeline;
+                                   macOS 15+/iOS 18+, requires pocket_state.mlmodelc)
 
             Voice Cloning examples:
               # Clone and synthesize in one step

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -70,6 +70,7 @@ public struct TTS {
         var voiceFilePath: String? = nil
         var saveVoicePath: String? = nil
         var pocketLanguage: PocketTtsLanguage = .english
+        var pocketPlacement: PocketTtsModelPlacement = .gpu
         // PocketTTS deterministic-seed mode (uses session API for fixed RNG).
         var pocketSeed: UInt64? = nil
         // StyleTTS2 zero-shot args.
@@ -233,6 +234,19 @@ public struct TTS {
                     saveVoicePath = arguments[i + 1]
                     i += 1
                 }
+            case "--placement":
+                if i + 1 < arguments.count {
+                    let raw = arguments[i + 1].lowercased()
+                    if let parsed = PocketTtsModelPlacement(rawValue: raw) {
+                        pocketPlacement = parsed
+                    } else {
+                        logger.error(
+                            "Unknown PocketTTS placement '\(arguments[i + 1])'. Supported: gpu, ane"
+                        )
+                        return
+                    }
+                    i += 1
+                }
             case "--language":
                 if i + 1 < arguments.count {
                     let raw = arguments[i + 1].lowercased()
@@ -270,7 +284,8 @@ public struct TTS {
                 text: text, output: output, voice: voice, deEss: deEss,
                 metricsPath: metricsPath, cloneVoicePath: cloneVoicePath,
                 voiceFilePath: voiceFilePath, saveVoicePath: saveVoicePath,
-                language: pocketLanguage, seed: pocketSeed)
+                language: pocketLanguage, seed: pocketSeed,
+                placement: pocketPlacement)
         case .kokoroAne:
             await runKokoroAne(
                 text: text, output: output, voice: voice, metricsPath: metricsPath,
@@ -351,7 +366,8 @@ public struct TTS {
         metricsPath: String?, cloneVoicePath: String?,
         voiceFilePath: String?, saveVoicePath: String?,
         language: PocketTtsLanguage,
-        seed: UInt64? = nil
+        seed: UInt64? = nil,
+        placement: PocketTtsModelPlacement = .gpu
     ) async {
         do {
             let tStart = Date()
@@ -359,8 +375,9 @@ public struct TTS {
                 voice == TtsConstants.recommendedVoice
                 ? PocketTtsConstants.defaultVoice : voice
             let manager = PocketTtsManager(
-                defaultVoice: pocketVoice, language: language)
-            logger.info("PocketTTS language: \(language.rawValue)")
+                defaultVoice: pocketVoice, language: language, placement: placement)
+            logger.info(
+                "PocketTTS language: \(language.rawValue), placement: \(placement.rawValue)")
 
             let tLoad0 = Date()
             try await manager.initialize()

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsPlacementTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsPlacementTests.swift
@@ -28,6 +28,39 @@ final class PocketTtsPlacementTests: XCTestCase {
         XCTAssertTrue(ane.contains(ModelNames.PocketTTS.mimiDecoderFile))
     }
 
+    func testRequiredModelsAneStateIsMultifunctionPlusMimi() {
+        let state = ModelNames.PocketTTS.requiredModels(precision: .fp16, placement: .aneState)
+        XCTAssertEqual(
+            state,
+            [
+                ModelNames.PocketTTS.pocketStateFile,
+                ModelNames.PocketTTS.mimiDecoderFile,
+                ModelNames.PocketTTS.constantsBinDir,
+            ]
+        )
+        // The multifunction package fuses conditioner + FlowLM + flow
+        // decoder, so NONE of the IO model files belong in the set.
+        XCTAssertFalse(state.contains(ModelNames.PocketTTS.flowDecoderFusedFile))
+        XCTAssertFalse(state.contains(ModelNames.PocketTTS.flowlmStepAneFile))
+        XCTAssertFalse(state.contains(ModelNames.PocketTTS.condPrefillAneFile))
+        // Precision is ignored (fp16 only): the int8 FlowLM never appears.
+        XCTAssertEqual(
+            ModelNames.PocketTTS.requiredModels(precision: .int8, placement: .aneState),
+            state
+        )
+    }
+
+    func testAneStatePlacementRawValueRoundTrip() {
+        // The CLI parses `--placement ane-state` via the raw value.
+        XCTAssertEqual(PocketTtsModelPlacement(rawValue: "ane-state"), .aneState)
+        XCTAssertEqual(PocketTtsModelPlacement.aneState.rawValue, "ane-state")
+        XCTAssertEqual(
+            ModelNames.PocketTTS.pocketStateFile, "pocket_state.mlmodelc")
+        XCTAssertEqual(ModelNames.PocketTTS.StateFunction.writeState, "write_state")
+        XCTAssertEqual(ModelNames.PocketTTS.StateFunction.prefill, "prefill")
+        XCTAssertEqual(ModelNames.PocketTTS.StateFunction.generate, "generate")
+    }
+
     // MARK: - PocketTtsLayerKeys.aneKeys
 
     func testAneKeysExplicitNamesAndOrdering() {

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsPlacementTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsPlacementTests.swift
@@ -1,0 +1,129 @@
+import CoreML
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Pure-logic unit tests for the `.ane` placement plumbing (rank-4 split-KV
+/// models, mobius Trials 19/20). No model files or network access required.
+final class PocketTtsPlacementTests: XCTestCase {
+
+    // MARK: - ModelNames.requiredModels(precision:placement:)
+
+    func testRequiredModelsGpuMatchesLegacySet() {
+        XCTAssertEqual(
+            ModelNames.PocketTTS.requiredModels(precision: .fp16, placement: .gpu),
+            ModelNames.PocketTTS.requiredModels(precision: .fp16)
+        )
+    }
+
+    func testRequiredModelsAneSwapsConditionerAndFlowLM() {
+        let ane = ModelNames.PocketTTS.requiredModels(precision: .fp16, placement: .ane)
+        XCTAssertTrue(ane.contains(ModelNames.PocketTTS.flowlmStepAneFile))
+        XCTAssertTrue(ane.contains(ModelNames.PocketTTS.condPrefillAneFile))
+        XCTAssertFalse(ane.contains(ModelNames.PocketTTS.flowlmStepFile))
+        XCTAssertFalse(ane.contains(ModelNames.PocketTTS.condPrefillFile))
+        // The fused flow decoder and mimi are shared across placements.
+        XCTAssertTrue(ane.contains(ModelNames.PocketTTS.flowDecoderFusedFile))
+        XCTAssertTrue(ane.contains(ModelNames.PocketTTS.mimiDecoderFile))
+    }
+
+    // MARK: - PocketTtsLayerKeys.aneKeys
+
+    func testAneKeysExplicitNamesAndOrdering() {
+        let keys = PocketTtsLayerKeys.aneKeys(layers: 6, kind: .flowlmStep)
+        XCTAssertTrue(keys.isSplitKV)
+        XCTAssertEqual(keys.layerCount, 6)
+        XCTAssertEqual(keys.cacheKeys, (0..<6).map { "new_k_cache\($0)" })
+        XCTAssertEqual(keys.vCacheKeys, (0..<6).map { "new_v_cache\($0)" })
+        XCTAssertEqual(keys.positionKeys, (0..<6).map { "new_position\($0)" })
+        XCTAssertEqual(keys.transformerOut, "transformer_out")
+        XCTAssertEqual(keys.eosLogit, "is_eos")
+    }
+
+    func testAneKeysCondKindHasNoFlowLMOutputs() {
+        let keys = PocketTtsLayerKeys.aneKeys(layers: 6, kind: .condStep)
+        XCTAssertTrue(keys.isSplitKV)
+        XCTAssertNil(keys.transformerOut)
+        XCTAssertNil(keys.eosLogit)
+    }
+
+    // MARK: - emptyKVCacheState
+
+    func testEmptyKVCacheStateSplitShapes() throws {
+        let maxLen = PocketTtsConstants.kvCacheMaxLen
+        let split = try PocketTtsSynthesizer.emptyKVCacheState(layers: 2, splitKV: true)
+        XCTAssertTrue(split.isSplitKV)
+        XCTAssertEqual(split.caches.count, 2)
+        XCTAssertEqual(split.vCaches?.count, 2)
+        XCTAssertEqual(split.caches[0].shape.map(\.intValue), [1, maxLen, 16, 64])
+        XCTAssertEqual(split.vCaches?[0].shape.map(\.intValue), [1, maxLen, 16, 64])
+
+        let combined = try PocketTtsSynthesizer.emptyKVCacheState(layers: 2)
+        XCTAssertFalse(combined.isSplitKV)
+        XCTAssertNil(combined.vCaches)
+        XCTAssertEqual(combined.caches[0].shape.map(\.intValue), [2, 1, maxLen, 16, 64])
+    }
+
+    // MARK: - kvCacheStateFromSnapshot (split)
+
+    func testSnapshotSplitMatchesCombinedBlocks() throws {
+        // One layer, tiny seq, deterministic values: K block = 1..<N,
+        // V block = 1000..<1000+N (flat row-major [2, 1, seq, 16, 64]).
+        let seqLen = 3
+        let perKV = seqLen * 16 * 64
+        var flat = [Float]()
+        flat.append(contentsOf: (0..<perKV).map { Float($0) })
+        flat.append(contentsOf: (0..<perKV).map { Float($0) + 1_000_000 })
+        let snapshot = PocketTtsVoiceCacheSnapshot(
+            layers: [.init(cache: flat, offset: seqLen)],
+            cacheSeqLen: seqLen
+        )
+
+        let split = try PocketTtsSynthesizer.kvCacheStateFromSnapshot(
+            snapshot, layers: 1, splitKV: true)
+        let combined = try PocketTtsSynthesizer.kvCacheStateFromSnapshot(
+            snapshot, layers: 1, splitKV: false)
+
+        XCTAssertEqual(split.positions[0][0].floatValue, Float(seqLen))
+        XCTAssertEqual(combined.positions[0][0].floatValue, Float(seqLen))
+
+        let destSeq = PocketTtsConstants.kvCacheMaxLen
+        let destPerKV = destSeq * 16 * 64
+        let kSplit = split.caches[0].dataPointer.bindMemory(to: Float.self, capacity: destPerKV)
+        let vSplit = split.vCaches![0].dataPointer.bindMemory(to: Float.self, capacity: destPerKV)
+        let comb = combined.caches[0].dataPointer.bindMemory(
+            to: Float.self, capacity: 2 * destPerKV)
+
+        // Valid prefix matches the combined layout's K and V blocks exactly.
+        for i in 0..<perKV {
+            XCTAssertEqual(kSplit[i], comb[i])
+            XCTAssertEqual(vSplit[i], comb[destPerKV + i])
+        }
+        // Slots beyond the prefix are zero (the `_ane` models' host contract).
+        XCTAssertEqual(kSplit[perKV], 0)
+        XCTAssertEqual(vSplit[perKV], 0)
+    }
+
+    // MARK: - BOS start sequence
+
+    func testBosStartSequenceSplitUsesBosLatent() throws {
+        let bos: [Float] = (0..<32).map { Float($0) * 0.5 }
+        let seq = try PocketTtsSynthesizer.createBosStartSequence(
+            bosEmbedding: bos, splitKV: true)
+        XCTAssertEqual(seq.shape.map(\.intValue), [1, 1, 32])
+        for i in 0..<32 {
+            XCTAssertEqual(seq[i].floatValue, bos[i])
+            XCTAssertFalse(seq[i].floatValue.isNaN)
+        }
+    }
+
+    func testBosStartSequenceCombinedUsesNaNProtocol() throws {
+        let bos: [Float] = (0..<32).map { Float($0) * 0.5 }
+        let seq = try PocketTtsSynthesizer.createBosStartSequence(
+            bosEmbedding: bos, splitKV: false)
+        for i in 0..<32 {
+            XCTAssertTrue(seq[i].floatValue.isNaN)
+        }
+    }
+}

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsStateEngineTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsStateEngineTests.swift
@@ -1,0 +1,196 @@
+import CoreML
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Tests for the Trial 23 `.aneState` MLState pipeline.
+///
+/// The pure-logic tests (fp16 conversion, snapshot layout) run everywhere on
+/// macOS 15+/iOS 18+. The functional tests additionally require the
+/// `pocket_state.mlmodelc` multifunction artifact in the local cache (it is
+/// not published on HuggingFace yet) and skip gracefully when absent.
+final class PocketTtsStateEngineTests: XCTestCase {
+
+    // MARK: - fp16 conversion (pure logic)
+
+    @available(macOS 15.0, iOS 18.0, *)
+    func assertFp16BufferMatchesSwiftRounding() {
+        // Values chosen to exercise rounding, subnormals, and specials.
+        let source: [Float] = [
+            0, -0, 1, -1, 0.1, -0.1, 65504, 1e-8, 3.14159265, 2.0001, -2.0001,
+            1024.05, 0.000061035156, 1.5e-5,
+        ]
+        let buffer = PocketTtsStateEngine.fp16Buffer(
+            from: source, offset: 0, count: source.count)
+        XCTAssertEqual(buffer.count, PocketTtsConstants.kvCacheMaxLen * 16 * 64)
+        #if arch(arm64)
+        for (i, value) in source.enumerated() {
+            XCTAssertEqual(
+                buffer[i], Float16(value).bitPattern,
+                "fp16 rounding mismatch at \(i) for \(value)")
+        }
+        #endif
+        // Padding beyond the source stays zero.
+        XCTAssertTrue(buffer[source.count...].allSatisfy { $0 == 0 })
+    }
+
+    func testFp16BufferMatchesSwiftRounding() throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else {
+            throw XCTSkip("MLState requires macOS 15+/iOS 18+")
+        }
+        assertFp16BufferMatchesSwiftRounding()
+    }
+
+    func testFp16SnapshotSplitsKVAndCarriesPosition() throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else {
+            throw XCTSkip("MLState requires macOS 15+/iOS 18+")
+        }
+        // One layer, tiny seq: K block = 1..N, V block = offset by 1e6
+        // (flat row-major [2, 1, seq, 16, 64], K then V — same layout the
+        // IO `kvCacheStateFromSnapshot` consumes).
+        let seqLen = 3
+        let perKV = seqLen * 16 * 64
+        var flat = [Float]()
+        flat.append(contentsOf: (0..<perKV).map { Float($0) })
+        flat.append(contentsOf: (0..<perKV).map { Float($0) + 1_000_000 })
+        let snapshot = PocketTtsVoiceCacheSnapshot(
+            layers: [.init(cache: flat, offset: seqLen)],
+            cacheSeqLen: seqLen
+        )
+
+        let fp16 = try PocketTtsStateEngine.fp16Snapshot(from: snapshot, layers: 1)
+        XCTAssertEqual(fp16.position, Float(seqLen))
+        XCTAssertEqual(fp16.kBuffers.count, 1)
+        XCTAssertEqual(fp16.vBuffers.count, 1)
+
+        let expectedK = PocketTtsStateEngine.fp16Buffer(from: flat, offset: 0, count: perKV)
+        let expectedV = PocketTtsStateEngine.fp16Buffer(from: flat, offset: perKV, count: perKV)
+        XCTAssertEqual(fp16.kBuffers[0], expectedK)
+        XCTAssertEqual(fp16.vBuffers[0], expectedV)
+        // Beyond the valid prefix the buffers are zero (reset contract).
+        XCTAssertTrue(fp16.kBuffers[0][perKV...].allSatisfy { $0 == 0 })
+        XCTAssertTrue(fp16.vBuffers[0][perKV...].allSatisfy { $0 == 0 })
+
+        XCTAssertThrowsError(
+            try PocketTtsStateEngine.fp16Snapshot(from: snapshot, layers: 2))
+    }
+
+    func testIsContiguous() throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else {
+            throw XCTSkip("MLState requires macOS 15+/iOS 18+")
+        }
+        XCTAssertTrue(
+            PocketTtsStateEngine.isContiguous(
+                shape: [1, 512, 16, 64], strides: [524_288, 1024, 64, 1]))
+        XCTAssertFalse(
+            PocketTtsStateEngine.isContiguous(
+                shape: [1, 512, 16, 64], strides: [524_288, 1056, 64, 1]))
+        XCTAssertFalse(
+            PocketTtsStateEngine.isContiguous(shape: [1, 512], strides: [1]))
+    }
+
+    // MARK: - Functional (artifact-gated)
+
+    /// Path of the locally installed multifunction package, or nil.
+    private func installedStateModelURL() -> URL? {
+        guard let cacheRoot = try? TtsCacheDirectory.ensure() else { return nil }
+        let url =
+            cacheRoot
+            .appendingPathComponent(PocketTtsConstants.defaultModelsSubdirectory)
+            .appendingPathComponent(Repo.pocketTts.folderName)
+            .appendingPathComponent(PocketTtsLanguage.english.repoSubdirectory)
+            .appendingPathComponent(ModelNames.PocketTTS.pocketStateFile)
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    @available(macOS 15.0, iOS 18.0, *)
+    private func loadEngine(from url: URL) throws -> PocketTtsStateEngine {
+        func config(_ functionName: String) -> MLModelConfiguration {
+            let c = MLModelConfiguration()
+            c.computeUnits = .cpuAndNeuralEngine
+            c.functionName = functionName
+            return c
+        }
+        let prefill = try MLModel(
+            contentsOf: url,
+            configuration: config(ModelNames.PocketTTS.StateFunction.prefill))
+        let generate = try MLModel(
+            contentsOf: url,
+            configuration: config(ModelNames.PocketTTS.StateFunction.generate))
+        return PocketTtsStateEngine(
+            models: PocketTtsStateModels(prefill: prefill, generate: generate),
+            layers: 6)
+    }
+
+    /// Host-side `MLState.withMultiArray` write → read round-trip must be
+    /// bit-exact (the property Trial 23 proved from python; this validates
+    /// the Swift plumbing — strides, fp16 handling, buffer naming).
+    func testStateWriteReadRoundTripBitExact() async throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else {
+            throw XCTSkip("MLState requires macOS 15+/iOS 18+")
+        }
+        guard let url = installedStateModelURL() else {
+            throw XCTSkip("pocket_state.mlmodelc not installed in the local cache")
+        }
+        let engine = try loadEngine(from: url)
+
+        // Deterministic pseudo-random fp32 KV values for a 7-position voice.
+        let seqLen = 7
+        let perKV = seqLen * 16 * 64
+        var rng = SeededRNG(seed: 7)
+        var layersData: [PocketTtsVoiceCacheSnapshot.LayerCache] = []
+        for _ in 0..<6 {
+            let cache = (0..<(2 * perKV)).map { _ in
+                Float.gaussianRandom(using: &rng)
+            }
+            layersData.append(.init(cache: cache, offset: seqLen))
+        }
+        let snapshot = PocketTtsVoiceCacheSnapshot(layers: layersData, cacheSeqLen: seqLen)
+        let fp16 = try PocketTtsStateEngine.fp16Snapshot(from: snapshot, layers: 6)
+
+        try await engine.reset(with: fp16)
+        let readBack = try await engine.captureSnapshot()
+        XCTAssertEqual(readBack.position, Float(seqLen))
+        for i in 0..<6 {
+            XCTAssertEqual(readBack.kBuffers[i], fp16.kBuffers[i], "k_cache\(i) round-trip")
+            XCTAssertEqual(readBack.vBuffers[i], fp16.vBuffers[i], "v_cache\(i) round-trip")
+        }
+    }
+
+    /// Full prefill → generate over the shared state: positions advance and
+    /// the fused step yields finite latent/EOS outputs.
+    func testPrefillAndGenerateAdvanceSharedState() async throws {
+        guard #available(macOS 15.0, iOS 18.0, *) else {
+            throw XCTSkip("MLState requires macOS 15+/iOS 18+")
+        }
+        guard let url = installedStateModelURL() else {
+            throw XCTSkip("pocket_state.mlmodelc not installed in the local cache")
+        }
+        let engine = try loadEngine(from: url)
+        try await engine.resetToZero()
+        let positionAfterReset = await engine.position
+        XCTAssertEqual(positionAfterReset, 0)
+
+        // 4-token zero conditioning block (content doesn't matter for the
+        // position contract).
+        let dim = PocketTtsConstants.embeddingDim
+        let flat = [Float](repeating: 0, count: 4 * dim)
+        try await engine.prefill(flatConditioning: flat, tokenCount: 4)
+        let positionAfterPrefill = await engine.position
+        XCTAssertEqual(positionAfterPrefill, 4)
+
+        var rng = SeededRNG(seed: 42)
+        let noise = (0..<PocketTtsConstants.latentDim).map { _ in
+            Float.gaussianRandom(using: &rng) * sqrtf(PocketTtsConstants.temperature)
+        }
+        let sequence = [Float](repeating: 0, count: PocketTtsConstants.latentDim)
+        let (latent, eosLogit) = try await engine.generateFrame(
+            sequence: sequence, noise: noise)
+        XCTAssertEqual(latent.count, PocketTtsConstants.latentDim)
+        XCTAssertTrue(latent.allSatisfy(\.isFinite), "latent must be finite")
+        XCTAssertTrue(eosLogit.isFinite, "eos logit must be finite")
+        let positionAfterGenerate = await engine.position
+        XCTAssertEqual(positionAfterGenerate, 5)
+    }
+}


### PR DESCRIPTION
## Summary

Two stacked opt-in placements for PocketTTS, both Swift-measured with the built-in Parakeet WER gate. `.gpu` default behavior unchanged.

### `.ane` — rank-4 split-KV models (mobius Trials 19/20)
The rank-5 v2.1 graphs fail `ANECCompile` outright; the rank-4 scatter-free rewrites are bit-identical and plan flowlm **100% ANE** / cond_prefill 92% under `.cpuAndNeuralEngine`.

| Placement | Inference | RTFx | WER |
|---|---|---|---|
| `.gpu` (shipped) | 1.32 s | 5.7 | 0 |
| `.ane` | **1.108 s (−19%)** | 7.1 | 0 |

- Split-KV `KVCacheState`, explicit-name layer keys, per-model compute units, CLI `--placement ane`
- BOS host contract: the `_ane` FlowLM has no NaN-BOS protocol — **the ANE mangles NaN inputs before `isnan` evaluates** (measured divergence 2.9 vs 3e-2 CPU); host passes the BOS latent directly
- All 11 language packs ship `*_ane.mlmodelc` on HF (`v2.1/<lang>/`); cold-download verified (en, de)

### `.aneState` — full-pipeline MLState multifunction (mobius Trial 23), macOS 15+/iOS 18+
One compiled package, three functions (`write_state`/`prefill`/`generate`) over **shared MLState KV buffers**: caches never cross the IO boundary, and generate is the fused flowlm+flowdec (one ANE call/frame).

| Placement | 3-sentence utt | ms/frame | WER | Seeded WAVs |
|---|---|---|---|---|
| `.ane` | 1.430 s | 11.6 | 0 | bit-identical |
| `.aneState` | **1.216 s (−14.9%)** | **10.0** | 0 | bit-identical |

- Measured −1.66 ms/frame matches Trial 23's python prediction (−1.69) exactly; mimi (CPU, unchanged) is the remaining floor
- New `PocketTtsStateEngine` actor: host-side `MLState.withMultiArray` voice-snapshot injection (bit-exact), windowed stateful prefill, fused generate; runtime `#available` gate; 24-tensor plumbing untouched for `.gpu`/`.ane`
- MLState×multifunction verified clean on macOS (state shared across function instances)

## Remaining ship gates (documented, not blockers for opt-in merge)
- `pocket_state.mlmodelc` (163 MB) not yet published to HF — `.aneState` errors with install instructions until then
- iPhone on-device ANE verification (known MLState×ANE iOS-18 caveat)

Evidence chain: mobius `feat/pocket-tts-flowlm-ane` (Trials 19–23) + mobius#70 (campaign index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Listening samples (same text, seed 42)
- [gpu](https://huggingface.co/FluidInference/pocket-tts-coreml/blob/main/samples/pr679/679_pocket_gpu.wav) · [ane](https://huggingface.co/FluidInference/pocket-tts-coreml/blob/main/samples/pr679/679_pocket_ane.wav) · [ane-state](https://huggingface.co/FluidInference/pocket-tts-coreml/blob/main/samples/pr679/679_pocket_ane-state.wav)
- gpu↔ane SNR 7.9 dB (fp16 tie-flips cascade through the AR loop — different but equivalent renderings, both WER 0); ane↔ane-state SNR 0.4 dB (**a different take, not a perturbation**: the fused step's RNG draw stream shifts, documented in code — within-placement output is bit-identical across runs)
- Listen before merge: all three should be natural; they will not sound like the *same* recording.