### PR TITLE
feat(asr/eou): opt-in fused decoder+joint_decision path (+7-9% RTFx, WER neutral-or-better)

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/EOU/StreamingEouAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/EOU/StreamingEouAsrManager.swift
@@ -298,7 +298,24 @@ public actor StreamingEouAsrManager {
         let vocabUrl = directory.appendingPathComponent("vocab.json")
         self.tokenizer = try Tokenizer(vocabPath: vocabUrl)
 
-        self.rnntDecoder = RnntDecoder(decoderModel: self.decoder!, jointModel: self.joint!)
+        // Opt-in fused decoder+joint_decision path (single MLModel.prediction per RNNT step).
+        // Enabled only when FLUID_EOU_FUSED=1 AND the fused mlmodelc is present alongside the
+        // other models. Default OFF: the fused fp16 graph is not bit-exact with the two-model
+        // reference (low-margin argmax ties can flip), so it ships opt-in.
+        var fusedModel: MLModel?
+        if ProcessInfo.processInfo.environment["FLUID_EOU_FUSED"] == "1" {
+            let fusedUrl = directory.appendingPathComponent("decoder_joint_decision_fused.mlmodelc")
+            if FileManager.default.fileExists(atPath: fusedUrl.path) {
+                fusedModel = try await MLModel.load(contentsOf: fusedUrl, configuration: self.configuration)
+                logger.info("FLUID_EOU_FUSED=1: using fused decoder+joint_decision (1 dispatch per RNNT step)")
+            } else {
+                logger.warning(
+                    "FLUID_EOU_FUSED=1 set but \(fusedUrl.lastPathComponent) not found in \(directory.path); using reference decoder+joint path"
+                )
+            }
+        }
+
+        self.rnntDecoder = RnntDecoder(decoderModel: self.decoder!, jointModel: self.joint!, fusedModel: fusedModel)
 
         // Initialize States
         try self.resetStates()

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/EOU/StreamingEouAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/EOU/StreamingEouAsrManager.swift
@@ -303,16 +303,15 @@ public actor StreamingEouAsrManager {
         // other models. Default OFF: the fused fp16 graph is not bit-exact with the two-model
         // reference (low-margin argmax ties can flip), so it ships opt-in.
         var fusedModel: MLModel?
-        if ProcessInfo.processInfo.environment["FLUID_EOU_FUSED"] == "1" {
-            let fusedUrl = directory.appendingPathComponent("decoder_joint_decision_fused.mlmodelc")
-            if FileManager.default.fileExists(atPath: fusedUrl.path) {
-                fusedModel = try await MLModel.load(contentsOf: fusedUrl, configuration: self.configuration)
-                logger.info("FLUID_EOU_FUSED=1: using fused decoder+joint_decision (1 dispatch per RNNT step)")
-            } else {
-                logger.warning(
-                    "FLUID_EOU_FUSED=1 set but \(fusedUrl.lastPathComponent) not found in \(directory.path); using reference decoder+joint path"
-                )
-            }
+        let fusedRequested = ProcessInfo.processInfo.environment["FLUID_EOU_FUSED"] == "1"
+        let fusedUrl = directory.appendingPathComponent("decoder_joint_decision_fused.mlmodelc")
+        if fusedRequested, FileManager.default.fileExists(atPath: fusedUrl.path) {
+            fusedModel = try await MLModel.load(contentsOf: fusedUrl, configuration: self.configuration)
+            logger.info("FLUID_EOU_FUSED=1: using fused decoder+joint_decision (1 dispatch per RNNT step)")
+        } else if fusedRequested {
+            logger.warning(
+                "FLUID_EOU_FUSED=1 set but \(fusedUrl.lastPathComponent) not found in \(directory.path); using reference decoder+joint path"
+            )
         }
 
         self.rnntDecoder = RnntDecoder(decoderModel: self.decoder!, jointModel: self.joint!, fusedModel: fusedModel)

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/RnntDecoder.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/RnntDecoder.swift
@@ -16,6 +16,11 @@ public struct DecodeResult: Sendable {
 public final class RnntDecoder {
     private let decoderModel: MLModel
     private let jointModel: MLModel
+    /// Optional fused decoder+joint_decision model. When set, each RNNT step runs a single
+    /// `MLModel.prediction` with inputs `targets/h_in/c_in/encoder_step` and reads
+    /// `token_id/h_out/c_out`, instead of dispatching decoder and joint separately.
+    /// Opt-in via `FLUID_EOU_FUSED=1` (see `StreamingEouAsrManager.loadModels`).
+    private let fusedModel: MLModel?
 
     // Decoder State
     private var hState: MLMultiArray
@@ -29,29 +34,32 @@ public final class RnntDecoder {
     private let hiddenSize = 640
     private let layers = 1
 
-    public init(decoderModel: MLModel, jointModel: MLModel) {
+    public init(decoderModel: MLModel, jointModel: MLModel, fusedModel: MLModel? = nil) {
         self.decoderModel = decoderModel
         self.jointModel = jointModel
+        self.fusedModel = fusedModel
 
         // Initialize state
-        self.hState = try! MLMultiArray(
-            shape: [NSNumber(value: layers), NSNumber(value: 1), NSNumber(value: hiddenSize)], dataType: .float32)
-        self.cState = try! MLMultiArray(
-            shape: [NSNumber(value: layers), NSNumber(value: 1), NSNumber(value: hiddenSize)], dataType: .float32)
+        self.hState = Self.makeZeroState(layers: layers, hiddenSize: hiddenSize)
+        self.cState = Self.makeZeroState(layers: layers, hiddenSize: hiddenSize)
         self.lastToken = blankId
+    }
 
-        resetState()
+    private static func makeZeroState(layers: Int, hiddenSize: Int) -> MLMultiArray {
+        // Reallocating (instead of zeroing in place) keeps resetState() correct even when the
+        // state arrays were replaced by model outputs of a different scalar type (e.g. the
+        // fused model emits fp16 h_out/c_out).
+        let array = try! MLMultiArray(
+            shape: [NSNumber(value: layers), NSNumber(value: 1), NSNumber(value: hiddenSize)], dataType: .float32)
+        array.withUnsafeMutableBufferPointer(ofType: Float.self) { ptr, _ in
+            ptr.baseAddress?.update(repeating: 0, count: ptr.count)
+        }
+        return array
     }
 
     public func resetState() {
-        // Zero out states
-        let count = hState.count
-        hState.withUnsafeMutableBufferPointer(ofType: Float.self) { ptr, _ in
-            ptr.baseAddress?.update(repeating: 0, count: count)
-        }
-        cState.withUnsafeMutableBufferPointer(ofType: Float.self) { ptr, _ in
-            ptr.baseAddress?.update(repeating: 0, count: count)
-        }
+        hState = Self.makeZeroState(layers: layers, hiddenSize: hiddenSize)
+        cState = Self.makeZeroState(layers: layers, hiddenSize: hiddenSize)
         lastToken = blankId
     }
 
@@ -88,56 +96,27 @@ public final class RnntDecoder {
             var symbolsAdded = 0
 
             while symbolsAdded < maxSymbolsPerStep {
-                // 1. Run Decoder
-                let decoderInput = try prepareDecoderInput(lastToken: lastToken, h: hState, c: cState)
-                let decoderOutput = try decoderModel.prediction(from: decoderInput)
-
-                guard let decoderArray = decoderOutput.featureValue(for: "decoder")?.multiArrayValue else {
-                    throw RnntDecoderError.missingOutput("decoder")
-                }
-                var decoderStep = decoderArray
-                // Decoder outputs [1, 640, 2] - NeMo uses the LAST frame
-                if decoderStep.shape.count == 3 && decoderStep.shape[2].intValue > 1 {
-                    // Slice to keep only the last frame [1, 640, 1]
-                    decoderStep = try sliceDecoderStep(decoderStep)
+                let step: RnntStepResult
+                if let fusedModel {
+                    step = try runFusedStep(fusedModel, encoderStep: encoderStep)
+                } else {
+                    step = try runReferenceStep(encoderStep: encoderStep)
                 }
 
-                // 2. Run Joint
-                let jointInput = try MLDictionaryFeatureProvider(dictionary: [
-                    "encoder_step": MLFeatureValue(multiArray: encoderStep),
-                    "decoder_step": MLFeatureValue(multiArray: decoderStep),
-                ])
-
-                let jointOutput = try jointModel.prediction(from: jointInput)
-
-                // 3. Get Token ID
-                // Output "token_id" is [1, 1, 1] (argmax)
-                guard let tokenIdMultiArray = jointOutput.featureValue(for: "token_id")?.multiArrayValue else {
-                    throw RnntDecoderError.missingOutput("token_id")
-                }
-                let tokenId = tokenIdMultiArray[0].int32Value
-
-                if tokenId == blankId {
+                if step.tokenId == blankId {
                     break
-                } else if tokenId == eouId {
+                } else if step.tokenId == eouId {
                     // EOU detected - signal and stop processing
                     eouDetected = true
                     break outerLoop
                 } else {
-                    predictedIds.append(Int(tokenId))
+                    predictedIds.append(Int(step.tokenId))
                     predictedFrames.append(t)
-                    lastToken = tokenId
+                    lastToken = step.tokenId
 
-                    // Update State
-                    guard let newH = decoderOutput.featureValue(for: "h_out")?.multiArrayValue else {
-                        throw RnntDecoderError.missingOutput("h_out")
-                    }
-                    guard let newC = decoderOutput.featureValue(for: "c_out")?.multiArrayValue else {
-                        throw RnntDecoderError.missingOutput("c_out")
-                    }
-
-                    hState = newH
-                    cState = newC
+                    // Update State (only on non-blank emission, matching NeMo greedy RNNT)
+                    hState = step.hOut
+                    cState = step.cOut
 
                     symbolsAdded += 1
                 }
@@ -145,6 +124,82 @@ public final class RnntDecoder {
         }
 
         return DecodeResult(tokenIds: predictedIds, tokenFrames: predictedFrames, eouDetected: eouDetected)
+    }
+
+    /// Result of a single RNNT step: predicted token plus the post-LSTM decoder state.
+    /// The state is only committed to `hState`/`cState` when a non-blank token is emitted.
+    private struct RnntStepResult {
+        let tokenId: Int32
+        let hOut: MLMultiArray
+        let cOut: MLMultiArray
+    }
+
+    /// Reference path: two dispatches per step (decoder, then joint_decision).
+    private func runReferenceStep(encoderStep: MLMultiArray) throws -> RnntStepResult {
+        // 1. Run Decoder
+        let decoderInput = try prepareDecoderInput(lastToken: lastToken, h: hState, c: cState)
+        let decoderOutput = try decoderModel.prediction(from: decoderInput)
+
+        guard let decoderArray = decoderOutput.featureValue(for: "decoder")?.multiArrayValue else {
+            throw RnntDecoderError.missingOutput("decoder")
+        }
+        var decoderStep = decoderArray
+        // Decoder outputs [1, 640, 2] - NeMo uses the LAST frame
+        if decoderStep.shape.count == 3 && decoderStep.shape[2].intValue > 1 {
+            // Slice to keep only the last frame [1, 640, 1]
+            decoderStep = try sliceDecoderStep(decoderStep)
+        }
+
+        // 2. Run Joint
+        let jointInput = try MLDictionaryFeatureProvider(dictionary: [
+            "encoder_step": MLFeatureValue(multiArray: encoderStep),
+            "decoder_step": MLFeatureValue(multiArray: decoderStep),
+        ])
+
+        let jointOutput = try jointModel.prediction(from: jointInput)
+
+        // 3. Get Token ID
+        // Output "token_id" is [1, 1, 1] (argmax)
+        guard let tokenIdMultiArray = jointOutput.featureValue(for: "token_id")?.multiArrayValue else {
+            throw RnntDecoderError.missingOutput("token_id")
+        }
+        guard let hOut = decoderOutput.featureValue(for: "h_out")?.multiArrayValue else {
+            throw RnntDecoderError.missingOutput("h_out")
+        }
+        guard let cOut = decoderOutput.featureValue(for: "c_out")?.multiArrayValue else {
+            throw RnntDecoderError.missingOutput("c_out")
+        }
+
+        return RnntStepResult(tokenId: tokenIdMultiArray[0].int32Value, hOut: hOut, cOut: cOut)
+    }
+
+    /// Fused path: one dispatch per step. The fused graph internally performs the decoder LSTM
+    /// step (including the last-frame slice) and the joint+argmax, so the host only feeds the
+    /// previous token, LSTM state, and the current encoder frame.
+    private func runFusedStep(_ model: MLModel, encoderStep: MLMultiArray) throws -> RnntStepResult {
+        let targets = try MLMultiArray(shape: [1, 1], dataType: .int32)
+        targets[0] = NSNumber(value: lastToken)
+
+        let input = try MLDictionaryFeatureProvider(dictionary: [
+            "targets": MLFeatureValue(multiArray: targets),
+            "h_in": MLFeatureValue(multiArray: hState),
+            "c_in": MLFeatureValue(multiArray: cState),
+            "encoder_step": MLFeatureValue(multiArray: encoderStep),
+        ])
+
+        let output = try model.prediction(from: input)
+
+        guard let tokenIdMultiArray = output.featureValue(for: "token_id")?.multiArrayValue else {
+            throw RnntDecoderError.missingOutput("token_id")
+        }
+        guard let hOut = output.featureValue(for: "h_out")?.multiArrayValue else {
+            throw RnntDecoderError.missingOutput("h_out")
+        }
+        guard let cOut = output.featureValue(for: "c_out")?.multiArrayValue else {
+            throw RnntDecoderError.missingOutput("c_out")
+        }
+
+        return RnntStepResult(tokenId: tokenIdMultiArray[0].int32Value, hOut: hOut, cOut: cOut)
     }
 
     private func extractEncoderStep(

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/RnntDecoderFusedTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/RnntDecoderFusedTests.swift
@@ -1,0 +1,60 @@
+import CoreML
+import XCTest
+
+@testable import FluidAudio
+
+/// Parity tests for the opt-in fused decoder+joint_decision path.
+///
+/// These tests require the real Parakeet EOU 160ms models plus the locally compiled
+/// `decoder_joint_decision_fused.mlmodelc` in the model cache; they skip when absent
+/// (e.g. on CI). No dummy models are used.
+final class RnntDecoderFusedTests: XCTestCase {
+
+    private static func modelDirectory() -> URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("FluidAudio/Models/parakeet-eou-streaming/160ms", isDirectory: true)
+    }
+
+    func testFusedDecodePathMatchesReferenceOnNeutralState() async throws {
+        let dir = Self.modelDirectory()
+        let decoderUrl = dir.appendingPathComponent("decoder.mlmodelc")
+        let jointUrl = dir.appendingPathComponent("joint_decision.mlmodelc")
+        let fusedUrl = dir.appendingPathComponent("decoder_joint_decision_fused.mlmodelc")
+
+        try XCTSkipIf(
+            !FileManager.default.fileExists(atPath: decoderUrl.path)
+                || !FileManager.default.fileExists(atPath: jointUrl.path)
+                || !FileManager.default.fileExists(atPath: fusedUrl.path),
+            "Parakeet EOU 160ms models (incl. fused mlmodelc) not present in local cache"
+        )
+
+        let configuration = MLModelConfiguration()
+        let decoderModel = try await MLModel.load(contentsOf: decoderUrl, configuration: configuration)
+        let jointModel = try await MLModel.load(contentsOf: jointUrl, configuration: configuration)
+        let fusedModel = try await MLModel.load(contentsOf: fusedUrl, configuration: configuration)
+
+        let reference = RnntDecoder(decoderModel: decoderModel, jointModel: jointModel)
+        let fused = RnntDecoder(decoderModel: decoderModel, jointModel: jointModel, fusedModel: fusedModel)
+
+        // Neutral (zero) encoder frames with zero LSTM state: both paths must agree
+        // (the model emits blank on silence-like input, so this exercises the fused IO
+        // contract — input/output names, shapes, and state plumbing — without audio).
+        let encoderOutput = try MLMultiArray(shape: [1, 512, 2], dataType: .float32)
+        encoderOutput.withUnsafeMutableBufferPointer(ofType: Float.self) { ptr, _ in
+            ptr.baseAddress?.update(repeating: 0, count: ptr.count)
+        }
+
+        let refResult = try reference.decodeWithEOU(encoderOutput: encoderOutput, validOutLen: 2)
+        let fusedResult = try fused.decodeWithEOU(encoderOutput: encoderOutput, validOutLen: 2)
+
+        XCTAssertEqual(fusedResult.tokenIds, refResult.tokenIds)
+        XCTAssertEqual(fusedResult.tokenFrames, refResult.tokenFrames)
+        XCTAssertEqual(fusedResult.eouDetected, refResult.eouDetected)
+
+        // State reset after fused predictions (fp16 h/c outputs) must not trap and the
+        // decoder must remain usable.
+        fused.resetState()
+        let afterReset = try fused.decodeWithEOU(encoderOutput: encoderOutput, validOutLen: 2)
+        XCTAssertEqual(afterReset.tokenIds, refResult.tokenIds)
+    }
+}


### PR DESCRIPTION
## Summary
Opt-in single-dispatch RNNT decode step for Parakeet EOU: when `FLUID_EOU_FUSED=1` **and** `decoder_joint_decision_fused.mlmodelc` is present in the 160ms pack, `RnntDecoder` runs one CoreML prediction per step instead of decoder → joint_decision. **Default OFF — zero behavior change without flag+artifact.**

## Measured (official `parakeet-eou --benchmark`, 160 ms, 400 files, release, M5 Pro, interleaved 2×2)
| round | base WER / RTFx | fused WER / RTFx |
|---|---|---|
| 1 | 8.39% / 14.68 | 8.28% / 15.60 |
| 2 | 8.41% / 14.16 | 8.29% / 15.43 |

- **+7–9% e2e RTFx, WER consistently equal-or-better.** Per-file (round 2): 24/400 hypotheses differ (symmetric fp16 tie-flips), 0 regressions >20 pp, 0 truncations.
- Full evidence chain (per-op LSTM gate, MIL fusion, 2,620-file three-way WER gate, traced≡lean proof): mobius `feat/eou-decode-ane` OPTIMIZATION.md.
- Exact NeMo greedy semantics preserved (h/c committed only on non-blank emission); parity test included (`RnntDecoderFusedTests`, skips when artifact absent).

## To activate for users
The fused mlmodelc must be uploaded to `FluidInference/parakeet-realtime-eou-120m-coreml` (160 ms dir) — not done in this PR. Until then the flag is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)