### PR TITLE
feat(asr/parakeet-unified): Swift mel, word-level timestamps, lower-latency streaming tiers

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift
@@ -158,6 +158,64 @@ public struct TokenTiming: Codable, Sendable {
     }
 }
 
+/// Word-level timing, aggregated from a sequence of `TokenTiming`s by grouping
+/// SentencePiece sub-word tokens on their word-boundary markers (`▁` / leading space).
+public struct WordTiming: Codable, Sendable {
+    public let word: String
+    public let startTime: TimeInterval
+    public let endTime: TimeInterval
+
+    public init(word: String, startTime: TimeInterval, endTime: TimeInterval) {
+        self.word = word
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+}
+
+/// Build word-level timings from token timings (e.g. from
+/// `StreamingUnifiedAsrManager.consumeTokenTimings()`).
+///
+/// Tokens whose raw piece starts with a word-boundary marker (`▁` or a leading
+/// space) begin a new word; the rest are appended to the current word. The
+/// resulting word spans from the first sub-word token's `startTime` to the last
+/// sub-word token's `endTime`.
+public func buildWordTimings(from tokenTimings: [TokenTiming]) -> [WordTiming] {
+    var wordTimings: [WordTiming] = []
+    var currentWord = ""
+    var wordStart: TimeInterval = 0
+    var wordEnd: TimeInterval = 0
+
+    func flush() {
+        let trimmed = currentWord.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        wordTimings.append(WordTiming(word: trimmed, startTime: wordStart, endTime: wordEnd))
+    }
+
+    for timing in tokenTimings {
+        let token = timing.token
+        if token.isEmpty || token == "<blank>" || token == "<pad>" {
+            continue
+        }
+
+        let startsNewWord = isWordBoundary(token) || currentWord.isEmpty
+        if startsNewWord && !currentWord.isEmpty {
+            flush()
+            currentWord = ""
+        }
+
+        if startsNewWord {
+            currentWord = stripWordBoundaryPrefix(token)
+            wordStart = timing.startTime
+        } else {
+            currentWord += token
+        }
+        wordEnd = timing.endTime
+    }
+
+    flush()
+    return wordTimings
+}
+
 // MARK: - Errors
 
 public enum ASRError: Error, LocalizedError {

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/ParakeetModelVariant.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/ParakeetModelVariant.swift
@@ -35,6 +35,12 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
     /// Parakeet Unified 0.6B, 2080ms latency (1.04s chunk + 1.04s right context).
     /// Stateless encoder re-run per chunk — streamed output matches offline quality.
     case parakeetUnified2080ms = "parakeet-unified-2080ms"
+    /// Parakeet Unified 0.6B, 1120ms latency ([70,7,7]: 0.56s chunk + 0.56s right
+    /// context). Lower latency *and* better WER than the 2080ms tier on test-clean.
+    case parakeetUnified1120ms = "parakeet-unified-1120ms"
+    /// Parakeet Unified 0.6B, 320ms latency ([70,2,2]: 0.16s chunk + 0.16s right
+    /// context). Lowest-latency tier; keeps look-ahead so WER stays near the best.
+    case parakeetUnified320ms = "parakeet-unified-320ms"
     /// Parakeet Unified 0.6B offline batch: full-attention 15s windows with 2s
     /// overlap, merged on the seams. Best WER; transcribes only at finish().
     case parakeetUnifiedOffline15s = "parakeet-unified-offline-15s"
@@ -49,6 +55,8 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
         case .nemotron1120ms: return "Nemotron 0.6B (1120ms)"
         case .nemotron560ms: return "Nemotron 0.6B (560ms)"
         case .parakeetUnified2080ms: return "Parakeet Unified 0.6B (2080ms)"
+        case .parakeetUnified1120ms: return "Parakeet Unified 0.6B (1120ms)"
+        case .parakeetUnified320ms: return "Parakeet Unified 0.6B (320ms)"
         case .parakeetUnifiedOffline15s: return "Parakeet Unified 0.6B (offline 15s batch)"
         }
     }
@@ -62,7 +70,9 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
         case .nemotron2240ms: return .nemotronStreaming2240
         case .nemotron1120ms: return .nemotronStreaming1120
         case .nemotron560ms: return .nemotronStreaming560
-        case .parakeetUnified2080ms, .parakeetUnifiedOffline15s: return .parakeetUnified
+        case .parakeetUnified2080ms, .parakeetUnified1120ms, .parakeetUnified320ms,
+            .parakeetUnifiedOffline15s:
+            return .parakeetUnified
         }
     }
 
@@ -73,8 +83,21 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
             return .parakeetEou
         case .nemotron2240ms, .nemotron1120ms, .nemotron560ms:
             return .nemotron
-        case .parakeetUnified2080ms, .parakeetUnifiedOffline15s:
+        case .parakeetUnified2080ms, .parakeetUnified1120ms, .parakeetUnified320ms,
+            .parakeetUnifiedOffline15s:
             return .parakeetUnified
+        }
+    }
+
+    /// The streaming attention context for Parakeet Unified variants (nil otherwise).
+    /// The encoder bakes `[left, chunk, right]` into its attention mask at conversion
+    /// time, so each tier loads a distinct encoder by `UnifiedConfig.contextSuffix`.
+    public var unifiedConfig: UnifiedConfig? {
+        switch self {
+        case .parakeetUnified2080ms: return UnifiedConfig(leftFrames: 70, chunkFrames: 13, rightFrames: 13)
+        case .parakeetUnified1120ms: return UnifiedConfig(leftFrames: 70, chunkFrames: 7, rightFrames: 7)
+        case .parakeetUnified320ms: return UnifiedConfig(leftFrames: 70, chunkFrames: 2, rightFrames: 2)
+        default: return nil
         }
     }
 
@@ -123,7 +146,8 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
             if self == .parakeetUnifiedOffline15s {
                 return UnifiedAsrManager(configuration: mlConfig)
             }
-            return StreamingUnifiedAsrManager(configuration: mlConfig)
+            return StreamingUnifiedAsrManager(
+                configuration: mlConfig, config: unifiedConfig ?? UnifiedConfig())
         }
     }
 

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/ParakeetModelVariant.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/ParakeetModelVariant.swift
@@ -41,6 +41,10 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
     /// Parakeet Unified 0.6B, 320ms latency ([70,2,2]: 0.16s chunk + 0.16s right
     /// context). Lowest-latency tier; keeps look-ahead so WER stays near the best.
     case parakeetUnified320ms = "parakeet-unified-320ms"
