### PR TITLE
feat(tts/kokoro-ane): Japanese variant + PyTorch-matched output level

### DIFF
--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -44,6 +44,7 @@ public enum Repo: String, CaseIterable, Sendable {
     case kokoro = "FluidInference/kokoro-82m-coreml"
     case kokoroAne = "FluidInference/kokoro-82m-coreml/ANE"
     case kokoroAneZh = "FluidInference/kokoro-82m-coreml/ANE-zh"
+    case kokoroAneJa = "FluidInference/kokoro-82m-coreml/ANE-ja"
     case sortformer = "FluidInference/diar-streaming-sortformer-coreml"
     case lseendAmi = "FluidInference/ls-eend-coreml/optimized/ami"
     case lseendCallHome = "FluidInference/ls-eend-coreml/optimized/ch"
@@ -108,6 +109,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "kokoro-82m-coreml/ANE"
         case .kokoroAneZh:
             return "kokoro-82m-coreml/ANE-zh"
+        case .kokoroAneJa:
+            return "kokoro-82m-coreml/ANE-ja"
         case .sortformer:
             return "diar-streaming-sortformer-coreml"
         case .lseendAmi:
@@ -142,7 +145,7 @@ public enum Repo: String, CaseIterable, Sendable {
             return "FluidInference/parakeet-ctc-0.6b-coreml"
         case .parakeetEou160, .parakeetEou320, .parakeetEou1280:
             return "FluidInference/parakeet-realtime-eou-120m-coreml"
-        case .kokoroAne, .kokoroAneZh:
+        case .kokoroAne, .kokoroAneZh, .kokoroAneJa:
             return "FluidInference/kokoro-82m-coreml"
         case .nemotronStreaming2240, .nemotronStreaming1120, .nemotronStreaming560:
             return "FluidInference/nemotron-speech-streaming-en-0.6b-coreml"
@@ -170,6 +173,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "ANE"
         case .kokoroAneZh:
             return "ANE-zh"
+        case .kokoroAneJa:
+            return "ANE-ja"
         case .parakeetEou160:
             return "160ms"
         case .parakeetEou320:
@@ -208,6 +213,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "kokoro-82m-coreml/ANE"
         case .kokoroAneZh:
             return "kokoro-82m-coreml/ANE-zh"
+        case .kokoroAneJa:
+            return "kokoro-82m-coreml/ANE-ja"
         case .parakeetEou160:
             return "parakeet-eou-streaming/160ms"
         case .parakeetEou320:
@@ -1141,6 +1148,12 @@ public enum ModelNames {
         /// `<repoDir>/voices/zf_001.bin`.
         public static let defaultVoiceFileZh = "voices/zf_001.bin"
 
+        /// Japanese (`ANE-ja/`) default voice. Mirrors the Mandarin layout —
+        /// voice packs live under a `voices/` subdirectory, so the path is
+        /// kept in the constant for the "all-required-files-present" check to
+        /// resolve against `<repoDir>/voices/jf_alpha.bin`.
+        public static let defaultVoiceFileJa = "voices/jf_alpha.bin"
+
         /// Mandarin g2pW polyphone-disambiguator CoreML bundle. Lives under
         /// `<repoDir>/g2pw/` — included in `requiredModelsZh` so the bulk
         /// `ensureModels(.mandarin)` grab pulls it without an extra round
@@ -1168,6 +1181,14 @@ public enum ModelNames {
             requiredCoreMLModels.union([
                 vocab, defaultVoiceFileZh, g2pwModelZh,
             ])
+        }
+
+        /// CoreML bundles + the vocab JSON + the Japanese default voice .bin
+        /// (under `voices/`). No G2P assets — the Japanese variant ships no
+        /// in-process text frontend; callers feed pre-computed IPA via
+        /// `synthesizeFromPhonemes(_:voice:)`.
+        public static var requiredModelsJa: Set<String> {
+            requiredCoreMLModels.union([vocab, defaultVoiceFileJa])
         }
     }
 
@@ -1226,6 +1247,8 @@ public enum ModelNames {
             return ModelNames.KokoroAne.requiredModels
         case .kokoroAneZh:
             return ModelNames.KokoroAne.requiredModelsZh
+        case .kokoroAneJa:
+            return ModelNames.KokoroAne.requiredModelsJa
         case .sortformer:
             if let variant = variant {
                 return [variant]

--- a/Sources/FluidAudio/Shared/AudioConverter.swift
+++ b/Sources/FluidAudio/Shared/AudioConverter.swift
@@ -457,10 +457,18 @@ final public class AudioConverter: Sendable {
 // MARK: - WAV Utilities (shared by TTS/ASR)
 public enum AudioWAV {
     /// Convert float samples to 16-bit PCM mono WAV at the given sample rate.
-    public static func data(from samples: [Float], sampleRate: Double) throws -> Data {
-        // Normalize to [-1, 1]
+    ///
+    /// - Parameter normalize: when `true` (default) the samples are peak-scaled
+    ///   to ±1.0 before quantization (consistent loudness). Pass `false` to
+    ///   write the samples at their native level — used by backends whose
+    ///   model output is already correctly leveled (e.g. KokoroAne, which
+    ///   matches the PyTorch reference level) so the output isn't slammed to
+    ///   0 dBFS. Out-of-range samples are still clamped to [-1, 1].
+    public static func data(
+        from samples: [Float], sampleRate: Double, normalize: Bool = true
+    ) throws -> Data {
         let maxVal = samples.map { abs($0) }.max() ?? 1.0
-        let norm = maxVal > 0 ? samples.map { $0 / maxVal } : samples
+        let norm = (normalize && maxVal > 0) ? samples.map { $0 / maxVal } : samples
 
         // Convert to 16-bit PCM
         var pcm = Data()

--- a/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
@@ -29,6 +29,8 @@ public enum KokoroAneResourceDownloader {
             required = ModelNames.KokoroAne.requiredModels
         case .mandarin:
             required = ModelNames.KokoroAne.requiredModelsZh
+        case .japanese:
+            required = ModelNames.KokoroAne.requiredModelsJa
         }
         let allPresent = required.allSatisfy { name in
             FileManager.default.fileExists(atPath: repoDir.appendingPathComponent(name).path)

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
@@ -13,6 +13,9 @@ public enum KokoroAneConstants {
     /// Default voice id for the Mandarin (`ANE-zh/`) variant.
     public static let defaultVoiceMandarin = "zf_001"
 
+    /// Default voice id for the Japanese (`ANE-ja/`) variant.
+    public static let defaultVoiceJapanese = "jf_alpha"
+
     /// Output sample rate of the iSTFT in `KokoroTail.mlpackage`.
     public static let sampleRate = 24_000
 
@@ -115,28 +118,37 @@ public enum KokoroAneConstants {
 /// the embedding vocab, HF subdirectory, voice-file layout, and the default
 /// voice id differ.
 ///
-/// | Variant      | HF subdir | Vocab | Default voice | Voice layout       |
-/// |--------------|-----------|-------|---------------|--------------------|
-/// | `.english`   | `ANE/`    | 177   | `af_heart`    | flat (`<voice>.bin`)            |
-/// | `.mandarin`  | `ANE-zh/` | 171   | `zf_001`      | nested (`voices/<voice>.bin`)   |
+/// | Variant      | HF subdir  | Default voice | Voice layout                  | Text frontend                |
+/// |--------------|------------|---------------|-------------------------------|------------------------------|
+/// | `.english`   | `ANE/`     | `af_heart`    | flat (`<voice>.bin`)          | `KokoroAneEnglishPhonemizer` |
+/// | `.mandarin`  | `ANE-zh/`  | `zf_001`      | nested (`voices/<voice>.bin`) | `MandarinG2P`                |
+/// | `.japanese`  | `ANE-ja/`  | `jf_alpha`    | nested (`voices/<voice>.bin`) | none — phoneme bypass only   |
+///
+/// The Japanese variant ships **no in-process text → phoneme frontend**.
+/// `synthesize(text:)` / `phonemes(for:)` throw for `.japanese`; callers feed
+/// pre-computed IPA through ``KokoroAneManager/synthesizeFromPhonemes(_:voice:speed:)``
+/// (the bypass path the 7-stage chain already supports). See issue #698.
 public enum KokoroAneVariant: String, CaseIterable, Sendable {
     case english
     case mandarin
+    case japanese
 
     /// Default voice id shipped with the variant's HF bundle.
     public var defaultVoice: String {
         switch self {
         case .english: return KokoroAneConstants.defaultVoice
         case .mandarin: return KokoroAneConstants.defaultVoiceMandarin
+        case .japanese: return KokoroAneConstants.defaultVoiceJapanese
         }
     }
 
-    /// True if voice packs live under a `voices/` subdirectory inside the
-    /// repo bundle (Mandarin); false if they sit at the bundle root (English).
+    /// True if voice packs live under a `voices/` subdirectory inside the repo
+    /// bundle (Mandarin / Japanese); false if they sit at the bundle root
+    /// (English).
     public var useVoicesSubdir: Bool {
         switch self {
         case .english: return false
-        case .mandarin: return true
+        case .mandarin, .japanese: return true
         }
     }
 
@@ -145,6 +157,7 @@ public enum KokoroAneVariant: String, CaseIterable, Sendable {
         switch self {
         case .english: return .kokoroAne
         case .mandarin: return .kokoroAneZh
+        case .japanese: return .kokoroAneJa
         }
     }
 }

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -324,9 +324,14 @@ public actor KokoroAneManager {
 
     private func wavData(from result: KokoroAneSynthesisResult) throws -> Data {
         do {
+            // Japanese writes at the model's native level (no peak-normalization)
+            // so the output matches the PyTorch reference instead of being
+            // slammed to 0 dBFS. English/Mandarin keep peak-normalization until
+            // their tails get the same COLA-corrected iSTFT (#698 follow-up).
             return try AudioWAV.data(
                 from: result.samples,
-                sampleRate: Double(result.sampleRate))
+                sampleRate: Double(result.sampleRate),
+                normalize: variant != .japanese)
         } catch {
             throw KokoroAneError.audioConversionFailed(error.localizedDescription)
         }

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -185,7 +185,9 @@ public actor KokoroAneManager {
     ///
     /// English: Misaki-lexicon-first with BART G2P fallback. Mandarin:
     /// the ``MandarinG2P`` pipeline for Hanzi input, pass-through for
-    /// strings that already look like phonemes.
+    /// strings that already look like phonemes. Japanese: no text frontend
+    /// — throws (use ``synthesizeFromPhonemes(_:voice:speed:)`` with
+    /// pre-computed IPA, issue #698).
     public func phonemes(for text: String) async throws -> String {
         switch variant {
         case .english:
@@ -201,6 +203,14 @@ public actor KokoroAneManager {
                 // still override pronunciation manually.
                 return text
             }
+        case .japanese:
+            // The Japanese variant ships no in-process kana/kanji → IPA
+            // frontend. Text synthesis isn't supported; callers feed
+            // pre-computed IPA via synthesizeFromPhonemes(_:voice:speed:),
+            // which bypasses phonemes(for:) entirely.
+            throw KokoroAneError.inputProcessingFailed(
+                "Japanese variant has no text G2P frontend; call "
+                    + "synthesizeFromPhonemes(_:voice:speed:) with pre-computed IPA (see #698).")
         }
     }
 

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -64,6 +64,11 @@ public struct TTS {
         var kokoroAneVariant: KokoroAneVariant = .english
         var lexiconPath: String? = nil
         var text: String? = nil
+        // KokoroAne: treat the positional/`--text` value as a pre-computed
+        // phoneme string (IPA for en/ja, Bopomofo+tone for zh) and bypass
+        // G2P via synthesizeFromPhonemes. Required for `.japanese`, which
+        // ships no text frontend (issue #698).
+        var treatAsPhonemes = false
         var deEss = true
         var backend: TtsBackend = .kokoroAne
         var cloneVoicePath: String? = nil
@@ -113,6 +118,8 @@ public struct TTS {
                     metricsPath = arguments[i + 1]
                     i += 1
                 }
+            case "--phonemes":
+                treatAsPhonemes = true
             case "--variant", "--model-variant":
                 if i + 1 < arguments.count {
                     let value = arguments[i + 1].lowercased()
@@ -291,7 +298,8 @@ public struct TTS {
         case .kokoroAne:
             await runKokoroAne(
                 text: text, output: output, voice: voice, metricsPath: metricsPath,
-                variant: kokoroAneVariant, lexiconPath: lexiconPath)
+                variant: kokoroAneVariant, lexiconPath: lexiconPath,
+                treatAsPhonemes: treatAsPhonemes)
         case .styletts2:
             await runStyleTTS2(
                 text: text, ipa: styletts2Ipa,
@@ -514,7 +522,7 @@ public struct TTS {
 
     private static func runKokoroAne(
         text: String, output: String, voice: String, metricsPath: String?,
-        variant: KokoroAneVariant, lexiconPath: String?
+        variant: KokoroAneVariant, lexiconPath: String?, treatAsPhonemes: Bool
     ) async {
         do {
             let tStart = Date()
@@ -548,11 +556,18 @@ public struct TTS {
             let tLoad1 = Date()
 
             let tSynth0 = Date()
-            // synthesizeDetailed handles both variants: English routes
-            // through G2PModel, Mandarin routes Hanzi through MandarinG2P
-            // (and passes through pre-computed Bopomofo verbatim).
-            let detailed = try await manager.synthesizeDetailed(
-                text: text, voice: resolvedVoice, speed: 1.0)
+            // synthesizeDetailed handles English (G2PModel) and Mandarin
+            // (MandarinG2P, with pass-through for pre-computed Bopomofo).
+            // With --phonemes, or for Japanese (no text frontend), bypass
+            // G2P and feed the input as a pre-computed phoneme string.
+            let detailed: KokoroAneSynthesisResult
+            if treatAsPhonemes || variant == .japanese {
+                detailed = try await manager.synthesizeFromPhonemesDetailed(
+                    text, voice: resolvedVoice, speed: 1.0)
+            } else {
+                detailed = try await manager.synthesizeDetailed(
+                    text: text, voice: resolvedVoice, speed: 1.0)
+            }
             let wav = try AudioWAV.data(
                 from: detailed.samples,
                 sampleRate: Double(detailed.sampleRate))

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -121,6 +121,8 @@ public struct TTS {
                         kokoroAneVariant = .english
                     case "zh", "mandarin", "zh-cn", "zh_cn":
                         kokoroAneVariant = .mandarin
+                    case "ja", "japanese", "jp":
+                        kokoroAneVariant = .japanese
                     default:
                         logger.warning("Unknown variant preference '\(arguments[i + 1])'; ignoring")
                     }
@@ -534,10 +536,10 @@ public struct TTS {
                     if let lex = try loadMandarinLexicon(from: lexiconPath) {
                         await manager.setMandarinCustomLexicon(lex)
                     }
-                case .english:
+                case .english, .japanese:
                     logger.warning(
-                        "--lexicon ignored: KokoroAne English variant has "
-                            + "no custom lexicon support yet (only Mandarin does).")
+                        "--lexicon ignored: only the KokoroAne Mandarin variant "
+                            + "supports a custom lexicon.")
                 }
             }
 

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -570,7 +570,8 @@ public struct TTS {
             }
             let wav = try AudioWAV.data(
                 from: detailed.samples,
-                sampleRate: Double(detailed.sampleRate))
+                sampleRate: Double(detailed.sampleRate),
+                normalize: variant != .japanese)
             let tSynth1 = Date()
 
             let outURL = resolveInputURL(output)

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneJapaneseVariantTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneJapaneseVariantTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Config tests for the `.japanese` KokoroAne variant (issue #698).
+///
+/// The Japanese variant reuses the language-agnostic 7-stage chain and the
+/// `synthesizeFromPhonemes` bypass; it ships no text frontend. These tests
+/// pin the wiring (HF paths, default voice, required-file set, routing) so a
+/// regression surfaces without needing the (separately uploaded) `ANE-ja/`
+/// CoreML weights.
+final class KokoroAneJapaneseVariantTests: XCTestCase {
+
+    func testVariantIsEnumerated() {
+        XCTAssertTrue(KokoroAneVariant.allCases.contains(.japanese))
+    }
+
+    func testVariantConfig() {
+        XCTAssertEqual(KokoroAneVariant.japanese.defaultVoice, "jf_alpha")
+        XCTAssertEqual(KokoroAneVariant.japanese.repo, .kokoroAneJa)
+        // Voice packs nest under `voices/` (mirrors Mandarin).
+        XCTAssertTrue(KokoroAneVariant.japanese.useVoicesSubdir)
+    }
+
+    func testRepoPaths() {
+        let repo = Repo.kokoroAneJa
+        XCTAssertEqual(repo.subPath, "ANE-ja")
+        XCTAssertEqual(repo.folderName, "kokoro-82m-coreml/ANE-ja")
+        XCTAssertEqual(repo.remotePath, "FluidInference/kokoro-82m-coreml")
+        XCTAssertEqual(repo.name, "kokoro-82m-coreml/ANE-ja")
+    }
+
+    func testRequiredModels() {
+        let required = ModelNames.KokoroAne.requiredModelsJa
+        // 7 CoreML bundles + vocab + the nested default voice = 9 files.
+        XCTAssertTrue(required.isSuperset(of: ModelNames.KokoroAne.requiredCoreMLModels))
+        XCTAssertTrue(required.contains(ModelNames.KokoroAne.vocab))
+        XCTAssertTrue(required.contains(ModelNames.KokoroAne.defaultVoiceFileJa))
+        XCTAssertEqual(ModelNames.KokoroAne.defaultVoiceFileJa, "voices/jf_alpha.bin")
+        // No Mandarin g2pW bundle — Japanese has no in-process G2P.
+        XCTAssertFalse(required.contains(ModelNames.KokoroAne.g2pwModelZh))
+        XCTAssertEqual(required.count, 9)
+    }
+
+    func testRequiredModelNamesRoutesToJa() {
+        XCTAssertEqual(
+            ModelNames.getRequiredModelNames(for: .kokoroAneJa, variant: nil),
+            ModelNames.KokoroAne.requiredModelsJa)
+    }
+
+    /// The Japanese variant has no text→phoneme frontend; `phonemes(for:)`
+    /// must throw rather than silently mis-synthesize. (Phoneme bypass via
+    /// `synthesizeFromPhonemes` does not route through this method.)
+    func testTextFrontendThrows() async {
+        let manager = KokoroAneManager(variant: .japanese)
+        do {
+            _ = try await manager.phonemes(for: "ありがとう")
+            XCTFail("expected phonemes(for:) to throw on the Japanese variant")
+        } catch let error as KokoroAneError {
+            guard case .inputProcessingFailed = error else {
+                return XCTFail("expected inputProcessingFailed, got \(error)")
+            }
+        } catch {
+            XCTFail("expected KokoroAneError.inputProcessingFailed, got \(error)")
+        }
+    }
+}

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVariantTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVariantTests.swift
@@ -35,9 +35,10 @@ final class KokoroAneVariantTests: XCTestCase {
     }
 
     func testVariantAllCases() {
-        XCTAssertEqual(KokoroAneVariant.allCases.count, 2)
+        XCTAssertEqual(KokoroAneVariant.allCases.count, 3)
         XCTAssertTrue(KokoroAneVariant.allCases.contains(.english))
         XCTAssertTrue(KokoroAneVariant.allCases.contains(.mandarin))
+        XCTAssertTrue(KokoroAneVariant.allCases.contains(.japanese))
     }
 
     // MARK: - Repo wiring


### PR DESCRIPTION
Adds `KokoroAneVariant.japanese` (phoneme-bypass synthesis via `synthesizeFromPhonemes`) and fixes the KokoroAne output level so Japanese matches the PyTorch reference. Resolves #698.

## Japanese variant
- `KokoroAneVariant.japanese` → `Repo.kokoroAneJa` (`ANE-ja/`), default `jf_alpha`, nested `voices/`. Reuses the language-agnostic 7-stage chain + shared vocab (no reconversion — only voice packs are new, extracted via `mobius/.../convert-voices.py`).
- No in-process text frontend: `phonemes(for:)` throws for `.japanese`; callers feed pre-computed IPA. `--variant ja` + `--phonemes` in the CLI.
- The `ANE-ja/` bundle is published to `FluidInference/kokoro-82m-coreml/ANE-ja/`.

## Output level (match PyTorch)
`AudioWAV.data` peak-normalized every output to 0 dBFS, making KokoroAne ~3x hotter than the PyTorch reference (raw peak ~0.30 → slammed to 1.0). Added an opt-out `normalize` flag (defaults `true`; PocketTTS/StyleTTS2/ASR unchanged); Japanese now writes at native level.

This also surfaced a genuine iSTFT bug: `CoreMLCustomSTFT` (KokoroTail) omitted the overlap-add/COLA normalization `torch.istft` applies, leaving output **exactly 1.5× too loud** (measured: interior per-sample ratio 1.5000, std 0, corr 1.0 — pure scalar, no spectral change). Fixed in mobius `convert-coreml.py`; the re-converted `KokoroTail` (re-uploaded to `ANE-ja/`) brings the raw level to **1.02× PyTorch**.

End-to-end (M5 Pro, jf_alpha): fixed tail + no-normalize → peak 0.306 vs PyTorch 0.299.

**Scope:** Japanese only for now. English/Mandarin keep peak-normalization (and their current tails) until they get the same COLA-corrected iSTFT — tracked as a follow-up. The `normalize` flag and the mobius iSTFT fix are the reusable pieces for that.

## Validation
`swift build` + `swift-format lint` clean; variant config tests; JA renders end-to-end through the shipped path at PyTorch-matched level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)