### PR TITLE
fix(tts/kokoro-ane): KokoroNoise v2 — atan2 phase fix (removes HF sharpness)

### DIFF
--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -1123,7 +1123,10 @@ public enum ModelNames {
         public static let postAlbert = "KokoroPostAlbert.mlmodelc"
         public static let alignment = "KokoroAlignment.mlmodelc"
         public static let prosody = "KokoroProsody.mlmodelc"
-        public static let noise = "KokoroNoise.mlmodelc"
+        // v2: atan2 phase-correction in the noise-source STFT (removes broad-spectrum
+        // HF noise / "sharpness"). Renamed (not overwritten) so cached clients
+        // re-download. See mobius laishere-coreml docs/trials-and-errors.md.
+        public static let noise = "KokoroNoise_v2.mlmodelc"
         public static let vocoder = "KokoroVocoder.mlmodelc"
         public static let tail = "KokoroTail.mlmodelc"
 

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer+Types.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer+Types.swift
@@ -68,7 +68,7 @@ public enum KokoroAneStage: String, CaseIterable, Sendable {
         case .postAlbert: return "KokoroPostAlbert.mlmodelc"
         case .alignment: return "KokoroAlignment.mlmodelc"
         case .prosody: return "KokoroProsody.mlmodelc"
-        case .noise: return "KokoroNoise.mlmodelc"
+        case .noise: return "KokoroNoise_v2.mlmodelc"  // v2: atan2 phase-correction (HF-noise fix)
         case .vocoder: return "KokoroVocoder.mlmodelc"
         case .tail: return "KokoroTail.mlmodelc"
         }


### PR DESCRIPTION
## What

Point the KokoroAne noise stage at `KokoroNoise_v2.mlmodelc` across all variants (English, Mandarin, Japanese).

## Why

The noise-source STFT computed phase as plain `atan2(imag, real)`, hitting a CoreML branch bug at the DC/Nyquist bins: when `real < 0` and `imag` is exactly 0 (DC) or at the fp32 noise floor ~1e-15 (Nyquist), CoreML returns `0` instead of `+π`. That π flip propagates through `noise_convs[0]` (a strided conv mixing ~11 frequency bins) into all 256 channels of `x_source_0`, smearing broad-spectrum high-frequency noise across the output — audible as sharp/clicky speech.

- **English + Mandarin** exhibited it (this PR fixes both via v2). Japanese shares the same language-agnostic noise model and is covered too.
- Mandarin's `ANE-zh/` chain had already shipped the equivalent correction in its own conversion; v2 unifies it under the shared name.

## Fix

Conversion-side (mobius `laishere-coreml/convert-coreml.py`, `CoreMLForwardSTFT.transform`): clip computational-zero imag (`eps=1e-5`), then apply PyTorch's branch convention `(imag==0 & real<0) -> π`. Ported from the `kokoro-v1.1-zh` Trial 11 fix.

## Deployment

`KokoroNoise_v2.mlmodelc` (+ `.mlpackage`) uploaded to `ANE/`, `ANE-ja/`, `ANE-zh/` of `FluidInference/kokoro-82m-coreml`. **Renamed rather than overwritten** so cached clients re-download instead of silently keeping the buggy file. The noise stage is language-agnostic — `model.mil` + `weight.bin` are byte-identical across `ANE/` and `ANE-ja/`.

## Verification

Reconvert (`--stages noise`) → recompile → swap cached model → regenerate. HF >=10 kHz band power drop:

| variant | HF rel | HF abs |
|---|---|---|
| English | -3.2 dB | -4.7 dB |
| Japanese | -4.7 dB | -3.5 dB |

Conversion fix + full trial log documented in mobius `laishere-coreml` (`README.md`, `docs/trials-and-errors.md`).