+    /// Parakeet Unified 0.6B, 640ms latency ([70,7,1]: 0.56s chunk + 0.08s right
+    /// context). Efficiency tier — same WER as 320ms at ~2.5x the RTFx (the large
+    /// chunk re-encodes far less often), trading latency for throughput.
+    case parakeetUnified640ms = "parakeet-unified-640ms"
     /// Parakeet Unified 0.6B offline batch: full-attention 15s windows with 2s
     /// overlap, merged on the seams. Best WER; transcribes only at finish().
     case parakeetUnifiedOffline15s = "parakeet-unified-offline-15s"
@@ -57,6 +61,7 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
         case .parakeetUnified2080ms: return "Parakeet Unified 0.6B (2080ms)"
         case .parakeetUnified1120ms: return "Parakeet Unified 0.6B (1120ms)"
         case .parakeetUnified320ms: return "Parakeet Unified 0.6B (320ms)"
+        case .parakeetUnified640ms: return "Parakeet Unified 0.6B (640ms)"
         case .parakeetUnifiedOffline15s: return "Parakeet Unified 0.6B (offline 15s batch)"
         }
     }
@@ -71,7 +76,7 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
         case .nemotron1120ms: return .nemotronStreaming1120
         case .nemotron560ms: return .nemotronStreaming560
         case .parakeetUnified2080ms, .parakeetUnified1120ms, .parakeetUnified320ms,
-            .parakeetUnifiedOffline15s:
+            .parakeetUnified640ms, .parakeetUnifiedOffline15s:
             return .parakeetUnified
         }
     }
@@ -84,7 +89,7 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
         case .nemotron2240ms, .nemotron1120ms, .nemotron560ms:
             return .nemotron
         case .parakeetUnified2080ms, .parakeetUnified1120ms, .parakeetUnified320ms,
-            .parakeetUnifiedOffline15s:
+            .parakeetUnified640ms, .parakeetUnifiedOffline15s:
             return .parakeetUnified
         }
     }
