### PR TITLE
Add Parakey to Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[Dettivo](https://dettivo.com)** | Local-first Mac app for private dictation, transcripts, and meeting workflows in one place, with developer tooling across CLI, MCP, REST, and app automation. Uses FluidAudio Parakeet TDT ASR and offline speaker diarization. |
 | **[Parleq](https://parleq.app/)** | Privacy-first macOS dictation — press a hotkey, speak, paste cleaned-up text. On-device Parakeet TDT v3 ASR with CTC vocabulary boosting (audio never leaves the Mac), provider-pluggable LLM cleanup (Gemini/Vertex, Bedrock, Azure), and reference windows that bring on-screen context into the cleanup. Open source. |
 | **[Local Narrator](https://www.localnarrator.app/)** | Privacy-first iOS audiobook reader that reads EPUB and PDF books aloud with on-device text-to-speech. Uses FluidAudio Kokoro TTS for local English and Spanish narration. |
+| **[Parakey](https://github.com/rcourtman/parakey)** | Open-source (MIT) menu-bar push-to-talk dictation for macOS — hold a key, speak, release; the transcript pastes at the cursor in about 100 ms. Uses Parakeet TDT v3 ASR on the Apple Neural Engine via FluidAudio. |
 
 ## Installation
 


### PR DESCRIPTION
Adds Parakey at the end of the Showcase table, per the note above it.

Parakey is an MIT-licensed menu-bar app for push-to-talk dictation on macOS — hold a key, speak, release, and the transcript pastes at the cursor. FluidAudio's Parakeet TDT v3 path on the ANE is the entire engine; the ~100 ms key-release-to-paste it enables is the whole product. Thanks for the library.