### PR TITLE
fix(tts): Misaki-lexicon-first English frontend for KokoroAne

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
@@ -273,6 +273,48 @@ public enum KokoroAneResourceDownloader {
         )
     }
 
+    /// Best-effort fetch of Kokoro's preprocessed Misaki lexicon cache
+    /// (`us_lexicon_cache.json`) into the shared kokoro cache directory
+    /// (next to the G2P CoreML assets — same file StyleTTS2 consumes via
+    /// `LexiconAssetCache`).
+    ///
+    /// Returns the kokoro cache directory when the file is resident
+    /// (pre-cached or freshly downloaded), or `nil` when it is missing
+    /// and could not be fetched — the English frontend then falls back
+    /// to BART-G2P-only phonemization. The lexicon is a pronunciation
+    /// quality booster (Misaki weak forms for function words, issue
+    /// #691), not a hard dependency.
+    public static func ensureEnglishLexicon(
+        directory: URL? = nil
+    ) async -> URL? {
+        let filename = "us_lexicon_cache.json"
+        do {
+            let modelsDirectory = try directory ?? defaultModelsDirectory()
+            let kokoroDir = modelsDirectory.appendingPathComponent(Repo.kokoro.folderName)
+            try FileManager.default.createDirectory(
+                at: kokoroDir, withIntermediateDirectories: true)
+
+            let localURL = kokoroDir.appendingPathComponent(filename)
+            if FileManager.default.fileExists(atPath: localURL.path) {
+                return kokoroDir
+            }
+
+            let remoteURL = try ModelRegistry.resolveModel(Repo.kokoro.remotePath, filename)
+            let descriptor = AssetDownloader.Descriptor(
+                description: filename,
+                remoteURL: remoteURL,
+                destinationURL: localURL
+            )
+            _ = try await AssetDownloader.ensure(descriptor, logger: logger)
+            return kokoroDir
+        } catch {
+            logger.warning(
+                "English lexicon cache unavailable (\(error.localizedDescription)) — "
+                    + "falling back to BART G2P only")
+            return nil
+        }
+    }
+
     /// Ensure a specific voice pack `.bin` file exists, downloading if missing.
     /// Default voice for each variant is included in `requiredModels(Zh)`; this
     /// helper covers any additional voice that ships separately.

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+/// English text frontend for the KokoroAne 7-stage chain.
+///
+/// Word resolution order (mirrors `StyleTTS2Phonemizer` and Kokoro's
+/// Misaki frontend):
+///   1. caller-supplied custom lexicon (case-sensitive, then lower-cased)
+///   2. case-sensitive Misaki lexicon hit on the original spelling
+///      (proper nouns, abbreviations like `AI`, `NATO`)
+///   3. case-sensitive hit on the normalized lower-case form
+///   4. lower-cased Misaki lexicon hit — this is what gives function
+///      words their weak forms (`to` → `tu`), instead of the BART G2P
+///      citation form (`tˈO`) that over-stresses them (issue #691)
+///   5. BART G2P CoreML fallback for OOV words (injected by the caller)
+///
+/// Punctuation supported by the chain's `vocab.json` (`, . ! ? ; …` etc.)
+/// is preserved and attached to the preceding word — Kokoro treats those
+/// tokens as prosody/pause cues, matching upstream `KPipeline.g2p` output.
+/// Unlike the StyleTTS2 frontend, Misaki diphthong shorthand (`A O I Y W`)
+/// is NOT expanded: the laishere vocab carries those tokens directly.
+struct KokoroAneEnglishPhonemizer: Sendable {
+
+    private static let logger = AppLogger(category: "KokoroAneEnglishPhonemizer")
+
+    /// Lower-cased word → ordered Misaki phoneme tokens (pre-filtered
+    /// against the chain vocab at load time by `LexiconAssetCache`).
+    let wordToPhonemes: [String: [String]]
+
+    /// Original-case word → phoneme tokens (`"AI"`, `"iPhone"`, …).
+    let caseSensitiveWordToPhonemes: [String: [String]]
+
+    /// Caller-supplied overrides (word → IPA string), checked before the
+    /// Misaki lexicon. Exact spelling wins over the lower-cased form.
+    let customLexicon: [String: String]
+
+    /// Punctuation characters the loaded `vocab.json` can encode.
+    /// Characters outside this set are dropped (they would be silently
+    /// skipped at `KokoroAneVocab.encode` anyway).
+    let allowedPunctuation: Set<Character>
+
+    init(
+        wordToPhonemes: [String: [String]] = [:],
+        caseSensitiveWordToPhonemes: [String: [String]] = [:],
+        customLexicon: [String: String] = [:],
+        allowedPunctuation: Set<Character> = []
+    ) {
+        self.wordToPhonemes = wordToPhonemes
+        self.caseSensitiveWordToPhonemes = caseSensitiveWordToPhonemes
+        self.customLexicon = customLexicon
+        self.allowedPunctuation = allowedPunctuation
+    }
+
+    /// Convert text to a Misaki-style IPA string. Words are joined with
+    /// single spaces; kept punctuation attaches to the preceding word
+    /// (`"Hello, world!"` → `"həlˈO, wˈɜɹld!"` shape).
+    ///
+    /// - Parameter fallback: per-word G2P for words missing from every
+    ///   lexicon. Receives the normalized (lower-cased) spelling. `nil`
+    ///   return skips the word with a warning; a thrown error aborts.
+    /// - Throws: `KokoroAneError.inputProcessingFailed` when the input is
+    ///   empty or nothing could be resolved.
+    func phonemize(
+        _ text: String,
+        fallback: (String) async throws -> [String]?
+    ) async throws -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw KokoroAneError.inputProcessingFailed("(empty input)")
+        }
+
+        var parts: [String] = []
+
+        for token in Self.splitWords(trimmed) {
+            if token.isEmpty { continue }
+
+            // Punctuation token (single non-word char from the splitter).
+            if token.count == 1, let ch = token.first, !ch.isLetter, !ch.isNumber {
+                guard allowedPunctuation.contains(ch) else { continue }
+                // Attach to the preceding word — Kokoro's vocab encodes
+                // punctuation as its own prosody token, but Misaki output
+                // never puts a space before it.
+                if parts.isEmpty {
+                    parts.append(String(ch))
+                } else {
+                    parts[parts.count - 1].append(ch)
+                }
+                continue
+            }
+
+            if let ipa = try await resolveWord(token, fallback: fallback) {
+                parts.append(ipa)
+            }
+        }
+
+        let joined = parts.joined(separator: " ")
+        if joined.isEmpty {
+            throw KokoroAneError.inputProcessingFailed(
+                "produced no phonemes for input '\(trimmed)'")
+        }
+        return joined
+    }
+
+    // MARK: - Word resolution
+
+    private func resolveWord(
+        _ word: String,
+        fallback: (String) async throws -> [String]?
+    ) async throws -> String? {
+        let normalized = Self.normalizeKey(word)
+
+        if let custom = customLexicon[word] ?? customLexicon[normalized] {
+            return custom
+        }
+
+        if let phonemes = caseSensitiveWordToPhonemes[word]
+            ?? caseSensitiveWordToPhonemes[normalized]
+            ?? wordToPhonemes[normalized],
+            !phonemes.isEmpty
+        {
+            return phonemes.joined()
+        }
+
+        guard !normalized.isEmpty else { return nil }
+        do {
+            if let phonemes = try await fallback(normalized), !phonemes.isEmpty {
+                return phonemes.joined()
+            }
+            Self.logger.warning("G2P returned nil for word '\(normalized)' — skipping")
+            return nil
+        } catch {
+            Self.logger.warning("G2P failed on word '\(normalized)': \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    /// Lowercase + strip non-letter/digit/apostrophe chars so we hit the
+    /// same Misaki cache entries the preprocessor wrote.
+    static func normalizeKey(_ word: String) -> String {
+        let lowered = word.lowercased()
+        let allowedSet = CharacterSet.letters.union(.decimalDigits)
+            .union(CharacterSet(charactersIn: "'"))
+        let filtered = lowered.unicodeScalars.filter { allowedSet.contains($0) }
+        return String(String.UnicodeScalarView(filtered))
+    }
+
+    // MARK: - Word splitter
+
+    /// Emit runs of letters/digits (apostrophes and hyphens stay inside
+    /// words: `don't`, `twenty-one`), single punctuation chars as their
+    /// own tokens, and drop whitespace. Same shape as the StyleTTS2
+    /// frontend's imitation of `nltk.word_tokenize`.
+    static func splitWords(_ text: String) -> [String] {
+        var out: [String] = []
+        var current: String = ""
+
+        @inline(__always) func flushCurrent() {
+            if !current.isEmpty {
+                out.append(current)
+                current.removeAll(keepingCapacity: true)
+            }
+        }
+
+        for ch in text {
+            if ch.isWhitespace {
+                flushCurrent()
+            } else if ch.isLetter || ch.isNumber || ch == "'" || ch == "-" {
+                current.append(ch)
+            } else {
+                flushCurrent()
+                out.append(String(ch))
+            }
+        }
+        flushCurrent()
+        return out
+    }
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -11,11 +11,12 @@ import Foundation
 /// Constraints:
 ///   * Single voice per variant (`af_heart.bin` for English).
 ///   * IPA input capped at 512 tokens — chunk longer prompts upstream.
-///   * No runtime custom-lexicon API.
 ///   * Loads from HF path `kokoro-82m-coreml/ANE/`.
 ///
 /// Pipeline:
-///   * Text → IPA via the existing `G2PModel` (per-word, joined with " ")
+///   * Text → IPA via ``KokoroAneEnglishPhonemizer`` (Misaki lexicon first
+///     — weak function-word forms, vocab punctuation kept as prosody
+///     tokens — with per-word BART `G2PModel` fallback for OOV words)
 ///   * IPA → input ids via `KokoroAneVocab`
 ///   * Voice pack slice via `KokoroAneVoicePack`
 ///   * 7 stages via `KokoroAneSynthesizer`
@@ -30,6 +31,14 @@ public actor KokoroAneManager {
     private let store: KokoroAneModelStore
     private let variant: KokoroAneVariant
     private var defaultVoice: String
+
+    /// English frontend: Misaki lexicon + custom overrides + punctuation
+    /// pass-through. Built lazily (needs the chain vocab + lexicon asset);
+    /// cached only after a successful lexicon load so a transient download
+    /// failure doesn't pin the degraded G2P-only path for the session.
+    private var englishPhonemizer: KokoroAneEnglishPhonemizer?
+    private var englishCustomLexicon: [String: String] = [:]
+    private let englishLexiconCache = LexiconAssetCache()
 
     public init(
         variant: KokoroAneVariant = .english,
@@ -73,6 +82,10 @@ public actor KokoroAneManager {
         if variant == .english {
             try await KokoroAneResourceDownloader.ensureG2PAssets(directory: nil)
             try await G2PModel.shared.ensureModelsAvailable()
+            // Best-effort pre-fetch of the Misaki lexicon cache (weak
+            // function-word forms, issue #691). Missing lexicon degrades
+            // to the BART-G2P-only path rather than failing initialize.
+            _ = await KokoroAneResourceDownloader.ensureEnglishLexicon(directory: nil)
         }
         if let voices = preloadVoices {
             for voice in voices {
@@ -107,9 +120,26 @@ public actor KokoroAneManager {
         await store.setMandarinCustomLexicon(lexicon)
     }
 
+    /// Install (or clear) a user-supplied English pronunciation override.
+    ///
+    /// Entries map a word to a Misaki-style IPA string (e.g.
+    /// `["to": "tə", "GIF": "ʤˈɪf"]`). The exact spelling is checked
+    /// first, then the lower-cased form, before the bundled Misaki
+    /// lexicon and the BART G2P fallback. Pass `[:]` to clear.
+    ///
+    /// Only meaningful for ``KokoroAneVariant/english`` — calling on the
+    /// Mandarin variant stores the value but has no synthesis effect
+    /// (use ``setMandarinCustomLexicon(_:)`` there).
+    public func setEnglishCustomLexicon(_ entries: [String: String]) {
+        englishCustomLexicon = entries
+        // Rebuild the cached frontend with the new overrides on next use.
+        englishPhonemizer = nil
+    }
+
     /// Drop loaded mlmodelcs + voice packs. The store reloads on next call.
     public func cleanup() async {
         await store.cleanup()
+        englishPhonemizer = nil
     }
 
     // MARK: - Synthesis
@@ -139,23 +169,33 @@ public actor KokoroAneManager {
         voice: String? = nil,
         speed: Float = KokoroAneConstants.defaultSpeed
     ) async throws -> KokoroAneSynthesisResult {
-        let phonemes: String
+        let resolved = try await phonemes(for: text)
+        return try await runChain(phonemes: resolved, voice: voice, speed: speed)
+    }
+
+    /// Resolve the exact phoneme string ``synthesize(text:voice:speed:)``
+    /// would feed the 7-stage chain — for diagnostics, tests, and
+    /// caller-side phoneme caching (issue #691).
+    ///
+    /// English: Misaki-lexicon-first with BART G2P fallback. Mandarin:
+    /// the ``MandarinG2P`` pipeline for Hanzi input, pass-through for
+    /// strings that already look like phonemes.
+    public func phonemes(for text: String) async throws -> String {
         switch variant {
         case .english:
-            phonemes = try await phonemize(text: text)
+            return try await phonemize(text: text)
         case .mandarin:
             try await store.loadIfNeeded()
             if MandarinG2P.looksLikeHanzi(text) {
                 let g2p = try await store.mandarinG2PPipeline()
-                phonemes = try await g2p.phonemize(text)
+                return try await g2p.phonemize(text)
             } else {
                 // No Hanzi present → caller already supplied bopomofo /
                 // ASCII punctuation. Pass through so power users can
                 // still override pronunciation manually.
-                phonemes = text
+                return text
             }
         }
-        return try await runChain(phonemes: phonemes, voice: voice, speed: speed)
     }
 
     /// Bypass G2P; feed an already-IPA phoneme string directly.
@@ -208,41 +248,62 @@ public actor KokoroAneManager {
         )
     }
 
-    /// Whitespace-split, per-word G2P, joined with " ". Punctuation is
-    /// stripped because the laishere vocab is IPA-only — punctuation chars
-    /// would just be dropped at `KokoroAneVocab.encode` anyway.
+    /// English text → Misaki-style IPA. Lexicon-first resolution (weak
+    /// function-word forms — `to` → `tu`, not the stressed BART citation
+    /// form `tˈO`, issue #691), per-word BART G2P fallback for OOV words,
+    /// and vocab-supported punctuation kept as prosody/pause tokens.
     private func phonemize(text: String) async throws -> String {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            throw KokoroAneError.inputProcessingFailed("(empty input)")
+        let phonemizer = await ensureEnglishPhonemizer()
+        return try await phonemizer.phonemize(text) { word in
+            try await G2PModel.shared.phonemize(word: word)
         }
+    }
 
-        let words = trimmed.split(whereSeparator: { $0.isWhitespace }).map(String.init)
-        var parts: [String] = []
-        parts.reserveCapacity(words.count)
+    /// Build (and cache) the English frontend: chain vocab → allowed
+    /// token/punctuation sets, Misaki lexicon cache → weak-form maps.
+    /// On any failure returns a transient G2P-only frontend (current
+    /// pre-#691 behavior) without caching it, so the lexicon is retried
+    /// on the next call.
+    private func ensureEnglishPhonemizer() async -> KokoroAneEnglishPhonemizer {
+        if let cached = englishPhonemizer { return cached }
 
-        for word in words {
-            let cleaned = word.trimmingCharacters(in: .punctuationCharacters).lowercased()
-            guard !cleaned.isEmpty else { continue }
-            do {
-                if let ipa = try await G2PModel.shared.phonemize(word: cleaned) {
-                    parts.append(ipa.joined())
-                } else {
-                    logger.warning("G2P returned nil for word '\(cleaned)' — skipping")
-                }
-            } catch {
-                logger.warning(
-                    "G2P failed on word '\(cleaned)': \(error.localizedDescription)")
-                throw error
+        var lower: [String: [String]] = [:]
+        var caseSensitive: [String: [String]] = [:]
+        var punctuation: Set<Character> = []
+        var lexiconLoaded = false
+
+        do {
+            try await store.loadIfNeeded()
+            let vocab = try await store.vocabulary()
+            // Stress/length marks (ˈ ˌ ː) are Unicode modifier letters, so
+            // `isLetter` keeps them out of the punctuation set.
+            punctuation = Set(
+                vocab.map.keys.filter { !$0.isLetter && !$0.isNumber && !$0.isWhitespace })
+
+            if let kokoroDir = await KokoroAneResourceDownloader.ensureEnglishLexicon(directory: nil) {
+                let allowedTokens = Set(vocab.map.keys.map(String.init))
+                try await englishLexiconCache.ensureLoaded(
+                    kokoroDirectory: kokoroDir, allowedTokens: allowedTokens)
+                let maps = await englishLexiconCache.lexicons()
+                lower = maps.word
+                caseSensitive = maps.caseSensitive
+                lexiconLoaded = true
             }
+        } catch {
+            logger.warning(
+                "English lexicon unavailable (\(error.localizedDescription)); using BART G2P only")
         }
 
-        let joined = parts.joined(separator: " ")
-        if joined.isEmpty {
-            throw KokoroAneError.inputProcessingFailed(
-                "G2P produced no phonemes for input '\(trimmed)'")
+        let phonemizer = KokoroAneEnglishPhonemizer(
+            wordToPhonemes: lower,
+            caseSensitiveWordToPhonemes: caseSensitive,
+            customLexicon: englishCustomLexicon,
+            allowedPunctuation: punctuation
+        )
+        if lexiconLoaded {
+            englishPhonemizer = phonemizer
         }
-        return joined
+        return phonemizer
     }
 
     private func wavData(from result: KokoroAneSynthesisResult) throws -> Data {

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
@@ -1,0 +1,180 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Tests for the English KokoroAne text frontend (issue #691): Misaki
+/// lexicon weak forms beat the BART G2P citation forms, punctuation is
+/// preserved as prosody tokens, and custom-lexicon overrides win.
+final class KokoroAneEnglishPhonemizerTests: XCTestCase {
+
+    /// Misaki-style lexicon stand-in. `to` is the issue #691 word: the
+    /// lexicon carries the unstressed weak form while BART G2P returns
+    /// the stressed citation form `tˈO`.
+    private let lexicon: [String: [String]] = [
+        "to": ["t", "u"],
+        "i": ["ˈ", "I"],
+        "want": ["w", "ˈ", "ɑ", "n", "t"],
+        "go": ["ɡ", "ˈ", "O"],
+        "hello": ["h", "ə", "l", "ˈ", "O"],
+        "world": ["w", "ˈ", "ɜ", "ɹ", "l", "d"],
+    ]
+
+    private let caseSensitive: [String: [String]] = [
+        "AI": ["ˈ", "A", "ˈ", "I"]
+    ]
+
+    /// Punctuation present in the real `ANE/vocab.json`.
+    private let punctuation: Set<Character> = [",", ".", "!", "?", ";", ":", "…"]
+
+    private func makePhonemizer(
+        custom: [String: String] = [:]
+    ) -> KokoroAneEnglishPhonemizer {
+        KokoroAneEnglishPhonemizer(
+            wordToPhonemes: lexicon,
+            caseSensitiveWordToPhonemes: caseSensitive,
+            customLexicon: custom,
+            allowedPunctuation: punctuation
+        )
+    }
+
+    /// G2P stand-in that returns the stressed citation form for "to" the
+    /// way the BART model does, and records which words reached it.
+    private actor FallbackRecorder {
+        var words: [String] = []
+        func g2p(_ word: String) -> [String]? {
+            words.append(word)
+            if word == "to" { return ["t", "ˈ", "O"] }
+            return ["<g2p:\(word)>"]
+        }
+    }
+
+    // MARK: - Weak forms (the issue #691 symptom)
+
+    func testFunctionWordToUsesLexiconWeakFormNotG2P() async throws {
+        let recorder = FallbackRecorder()
+        let result = try await makePhonemizer().phonemize("I want to go") { await recorder.g2p($0) }
+
+        XCTAssertEqual(result, "ˈI wˈɑnt tu ɡˈO")
+        XCTAssertFalse(result.contains("tˈO"), "'to' must not get the stressed citation form")
+        let recordedEmpty = await recorder.words.isEmpty
+        XCTAssertTrue(recordedEmpty, "all words should resolve from the lexicon")
+    }
+
+    func testUppercaseToStillResolvesWeakForm() async throws {
+        // "TO" has no case-sensitive entry; it must hit the lower-cased
+        // lexicon, not fall through to G2P.
+        let recorder = FallbackRecorder()
+        let result = try await makePhonemizer().phonemize("TO") { await recorder.g2p($0) }
+        XCTAssertEqual(result, "tu")
+        let recorded = await recorder.words
+        XCTAssertTrue(recorded.isEmpty)
+    }
+
+    // MARK: - Resolution order
+
+    func testCaseSensitiveLexiconWinsForAbbreviations() async throws {
+        let result = try await makePhonemizer().phonemize("AI") { _ in nil }
+        XCTAssertEqual(result, "ˈAˈI")
+    }
+
+    func testOOVWordFallsBackToG2PWithNormalizedSpelling() async throws {
+        let recorder = FallbackRecorder()
+        let result = try await makePhonemizer().phonemize("I want Zorblax") { await recorder.g2p($0) }
+        XCTAssertEqual(result, "ˈI wˈɑnt <g2p:zorblax>")
+        let recordedWords = await recorder.words
+        XCTAssertEqual(recordedWords, ["zorblax"])
+    }
+
+    func testCustomLexiconOverridesEverything() async throws {
+        let phonemizer = makePhonemizer(custom: ["to": "tə"])
+        let result = try await phonemizer.phonemize("I want to go") { _ in nil }
+        XCTAssertEqual(result, "ˈI wˈɑnt tə ɡˈO")
+    }
+
+    func testCustomLexiconExactSpellingBeatsLowercased() async throws {
+        let phonemizer = makePhonemizer(custom: ["to": "tə", "TO": "tˈu"])
+        let emphatic = try await phonemizer.phonemize("TO") { _ in nil }
+        XCTAssertEqual(emphatic, "tˈu")
+        let weak = try await phonemizer.phonemize("to") { _ in nil }
+        XCTAssertEqual(weak, "tə")
+    }
+
+    // MARK: - Punctuation
+
+    func testSupportedPunctuationAttachesToPrecedingWord() async throws {
+        let result = try await makePhonemizer().phonemize("Hello, world!") { _ in nil }
+        XCTAssertEqual(result, "həlˈO, wˈɜɹld!")
+    }
+
+    func testUnsupportedPunctuationIsDropped() async throws {
+        // '#' is not in the chain vocab → dropped, no stray space.
+        let result = try await makePhonemizer().phonemize("hello # world") { _ in nil }
+        XCTAssertEqual(result, "həlˈO wˈɜɹld")
+    }
+
+    func testApostropheWordsStayIntactForLexiconLookup() async throws {
+        let phonemizer = KokoroAneEnglishPhonemizer(
+            wordToPhonemes: ["don't": ["d", "ˈ", "O", "n", "t"]],
+            allowedPunctuation: punctuation
+        )
+        let result = try await phonemizer.phonemize("don't") { _ in nil }
+        XCTAssertEqual(result, "dˈOnt")
+    }
+
+    // MARK: - Degraded paths
+
+    func testG2PNilSkipsWordButKeepsRest() async throws {
+        let result = try await makePhonemizer().phonemize("want zzz go") { word in
+            word == "zzz" ? nil : ["x"]
+        }
+        XCTAssertEqual(result, "wˈɑnt ɡˈO")
+    }
+
+    func testG2PErrorPropagates() async {
+        struct Boom: Error {}
+        do {
+            _ = try await makePhonemizer().phonemize("Zorblax") { _ in throw Boom() }
+            XCTFail("expected error to propagate")
+        } catch {
+            XCTAssertTrue(error is Boom)
+        }
+    }
+
+    func testEmptyInputThrows() async {
+        do {
+            _ = try await makePhonemizer().phonemize("   ") { _ in nil }
+            XCTFail("expected inputProcessingFailed")
+        } catch let error as KokoroAneError {
+            guard case .inputProcessingFailed = error else {
+                return XCTFail("unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testNothingResolvedThrows() async {
+        do {
+            _ = try await makePhonemizer().phonemize("zzz") { _ in nil }
+            XCTFail("expected inputProcessingFailed")
+        } catch let error as KokoroAneError {
+            guard case .inputProcessingFailed = error else {
+                return XCTFail("unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Without lexicon (pre-#691 behavior preserved)
+
+    func testEmptyLexiconFallsBackToG2PForEveryWord() async throws {
+        let phonemizer = KokoroAneEnglishPhonemizer(allowedPunctuation: punctuation)
+        let recorder = FallbackRecorder()
+        let result = try await phonemizer.phonemize("I want to go") { await recorder.g2p($0) }
+        let recordedAll = await recorder.words
+        XCTAssertEqual(recordedAll, ["i", "want", "to", "go"])
+        XCTAssertTrue(result.contains("tˈO"), "G2P-only path keeps the old citation form")
+    }
+}


### PR DESCRIPTION
Fixes #691.

## Problem

`KokoroAneManager`'s English frontend whitespace-split the text and ran every word through the BART G2P CoreML model, which returns stressed citation forms. The function word `to` came back as `tˈO` and rendered as a stressed "toe" in ordinary sentences like "I want to go" with `af_heart`.

## Fix

Resolve words against Kokoro's preprocessed Misaki lexicon cache first (`us_lexicon_cache.json` — the same asset and `LexiconAssetCache` loader the StyleTTS2 frontend already uses), keeping BART G2P as the OOV fallback. The lexicon carries the weak forms (`to` → `tu`, unstressed), and all 46 of its distinct phoneme tokens are present in the ANE chain vocab, so entries feed the chain unmodified (Misaki diphthong shorthand `A O I Y W` is NOT expanded, unlike the StyleTTS2 frontend).

New `KokoroAneEnglishPhonemizer` resolution order:
1. caller-supplied custom lexicon (exact spelling, then lower-cased)
2. case-sensitive Misaki hit (`AI`, `NATO`, …)
3. lower-cased Misaki hit (weak function-word forms)
4. BART G2P fallback for OOV words

Also:
- **Punctuation kept as prosody tokens.** The chain vocab encodes `, . ! ? ; …` etc.; the old frontend stripped them on the wrong assumption the vocab was IPA-only. Kept punctuation attaches to the preceding word, matching upstream `KPipeline.g2p` output shape.
- **`phonemes(for:)`** — public diagnostic API exposing the exact phoneme string `synthesize(text:)` feeds the 7-stage chain (both variants).
- **`setEnglishCustomLexicon(_:)`** — override hook mirroring the existing Mandarin custom lexicon API, so downstream apps no longer need to bypass `synthesize(text:)` for pronunciation fixes.
- **Best-effort lexicon download** — a missing/unfetchable lexicon degrades to the previous BART-G2P-only path instead of failing; the degraded frontend is not cached, so the lexicon is retried on the next call.

## Verification

- 14 unit tests for the new frontend (weak forms, resolution order, punctuation attach/drop, custom-lexicon precedence, degraded paths).
- ASR round-trip with real assets on "I want to go to the store.": the first `to` token confidence goes **0.442 → 1.000** (clip confidence 0.924 → 0.998); lexicon load (178,546 entries) confirmed in logs.