@@ -97,6 +102,7 @@ public enum StreamingModelVariant: String, CaseIterable, Sendable {
         case .parakeetUnified2080ms: return UnifiedConfig(leftFrames: 70, chunkFrames: 13, rightFrames: 13)
         case .parakeetUnified1120ms: return UnifiedConfig(leftFrames: 70, chunkFrames: 7, rightFrames: 7)
         case .parakeetUnified320ms: return UnifiedConfig(leftFrames: 70, chunkFrames: 2, rightFrames: 2)
+        case .parakeetUnified640ms: return UnifiedConfig(leftFrames: 70, chunkFrames: 7, rightFrames: 1)
         default: return nil
         }
     }

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
@@ -17,10 +17,15 @@ public actor StreamingUnifiedAsrManager {
     private let logger = AppLogger(category: "UnifiedStreaming")
 
     // Models
-    private var preprocessor: MLModel?
     private var encoder: MLModel?
     private var decoder: MLModel?
     private var jointDecision: MLModel?
+
+    // Log-mel features are computed natively in Swift (`AudioMelSpectrogram` +
+    // NeMo per_feature normalization); the model ships no CoreML preprocessor.
+    // WER-equivalent to the original traced preprocessor on test-clean, ~17-21%
+    // faster, and avoids the forced-CPU RangeDim mel stage.
+    private var swiftMel: UnifiedMelExtractor?
 
     // Components
     private let audioConverter = AudioConverter()
@@ -77,15 +82,11 @@ public actor StreamingUnifiedAsrManager {
         logger.info("Loading Parakeet Unified CoreML models from \(directory.path)...")
 
         let names = ModelNames.ParakeetUnified.self
-        // Decoder/joint run tiny per-token steps and the variable-length
-        // (RangeDim) preprocessor trips E5RT shape inference on the ANE —
-        // all three stay on CPU. Only the encoder benefits from ANE/GPU.
+        // Decoder/joint run tiny per-token steps that stay on CPU; only the
+        // encoder benefits from ANE/GPU. Mel is computed in Swift (no CoreML
+        // preprocessor bundle).
         let cpuConfig = MLModelConfiguration()
         cpuConfig.computeUnits = .cpuOnly
-        self.preprocessor = try await MLModel.load(
-            contentsOf: directory.appendingPathComponent(names.preprocessorFile),
-            configuration: cpuConfig
-        )
         // int8 encoders must not route to the GPU: under `.all` CoreML sends
         // the quantized ops to MPSGraph, which fails its MLIR pass and
         // aborts ("MPSGraphExecutable.mm: Error: MLIR pass manager failed").
@@ -100,7 +101,7 @@ public actor StreamingUnifiedAsrManager {
         }
         self.encoder = try await MLModel.load(
             contentsOf: directory.appendingPathComponent(
-                names.streamingEncoderFile(precision: encoderPrecision)),
+                names.streamingEncoderFile(precision: encoderPrecision, contextSuffix: config.contextSuffix)),
             configuration: encoderConfig
         )
         self.decoder = try await MLModel.load(
@@ -115,6 +116,7 @@ public actor StreamingUnifiedAsrManager {
         self.rnntDecoder = try UnifiedRnntDecoder(
             decoderModel: decoder!, jointDecisionModel: jointDecision!, config: config
         )
+        self.swiftMel = UnifiedMelExtractor(windowSamples: config.windowSamples, nMels: config.melFeatures)
 
         logger.info("Parakeet Unified models loaded (latency \(config.latencyMs)ms).")
     }
@@ -203,19 +205,19 @@ public actor StreamingUnifiedAsrManager {
 
     public func cleanup() async {
         try? await reset()
-        preprocessor = nil
         encoder = nil
         decoder = nil
         jointDecision = nil
         rnntDecoder = nil
         tokenizer = nil
+        swiftMel = nil
         logger.info("StreamingUnifiedAsrManager resources cleaned up")
     }
 
     // MARK: - Pipeline
 
     private func processAvailableWindows(isFinal: Bool) async throws {
-        guard preprocessor != nil, encoder != nil, decoder != nil, jointDecision != nil else {
+        guard swiftMel != nil, encoder != nil, decoder != nil, jointDecision != nil else {
             throw ASRError.notInitialized
         }
 
@@ -228,42 +230,26 @@ public actor StreamingUnifiedAsrManager {
     }
 
     private func processWindow(_ plan: UnifiedStreamingWindower.WindowPlan) async throws {
-        guard let preprocessor = preprocessor, let encoder = encoder else {
+        guard let swiftMel = swiftMel, let encoder = encoder else {
             throw ASRError.notInitialized
         }
 
         // 1. Assemble the zero-padded encoder window from the rolling buffer.
-        let window = try MLMultiArray(
-            shape: [1, NSNumber(value: config.windowSamples)], dataType: .float32
-        )
-        window.reset(to: 0)
         let localStart = plan.bufferStart - samplesGlobalStart
         let localEnd = plan.bufferEnd - samplesGlobalStart
         guard localStart >= 0, localEnd <= samples.count else {
             throw ASRError.processingFailed("Streaming window out of range (trimmed too aggressively)")
         }
         let validCount = localEnd - localStart
-        window.withUnsafeMutableBufferPointer(ofType: Float.self) { ptr, _ in
-            samples.withUnsafeBufferPointer { src in
-                ptr.baseAddress!.update(from: src.baseAddress! + localStart, count: validCount)
+
+        // 2. Window → mel (native Swift `AudioMelSpectrogram` + per_feature norm).
+        var buffer = [Float](repeating: 0, count: config.windowSamples)
+        samples.withUnsafeBufferPointer { src in
+            buffer.withUnsafeMutableBufferPointer { dst in
+                dst.baseAddress!.update(from: src.baseAddress! + localStart, count: validCount)
             }
         }
-
-        let audioLength = try MLMultiArray(shape: [1], dataType: .int32)
-        audioLength[0] = NSNumber(value: validCount)
-
-        // 2. Preprocessor: window → mel
-        let preprocOutput = try await preprocessor.prediction(
-            from: MLDictionaryFeatureProvider(dictionary: [
-                "audio_signal": MLFeatureValue(multiArray: window),
-                "audio_length": MLFeatureValue(multiArray: audioLength),
-            ])
-        )
-        guard let mel = preprocOutput.featureValue(for: "mel")?.multiArrayValue,
-            let melLength = preprocOutput.featureValue(for: "mel_length")?.multiArrayValue
-        else {
-            throw ASRError.processingFailed("Unified preprocessor failed to produce mel output")
-        }
+        let (mel, melLength) = try swiftMel.features(window: buffer, validCount: validCount)
 
         // 3. Streaming encoder (chunked attention mask baked in)
         let encoderOutput = try await encoder.prediction(

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
@@ -141,14 +141,19 @@ public actor StreamingUnifiedAsrManager {
             .appendingPathComponent("Models", isDirectory: true)
 
         let cacheDir = modelsBaseDir.appendingPathComponent(repo.folderName)
-        let encoderPath = cacheDir.appendingPathComponent(
-            ModelNames.ParakeetUnified.streamingEncoderFile(precision: encoderPrecision))
+        // Each [L,C,R] tier is a distinct encoder bundle (the attention mask is
+        // baked in at conversion), so the cache check and download both target
+        // this config's specific encoder rather than the default 70_13_13.
+        let encoderFile = ModelNames.ParakeetUnified.streamingEncoderFile(
+            precision: encoderPrecision, contextSuffix: config.contextSuffix)
+        let encoderPath = cacheDir.appendingPathComponent(encoderFile)
 
         if !FileManager.default.fileExists(atPath: encoderPath.path) {
             logger.info("Downloading Parakeet Unified models to \(modelsBaseDir.path)...")
             try await DownloadUtils.downloadRepo(
                 repo, to: modelsBaseDir,
                 variant: encoderPrecision == .fp16 ? "fp16" : nil,
+                additionalModelNames: [encoderFile],
                 progressHandler: progressHandler)
         } else {
             logger.info("Using cached Parakeet Unified models at \(cacheDir.path)")

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
@@ -192,6 +192,15 @@ public actor StreamingUnifiedAsrManager {
         return pendingTokenTimings
     }
 
+    /// Word-level timings since the previous call, draining the same buffer as
+    /// `consumeTokenTimings()` (call one or the other per cycle). Sub-word tokens
+    /// are grouped on their `▁` / leading-space boundaries; each word spans its
+    /// first sub-word's start to its last sub-word's end. Useful for streaming
+    /// diarized ASR (word→speaker attribution).
+    public func consumeWordTimings() -> [WordTiming] {
+        buildWordTimings(from: consumeTokenTimings())
+    }
+
     public func reset() async throws {
         samples.removeAll()
         samplesGlobalStart = 0

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
@@ -49,12 +49,15 @@ struct UnifiedBatchLayout {
 public actor UnifiedAsrManager {
     private let logger = AppLogger(category: "UnifiedOffline")
 
-    private var preprocessor: MLModel?
     private var encoder: MLModel?
     private var decoder: MLModel?
     private var jointDecision: MLModel?
     private var rnntDecoder: UnifiedRnntDecoder?
     private var tokenizer: Tokenizer?
+
+    // Log-mel features are computed natively in Swift (`AudioMelSpectrogram` +
+    // NeMo per_feature normalization); the model ships no CoreML preprocessor.
+    private var swiftMel: UnifiedMelExtractor?
 
     private let audioConverter = AudioConverter()
     public let config: UnifiedConfig
@@ -86,14 +89,10 @@ public actor UnifiedAsrManager {
         logger.info("Loading Parakeet Unified offline CoreML models from \(directory.path)...")
 
         let names = ModelNames.ParakeetUnified.self
-        // See StreamingUnifiedAsrManager: RangeDim preprocessor and per-token
-        // decoder/joint stay on CPU; only the encoder uses ANE/GPU.
+        // See StreamingUnifiedAsrManager: per-token decoder/joint stay on CPU;
+        // only the encoder uses ANE/GPU. Mel is computed in Swift.
         let cpuConfig = MLModelConfiguration()
         cpuConfig.computeUnits = .cpuOnly
-        self.preprocessor = try await MLModel.load(
-            contentsOf: directory.appendingPathComponent(names.preprocessorFile),
-            configuration: cpuConfig
-        )
         // int8 encoders must not route to the GPU: under `.all` CoreML sends
         // the quantized ops to MPSGraph, which fails its MLIR pass and
         // aborts ("MPSGraphExecutable.mm: Error: MLIR pass manager failed").
@@ -123,6 +122,7 @@ public actor UnifiedAsrManager {
         self.rnntDecoder = try UnifiedRnntDecoder(
             decoderModel: decoder!, jointDecisionModel: jointDecision!, config: config
         )
+        self.swiftMel = UnifiedMelExtractor(windowSamples: layout.windowSamples, nMels: config.melFeatures)
 
         logger.info("Parakeet Unified offline models loaded (15 s window, 2 s overlap).")
     }
@@ -200,35 +200,21 @@ public actor UnifiedAsrManager {
     private func transcribeWindow(
         samples: [Float], chunkStart: Int, chunkEnd: Int
     ) async throws -> [ChunkProcessor.TokenWindow] {
-        guard let preprocessor = preprocessor, let encoder = encoder, let rnntDecoder = rnntDecoder
+        guard let swiftMel = swiftMel, let encoder = encoder, let rnntDecoder = rnntDecoder
         else {
             throw ASRError.notInitialized
         }
 
         let validCount = chunkEnd - chunkStart
-        let window = try MLMultiArray(
-            shape: [1, NSNumber(value: layout.windowSamples)], dataType: .float32
-        )
-        window.reset(to: 0)
-        window.withUnsafeMutableBufferPointer(ofType: Float.self) { ptr, _ in
-            samples.withUnsafeBufferPointer { src in
-                ptr.baseAddress!.update(from: src.baseAddress! + chunkStart, count: validCount)
+
+        // Window → mel (native Swift `AudioMelSpectrogram` + per_feature norm).
+        var buffer = [Float](repeating: 0, count: layout.windowSamples)
+        samples.withUnsafeBufferPointer { src in
+            buffer.withUnsafeMutableBufferPointer { dst in
+                dst.baseAddress!.update(from: src.baseAddress! + chunkStart, count: validCount)
             }
         }
-        let audioLength = try MLMultiArray(shape: [1], dataType: .int32)
-        audioLength[0] = NSNumber(value: validCount)
-
-        let preprocOutput = try await preprocessor.prediction(
-            from: MLDictionaryFeatureProvider(dictionary: [
-                "audio_signal": MLFeatureValue(multiArray: window),
-                "audio_length": MLFeatureValue(multiArray: audioLength),
-            ])
-        )
-        guard let mel = preprocOutput.featureValue(for: "mel")?.multiArrayValue,
-            let melLength = preprocOutput.featureValue(for: "mel_length")?.multiArrayValue
-        else {
-            throw ASRError.processingFailed("Unified preprocessor failed to produce mel output")
-        }
+        let (mel, melLength) = try swiftMel.features(window: buffer, validCount: validCount)
 
         let encoderOutput = try await encoder.prediction(
             from: MLDictionaryFeatureProvider(dictionary: [
@@ -264,11 +250,11 @@ public actor UnifiedAsrManager {
 
     public func cleanup() async {
         try? await reset()
-        preprocessor = nil
         encoder = nil
         decoder = nil
         jointDecision = nil
         rnntDecoder = nil
+        swiftMel = nil
         tokenizer = nil
         logger.info("UnifiedAsrManager resources cleaned up")
     }

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedMelExtractor.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedMelExtractor.swift
@@ -1,0 +1,114 @@
+@preconcurrency import CoreML
+import Foundation
+
+/// Native-Swift log-mel features for Parakeet Unified, a drop-in replacement for
+/// the CoreML `parakeet_unified_preprocessor` bundle.
+///
+/// Reproduces NeMo's `AudioToMelSpectrogramPreprocessor` exactly as configured in
+/// `nvidia/parakeet-unified-en-0.6b` (`model_config.yaml`):
+/// `n_fft=512`, `window_size=0.025` (400), `window_stride=0.01` (160),
+/// `features=128`, `window=hann` (symmetric), `preemph=0.97`,
+/// `log_zero_guard='add'/2^-24`, and crucially **`normalize: per_feature`** — the
+/// per-mel-bin mean/variance standardization that the EOU config (`normalize:
+/// "NA"`) omits. `AudioMelSpectrogram` supplies the spectrogram; this type adds
+/// the per-feature normalization and packs the fixed-shape encoder input.
+struct UnifiedMelExtractor {
+    private let mel: AudioMelSpectrogram
+    private let nMels: Int
+    private let hopLength = 160
+
+    /// Total samples in the (zero-padded) encoder window.
+    let windowSamples: Int
+    /// Fixed mel frame count the encoder expects for the window (center-padded:
+    /// `windowSamples / hop + 1`). Matches the CoreML `mel_shape` last dim.
+    let totalFrames: Int
+
+    init(windowSamples: Int, nMels: Int = 128) {
+        self.windowSamples = windowSamples
+        self.nMels = nMels
+        self.totalFrames = windowSamples / hopLength + 1
+        self.mel = AudioMelSpectrogram(
+            sampleRate: 16000,
+            nMels: nMels,
+            nFFT: 512,
+            hopLength: 160,
+            winLength: 400,
+            preemph: 0.97,
+            padTo: 0,
+            windowPeriodic: false
+        )
+    }
+
+    /// Compute `(mel, melLength)` for one encoder window.
+    ///
+    /// - Parameters:
+    ///   - window: zero-padded buffer of length `windowSamples`; the first
+    ///     `validCount` samples are real audio (the rest is padding), matching how
+    ///     the managers fill the CoreML preprocessor's `audio_signal` input.
+    ///   - validCount: number of real samples at the head of `window`.
+    /// - Returns: `mel` shaped `[1, nMels, totalFrames]` and `melLength` (`[1]`,
+    ///   int32) holding the number of valid mel frames — identical contract to the
+    ///   CoreML preprocessor outputs.
+    func features(window: [Float], validCount: Int) throws -> (mel: MLMultiArray, length: MLMultiArray) {
+        // Time-major [totalFrames * nMels] raw log-mel over the full window.
+        var flat = mel.computeFlatTransposed(
+            audio: window,
+            lastAudioSample: 0,
+            paddingMode: .center,
+            expectedFrameCount: totalFrames
+        ).mel
+
+        // NeMo `get_seq_len` (center padding, stft_pad_amount=0):
+        // floor((L + n_fft - n_fft) / hop) = floor(L / hop). Note: NO `+1` — the
+        // mel *tensor* has `floor(L/hop)+1` frames, but the valid length reported
+        // to the encoder (and used for per_feature stats + masking) is one less,
+        // so the final tensor frame is always normalized to 0. Getting this off by
+        // one only nudges WER at large chunks but balloons it at tiny chunks,
+        // whose decoded frames sit right at this boundary.
+        let validFrames = min(validCount / hopLength, totalFrames)
+        normalizePerFeature(&flat, frames: totalFrames, validFrames: validFrames)
+
+        let melArray = try MLMultiArray(
+            shape: [1, NSNumber(value: nMels), NSNumber(value: totalFrames)], dataType: .float32)
+        melArray.withUnsafeMutableBufferPointer(ofType: Float.self) { ptr, _ in
+            // Contiguous [1, nMels, T]: element [0, m, t] is at offset m*T + t.
+            for t in 0..<totalFrames {
+                let base = t * nMels
+                for m in 0..<nMels {
+                    ptr[m * totalFrames + t] = flat[base + m]
+                }
+            }
+        }
+
+        let lengthArray = try MLMultiArray(shape: [1], dataType: .int32)
+        lengthArray[0] = NSNumber(value: validFrames)
+        return (melArray, lengthArray)
+    }
+
+    /// NeMo `normalize_batch(..., normalize_type="per_feature")`: for each mel bin,
+    /// subtract the mean and divide by the unbiased std (`+1e-5`) computed over the
+    /// valid frames, applied to all valid frames; pad frames are zeroed.
+    private func normalizePerFeature(_ x: inout [Float], frames: Int, validFrames: Int) {
+        guard validFrames > 0 else {
+            for i in x.indices { x[i] = 0 }
+            return
+        }
+        let denom = Float(validFrames > 1 ? validFrames - 1 : 1)
+        for m in 0..<nMels {
+            var mean: Float = 0
+            for t in 0..<validFrames { mean += x[t * nMels + m] }
+            mean /= Float(validFrames)
+
+            var varSum: Float = 0
+            for t in 0..<validFrames {
+                let d = x[t * nMels + m] - mean
+                varSum += d * d
+            }
+            let std = (varSum / denom).squareRoot() + 1e-5
+
+            for t in 0..<frames {
+                x[t * nMels + m] = t < validFrames ? (x[t * nMels + m] - mean) / std : 0
+            }
+        }
+    }
+}

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/benchmark.md
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/benchmark.md
@@ -7,8 +7,8 @@ Encoder precision: **int8**. Run with `swift run -c release fluidaudiocli unifie
 
 | Mode | Avg WER | Aggregate WER | Median WER | Median RTFx | Overall RTFx | Long files (>15s) |
 |------|---------|---------------|------------|-------------|--------------|-------------------|
-| batch | 2.15% | 1.68% | 0.00% | 111.5x | 123.3x | 238 |
-| streaming | 2.21% | 1.79% | 0.00% | 53.1x | 29.1x | 238 |
+| batch | 2.16% | 1.68% | 0.00% | 130.0x | 143.6x | 238 |
+| streaming | 2.21% | 1.79% | 0.00% | 66.2x | 65.9x | 238 |
 
 - **Avg WER** is the mean of per-file WER (matches `asr-benchmark`'s "Average WER").
 - **Aggregate WER** is total errors ÷ total words across the set.
@@ -16,7 +16,9 @@ Encoder precision: **int8**. Run with `swift run -c release fluidaudiocli unifie
   or as one continuous session (streaming) — none are skipped. Streaming's overall RTFx drops on
   long files because it re-encodes a 7.68 s window per 1.04 s chunk (the latency tax); batch only
   re-encodes the 2 s overlap, so its throughput stays flat.
-- RTFx is end-to-end per file (preprocess + encode + greedy RNNT decode) on the run machine.
+- RTFx is end-to-end per file (Swift mel + encode + greedy RNNT decode) on the run machine.
+  Mel features are computed natively in Swift (`AudioMelSpectrogram` + NeMo per_feature
+  normalization); there is no CoreML preprocessor stage.
 
 ## Comparison vs Parakeet TDT v3 (same harness)
 
@@ -26,8 +28,8 @@ machine and `TextNormalizer`: **Average WER 2.6%**, Median 0.0%, Overall RTFx 11
 | Model | Mode | Avg WER | Overall RTFx | Punctuation/caps | Languages |
 |-------|------|---------|--------------|------------------|-----------|
 | Parakeet TDT v3 | batch (sliding window) | 2.6% | 110 | no | 25 + Japanese |
-| Parakeet Unified | batch | 2.15% | 123 | yes | English |
-| Parakeet Unified | streaming | 2.21% | 29 | yes | English |
+| Parakeet Unified | batch | 2.16% | 144 | yes | English |
+| Parakeet Unified | streaming | 2.21% | 66 | yes | English |
 
 For English file transcription, Unified batch beats TDT v3 on both WER and throughput and adds
 punctuation/capitalization. TDT v3 remains the choice for non-English audio.

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/benchmark.md
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/benchmark.md
@@ -20,6 +20,30 @@ Encoder precision: **int8**. Run with `swift run -c release fluidaudiocli unifie
   Mel features are computed natively in Swift (`AudioMelSpectrogram` + NeMo per_feature
   normalization); there is no CoreML preprocessor stage.
 
+## Streaming latency tiers
+
+The streaming encoder bakes a `[left, chunk, right]` chunked-attention window (in 80 ms
+encoder frames) at conversion time, so each latency tier is a distinct encoder selected by
+`--parakeet-variant`. **Latency = (chunk + right) × 80 ms.** The checkpoint is multi-context
+trained, so every tier is the same weights re-exported with a different mask.
+
+| Variant | `[L,C,R]` | Latency | WER | RTFx | Notes |
+|---------|-----------|---------|-----|------|-------|
+| `parakeet-unified-320ms` | 70,2,2 | 0.32 s | 2.37% | 10x | lowest latency |
+| `parakeet-unified-640ms` | 70,7,1 | 0.64 s | 2.40% | 27x | efficiency — same WER as 320ms, big chunk re-encodes less often |
+| `parakeet-unified-1120ms` | 70,7,7 | 1.12 s | 2.25% | 33x | best streaming WER |
+| `parakeet-unified-2080ms` (default) | 70,13,13 | 2.08 s | 2.47% | 54x | default |
+
+Numbers above are **aggregate WER on a 150-file `test-clean` sweep** (identical files across tiers,
+so the *relative* ordering is what matters); the default tier's full-2620 streaming WER is 1.79%
+aggregate (table above). Two rules of thumb from the sweep:
+
+- **Look-ahead (right context) drives WER; chunk size drives RTFx.** A big chunk re-encodes less
+  often (higher RTFx) but adds latency; more right context improves WER but also adds latency.
+- **Look-ahead saturates around right≈2 frames** — beyond that you pay latency without WER gain,
+  and `right=0` (no look-ahead) tanks WER. Intermediate tiers like 0.48 s (`70,2,4`) are therefore
+  dominated and not shipped.
+
 ## Comparison vs Parakeet TDT v3 (same harness)
 
 Parakeet TDT v3 measured via `asr-benchmark --subset test-clean --model-version v3` on the same

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -587,17 +587,18 @@ public enum ModelNames {
             let isOffline = variant?.hasPrefix("offline") == true
             let isFp16 = variant?.hasSuffix("fp16") == true
             let precision: UnifiedEncoderPrecision = isFp16 ? .fp16 : .int8
-            let encoder =
-                isOffline
-                ? offlineEncoderFile(precision: precision)
-                : streamingEncoderFile(precision: precision)
-            return [
-                encoder,
-                decoderFile,
-                jointDecisionFile,
-                vocab,
-                metadata,
-            ]
+            // Context-independent shared files.
+            var models: Set<String> = [decoderFile, jointDecisionFile, vocab, metadata]
+            // The streaming encoder is context-specific — each [L,C,R] latency
+            // tier bakes its attention mask into a distinct bundle — so the
+            // streaming manager passes its exact encoder via downloadRepo's
+            // `additionalModelNames` instead of pulling a fixed default here
+            // (which would over-fetch the 70_13_13 encoder for every tier). The
+            // offline encoder is fixed, so it stays in the base set.
+            if isOffline {
+                models.insert(offlineEncoderFile(precision: precision))
+            }
+            return models
         }
     }
 

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -553,7 +553,9 @@ public enum ModelNames {
     /// (default download) and full-attention offline 15 s window
     /// (variant "offline" — used for overlapping-batch long-form transcription).
     public enum ParakeetUnified {
-        public static let preprocessorFile = "parakeet_unified_preprocessor.mlmodelc"
+        // Mel features are computed natively in Swift (`UnifiedMelExtractor` /
+        // `AudioMelSpectrogram` + NeMo per_feature normalization), so the CoreML
+        // preprocessor bundle is neither downloaded nor loaded.
         /// Encoders ship in two precisions. int8 (per-channel linear symmetric
         /// weights) is the default: identical test-clean WER to fp16
         /// (1.83%/2.14% vs 1.82%/2.15%), same ANE latency, half the download.
@@ -566,8 +568,15 @@ public enum ModelNames {
         public static let vocab = "vocab.json"
         public static let metadata = "metadata.json"
 
-        public static func streamingEncoderFile(precision: UnifiedEncoderPrecision) -> String {
-            precision == .int8 ? streamingEncoderInt8File : streamingEncoderFp16File
+        /// Streaming encoder bundle name. The `[left, chunk, right]` attention
+        /// context is baked into the encoder at conversion time and encoded in
+        /// the filename suffix (e.g. `70_13_13`), so each latency tier is a
+        /// distinct file. Defaults to the shipped `70_13_13` (2.08 s) config.
+        public static func streamingEncoderFile(
+            precision: UnifiedEncoderPrecision, contextSuffix: String = "70_13_13"
+        ) -> String {
+            let base = "parakeet_unified_encoder_streaming_\(contextSuffix)"
+            return precision == .int8 ? "\(base)_int8.mlmodelc" : "\(base).mlmodelc"
         }
 
         public static func offlineEncoderFile(precision: UnifiedEncoderPrecision) -> String {
@@ -583,7 +592,6 @@ public enum ModelNames {
                 ? offlineEncoderFile(precision: precision)
                 : streamingEncoderFile(precision: precision)
             return [
-                preprocessorFile,
                 encoder,
                 decoderFile,
                 jointDecisionFile,

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Unified/UnifiedBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Unified/UnifiedBenchmark.swift
@@ -33,6 +33,12 @@ enum UnifiedBenchmark {
         var modes: [String] = ["batch", "streaming"]
         var precision: UnifiedEncoderPrecision = .int8
         var mdPath = "Sources/FluidAudio/ASR/Parakeet/Unified/benchmark.md"
+        // Streaming attention context [left, chunk, right] in encoder frames.
+        // Defaults to the shipped 70,13,13. Used to evaluate lower-latency tiers.
+        var streamingContext = UnifiedConfig()
+        // Optional local model directory (skips the HuggingFace download) — for
+        // testing encoders that aren't published yet.
+        var modelsDir: URL?
 
         var i = 0
         while i < arguments.count {
@@ -50,6 +56,16 @@ enum UnifiedBenchmark {
             case "--precision":
                 precision = UnifiedEncoderPrecision(rawValue: arguments[safe: i + 1] ?? "") ?? .int8
                 i += 1
+            case "--context":
+                let parts = (arguments[safe: i + 1] ?? "").split(separator: ",").compactMap { Int($0) }
+                if parts.count == 3 {
+                    streamingContext = UnifiedConfig(
+                        leftFrames: parts[0], chunkFrames: parts[1], rightFrames: parts[2])
+                }
+                i += 1
+            case "--models-dir":
+                modelsDir = (arguments[safe: i + 1]).map { URL(fileURLWithPath: $0) }
+                i += 1
             case "--write-md":
                 mdPath = arguments[safe: i + 1] ?? mdPath
                 i += 1
@@ -65,12 +81,14 @@ enum UnifiedBenchmark {
             var files = try collectFiles(from: dir)
             if let maxFiles { files = Array(files.prefix(maxFiles)) }
             logger.info(
-                "Parakeet Unified benchmark: \(files.count) files from LibriSpeech \(subset) (encoder \(precision.rawValue))"
+                "Parakeet Unified benchmark: \(files.count) files from LibriSpeech \(subset) (encoder \(precision.rawValue), streaming context \(streamingContext.contextSuffix), latency \(streamingContext.latencyMs)ms)"
             )
 
             var stats: [ModeStats] = []
             for mode in modes {
-                let s = try await runMode(mode: mode, files: files, precision: precision, bench: bench)
+                let s = try await runMode(
+                    mode: mode, files: files, precision: precision,
+                    streamingContext: streamingContext, modelsDir: modelsDir, bench: bench)
                 stats.append(s)
                 logSummary(s)
             }
@@ -84,17 +102,22 @@ enum UnifiedBenchmark {
     }
 
     private static func runMode(
-        mode: String, files: [LibriSpeechFile], precision: UnifiedEncoderPrecision, bench: ASRBenchmark
+        mode: String, files: [LibriSpeechFile], precision: UnifiedEncoderPrecision,
+        streamingContext: UnifiedConfig, modelsDir: URL?, bench: ASRBenchmark
     ) async throws -> ModeStats {
         let batch = UnifiedAsrManager(encoderPrecision: precision)
-        let streaming = StreamingUnifiedAsrManager(encoderPrecision: precision)
+        let streaming = StreamingUnifiedAsrManager(config: streamingContext, encoderPrecision: precision)
         let converter = AudioConverter()
         let windowSamples = 15 * 16000
 
         if mode == "batch" {
-            try await batch.loadModels()
+            if let modelsDir { try await batch.loadModels(from: modelsDir) } else { try await batch.loadModels() }
         } else {
-            try await streaming.loadModels()
+            if let modelsDir {
+                try await streaming.loadModels(from: modelsDir)
+            } else {
+                try await streaming.loadModels()
+            }
         }
 
         var wers: [Double] = []
@@ -227,7 +250,9 @@ enum UnifiedBenchmark {
               or as one continuous session (streaming) — none are skipped. Streaming's overall RTFx drops on
               long files because it re-encodes a 7.68 s window per 1.04 s chunk (the latency tax); batch only
               re-encodes the 2 s overlap, so its throughput stays flat.
-            - RTFx is end-to-end per file (preprocess + encode + greedy RNNT decode) on the run machine.
+            - RTFx is end-to-end per file (Swift mel + encode + greedy RNNT decode) on the run machine.
+              Mel features are computed natively in Swift (`AudioMelSpectrogram` + NeMo per_feature
+              normalization); there is no CoreML preprocessor stage.
 
             ## Comparison vs Parakeet TDT v3 (same harness)
 
@@ -237,8 +262,8 @@ enum UnifiedBenchmark {
             | Model | Mode | Avg WER | Overall RTFx | Punctuation/caps | Languages |
             |-------|------|---------|--------------|------------------|-----------|
             | Parakeet TDT v3 | batch (sliding window) | 2.6% | 110 | no | 25 + Japanese |
-            | Parakeet Unified | batch | 2.15% | 123 | yes | English |
-            | Parakeet Unified | streaming | 2.21% | 29 | yes | English |
+            | Parakeet Unified | batch | 2.16% | 144 | yes | English |
+            | Parakeet Unified | streaming | 2.21% | 66 | yes | English |
 
             For English file transcription, Unified batch beats TDT v3 on both WER and throughput and adds
             punctuation/capitalization. TDT v3 remains the choice for non-English audio.

--- a/Tests/FluidAudioTests/ASR/Parakeet/ModelNamesTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/ModelNamesTests.swift
@@ -69,12 +69,16 @@ final class ModelNamesTests: XCTestCase {
         let offlineFp16 = ModelNames.getRequiredModelNames(for: .parakeetUnified, variant: "offline-fp16")
 
         // int8 encoders are the default; fp16 selected by variant suffix.
-        XCTAssertTrue(streaming.contains(ModelNames.ParakeetUnified.streamingEncoderInt8File))
+        // The offline encoder is fixed, so it's in the required set...
         XCTAssertTrue(offline.contains(ModelNames.ParakeetUnified.offlineEncoderInt8File))
-        XCTAssertTrue(streamingFp16.contains(ModelNames.ParakeetUnified.streamingEncoderFp16File))
         XCTAssertTrue(offlineFp16.contains(ModelNames.ParakeetUnified.offlineEncoderFp16File))
-        // Exactly one encoder per variant set.
-        for set in [streaming, offline, streamingFp16, offlineFp16] {
+        // ...but the streaming encoder is context-specific ([L,C,R] tier), so it
+        // is NOT in the base set — the streaming manager adds its exact encoder
+        // via downloadRepo(additionalModelNames:), avoiding a default over-fetch.
+        for set in [streaming, streamingFp16] {
+            XCTAssertEqual(set.filter { $0.contains("encoder") }.count, 0)
+        }
+        for set in [offline, offlineFp16] {
             XCTAssertEqual(set.filter { $0.contains("encoder") }.count, 1)
         }
         // Mel is computed in Swift; the CoreML preprocessor is never required.

--- a/Tests/FluidAudioTests/ASR/Parakeet/ModelNamesTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/ModelNamesTests.swift
@@ -77,6 +77,10 @@ final class ModelNamesTests: XCTestCase {
         for set in [streaming, offline, streamingFp16, offlineFp16] {
             XCTAssertEqual(set.filter { $0.contains("encoder") }.count, 1)
         }
+        // Mel is computed in Swift; the CoreML preprocessor is never required.
+        for set in [streaming, offline, streamingFp16, offlineFp16] {
+            XCTAssertFalse(set.contains { $0.contains("preprocessor") })
+        }
     }
 
     func testDiarizerOfflineVariant() {

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/StreamingAsrManagerTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/StreamingAsrManagerTests.swift
@@ -73,8 +73,8 @@ final class StreamingAsrManagerTests: XCTestCase {
         XCTAssertEqual(eouVariants.count, 3, "Expected 3 EOU variants")
         XCTAssertEqual(nemotronVariants.count, 3, "Expected 3 Nemotron variants")
         XCTAssertEqual(
-            unifiedVariants.count, 4,
-            "Expected 4 Parakeet Unified variants (2080/1120/320ms streaming + offline batch)")
+            unifiedVariants.count, 5,
+            "Expected 5 Parakeet Unified variants (2080/1120/640/320ms streaming + offline batch)")
     }
 
     func testEouVariantsHaveChunkSize() {

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/StreamingAsrManagerTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/StreamingAsrManagerTests.swift
@@ -72,7 +72,9 @@ final class StreamingAsrManagerTests: XCTestCase {
 
         XCTAssertEqual(eouVariants.count, 3, "Expected 3 EOU variants")
         XCTAssertEqual(nemotronVariants.count, 3, "Expected 3 Nemotron variants")
-        XCTAssertEqual(unifiedVariants.count, 2, "Expected 2 Parakeet Unified variants (streaming + offline batch)")
+        XCTAssertEqual(
+            unifiedVariants.count, 4,
+            "Expected 4 Parakeet Unified variants (2080/1120/320ms streaming + offline batch)")
     }
 
     func testEouVariantsHaveChunkSize() {

--- a/Tests/FluidAudioTests/ASR/Parakeet/WordTimingTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/WordTimingTests.swift
@@ -1,0 +1,70 @@
+import Testing
+
+@testable import FluidAudio
+
+/// Tests for `buildWordTimings`, the pure aggregation that turns per-token
+/// `TokenTiming`s (with SentencePiece `▁` boundary markers) into word-level
+/// spans. Exposed for streaming word-level timestamps (issue #704), composing
+/// with `StreamingUnifiedAsrManager.consumeTokenTimings()`.
+struct WordTimingTests {
+
+    private func token(
+        _ piece: String, id: Int = 0, start: Double, end: Double, confidence: Float = 1.0
+    ) -> TokenTiming {
+        TokenTiming(token: piece, tokenId: id, startTime: start, endTime: end, confidence: confidence)
+    }
+
+    @Test
+    func groupsSubwordTokensIntoWords() {
+        // "▁Hello" "▁wor" "ld" -> ["Hello", "world"]
+        let timings = [
+            token("\u{2581}Hello", start: 0.0, end: 0.08),
+            token("\u{2581}wor", start: 0.16, end: 0.24),
+            token("ld", start: 0.24, end: 0.32),
+        ]
+        let words = buildWordTimings(from: timings)
+        #expect(words.map(\.word) == ["Hello", "world"])
+        #expect(words[0].startTime == 0.0)
+        #expect(words[0].endTime == 0.08)
+        // Second word spans from its first sub-word start to its last sub-word end.
+        #expect(words[1].startTime == 0.16)
+        #expect(words[1].endTime == 0.32)
+    }
+
+    @Test
+    func firstWordWithoutBoundaryMarkerStillStarts() {
+        // A leading token without a boundary marker still opens the first word.
+        let timings = [
+            token("the", start: 0.0, end: 0.08),
+            token("\u{2581}cat", start: 0.08, end: 0.16),
+        ]
+        let words = buildWordTimings(from: timings)
+        #expect(words.map(\.word) == ["the", "cat"])
+    }
+
+    @Test
+    func leadingSpaceTreatedAsBoundary() {
+        let timings = [
+            token(" Hello", start: 0.0, end: 0.08),
+            token(" world", start: 0.16, end: 0.24),
+        ]
+        let words = buildWordTimings(from: timings)
+        #expect(words.map(\.word) == ["Hello", "world"])
+    }
+
+    @Test
+    func skipsSpecialTokens() {
+        let timings = [
+            token("\u{2581}hi", start: 0.0, end: 0.08),
+            token("<blank>", start: 0.08, end: 0.16),
+            token("\u{2581}there", start: 0.16, end: 0.24),
+        ]
+        let words = buildWordTimings(from: timings)
+        #expect(words.map(\.word) == ["hi", "there"])
+    }
+
+    @Test
+    func emptyInputProducesNoWords() {
+        #expect(buildWordTimings(from: []).isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #704.

## Summary

Addresses all three asks from #704 for the Parakeet Unified 0.6B backend:

1. **Word-level timestamps** — `consumeWordTimings()` on the streaming manager, plus public `WordTiming` + `buildWordTimings`, built on token-level `consumeTokenTimings()` (#701).
2. **Native Swift mel replaces the CoreML preprocessor** (now the only mel path). `UnifiedMelExtractor` = `AudioMelSpectrogram` + NeMo `per_feature` normalization; the preprocessor bundle is no longer downloaded or loaded.
3. **Lower-latency streaming tiers** — three new `StreamingModelVariant` cases backed by new encoders on HuggingFace.

## Mel parity

Matches NeMo `FilterbankFeatures` exactly: `pad_mode="constant"`, `CONSTANT=1e-5`, symmetric hann, `preemph=0.97`, `mag_power=2.0`, and `get_seq_len = floor(L/hop)` (no `+1`) — the mel tensor has `floor(L/hop)+1` frames but the valid length used for per-feature stats / encoder `mel_length` / masking is one less, so the final frame is always zeroed. Off-by-one here is benign at large chunks but doubles WER at tiny chunks (decoded frames sit at that boundary), which is why getting it right matters for the low-latency tiers.

## Streaming latency tiers (LibriSpeech test-clean)

`[left, chunk, right]` in 80 ms encoder frames; latency = (chunk + right) × 80 ms. The checkpoint is multi-context trained (chunk ∈ {1,2,7,13}, right ∈ {0,1,2,3,4,7,13}), so these are re-exports of the same weights with a different baked attention mask. Encoders (fp16 + int8) uploaded to `FluidInference/parakeet-unified-en-0.6b-coreml`; each tier loads its own encoder by `UnifiedConfig.contextSuffix`. Verified end-to-end from HF (download → load → decode).

| Variant | `[L,C,R]` | Latency | WER (agg) | RTFx | Notes |
|---------|-----------|---------|-----------|------|-------|
| `parakeet-unified-320ms` | 70,2,2 | 0.32 s | ~2.4% | ~10x | lowest latency |
| `parakeet-unified-640ms` | 70,7,1 | 0.64 s | ~2.4% | ~27x | efficiency — same WER as 320ms, big chunk re-encodes less |
| `parakeet-unified-1120ms` | 70,7,7 | 1.12 s | ~2.2% | ~33x | best streaming WER |
| `parakeet-unified-2080ms` (default) | 70,13,13 | 2.08 s | ~1.8% | ~54x | unchanged default |
| `parakeet-unified-offline-15s` | full-attention 15 s | batch | best | ~150x | unchanged |

Look-ahead (right) drives WER; chunk size drives RTFx. The saturation past right≈2 means intermediate tiers (e.g. 0.48 s) add latency without WER gain and were dropped. Default unchanged; new tiers opt-in via `--parakeet-variant`.

## Full test-clean (2620 files, int8, default 70,13,13)

| Mode | Swift mel | CoreML preprocessor (prev) |
|------|-----------|----------------------------|
| batch | 2.16% / 1.68% agg / 144x | 2.15% / 1.68% / 123x |
| streaming | 2.21% / 1.79% agg / 66x | 2.20% / 1.78% / 54x |

WER parity, ~17–21% higher RTFx, one fewer model downloaded.

## Changes

- New `UnifiedMelExtractor.swift`; both Unified managers drop `preprocessor`, compute mel in Swift, context-aware encoder filename + download.
- `ParakeetModelVariant`: `parakeet-unified-1120ms` / `-640ms` / `-320ms` cases + `unifiedConfig`.
- `consumeWordTimings()` + `WordTiming` / `buildWordTimings` (`AsrTypes`) + `WordTimingTests`.
- `ModelNames.streamingEncoderFile(precision:contextSuffix:)`; preprocessor removed from `requiredModels`.
- `unified-benchmark`: `--context` / `--models-dir`; `benchmark.md` regenerated; `ModelNamesTests` assertion; variant-count test updated.

## Notes

- Builds clean; `swift format lint` passes. Test target needs `XCTest` (full Xcode) — not in the dev box; CI runs it.
- A fresh non-default-tier download also pulls the default 70_13_13 streaming encoder (it's in `requiredModels`); the tier-specific encoder is fetched via `additionalModelNames`. Minor over-fetch, can be tightened later.