### PR TITLE
fix(tts): treat KokoroAne quote delimiters as punctuation

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
@@ -145,6 +145,10 @@ struct KokoroAneEnglishPhonemizer: Sendable {
 
     // MARK: - Word splitter
 
+    private static let knownLeadingApostropheWords: Set<String> = [
+        "'cause", "'em", "'til", "'tis", "'twas", "'twere",
+    ]
+
     /// Emit runs of letters/digits (internal apostrophes and hyphens stay
     /// inside words: `don't`, `twenty-one`), single punctuation chars as
     /// their own tokens, and drop whitespace. Same shape as the StyleTTS2
@@ -166,9 +170,12 @@ struct KokoroAneEnglishPhonemizer: Sendable {
                 flushCurrent()
             } else if ch == "'" {
                 let nextIndex = text.index(after: index)
-                let nextIsWord = nextIndex < text.endIndex
+                let nextIsWord =
+                    nextIndex < text.endIndex
                     && (text[nextIndex].isLetter || text[nextIndex].isNumber)
                 if !current.isEmpty && nextIsWord {
+                    current.append(ch)
+                } else if current.isEmpty && Self.startsKnownLeadingApostropheWord(in: text, at: index) {
                     current.append(ch)
                 } else {
                     flushCurrent()
@@ -183,5 +190,23 @@ struct KokoroAneEnglishPhonemizer: Sendable {
         }
         flushCurrent()
         return out
+    }
+
+    private static func startsKnownLeadingApostropheWord(
+        in text: String,
+        at apostropheIndex: String.Index
+    ) -> Bool {
+        let nextIndex = text.index(after: apostropheIndex)
+        guard nextIndex < text.endIndex, text[nextIndex].isLetter else {
+            return false
+        }
+
+        var endIndex = nextIndex
+        while endIndex < text.endIndex, text[endIndex].isLetter {
+            endIndex = text.index(after: endIndex)
+        }
+
+        let candidate = "'" + text[nextIndex..<endIndex].lowercased()
+        return knownLeadingApostropheWords.contains(candidate)
     }
 }

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
@@ -145,9 +145,9 @@ struct KokoroAneEnglishPhonemizer: Sendable {
 
     // MARK: - Word splitter
 
-    /// Emit runs of letters/digits (apostrophes and hyphens stay inside
-    /// words: `don't`, `twenty-one`), single punctuation chars as their
-    /// own tokens, and drop whitespace. Same shape as the StyleTTS2
+    /// Emit runs of letters/digits (internal apostrophes and hyphens stay
+    /// inside words: `don't`, `twenty-one`), single punctuation chars as
+    /// their own tokens, and drop whitespace. Same shape as the StyleTTS2
     /// frontend's imitation of `nltk.word_tokenize`.
     static func splitWords(_ text: String) -> [String] {
         var out: [String] = []
@@ -160,10 +160,21 @@ struct KokoroAneEnglishPhonemizer: Sendable {
             }
         }
 
-        for ch in text {
+        for index in text.indices {
+            let ch = text[index]
             if ch.isWhitespace {
                 flushCurrent()
-            } else if ch.isLetter || ch.isNumber || ch == "'" || ch == "-" {
+            } else if ch == "'" {
+                let nextIndex = text.index(after: index)
+                let nextIsWord = nextIndex < text.endIndex
+                    && (text[nextIndex].isLetter || text[nextIndex].isNumber)
+                if !current.isEmpty && nextIsWord {
+                    current.append(ch)
+                } else {
+                    flushCurrent()
+                    out.append(String(ch))
+                }
+            } else if ch.isLetter || ch.isNumber || ch == "-" {
                 current.append(ch)
             } else {
                 flushCurrent()

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
@@ -12,6 +12,9 @@ final class KokoroAneEnglishPhonemizerTests: XCTestCase {
     /// lexicon carries the unstressed weak form while BART G2P returns
     /// the stressed citation form `tˈO`.
     private let lexicon: [String: [String]] = [
+        "'em": ["ə", "m"],
+        "'til": ["t", "ˈ", "I", "l"],
+        "'twas": ["t", "w", "ˈ", "ɑ", "z"],
         "to": ["t", "u"],
         "i": ["ˈ", "I"],
         "want": ["w", "ˈ", "ɑ", "n", "t"],
@@ -137,6 +140,17 @@ final class KokoroAneEnglishPhonemizerTests: XCTestCase {
             await recorder.g2p($0)
         }
         XCTAssertEqual(result, "ðɛɹz tu")
+        let recorded = await recorder.words
+        XCTAssertTrue(recorded.isEmpty)
+    }
+
+    func testKnownLeadingApostropheWordsStayIntactForLexiconLookup() async throws {
+        let recorder = FallbackRecorder()
+        let result = try await makePhonemizer().phonemize("'twas 'em 'til 'to'") {
+            await recorder.g2p($0)
+        }
+
+        XCTAssertEqual(result, "twˈɑz əm tˈIl tu")
         let recorded = await recorder.words
         XCTAssertTrue(recorded.isEmpty)
     }

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
@@ -17,6 +17,7 @@ final class KokoroAneEnglishPhonemizerTests: XCTestCase {
         "want": ["w", "ˈ", "ɑ", "n", "t"],
         "go": ["ɡ", "ˈ", "O"],
         "hello": ["h", "ə", "l", "ˈ", "O"],
+        "there's": ["ð", "ɛ", "ɹ", "z"],
         "world": ["w", "ˈ", "ɜ", "ɹ", "l", "d"],
     ]
 
@@ -100,7 +101,7 @@ final class KokoroAneEnglishPhonemizerTests: XCTestCase {
         XCTAssertEqual(weak, "tə")
     }
 
-    // MARK: - Punctuation
+    // MARK: - Punctuation and quote delimiters
 
     func testSupportedPunctuationAttachesToPrecedingWord() async throws {
         let result = try await makePhonemizer().phonemize("Hello, world!") { _ in nil }
@@ -120,6 +121,24 @@ final class KokoroAneEnglishPhonemizerTests: XCTestCase {
         )
         let result = try await phonemizer.phonemize("don't") { _ in nil }
         XCTAssertEqual(result, "dˈOnt")
+    }
+
+    func testSingleQuotesAreDelimitersNotPartOfLexiconKey() async throws {
+        let recorder = FallbackRecorder()
+        let result = try await makePhonemizer().phonemize("'to'") { await recorder.g2p($0) }
+        XCTAssertEqual(result, "tu")
+        let recorded = await recorder.words
+        XCTAssertTrue(recorded.isEmpty)
+    }
+
+    func testQuotedSentenceKeepsContractionsIntact() async throws {
+        let recorder = FallbackRecorder()
+        let result = try await makePhonemizer().phonemize("'there's to'") {
+            await recorder.g2p($0)
+        }
+        XCTAssertEqual(result, "ðɛɹz tu")
+        let recorded = await recorder.words
+        XCTAssertTrue(recorded.isEmpty)
     }
 
     // MARK: - Degraded paths


### PR DESCRIPTION
Fixes #695.
Follow-up to #691 and #692.

## Summary

- Treat ASCII apostrophe as a KokoroAne English word character only when it is internal to a word.
- Preserve contractions such as `there's` and `don't`.
- Let quoted words such as `'to'` resolve through the same Misaki lexicon key as `to` instead of falling through to BART G2P.
- Add regression tests for quoted `to` and a quoted sentence containing `there's`.

## Root cause

After #692, lexicon-first lookup fixes ordinary `to`, but `splitWords` still kept every ASCII apostrophe inside the current word token. A quoted example word like `'to'` could therefore miss the Misaki lexicon and fall back to BART G2P.

## Validation

- `swift build --target FluidAudio`
- `git diff --check -- Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift`

`swift test --filter KokoroAneEnglishPhonemizerTests` currently does not complete on `main` in this checkout because the package build hits an existing CLI compile error in `Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronMultilingualFleursBenchmark.swift` (`the compiler is unable to type-check this expression in reasonable time`).
