### PR TITLE
fix(asr): repair stale corrupt Nemotron multilingual latin tokenizer on download

### DIFF
--- a/Documentation/ASR/NemotronMultilingual.md
+++ b/Documentation/ASR/NemotronMultilingual.md
@@ -123,6 +123,7 @@ WER% for spaced scripts, CER% for ja_jp (segmentation-free). Full `google/fleurs
 - **int8 vs fp16 is a wash.** Average WER is identical at all three chunk sizes; per-language drift is within ±1 pp. Ship int8 for the 50% size win and ANE residency.
 - **Two independent latency axes.** NVIDIA's published modes (`att_context_size = [56,0] / [56,3] / [56,6] / [56,13]` → ~80 / 320 / 560 / 1120 ms architectural lookahead) control right-context inside the encoder. Our `320 / 560 / 1120 ms` build labels refer to `chunk_mel_frames` (processing chunk size), not lookahead. All FluidAudio builds currently ship `[56,0]` (no lookahead).
 - **CJK languages** use character-level edit rate as the "WER" field by convention; whitespace tokenization is meaningless for ja/ko/zh/th.
+- **Punctuation density drops at small chunk sizes** ([#687](https://github.com/FluidInference/FluidAudio/issues/687)). On long continuous speech the 560 ms build starts punctuating normally, then commas/periods become increasingly sparse as the session continues; 1120 ms and 2240 ms retain noticeably more punctuation on the same audio, and a session reset restores it. The words themselves are unaffected (WER-neutral) — only punctuation marks thin out. Cause is model-side: shorter chunks give the encoder less right context at sentence boundaries than the published builds' `att_context_size` assumes, and greedy RNN-T decoding compounds the miss over the session. If punctuation matters for your use case, ship 1120 ms or larger, or segment long streams (e.g. reset on VAD silence).
 
 ## See Also
 

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Shared.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Shared.swift
@@ -341,6 +341,9 @@ extension StreamingNemotronMultilingualAsrManager {
     ///     "auto"/"multilingual" for the full-vocab model. Per-language ships
     ///     are vocab-pruned (faster); the multilingual ship covers 100+ langs.
     ///   - chunkMs: Chunk size tier — 560, 1120, 2240 (recommended), or 4480.
+    ///     Note: on long continuous sessions the 560 ms tier emits increasingly
+    ///     sparse punctuation (words are unaffected); prefer 1120 ms+ when
+    ///     punctuation matters, or reset the session on silence. See issue #687.
     ///   - directory: Model cache root (default: Application Support/FluidAudio/Models).
     public static func downloadAndPreloadShared(
         languageCode: String = "auto",
@@ -382,7 +385,43 @@ extension StreamingNemotronMultilingualAsrManager {
             ModelNames.NemotronMultilingualStreaming.metadata)
 
         if FileManager.default.fileExists(atPath: metadataPath.path) {
-            logger.info("Using cached multilingual variant at \(variantDir.path)")
+            // Repair pass for variants cached before 2026-05-31: the latin
+            // tokenizer.json shipped with a corrupt entry — id 2224 read
+            // "<blank>" (duplicating the real blank at 2828) instead of
+            // "▁there", so every "there" in a transcript decoded as the
+            // literal text "<blank>". The repo file is fixed upstream;
+            // re-fetch the tokenizer when the cached copy still has the
+            // corruption (https://github.com/FluidInference/FluidAudio/issues/687).
+            let tokenizerPath = variantDir.appendingPathComponent(
+                ModelNames.NemotronMultilingualStreaming.tokenizer)
+            if Self.tokenizerHasCorruptBlankEntry(tokenizerPath: tokenizerPath, metadataPath: metadataPath) {
+                logger.warning(
+                    "Cached tokenizer.json at \(tokenizerPath.path) has a corrupt duplicate '<blank>' entry — re-downloading the fixed file"
+                )
+                // Move the corrupt file aside so downloadSubdirectory re-fetches
+                // it; restore on failure so offline users keep a working variant.
+                let backupPath = tokenizerPath.appendingPathExtension("corrupt")
+                try? FileManager.default.removeItem(at: backupPath)
+                try FileManager.default.moveItem(at: tokenizerPath, to: backupPath)
+                do {
+                    try await DownloadUtils.downloadSubdirectory(
+                        .nemotronMultilingual,
+                        subdirectory: subdirectory,
+                        to: repoCacheDir,
+                        progressHandler: progressHandler,
+                        shouldSkip: { $0.contains(".mlpackage") }
+                    )
+                    try? FileManager.default.removeItem(at: backupPath)
+                    logger.info("Repaired tokenizer.json for \(subdirectory)")
+                } catch {
+                    try? FileManager.default.moveItem(at: backupPath, to: tokenizerPath)
+                    logger.warning(
+                        "Could not re-download tokenizer.json (\(error.localizedDescription)); keeping the cached copy"
+                    )
+                }
+            } else {
+                logger.info("Using cached multilingual variant at \(variantDir.path)")
+            }
         } else {
             logger.info("Downloading multilingual variant \(subdirectory) (.mlmodelc only)...")
             try await DownloadUtils.downloadSubdirectory(
@@ -394,6 +433,25 @@ extension StreamingNemotronMultilingualAsrManager {
             )
         }
         return variantDir
+    }
+
+    /// Detect the known tokenizer.json corruption shipped with latin variants
+    /// before 2026-05-31: a "<blank>" piece at an id other than the blank
+    /// index (id 2224, which should be "▁there", duplicated the real blank
+    /// entry at the blank index). A healthy tokenizer maps every id below
+    /// `blank_idx` to a real piece — "<blank>" may only appear at `blank_idx`.
+    ///
+    /// Returns `false` when either file is missing or unreadable; missing
+    /// files are handled by the normal download path.
+    internal static func tokenizerHasCorruptBlankEntry(tokenizerPath: URL, metadataPath: URL) -> Bool {
+        guard let config = try? NemotronMultilingualStreamingConfig(from: metadataPath),
+            let data = try? Data(contentsOf: tokenizerPath),
+            let vocab = try? JSONSerialization.jsonObject(with: data) as? [String: String]
+        else { return false }
+        return vocab.contains { entry in
+            guard entry.value == "<blank>", let id = Int(entry.key) else { return false }
+            return id != config.blankIdx
+        }
     }
 
     /// Compile-if-needed + load helper for required model files.

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronMultilingualTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronMultilingualTests.swift
@@ -198,6 +198,88 @@ final class NemotronMultilingualTests: XCTestCase {
         XCTAssertEqual(ModelNames.NemotronMultilingualStreaming.metadata, "metadata.json")
     }
 
+    // MARK: - Corrupt tokenizer detection (issue #687)
+
+    /// Write a metadata.json + tokenizer.json pair into a fresh temp
+    /// directory and return their URLs. Caller removes the directory.
+    private func makeVariantDir(
+        blankIdx: Int,
+        vocab: [String: String]
+    ) throws -> (dir: URL, tokenizer: URL, metadata: URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("multilingual_variant_\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let metadata: [String: Any] = [
+            "vocab_size": blankIdx,
+            "blank_idx": blankIdx,
+            "prompt_dictionary": ["auto": 101],
+            "lang_tag_token_ids": [Int](),
+        ]
+        let metadataURL = dir.appendingPathComponent("metadata.json")
+        try JSONSerialization.data(withJSONObject: metadata).write(to: metadataURL)
+
+        let tokenizerURL = dir.appendingPathComponent("tokenizer.json")
+        try JSONSerialization.data(withJSONObject: vocab).write(to: tokenizerURL)
+        return (dir, tokenizerURL, metadataURL)
+    }
+
+    func testCorruptBlankEntryDetected() throws {
+        // Pre-2026-05-31 latin tokenizer: "<blank>" at id 2224 (should be
+        // "▁there") in addition to the legitimate blank at blank_idx 2828.
+        let (dir, tokenizer, metadata) = try makeVariantDir(
+            blankIdx: 2828,
+            vocab: ["0": "<unk>", "2224": "<blank>", "2828": "<blank>"]
+        )
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        XCTAssertTrue(
+            StreamingNemotronMultilingualAsrManager.tokenizerHasCorruptBlankEntry(
+                tokenizerPath: tokenizer, metadataPath: metadata))
+    }
+
+    func testHealthyTokenizerWithBlankAtBlankIdxPasses() throws {
+        // Fixed latin tokenizer: "▁there" restored at 2224, "<blank>" only
+        // at the blank index.
+        let (dir, tokenizer, metadata) = try makeVariantDir(
+            blankIdx: 2828,
+            vocab: ["0": "<unk>", "2224": "▁there", "2828": "<blank>"]
+        )
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        XCTAssertFalse(
+            StreamingNemotronMultilingualAsrManager.tokenizerHasCorruptBlankEntry(
+                tokenizerPath: tokenizer, metadataPath: metadata))
+    }
+
+    func testHealthyTokenizerWithoutBlankPiecePasses() throws {
+        // Full multilingual tokenizer ships no "<blank>" entry at all.
+        let (dir, tokenizer, metadata) = try makeVariantDir(
+            blankIdx: 13087,
+            vocab: ["0": "<unk>", "2224": "▁lahko"]
+        )
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        XCTAssertFalse(
+            StreamingNemotronMultilingualAsrManager.tokenizerHasCorruptBlankEntry(
+                tokenizerPath: tokenizer, metadataPath: metadata))
+    }
+
+    func testMissingTokenizerFileIsNotCorrupt() throws {
+        // Missing files are the normal-download path's job, not the
+        // repair pass's.
+        let (dir, tokenizer, metadata) = try makeVariantDir(
+            blankIdx: 2828,
+            vocab: ["0": "<unk>"]
+        )
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try FileManager.default.removeItem(at: tokenizer)
+
+        XCTAssertFalse(
+            StreamingNemotronMultilingualAsrManager.tokenizerHasCorruptBlankEntry(
+                tokenizerPath: tokenizer, metadataPath: metadata))
+    }
+
     // MARK: - Helpers
 
     private func makeConfig(


### PR DESCRIPTION
Fixes #687.

## Problem

Two distinct issues were reported:

1. **The word "there" is dropped / two `<blank>` tokens in the latin vocab.** Latin `tokenizer.json` files published before 2026-05-31 had id 2224 corrupted to `<blank>` (duplicating the real blank at id 2828) instead of `▁there`, so the model emits the token correctly but every "there" decodes as the literal text `<blank>`. The HuggingFace repo file was fixed upstream on May 31, but `downloadVariant()` reuses any cached variant whose `metadata.json` exists — it never revalidates — so users who downloaded before the fix kept the corrupt tokenizer indefinitely.

2. **Punctuation becomes increasingly sparse at the 560 ms chunk tier.** Reproduced with the issue's attached audio. This is model-side behavior of the small-chunk build, not a pipeline bug: shorter chunks give the encoder less right context at sentence boundaries than the published builds' `att_context_size` assumes, and greedy RNN-T decoding compounds the miss over a continuous session. Verified the streaming state handling is correct (`cache_len` saturates at 42 as expected; a fresh session on the same audio restores punctuation; explicit language vs auto prompt makes no difference).

## Fix

- `downloadVariant()` now detects the corruption signature in a cached tokenizer (`<blank>` piece at an id other than `blank_idx`) and re-fetches the fixed file. The corrupt copy is restored if the re-download fails, so offline users keep a working variant.
- Documented the 560 ms punctuation behavior in `Documentation/ASR/NemotronMultilingual.md` and on the `chunkMs` parameter: prefer 1120 ms+ when punctuation matters, or reset the session on silence boundaries.

## Verification

- 4 new unit tests for the corruption detector (corrupt latin, fixed latin, full-vocab, missing-file cases).
- End-to-end on a real pre-fix cache: the repair pass detected the corrupt `latin/2240ms` tokenizer, re-fetched the fixed file, and the variant then transcribed every "there" in the issue's audio correctly.
- Reporter's exact config (latin 560 ms, auto mode) against the issue's ground truth: all six "there" instances present post-fix; remaining deltas are normalization-grade ("T-H-E-R-E" → "THERE", "they're" → "they are") plus the documented small-chunk punctuation sparsity.