### PR TITLE
fix(asr): splice long-form chunk merges on SentencePiece word boundaries

### DIFF
--- a/Documentation/ASR/LongTranscription.md
+++ b/Documentation/ASR/LongTranscription.md
@@ -213,7 +213,7 @@ Notes for tuning:
 After each chunk decodes independently, `ChunkProcessor.mergeChunks` stitches
 adjacent chunks into a single token timeline. The merger never re-runs the
 decoder and never invents tokens; it only chooses which side of the overlap
-each token comes from. The strategy is a three-step ladder:
+each token comes from. The strategy is a four-step ladder:
 
 1. **Disjoint shortcut.** If the left chunk's last token ends before the
    right chunk's first token begins, concatenate without merging.
@@ -234,6 +234,35 @@ cannot collapse two different words that happen to share a substring, and it
 is robust to small per-chunk timestamp jitter. The contiguous-match path
 preserves order strictly; LCS is only entered when adjacent chunks disagree
 enough that a contiguous run would be dishonest.
+
+### Word-Boundary Splice Repair
+
+Matching alone does not make the *splice points* safe: the two windows
+tokenize the same seam audio independently, and the right window often
+segments its first word differently (frequently without the SentencePiece
+`▁` word-start prefix, since for that decoder the word is utterance-initial).
+Splicing a continuation piece from the right stream directly after a left
+token decodes as a glued or hybrid word — `"work" + "ks"` → `"worksks"`
+(issue #683).
+
+To prevent this, `mergeChunks` derives a set of *splice-safe* token IDs from
+the model vocabulary once per merge pass: pieces with a `▁`/space prefix or
+punctuation-only pieces. Splices are then repaired at word granularity:
+
+- **`mergeUsingMatches`** — when the post-match tail of the right stream
+  starts with a continuation piece, the merger adopts the right window's
+  segmentation of the entire seam word (the left chunk is typically the one
+  cut mid-word). Only when the right stream itself begins mid-word — the
+  construction that produced glued words — does the left window keep the
+  seam word, with the right stream resuming at its next word-initial piece.
+- **`mergeByMidpoint`** — the time cutoff is adjusted so the left stream
+  finishes the word it started, and orphaned continuation pieces (whose
+  word-initial piece was trimmed away) are dropped from the right stream's
+  head.
+
+The repair inspects only the tokenizer's own word-boundary marker, never
+transcript text, so it is language-agnostic. Without a vocabulary the merge
+is byte-for-byte unchanged.
 
 ## Streaming Threshold for Large Files
 
@@ -303,6 +332,8 @@ auditable instead of relying on memory of why a clip was added.
     gating
   - `mergeChunks(...)` / `mergeUsingMatches(...)` / `mergeByMidpoint(...)` —
     overlap merge ladder (contiguous → LCS → midpoint)
+  - `spliceSafeTokenIds(vocabulary:)` / `isSpliceSafePiece(...)` —
+    vocabulary-derived word-boundary gating for seam splices (issue #683)
   - `makeWorkerPool(...)` and the static `transcribeChunk(...)` task body
     used by the parallel dispatch loop
 - `Sources/FluidAudio/ASR/Parakeet/TokenDeduplication/SequenceMatcher.swift`

--- a/Documentation/ASR/LongTranscription.md
+++ b/Documentation/ASR/LongTranscription.md
@@ -44,6 +44,9 @@ When reviewing long-form ASR output, check the transcript for:
 
 - boundary word drops, especially short function words or one-word clauses
 - duplicated words or partial BPE fragments around overlaps
+- glued words (two words joined without a space) or hybrid words stitched
+  from both windows' segmentation of the same seam word — `"worksks"`,
+  `"automoti"`, mid-word punctuation like `"ye,ah"` (issue #683)
 - missing clauses or full sentences after a boundary
 - wrong-language insertions in otherwise single-language audio
 - wrong-script bursts on multilingual v3 audio
@@ -309,6 +312,55 @@ When adding a new fixture, record the language, approximate duration, reference
 source, and the specific failure it is meant to catch. This makes future changes
 auditable instead of relying on memory of why a clip was added.
 
+### Seam Canary (required for boundary or merge changes)
+
+Any change to `ChunkProcessor`'s boundary search or overlap merge must be
+A/B'd against the baseline build on a seam-dense fixture before merging.
+Short-clip WER is not a substitute: the issue #683 fix repaired six seam
+artifacts in one hour of earnings audio while remaining exactly WER-neutral
+on FLEURS — a merge bug can be invisible to the aggregate metric and still
+make transcripts unusable.
+
+The procedure:
+
+1. Transcribe a long fixture with both builds. The cached
+   `earnings22-1h/earnings22_top4_1h.wav` (~1 h, ~277 seams) is the standard
+   choice; `swift run fluidaudiocli transcribe <file>` on each build.
+2. Word-diff the two transcripts (`diff <(tr ' ' '\n' < a.txt) <(tr ' ' '\n'
+   < b.txt)`). Inspect every diff individually — each one must be
+   explainable as an intended repair. Do not accept a net count.
+3. Scan both outputs for mechanical seam artifacts that need no reference
+   transcript: mid-word punctuation (`grep -oE '[a-z],[a-z]+'`), and any
+   diff hunk that concatenates two previously separate words.
+
+### Invariants Must Be Executable
+
+The history of this path is a caution: the overlap merge ladder shipped in
+PR #177 (2025-11) and its first token-stream tests arrived with PR #604
+(2026-05); issue #683's glued-word class survived that entire gap. The
+failure mode was even listed in this document while the Overlap Merge
+section asserted the matcher was safe — the claim was about the wrong
+layer, and nothing executable connected the two.
+
+The rules that follow from that:
+
+- A safety claim about the merge belongs in a test, not (only) in this
+  document. If a sentence here says the merger "cannot" do something,
+  there must be a unit test that fails when it does.
+- Merge unit tests must drive realistic token streams *with* a splice-safe
+  vocabulary set (`mergeTokenWindowsForTesting(left:right:spliceSafeTokenIds:)`).
+  Bare integer token IDs are structurally blind to word-level artifacts —
+  that blindness is exactly why #683 was untestable before PR #688.
+- Every seam-affecting invariant the code enforces today is listed here;
+  keep this list in sync when adding one:
+  - a splice from the right window never starts mid-word
+    (`spliceSafeTokenIds` gating, issue #683)
+  - the midpoint cutoff never strands a word's continuation pieces on the
+    wrong side of the seam (`mergeByMidpoint`, issue #683)
+  - chunk starts are always frame-aligned (`chunkLayout`)
+  - at least 6 encoder frames of seam overlap are preserved
+    (`silenceAlignedChunkStarts`)
+
 ## Relevant Code
 
 - `Sources/FluidAudio/Shared/ASRConstants.swift`
@@ -359,3 +411,8 @@ swift test --filter TdtRefactoredComponentsTests
 swift test --filter TdtDecoderV2Tests
 swift test --filter ASRConfigTests   # covers parallelChunkConcurrency default, clamping, override
 ```
+
+`ChunkProcessorTests` includes word-boundary splice tests that pass a
+splice-safe token set. When adding merge tests, do the same: a merge test
+without one exercises only the token-ID layer and cannot catch glued or
+hybrid words (see "Invariants Must Be Executable" above).

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
@@ -375,9 +375,10 @@ struct ChunkProcessor {
 
     internal func mergeTokenWindowsForTesting(
         left: [(token: Int, timestamp: Int, confidence: Float, duration: Int)],
-        right: [(token: Int, timestamp: Int, confidence: Float, duration: Int)]
+        right: [(token: Int, timestamp: Int, confidence: Float, duration: Int)],
+        spliceSafeTokenIds: Set<Int>? = nil
     ) -> [(token: Int, timestamp: Int, confidence: Float, duration: Int)] {
-        mergeChunks(left, right)
+        mergeChunks(left, right, spliceSafeTokenIds: spliceSafeTokenIds)
     }
     #endif
 
@@ -577,8 +578,9 @@ struct ChunkProcessor {
         }
 
         if orderedChunkOutputs.count > 1 {
+            let spliceSafeTokenIds = Self.spliceSafeTokenIds(vocabulary: await manager.vocabulary)
             for chunk in orderedChunkOutputs.dropFirst() {
-                mergedTokens = mergeChunks(mergedTokens, chunk)
+                mergedTokens = mergeChunks(mergedTokens, chunk, spliceSafeTokenIds: spliceSafeTokenIds)
             }
         }
 
@@ -672,9 +674,36 @@ struct ChunkProcessor {
         return (hypothesis.ySequence, hypothesis.timestamps, hypothesis.tokenConfidences, hypothesis.tokenDurations)
     }
 
+    /// Token IDs whose vocabulary piece may safely start the portion spliced
+    /// in from the `right` window at a seam: SentencePiece word-initial pieces
+    /// (`▁` prefix) or punctuation-only pieces (which attach to the previous
+    /// word by design). Returns nil for an empty vocabulary so merge behavior
+    /// is unchanged when no vocabulary is available (issue #683).
+    static func spliceSafeTokenIds(vocabulary: [Int: String]) -> Set<Int>? {
+        guard !vocabulary.isEmpty else { return nil }
+        var ids = Set<Int>()
+        for (id, piece) in vocabulary where isSpliceSafePiece(piece) {
+            ids.insert(id)
+        }
+        return ids
+    }
+
+    /// A piece is splice-safe when decoding it right after another word does
+    /// not glue two words together: it either starts a new word (`▁`/space
+    /// prefix) or is pure punctuation/symbols.
+    static func isSpliceSafePiece(_ piece: String) -> Bool {
+        guard !piece.isEmpty else { return false }
+        if isWordBoundary(piece) { return true }
+        return piece.unicodeScalars.allSatisfy { scalar in
+            CharacterSet.punctuationCharacters.contains(scalar)
+                || CharacterSet.symbols.contains(scalar)
+        }
+    }
+
     func mergeChunks(
         _ left: [TokenWindow],
-        _ right: [TokenWindow]
+        _ right: [TokenWindow],
+        spliceSafeTokenIds: Set<Int>? = nil
     ) -> [TokenWindow] {
         if left.isEmpty { return right }
         if right.isEmpty { return left }
@@ -714,7 +743,7 @@ struct ChunkProcessor {
         guard overlapLeft.count >= 2 && overlapRight.count >= 2 else {
             return mergeByMidpoint(
                 left: left, right: right, leftEndTime: leftEndTime, rightStartTime: rightStartTime,
-                frameDuration: frameDuration)
+                frameDuration: frameDuration, spliceSafeTokenIds: spliceSafeTokenIds)
         }
 
         let minimumPairs = max(overlapLeft.count / 2, 1)
@@ -739,7 +768,8 @@ struct ChunkProcessor {
                 overlapLeft: overlapLeft,
                 overlapRight: overlapRight,
                 left: left,
-                right: right
+                right: right,
+                spliceSafeTokenIds: spliceSafeTokenIds
             )
         }
 
@@ -753,7 +783,7 @@ struct ChunkProcessor {
         guard !lcsMatches.isEmpty else {
             return mergeByMidpoint(
                 left: left, right: right, leftEndTime: leftEndTime, rightStartTime: rightStartTime,
-                frameDuration: frameDuration)
+                frameDuration: frameDuration, spliceSafeTokenIds: spliceSafeTokenIds)
         }
 
         // Map LCS matches directly to pairs (no consolidation)
@@ -765,7 +795,8 @@ struct ChunkProcessor {
             overlapLeft: overlapLeft,
             overlapRight: overlapRight,
             left: left,
-            right: right
+            right: right,
+            spliceSafeTokenIds: spliceSafeTokenIds
         )
     }
 
@@ -780,7 +811,8 @@ struct ChunkProcessor {
         overlapLeft: [IndexedToken],
         overlapRight: [IndexedToken],
         left: [TokenWindow],
-        right: [TokenWindow]
+        right: [TokenWindow],
+        spliceSafeTokenIds: Set<Int>?
     ) -> [TokenWindow] {
         let leftIndices = matches.map { overlapLeft[$0.0].index }
         let rightIndices = matches.map { overlapRight[$0.1].index }
@@ -813,10 +845,83 @@ struct ChunkProcessor {
         }
 
         if let lastRight = rightIndices.last, lastRight + 1 < right.count {
-            result.append(contentsOf: right[(lastRight + 1)...])
+            let tail = right[(lastRight + 1)...]
+            if let safeIds = spliceSafeTokenIds,
+                let firstTail = tail.first,
+                !safeIds.contains(firstTail.token)
+            {
+                // Issue #683: the splice lands mid-word — right's first
+                // post-match piece continues the word containing the matched
+                // anchor, so splicing here can decode a left-prefix +
+                // right-suffix hybrid or glue two words together. Re-splice
+                // at a word boundary so exactly one window segments the
+                // seam word.
+                if let wordStart = wordInitialIndex(in: right, endingAt: lastRight, safeIds: safeIds),
+                    popSeamWord(from: &result, safeIds: safeIds)
+                {
+                    // The right window heard the seam word from its start —
+                    // adopt its segmentation of the whole word. (The left
+                    // window's chunk often ends mid-word here, so its view
+                    // of the word is the truncated one.)
+                    result.append(contentsOf: right[wordStart...])
+                } else {
+                    // The right window was cut mid-word at its stream start
+                    // (no word-initial piece before the anchor): the left
+                    // window owns the seam word. Complete it with left's own
+                    // continuation pieces and resume right at its next
+                    // word-initial piece instead of gluing.
+                    if let lastLeft = leftIndices.last {
+                        var cursor = lastLeft + 1
+                        while cursor < left.count, !safeIds.contains(left[cursor].token) {
+                            result.append(left[cursor])
+                            cursor += 1
+                        }
+                    }
+                    if let resume = tail.firstIndex(where: { safeIds.contains($0.token) }) {
+                        result.append(contentsOf: tail[resume...])
+                    }
+                }
+            } else {
+                result.append(contentsOf: tail)
+            }
         }
 
         return result
+    }
+
+    /// Index of the word-initial (or punctuation) piece starting the word
+    /// that contains `anchor`, or nil when the stream begins mid-word.
+    private func wordInitialIndex(
+        in stream: [TokenWindow],
+        endingAt anchor: Int,
+        safeIds: Set<Int>
+    ) -> Int? {
+        var index = anchor
+        while index >= 0 {
+            if safeIds.contains(stream[index].token) { return index }
+            index -= 1
+        }
+        return nil
+    }
+
+    /// Remove the trailing seam word (continuation pieces plus its
+    /// word-initial piece) from `result` so the right window's segmentation
+    /// of the same word can replace it. Returns false — leaving `result`
+    /// untouched — when no word-initial piece exists within a plausible
+    /// word length.
+    private func popSeamWord(from result: inout [TokenWindow], safeIds: Set<Int>) -> Bool {
+        let maxPiecesPerWord = 12
+        var cursor = result.count - 1
+        var inspected = 0
+        while cursor >= 0, inspected < maxPiecesPerWord {
+            if safeIds.contains(result[cursor].token) {
+                result.removeLast(result.count - cursor)
+                return true
+            }
+            cursor -= 1
+            inspected += 1
+        }
+        return false
     }
 
     private func mergeByMidpoint(
@@ -824,11 +929,28 @@ struct ChunkProcessor {
         right: [TokenWindow],
         leftEndTime: Double,
         rightStartTime: Double,
-        frameDuration: Double
+        frameDuration: Double,
+        spliceSafeTokenIds: Set<Int>?
     ) -> [TokenWindow] {
         let cutoff = (leftEndTime + rightStartTime) / 2
-        let trimmedLeft = left.filter { Double($0.timestamp) * frameDuration < cutoff }
-        let trimmedRight = right.filter { Double($0.timestamp) * frameDuration >= cutoff }
-        return trimmedLeft + trimmedRight
+        // Token streams are emitted in timestamp order, so the cutoff filter
+        // is equivalent to a prefix/suffix split.
+        var leftEnd = left.firstIndex { Double($0.timestamp) * frameDuration >= cutoff } ?? left.count
+        var rightStart = right.firstIndex { Double($0.timestamp) * frameDuration >= cutoff } ?? right.count
+        if let safeIds = spliceSafeTokenIds {
+            // Issue #683: a pure time cutoff can split a word. Extend the
+            // left stream until the word it started is complete, and drop
+            // orphaned continuation pieces (whose word-initial piece was
+            // trimmed away) from the head of the right stream.
+            if leftEnd > 0 {
+                while leftEnd < left.count, !safeIds.contains(left[leftEnd].token) {
+                    leftEnd += 1
+                }
+            }
+            while rightStart < right.count, !safeIds.contains(right[rightStart].token) {
+                rightStart += 1
+            }
+        }
+        return Array(left[..<leftEnd]) + Array(right[rightStart...])
     }
 }

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/DualDecodeArbitration.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/DualDecodeArbitration.swift
@@ -312,8 +312,9 @@ extension ChunkProcessor {
         }
 
         if chunkOutputs.count > 1 {
+            let spliceSafeTokenIds = Self.spliceSafeTokenIds(vocabulary: await manager.vocabulary)
             for chunk in chunkOutputs.dropFirst() {
-                mergedTokens = mergeChunks(mergedTokens, chunk)
+                mergedTokens = mergeChunks(mergedTokens, chunk, spliceSafeTokenIds: spliceSafeTokenIds)
             }
         }
 

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessorTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessorTests.swift
@@ -591,6 +591,202 @@ final class ChunkProcessorTests: XCTestCase {
         XCTAssertNotNil(processor)
     }
 
+    // MARK: - Word Boundary Splice Tests (Issue #683)
+
+    /// Vocabulary for splice tests: tokens 21/22/25/26/28/50 are SentencePiece
+    /// continuation pieces (no `▁` prefix), the rest are word-initial.
+    private let spliceTestVocabulary: [Int: String] = [
+        10: "▁hello",
+        20: "▁wor",
+        21: "ld",
+        22: "ldo",
+        24: "▁Gre",
+        25: "nl",
+        26: "and",
+        27: "▁Green",
+        28: "andia",
+        30: "▁there",
+        40: "▁friend",
+        50: "ne",
+        60: "▁o",
+    ]
+
+    private var spliceTestSafeIds: Set<Int> {
+        ChunkProcessor.spliceSafeTokenIds(vocabulary: spliceTestVocabulary)!
+    }
+
+    func testPostMatchTailAdoptsRightSegmentationOfSeamWord() {
+        // Issue #683: the matched anchor lands mid-word ("nl") and the two
+        // windows segment the seam word differently. Splicing left's prefix
+        // onto right's suffix would decode a hybrid word ("▁Gre"+"nl"+
+        // "andia"). Since the right window heard the word from its start,
+        // the merge must adopt right's segmentation of the whole word.
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+
+        let left: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 10, timestamp: 120, confidence: 0.98, duration: 1),  // ▁hello
+            (token: 24, timestamp: 130, confidence: 0.97, duration: 1),  // ▁Gre
+            (token: 25, timestamp: 131, confidence: 0.96, duration: 1),  // nl (matched anchor)
+            (token: 26, timestamp: 132, confidence: 0.95, duration: 1),  // and
+        ]
+        let right: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 27, timestamp: 130, confidence: 0.97, duration: 1),  // ▁Green
+            (token: 25, timestamp: 131, confidence: 0.96, duration: 1),  // nl (matched anchor)
+            (token: 28, timestamp: 132, confidence: 0.95, duration: 1),  // andia (continuation)
+            (token: 30, timestamp: 134, confidence: 0.97, duration: 1),  // ▁there
+        ]
+
+        let merged = processor.mergeTokenWindowsForTesting(
+            left: left, right: right, spliceSafeTokenIds: spliceTestSafeIds
+        ).map(\.token)
+
+        // "▁hello ▁Green nl andia ▁there" — the seam word is segmented by
+        // the right window alone; left's truncated view of it is dropped.
+        XCTAssertEqual(merged, [10, 27, 25, 28, 30])
+    }
+
+    func testPostMatchTailKeepsLeftWordWhenRightCutMidWord() {
+        // Issue #683 glue repro: the right window's stream starts mid-word
+        // (utterance-initial, no `▁` piece before the anchor), so right
+        // never heard the word start. The merge must keep the left window's
+        // segmentation of the seam word and resume right at its next
+        // word-initial piece — never glue "and"-style continuations onto a
+        // different word.
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+
+        let left: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 10, timestamp: 120, confidence: 0.98, duration: 1),  // ▁hello
+            (token: 24, timestamp: 130, confidence: 0.97, duration: 1),  // ▁Gre
+            (token: 25, timestamp: 131, confidence: 0.96, duration: 1),  // nl (matched anchor)
+            (token: 26, timestamp: 132, confidence: 0.95, duration: 1),  // and
+        ]
+        let right: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 25, timestamp: 131, confidence: 0.96, duration: 1),  // nl (stream starts mid-word)
+            (token: 28, timestamp: 132, confidence: 0.95, duration: 1),  // andia (continuation)
+            (token: 30, timestamp: 134, confidence: 0.97, duration: 1),  // ▁there
+        ]
+
+        let merged = processor.mergeTokenWindowsForTesting(
+            left: left, right: right, spliceSafeTokenIds: spliceTestSafeIds
+        ).map(\.token)
+
+        // "▁hello ▁Gre nl and ▁there" — left's word completed from left,
+        // right's orphaned continuation skipped.
+        XCTAssertEqual(merged, [10, 24, 25, 26, 30])
+    }
+
+    func testPostMatchTailLegacyBehaviorWithoutVocabulary() {
+        // Without a vocabulary the merge must behave exactly as before:
+        // the tail is appended verbatim (this is the glued-word output).
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+
+        let left: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 10, timestamp: 120, confidence: 0.98, duration: 1),
+            (token: 20, timestamp: 130, confidence: 0.97, duration: 1),
+            (token: 21, timestamp: 131, confidence: 0.96, duration: 1),
+        ]
+        let right: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 20, timestamp: 130, confidence: 0.97, duration: 1),
+            (token: 22, timestamp: 131, confidence: 0.95, duration: 1),
+            (token: 30, timestamp: 133, confidence: 0.97, duration: 1),
+            (token: 40, timestamp: 134, confidence: 0.98, duration: 1),
+        ]
+
+        let merged = processor.mergeTokenWindowsForTesting(left: left, right: right).map(\.token)
+
+        XCTAssertEqual(merged, [10, 20, 22, 30, 40])
+    }
+
+    func testPostMatchTailKeepsWordInitialTailVerbatim() {
+        // When the right tail already starts at a word boundary the splice
+        // is untouched.
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+
+        let left: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 10, timestamp: 120, confidence: 0.98, duration: 1),
+            (token: 20, timestamp: 130, confidence: 0.97, duration: 1),
+            (token: 21, timestamp: 131, confidence: 0.96, duration: 1),
+        ]
+        let right: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 21, timestamp: 131, confidence: 0.97, duration: 1),  // ld (matched anchor)
+            (token: 30, timestamp: 133, confidence: 0.97, duration: 1),  // ▁there
+            (token: 40, timestamp: 134, confidence: 0.98, duration: 1),  // ▁friend
+        ]
+
+        let merged = processor.mergeTokenWindowsForTesting(
+            left: left, right: right, spliceSafeTokenIds: spliceTestSafeIds
+        ).map(\.token)
+
+        XCTAssertEqual(merged, [10, 20, 21, 30, 40])
+    }
+
+    func testMidpointMergeDoesNotCutWords() {
+        // No tokens match (disjoint IDs) so the merge falls back to the
+        // midpoint cutoff. The cutoff lands inside left's last word and the
+        // first right token past the cutoff is an orphaned continuation
+        // piece; both sides must be adjusted to word boundaries.
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+
+        let left: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 10, timestamp: 120, confidence: 0.98, duration: 1),  // ▁hello
+            (token: 20, timestamp: 133, confidence: 0.97, duration: 1),  // ▁wor
+            (token: 21, timestamp: 135, confidence: 0.96, duration: 1),  // ld (past cutoff)
+        ]
+        let right: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 60, timestamp: 134, confidence: 0.90, duration: 1),  // ▁o (before cutoff, trimmed)
+            (token: 50, timestamp: 136, confidence: 0.91, duration: 1),  // ne (orphaned continuation)
+            (token: 30, timestamp: 138, confidence: 0.97, duration: 1),  // ▁there
+        ]
+
+        let merged = processor.mergeTokenWindowsForTesting(
+            left: left, right: right, spliceSafeTokenIds: spliceTestSafeIds
+        ).map(\.token)
+
+        // "▁hello ▁wor ld ▁there" — left's word completed past the cutoff,
+        // right's headless continuation dropped.
+        XCTAssertEqual(merged, [10, 20, 21, 30])
+    }
+
+    func testMidpointMergeLegacyBehaviorWithoutVocabulary() {
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+
+        let left: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 10, timestamp: 120, confidence: 0.98, duration: 1),
+            (token: 20, timestamp: 133, confidence: 0.97, duration: 1),
+            (token: 21, timestamp: 135, confidence: 0.96, duration: 1),
+        ]
+        let right: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 60, timestamp: 134, confidence: 0.90, duration: 1),
+            (token: 50, timestamp: 136, confidence: 0.91, duration: 1),
+            (token: 30, timestamp: 138, confidence: 0.97, duration: 1),
+        ]
+
+        let merged = processor.mergeTokenWindowsForTesting(left: left, right: right).map(\.token)
+
+        // Pure time cutoff: left's "ld" trimmed, right's "ne" glued in.
+        XCTAssertEqual(merged, [10, 20, 50, 30])
+    }
+
+    func testSpliceSafePieceClassification() {
+        XCTAssertTrue(ChunkProcessor.isSpliceSafePiece("▁word"))
+        XCTAssertTrue(ChunkProcessor.isSpliceSafePiece("▁"))
+        XCTAssertTrue(ChunkProcessor.isSpliceSafePiece(" word"))
+        XCTAssertTrue(ChunkProcessor.isSpliceSafePiece(","))
+        XCTAssertTrue(ChunkProcessor.isSpliceSafePiece("..."))
+        XCTAssertTrue(ChunkProcessor.isSpliceSafePiece("?"))
+        XCTAssertFalse(ChunkProcessor.isSpliceSafePiece("ld"))
+        XCTAssertFalse(ChunkProcessor.isSpliceSafePiece("ня"))
+        XCTAssertFalse(ChunkProcessor.isSpliceSafePiece(""))
+        XCTAssertFalse(ChunkProcessor.isSpliceSafePiece("<unk>"))
+    }
+
+    func testSpliceSafeTokenIdsFromVocabulary() {
+        XCTAssertNil(ChunkProcessor.spliceSafeTokenIds(vocabulary: [:]))
+
+        let ids = ChunkProcessor.spliceSafeTokenIds(vocabulary: spliceTestVocabulary)
+        XCTAssertEqual(ids, [10, 20, 24, 27, 30, 40, 60])
+    }
+
     // MARK: - Chunk Count Prediction with Overlap
 
     func testPredictableChunkCountWithOverlap() {


### PR DESCRIPTION
Fixes #683.

## Problem

`ChunkProcessor`'s window merge splices token streams purely by token IDs and timestamps. None of the three merge paths checks SentencePiece word boundaries, so a seam splice could decode:

- a **hybrid word** — left window's word prefix + right window's continuation pieces,
- a **glued word** — a continuation piece (no `▁` prefix) appended directly onto a completed word, or
- a **truncated word** — a raw time cutoff splitting a word.

## Fix

- `ChunkProcessor.spliceSafeTokenIds(vocabulary:)` derives the set of word-initial token IDs (`▁`/space-prefixed or punctuation-only pieces) from the model vocabulary, computed once per merge pass and threaded through `mergeChunks`.
- **`mergeUsingMatches` post-match tail**: when the splice lands mid-word (first tail token is a continuation piece), adopt the **right window's segmentation of the whole seam word** — the left chunk is typically the one whose audio was cut mid-word. Only when the right stream itself starts mid-word (no `▁` piece before the matched anchor — the construction that produces glued words) does the merge keep the left window's word and resume right at its next word-initial piece.
- **`mergeByMidpoint`**: extends the left stream to finish the word the time cutoff splits, and drops orphaned continuation pieces from the right stream's head.
- Without a vocabulary the merge is byte-for-byte unchanged.

Note on the issue's analysis: gap fills turned out to be structurally safe — splices between matches are always anchored at identical token IDs, so they stay stream-contiguous. Only the post-match tail and the midpoint cutoff can splice mid-word.

The issue's suggested repair (complete the seam word from the *left* window) was implemented first and rejected empirically: on FLEURS uk_ua it truncated 4 seam words (e.g. `Гренландією`→`Гренланді`, `воскресіння`→`воскресен`) because at a seam the left window is the one cut mid-word — the right window heard the word in full.

## Validation

- **1h earnings22 audio (~277 window seams)**: the only 3 word-level diffs vs baseline are organic seam-splice artifacts repaired by this change — `Patrict.`→`Patrick.` (seam 47), `outlocate`→`allocate` (seam 144), `automoti`→`automotive` (seam 274). Zero regressions.
- **FLEURS uk_ua, 200 samples**: WER 7.0% == baseline (CER 2.3%); the 28 files ≥ 15s (every one with a seam) are WER-neutral with no truncated or hybrid seam words.
- **FLEURS en_us, 200 samples**: WER 5.0% == baseline. RTFx unchanged (~140x).
- New unit tests cover the glue repro from the issue, the adopt-right-segmentation path, the right-cut-mid-word fallback, the midpoint path, piece classification, and unchanged legacy behavior without a vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)