### PR TITLE
Make SenseVoice downloads precision-aware

### DIFF
--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
@@ -73,7 +73,12 @@ public struct SenseVoiceModels: Sendable {
         if force { try? FileManager.default.removeItem(at: targetDir) }
 
         logger.info("Downloading SenseVoice models from HuggingFace...")
-        try await DownloadUtils.downloadRepo(.senseVoiceSmall, to: modelsRoot, progressHandler: progressHandler)
+        try await DownloadUtils.downloadRepo(
+            .senseVoiceSmall,
+            to: modelsRoot,
+            variant: precision.rawValue,
+            progressHandler: progressHandler
+        )
         logger.info("Successfully downloaded SenseVoice models")
         return targetDir
     }

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -400,12 +400,23 @@ public enum ModelNames {
         public static let encoderFp32File = encoderFp32 + ".mlmodelc"
         public static let vocabularyFile = "vocab.json"
 
-        public static let requiredModels: Set<String> = [
-            preprocessorFile,
-            encoderFile,
-            encoderInt8File,
-            encoderFp32File,
-        ]
+        public static func requiredModels(precision: String? = nil) -> Set<String> {
+            let encoder: String
+            switch precision {
+            case "int8":
+                encoder = encoderInt8File
+            case "fp32":
+                encoder = encoderFp32File
+            default:
+                encoder = encoderFile
+            }
+            return [
+                preprocessorFile,
+                encoder,
+            ]
+        }
+
+        public static let requiredModels: Set<String> = requiredModels()
     }
 
     /// Paraformer-large (zh) model names. 4 CoreML stages + host CIF:
@@ -1198,7 +1209,7 @@ public enum ModelNames {
         case .parakeetCtc110m, .parakeetCtc06b:
             return ModelNames.CTC.requiredModels
         case .senseVoiceSmall:
-            return ModelNames.SenseVoice.requiredModels
+            return ModelNames.SenseVoice.requiredModels(precision: variant)
         case .paraformerLargeZh:
             return ModelNames.ParaformerZh.requiredModels
         case .parakeetJa:

--- a/Tests/FluidAudioTests/CI/CITests.swift
+++ b/Tests/FluidAudioTests/CI/CITests.swift
@@ -169,6 +169,44 @@ final class CITests: XCTestCase {
         XCTAssertEqual(modelPaths.embeddingPath.absoluteString, "file:///path/to/embedding.mlmodelc")
     }
 
+    func testSenseVoiceRequiredModelsRespectPrecisionVariant() {
+        let expectedFp16: Set<String> = [
+            ModelNames.SenseVoice.preprocessorFile,
+            ModelNames.SenseVoice.encoderFile,
+        ]
+        let expectedInt8: Set<String> = [
+            ModelNames.SenseVoice.preprocessorFile,
+            ModelNames.SenseVoice.encoderInt8File,
+        ]
+        let expectedFp32: Set<String> = [
+            ModelNames.SenseVoice.preprocessorFile,
+            ModelNames.SenseVoice.encoderFp32File,
+        ]
+
+        XCTAssertEqual(ModelNames.SenseVoice.requiredModels(), expectedFp16)
+        XCTAssertEqual(ModelNames.SenseVoice.requiredModels(precision: "fp16"), expectedFp16)
+        XCTAssertEqual(ModelNames.SenseVoice.requiredModels(precision: "int8"), expectedInt8)
+        XCTAssertEqual(ModelNames.SenseVoice.requiredModels(precision: "fp32"), expectedFp32)
+        XCTAssertEqual(ModelNames.SenseVoice.requiredModels, expectedFp16)
+    }
+
+    func testSenseVoiceRepoRequirementsForwardVariant() {
+        XCTAssertEqual(
+            ModelNames.getRequiredModelNames(for: .senseVoiceSmall, variant: "int8"),
+            [
+                ModelNames.SenseVoice.preprocessorFile,
+                ModelNames.SenseVoice.encoderInt8File,
+            ]
+        )
+        XCTAssertEqual(
+            ModelNames.getRequiredModelNames(for: .senseVoiceSmall, variant: "fp32"),
+            [
+                ModelNames.SenseVoice.preprocessorFile,
+                ModelNames.SenseVoice.encoderFp32File,
+            ]
+        )
+    }
+
     // MARK: - Backend Enum Tests
 
     func testManagerTypes() {


### PR DESCRIPTION
## Summary

Make SenseVoice downloads honor the requested encoder precision.

`SenseVoiceModels.download(precision:)` already accepts `.fp16`, `.int8`, and `.fp32`, and the loader validates only the selected encoder. The download path still called `DownloadUtils.downloadRepo(.senseVoiceSmall, ...)` without forwarding the precision, so the repo selection included every encoder variant.

This PR passes `precision.rawValue` through to `downloadRepo` and maps the SenseVoice required model set by variant:

- default / `fp16`: `SenseVoicePreprocessor.mlmodelc` + `SenseVoiceSmall.mlmodelc`
- `int8`: `SenseVoicePreprocessor.mlmodelc` + `SenseVoiceSmall_int8.mlmodelc`
- `fp32`: `SenseVoicePreprocessor.mlmodelc` + `SenseVoiceSmall_fp32.mlmodelc`

The shared `vocab.json` continues to be included by the existing JSON handling in `DownloadUtils.downloadRepo`.

## Testing

- `swift build --package-path /tmp/FluidAudio-verify --scratch-path "$HOME/Library/Caches/muesli-spm/fluidaudio-precision-aware" --target FluidAudio`
- Attempted `swift test --package-path /tmp/FluidAudio-verify --scratch-path "$HOME/Library/Caches/muesli-spm/fluidaudio-precision-aware" --filter CITests/testSenseVoice`, but the test build stops before executing tests on an unrelated existing `FluidAudioCLI` type-check issue in `Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronMultilingualFleursBenchmark.swift:790`.
