### PR TITLE
fix(asr): make SlidingWindowAsrConfig.default fit the model's 240k-sample input

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -50,6 +50,11 @@ public actor SlidingWindowAsrManager {
     private var startTime: Date?
     private var processedChunks: Int = 0
 
+    // Window-processing error tracking so total failure is surfaced by finish()
+    // instead of being silently absorbed by error recovery
+    private var failedWindowCount: Int = 0
+    private var lastWindowError: SlidingWindowAsrError?
+
     // Vocabulary boosting
     // These are initialized via configureVocabularyBoosting() before start()
     private var customVocabulary: CustomVocabularyContext?
@@ -152,8 +157,12 @@ public actor SlidingWindowAsrManager {
     /// Models must be loaded first via `loadModels()` or `loadModels(_:)`
     ///
     /// - Parameter source: The audio source to use (default: microphone)
-    /// - Throws: ASRError.notInitialized if models are not loaded
+    /// - Throws: `SlidingWindowAsrError.invalidConfiguration` if the configured window
+    ///   (left + chunk + right context) exceeds the model's maximum input size,
+    ///   `ASRError.notInitialized` if models are not loaded
     public func startStreaming(source: AudioSource = .microphone) async throws {
+        try config.validate()
+
         guard asrManager != nil else {
             throw ASRError.notInitialized
         }
@@ -171,6 +180,8 @@ public actor SlidingWindowAsrManager {
         segmentIndex = 0
         lastProcessedFrame = 0
         accumulatedTokens.removeAll()
+        failedWindowCount = 0
+        lastWindowError = nil
 
         startTime = Date()
 
@@ -242,6 +253,21 @@ public actor SlidingWindowAsrManager {
             throw error
         }
 
+        // Surface total failure: every window errored, so the transcript is empty
+        // or covers only a fraction of the audio. Silently returning it would be
+        // indistinguishable from silence in the input.
+        if processedChunks == 0, let windowError = lastWindowError {
+            logger.error(
+                "All \(self.failedWindowCount) window(s) failed to process; throwing last error instead of returning an empty transcript"
+            )
+            throw windowError
+        }
+        if failedWindowCount > 0 {
+            logger.warning(
+                "\(self.failedWindowCount) window(s) failed during streaming; transcript may be missing segments"
+            )
+        }
+
         let finalText: String
         if vocabBoostingEnabled {
             // Text-based reconstruction preserves rescored corrections from processWindow().
@@ -272,6 +298,8 @@ public actor SlidingWindowAsrManager {
         volatileTranscript = ""
         confirmedTranscript = ""
         processedChunks = 0
+        failedWindowCount = 0
+        lastWindowError = nil
         startTime = Date()
         sampleBuffer.removeAll(keepingCapacity: false)
         bufferStartIndex = 0
@@ -510,7 +538,11 @@ public actor SlidingWindowAsrManager {
                 return
             }
             let streamingError = SlidingWindowAsrError.modelProcessingFailed(error)
-            logger.error("Model processing error: \(streamingError.localizedDescription)")
+            failedWindowCount += 1
+            lastWindowError = streamingError
+            logger.error(
+                "Model processing error (window failure #\(self.failedWindowCount)): \(streamingError.localizedDescription)"
+            )
 
             // Attempt error recovery
             await attemptErrorRecovery(error: streamingError)
@@ -695,11 +727,13 @@ public struct SlidingWindowAsrConfig: Sendable {
     /// `AsrManager`'s internal blank-token auto-adaptation.
     public let tdtConfig: TdtConfig?
 
-    /// Default configuration aligned with previous API expectations
+    /// Default configuration using the proven 11+2+2 window layout.
+    /// The assembled window (left + chunk + right) must fit the model's fixed
+    /// 15 s input (`ASRConstants.maxModelSamples`); 2 + 11 + 2 = 15 s fits exactly.
     public static let `default` = SlidingWindowAsrConfig(
-        chunkSeconds: 15.0,
+        chunkSeconds: 11.0,
         hypothesisChunkSeconds: 2.0,
-        leftContextSeconds: 10.0,
+        leftContextSeconds: 2.0,
         rightContextSeconds: 2.0,
         minContextForConfirmation: 10.0,
         confirmationThreshold: 0.85
@@ -756,7 +790,7 @@ public struct SlidingWindowAsrConfig: Sendable {
         self.init(
             chunkSeconds: chunkDuration,
             hypothesisChunkSeconds: min(1.0, chunkDuration / 2.0),  // Default to half chunk duration
-            leftContextSeconds: 10.0,
+            leftContextSeconds: 2.0,
             rightContextSeconds: 2.0,
             minContextForConfirmation: 10.0,
             confirmationThreshold: confirmationThreshold
@@ -771,7 +805,7 @@ public struct SlidingWindowAsrConfig: Sendable {
         SlidingWindowAsrConfig(
             chunkSeconds: chunkDuration,
             hypothesisChunkSeconds: min(1.0, chunkDuration / 2.0),  // Default to half chunk duration
-            leftContextSeconds: 10.0,
+            leftContextSeconds: 2.0,
             rightContextSeconds: 2.0,
             minContextForConfirmation: 10.0,
             confirmationThreshold: confirmationThreshold
@@ -792,6 +826,25 @@ public struct SlidingWindowAsrConfig: Sendable {
     var leftContextSamples: Int { Int(leftContextSeconds * 16000) }
     var rightContextSamples: Int { Int(rightContextSeconds * 16000) }
     var minContextForConfirmationSamples: Int { Int(minContextForConfirmation * 16000) }
+
+    /// Total samples in an assembled window: left context + chunk + right context.
+    public var windowSamples: Int { leftContextSamples + chunkSamples + rightContextSamples }
+
+    /// Validates that the assembled window fits the model's fixed input size.
+    /// - Throws: `SlidingWindowAsrError.invalidConfiguration` if
+    ///   `leftContextSeconds + chunkSeconds + rightContextSeconds` exceeds the
+    ///   model's maximum input (`ASRConstants.maxModelSamples`, 15 s at 16 kHz).
+    public func validate() throws {
+        guard windowSamples <= ASRConstants.maxModelSamples else {
+            let windowSeconds = leftContextSeconds + chunkSeconds + rightContextSeconds
+            let maxSeconds = Double(ASRConstants.maxModelSamples) / 16000.0
+            throw SlidingWindowAsrError.invalidConfiguration(
+                "leftContextSeconds + chunkSeconds + rightContextSeconds = \(windowSeconds)s "
+                    + "(\(windowSamples) samples) exceeds the model's maximum input of "
+                    + "\(maxSeconds)s (\(ASRConstants.maxModelSamples) samples at 16 kHz)"
+            )
+        }
+    }
 
     // Backward-compat convenience for existing call-sites/tests
     var chunkDuration: TimeInterval { chunkSeconds }

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
@@ -44,7 +44,57 @@ final class SlidingWindowAsrManagerTests: XCTestCase {
         // Test default config
         let defaultConfig = SlidingWindowAsrConfig.default
         XCTAssertEqual(defaultConfig.confirmationThreshold, 0.85)
-        XCTAssertEqual(defaultConfig.chunkDuration, 15.0)
+        XCTAssertEqual(defaultConfig.chunkDuration, 11.0)
+    }
+
+    func testPresetWindowsFitModelInput() throws {
+        // The assembled window (left + chunk + right) feeds a fixed-shape
+        // [1, 240000] preprocessor input — presets must never exceed it (issue #686)
+        for config in [SlidingWindowAsrConfig.default, SlidingWindowAsrConfig.streaming] {
+            XCTAssertLessThanOrEqual(config.windowSamples, ASRConstants.maxModelSamples)
+            XCTAssertNoThrow(try config.validate())
+        }
+    }
+
+    func testValidateThrowsForOversizedWindow() {
+        // The old default: 10 + 15 + 2 = 27s = 432,000 samples > 240,000
+        let oversized = SlidingWindowAsrConfig(
+            chunkSeconds: 15.0,
+            leftContextSeconds: 10.0,
+            rightContextSeconds: 2.0
+        )
+        XCTAssertThrowsError(try oversized.validate()) { error in
+            guard case SlidingWindowAsrError.invalidConfiguration = error else {
+                return XCTFail("Expected invalidConfiguration, got \(error)")
+            }
+        }
+    }
+
+    func testStartStreamingThrowsForOversizedWindow() async {
+        let oversized = SlidingWindowAsrConfig(
+            chunkSeconds: 15.0,
+            leftContextSeconds: 10.0,
+            rightContextSeconds: 2.0
+        )
+        let manager = SlidingWindowAsrManager(config: oversized)
+        do {
+            try await manager.startStreaming()
+            XCTFail("startStreaming should reject a window larger than the model input")
+        } catch {
+            guard case SlidingWindowAsrError.invalidConfiguration = error else {
+                return XCTFail("Expected invalidConfiguration, got \(error)")
+            }
+        }
+    }
+
+    func testConvenienceInitializersFitModelInput() throws {
+        // chunkDuration-based initializers must produce valid windows for
+        // any chunk up to the model limit minus their fixed contexts
+        let config = SlidingWindowAsrConfig(chunkDuration: 11.0)
+        XCTAssertNoThrow(try config.validate())
+
+        let custom = SlidingWindowAsrConfig.custom(chunkDuration: 11.0, confirmationThreshold: 0.8)
+        XCTAssertNoThrow(try custom.validate())
     }
 
     func testConfigCalculatedProperties() {


### PR DESCRIPTION
Fixes #686

## Problem

`SlidingWindowAsrConfig.default` used a 10+15+2 layout, assembling 27 s (432,000-sample) windows — but the Parakeet TDT v3 preprocessor has a fixed `[1, 240000]` (15 s) input. Every live window threw a shape error that `attemptErrorRecovery` swallowed (OSLog only), so:

- the update stream never yielded anything (0 updates on a 34-min recording per the issue report),
- `finish()` returned only the last few seconds of audio,
- and the consumer had no signal that anything was wrong.

## Fix

- **`.default` now uses the proven 11+2+2 layout** (2 + 11 + 2 = 15 s, fits the model input exactly), matching `.streaming` and the CLI streaming defaults.
- **Fixed the `chunkDuration` convenience initializers' 10 s left context** (broken for any chunk > 3 s) to 2 s.
- **`startStreaming` now validates** `left + chunk + right <= ASRConstants.maxModelSamples` and throws `SlidingWindowAsrError.invalidConfiguration` so misconfiguration fails loudly at startup instead of failing every window silently.
- **Window-processing failures are now tracked**: `finish()` throws the last window error when *every* window failed (instead of silently returning a truncated transcript), and logs a warning when only some windows failed.

## Validation

- New unit tests: presets fit the model input, `validate()` rejects the old oversized layout, `startStreaming` throws for oversized configs, convenience initializers produce valid windows.
- E2E smoke: `fluidaudiocli transcribe --streaming` on a 28.9 s FLEURS uk_ua file produces the full transcript through the sliding-window path.
- `swift build` clean, `swift format lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)