### PR TITLE
fix(asr): remove chunk-merge seam artifacts in offline transcription (#706)

### DIFF
--- a/Scripts/materialize_earnings22_longform.py
+++ b/Scripts/materialize_earnings22_longform.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Materialize full-length Earnings-22 recordings for the long-form ASR benchmark.
+
+Earnings-22 is the standard long-form ASR benchmark (≈1 h files of accented
+earnings calls). This pulls full-length audio + reference transcripts from the
+`AudioLLMs/earnings22_test` dataset (16 kHz mono WAV embedded in parquet) and
+writes them as `{id}.wav` + `{id}.txt` into FluidAudio's Application Support
+directory, where `fluidaudiocli unified-benchmark --longform-dir <dir>` reads
+them.
+
+Usage:
+    pip install pyarrow huggingface_hub
+    python3 Scripts/materialize_earnings22_longform.py [num_shards]
+
+Each parquet shard holds ~5 full-length files; pass the shard count to control
+how much audio to materialize (default: 1 shard ≈ 5 files ≈ 5 h).
+"""
+
+import os
+import re
+import sys
+
+from huggingface_hub import hf_hub_download
+import pyarrow.parquet as pq
+
+REPO = "AudioLLMs/earnings22_test"
+REVISION = "refs/convert/parquet"
+OUT = os.path.expanduser(
+    "~/Library/Application Support/FluidAudio/earnings22-longform"
+)
+
+
+def main() -> None:
+    nshards = int(sys.argv[1]) if len(sys.argv) > 1 else 1
+    os.makedirs(OUT, exist_ok=True)
+
+    count = 0
+    for shard in range(nshards):
+        path = hf_hub_download(
+            REPO,
+            f"default/partial-test/{shard:04d}.parquet",
+            repo_type="dataset",
+            revision=REVISION,
+        )
+        pf = pq.ParquetFile(path)
+        for rg in range(pf.num_row_groups):
+            table = pf.read_row_group(rg)
+            context = table.column("context")
+            answer = table.column("answer")
+            for i in range(table.num_rows):
+                entry = context[i].as_py()
+                src = entry.get("path") or f"shard{shard}_rg{rg}_{i}"
+                file_id = re.sub(
+                    r"[^A-Za-z0-9_]", "_", os.path.splitext(os.path.basename(src))[0]
+                )
+                wav_bytes = entry["bytes"]
+                # The .nlp reconstruction prefixes a junk "TOKEN" header word.
+                text = re.sub(r"^\s*TOKEN\s+", "", answer[i].as_py() or "").strip()
+
+                with open(os.path.join(OUT, file_id + ".wav"), "wb") as f:
+                    f.write(wav_bytes)
+                with open(os.path.join(OUT, file_id + ".txt"), "w") as f:
+                    f.write(text)
+                count += 1
+                print(
+                    f"  {file_id}: wav={len(wav_bytes) // 1024}KB "
+                    f"ref_words={len(text.split())}"
+                )
+
+    print(f"materialized {count} files to {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
@@ -376,9 +376,10 @@ struct ChunkProcessor {
     internal func mergeTokenWindowsForTesting(
         left: [(token: Int, timestamp: Int, confidence: Float, duration: Int)],
         right: [(token: Int, timestamp: Int, confidence: Float, duration: Int)],
-        spliceSafeTokenIds: Set<Int>? = nil
+        spliceSafeTokenIds: Set<Int>? = nil,
+        caseVariantIds: [Int: Int]? = nil
     ) -> [(token: Int, timestamp: Int, confidence: Float, duration: Int)] {
-        mergeChunks(left, right, spliceSafeTokenIds: spliceSafeTokenIds)
+        mergeChunks(left, right, spliceSafeTokenIds: spliceSafeTokenIds, caseVariantIds: caseVariantIds)
     }
     #endif
 
@@ -578,13 +579,22 @@ struct ChunkProcessor {
         }
 
         if orderedChunkOutputs.count > 1 {
-            let spliceSafeTokenIds = Self.spliceSafeTokenIds(vocabulary: await manager.vocabulary)
+            let vocabulary = await manager.vocabulary
+            let spliceSafeTokenIds = Self.spliceSafeTokenIds(vocabulary: vocabulary)
+            let caseVariantIds = Self.caseVariantCanonicalIds(vocabulary: vocabulary)
             for chunk in orderedChunkOutputs.dropFirst() {
-                mergedTokens = mergeChunks(mergedTokens, chunk, spliceSafeTokenIds: spliceSafeTokenIds)
+                mergedTokens = mergeChunks(
+                    mergedTokens,
+                    chunk,
+                    spliceSafeTokenIds: spliceSafeTokenIds,
+                    caseVariantIds: caseVariantIds
+                )
             }
-        }
-
-        if mergedTokens.count > 1 {
+            if mergedTokens.count > 1 {
+                mergedTokens.sort { $0.timestamp < $1.timestamp }
+            }
+            mergedTokens = collapseSeamWordDuplicates(mergedTokens, vocabulary: vocabulary)
+        } else if mergedTokens.count > 1 {
             mergedTokens.sort { $0.timestamp < $1.timestamp }
         }
 
@@ -688,6 +698,139 @@ struct ChunkProcessor {
         return ids
     }
 
+    /// Maps every token ID that has a case-only twin in the vocabulary to a
+    /// shared canonical ID, so the overlap matcher can treat e.g. `▁Meeting`
+    /// and `▁meeting` as the same word (issue #706).
+    ///
+    /// A window that begins mid-sentence biases the RNNT decoder to capitalize
+    /// its first word as if it started a sentence. In the 2 s overlap the
+    /// previous (left) window already heard that word lower-cased with real
+    /// left context, but the exact-ID matcher misses the seam pair because the
+    /// IDs differ — so the word survives in both windows and decodes twice,
+    /// the second copy spuriously capitalized ("the meeting Meeting was").
+    /// Folding case at match time lets the seam word anchor and collapse to the
+    /// left window's contextually-correct casing.
+    ///
+    /// Only IDs that actually share a folded piece with another ID are
+    /// included, so the map stays small and exact-ID matching is unchanged for
+    /// every token without a case twin. Returns nil for an empty vocabulary so
+    /// behavior is unchanged when no vocabulary is available.
+    static func caseVariantCanonicalIds(vocabulary: [Int: String]) -> [Int: Int]? {
+        guard !vocabulary.isEmpty else { return nil }
+        var groups: [String: [Int]] = [:]
+        for (id, piece) in vocabulary {
+            groups[piece.lowercased(), default: []].append(id)
+        }
+        var canon: [Int: Int] = [:]
+        for (folded, ids) in groups where ids.count > 1 {
+            // Only groups with a genuine case twin survive; pure-lowercase,
+            // punctuation and numeric pieces are unique and stay singletons.
+            // Make the all-lower-case variant the canonical ID so a later
+            // collapse can tell which copy of a seam duplicate to keep.
+            let canonical = ids.first { vocabulary[$0] == folded } ?? ids.min()!
+            for id in ids { canon[id] = canonical }
+        }
+        return canon.isEmpty ? nil : canon
+    }
+
+    /// Issue #706: drop an adjacent case-only duplicate of a seam *word* left by
+    /// a window that re-emitted the seam word as a false sentence start — e.g.
+    /// the previous window ended `...we don't have` and the next emitted
+    /// `Have a...`, leaving `we don't have Have a`. Works at the word level
+    /// (reconstructing SentencePiece words from the token stream) so it catches
+    /// multi-token words too — essential for the small Unified subword vocab,
+    /// where whole words like `have`/`Have` are several pieces and a token-level
+    /// check never sees them as a unit.
+    ///
+    /// A pair collapses only when the two words are equal up to case, differ in
+    /// case, start within the overlap window, and the earlier word does not end
+    /// a sentence — so genuine repeats (`that that`), same-case duplicates, and
+    /// legitimate sentence boundaries (`...thank you. You said...`) are left
+    /// alone. The lower-cased copy is kept (it is the one with real left
+    /// context); if neither is lower-case the earlier copy wins.
+    func collapseSeamWordDuplicates(
+        _ tokens: [TokenWindow],
+        vocabulary: [Int: String]
+    ) -> [TokenWindow] {
+        guard !vocabulary.isEmpty, tokens.count > 1 else { return tokens }
+        let overlapFrames = Int((overlapSeconds / ASRConstants.secondsPerEncoderFrame).rounded())
+
+        func piece(_ id: Int) -> String { vocabulary[id] ?? "" }
+        func startsWord(_ id: Int) -> Bool {
+            let p = piece(id)
+            return p.hasPrefix(ASRConstants.sentencePieceWordBoundary) || p.hasPrefix(" ")
+        }
+
+        struct Word {
+            var tokens: [TokenWindow]
+            var core: String
+            var startTimestamp: Int
+            var endsSentence: Bool
+        }
+
+        // Segment the token stream into words on word-initial pieces.
+        var words: [Word] = []
+        for token in tokens {
+            if words.isEmpty || startsWord(token.token) {
+                words.append(Word(tokens: [token], core: "", startTimestamp: token.timestamp, endsSentence: false))
+            } else {
+                words[words.count - 1].tokens.append(token)
+            }
+        }
+
+        let strippable = CharacterSet.punctuationCharacters.union(.whitespaces)
+        for index in words.indices {
+            var text = ""
+            for token in words[index].tokens {
+                text += stripWordBoundaryPrefix(piece(token.token))
+            }
+            words[index].core = text.trimmingCharacters(in: strippable)
+            if let last = text.last { words[index].endsSentence = ".?!:".contains(last) }
+        }
+
+        var keep = [Bool](repeating: true, count: words.count)
+        var lastKept = -1
+        for index in words.indices {
+            guard lastKept >= 0 else {
+                lastKept = index
+                continue
+            }
+            let previous = words[lastKept]
+            let current = words[index]
+            let previousCore = previous.core
+            let currentCore = current.core
+
+            let isSeamDuplicate =
+                !previousCore.isEmpty && !currentCore.isEmpty
+                && previousCore != currentCore
+                && previousCore.lowercased() == currentCore.lowercased()
+                && currentCore.first?.isLetter == true
+                && !previous.endsSentence
+                && current.startTimestamp - previous.startTimestamp <= overlapFrames
+
+            guard isSeamDuplicate else {
+                lastKept = index
+                continue
+            }
+
+            // Keep the lower-cased copy; if neither is lower-case keep the
+            // earlier (left-context) one.
+            if currentCore == currentCore.lowercased(), previousCore != previousCore.lowercased() {
+                keep[lastKept] = false
+                lastKept = index
+            } else {
+                keep[index] = false
+            }
+        }
+
+        var result: [TokenWindow] = []
+        result.reserveCapacity(tokens.count)
+        for index in words.indices where keep[index] {
+            result.append(contentsOf: words[index].tokens)
+        }
+        return result
+    }
+
     /// A piece is splice-safe when decoding it right after another word does
     /// not glue two words together: it either starts a new word (`▁`/space
     /// prefix) or is pure punctuation/symbols.
@@ -703,7 +846,8 @@ struct ChunkProcessor {
     func mergeChunks(
         _ left: [TokenWindow],
         _ right: [TokenWindow],
-        spliceSafeTokenIds: Set<Int>? = nil
+        spliceSafeTokenIds: Set<Int>? = nil,
+        caseVariantIds: [Int: Int]? = nil
     ) -> [TokenWindow] {
         if left.isEmpty { return right }
         if right.isEmpty { return left }
@@ -750,7 +894,7 @@ struct ChunkProcessor {
 
         // EXTRACTED: Contiguous matching using SequenceMatcher
         let timeTolerantMatcher: (IndexedToken, IndexedToken) -> Bool = { [self] l, r in
-            tokensMatch(l, r, tolerance: halfOverlapWindow)
+            tokensMatch(l, r, tolerance: halfOverlapWindow, caseVariantIds: caseVariantIds)
         }
 
         let contiguousMatches = SequenceMatcher.findContiguousMatches(
@@ -800,10 +944,29 @@ struct ChunkProcessor {
         )
     }
 
-    private func tokensMatch(_ left: IndexedToken, _ right: IndexedToken, tolerance: Double) -> Bool {
-        guard left.token.token == right.token.token else { return false }
+    private func tokensMatch(
+        _ left: IndexedToken,
+        _ right: IndexedToken,
+        tolerance: Double,
+        caseVariantIds: [Int: Int]? = nil
+    ) -> Bool {
+        guard tokenIdsMatch(left.token.token, right.token.token, caseVariantIds: caseVariantIds) else {
+            return false
+        }
         let timeDifference = abs(left.start - right.start)
         return timeDifference < tolerance
+    }
+
+    /// Two token IDs match when they are equal, or — issue #706 — when they are
+    /// case-only variants of the same vocabulary piece (e.g. `▁Meeting`/
+    /// `▁meeting`), so a seam word the right window capitalized as a false
+    /// sentence start still anchors against the left window's lower-cased copy.
+    private func tokenIdsMatch(_ left: Int, _ right: Int, caseVariantIds: [Int: Int]?) -> Bool {
+        if left == right { return true }
+        guard let caseVariantIds, let lhs = caseVariantIds[left], let rhs = caseVariantIds[right] else {
+            return false
+        }
+        return lhs == rhs
     }
 
     private func mergeUsingMatches(

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/DualDecodeArbitration.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/DualDecodeArbitration.swift
@@ -312,13 +312,22 @@ extension ChunkProcessor {
         }
 
         if chunkOutputs.count > 1 {
-            let spliceSafeTokenIds = Self.spliceSafeTokenIds(vocabulary: await manager.vocabulary)
+            let vocabulary = await manager.vocabulary
+            let spliceSafeTokenIds = Self.spliceSafeTokenIds(vocabulary: vocabulary)
+            let caseVariantIds = Self.caseVariantCanonicalIds(vocabulary: vocabulary)
             for chunk in chunkOutputs.dropFirst() {
-                mergedTokens = mergeChunks(mergedTokens, chunk, spliceSafeTokenIds: spliceSafeTokenIds)
+                mergedTokens = mergeChunks(
+                    mergedTokens,
+                    chunk,
+                    spliceSafeTokenIds: spliceSafeTokenIds,
+                    caseVariantIds: caseVariantIds
+                )
             }
-        }
-
-        if mergedTokens.count > 1 {
+            if mergedTokens.count > 1 {
+                mergedTokens.sort { $0.timestamp < $1.timestamp }
+            }
+            mergedTokens = collapseSeamWordDuplicates(mergedTokens, vocabulary: vocabulary)
+        } else if mergedTokens.count > 1 {
             mergedTokens.sort { $0.timestamp < $1.timestamp }
         }
 

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
@@ -173,9 +173,15 @@ public actor UnifiedAsrManager {
         guard let tokenizer = tokenizer else { throw ASRError.notInitialized }
 
         var merged: [ChunkProcessor.TokenWindow] = []
-        let merger = ChunkProcessor(audioSamples: [])
+        // Reuse the TDT overlap merger to dedupe adjacent windows.
+        let merger = ChunkProcessor(audioSamples: samples)
         let spliceSafeTokenIds = ChunkProcessor.spliceSafeTokenIds(vocabulary: tokenizer.vocabulary)
+        let caseVariantIds = ChunkProcessor.caseVariantCanonicalIds(vocabulary: tokenizer.vocabulary)
 
+        // Fixed-stride 15 s / 2 s grid. Silence-aligned starts were measured to
+        // cost ~1 WER point on the 15 s offline encoder (Earnings-22 long-form)
+        // with no artifact benefit, so the seam artifacts (#706) are handled
+        // purely by the merge: case-folded matching + word-level collapse below.
         for chunkStart in layout.chunkStarts(totalSamples: samples.count) {
             let chunkEnd = min(chunkStart + layout.chunkSamples, samples.count)
             let windowTokens = try await transcribeWindow(
@@ -184,10 +190,16 @@ public actor UnifiedAsrManager {
             merged =
                 merged.isEmpty
                 ? windowTokens
-                : merger.mergeChunks(merged, windowTokens, spliceSafeTokenIds: spliceSafeTokenIds)
+                : merger.mergeChunks(
+                    merged,
+                    windowTokens,
+                    spliceSafeTokenIds: spliceSafeTokenIds,
+                    caseVariantIds: caseVariantIds
+                )
         }
 
         merged.sort { $0.timestamp < $1.timestamp }
+        merged = merger.collapseSeamWordDuplicates(merged, vocabulary: tokenizer.vocabulary)
         return tokenizer.decode(ids: merged.map(\.token))
     }
 

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Unified/UnifiedBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Unified/UnifiedBenchmark.swift
@@ -33,10 +33,18 @@ enum UnifiedBenchmark {
         var modes: [String] = ["batch", "streaming"]
         var precision: UnifiedEncoderPrecision = .int8
         var mdPath = "Sources/FluidAudio/ASR/Parakeet/Unified/benchmark.md"
+        var inputFile: String?
+        var longformDir: String?
 
         var i = 0
         while i < arguments.count {
             switch arguments[i] {
+            case "--input":
+                inputFile = arguments[safe: i + 1]
+                i += 1
+            case "--longform-dir":
+                longformDir = arguments[safe: i + 1]
+                i += 1
             case "--subset":
                 subset = arguments[safe: i + 1] ?? subset
                 i += 1
@@ -56,6 +64,16 @@ enum UnifiedBenchmark {
             default: break
             }
             i += 1
+        }
+
+        if let inputFile {
+            await runSeamComparison(path: inputFile, precision: precision)
+            return
+        }
+
+        if let longformDir {
+            await runLongformBenchmark(dir: longformDir, precision: precision, maxFiles: maxFiles)
+            return
         }
 
         let bench = ASRBenchmark()
@@ -244,6 +262,247 @@ enum UnifiedBenchmark {
             punctuation/capitalization. TDT v3 remains the choice for non-English audio.
             """
         try? md.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - Single-File Seam Comparison (Issue #706)
+
+    /// Transcribe one (typically long) file with Unified batch and Parakeet TDT
+    /// v3, then count the chunk-merge seam artifacts #706 is about: adjacent
+    /// case-only duplicate words ("meeting Meeting") and mid-sentence
+    /// capitalized words. No reference transcript is needed — the metric is the
+    /// artifact, and TDT v3 (which already silence-aligns its chunks) is the
+    /// quality baseline.
+    private static func runSeamComparison(path: String, precision: UnifiedEncoderPrecision) async {
+        let url = URL(fileURLWithPath: path)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            logger.error("Input file not found: \(path)")
+            return
+        }
+
+        do {
+            let converter = AudioConverter()
+            let samples = try converter.resampleAudioFile(url)
+            let audioSeconds = Double(samples.count) / 16000.0
+            logger.info(
+                "Seam comparison on \(url.lastPathComponent): \(String(format: "%.1f", audioSeconds))s of audio")
+
+            // Unified batch (silence-aligned chunks + case-folded merge).
+            let batch = UnifiedAsrManager(encoderPrecision: precision)
+            try await batch.loadModels()
+            let unifiedStart = Date()
+            let unifiedText = try await batch.transcribe(samples)
+            let unifiedSeconds = Date().timeIntervalSince(unifiedStart)
+
+            // Parakeet TDT v3 (sliding-window reference).
+            let tdtModels = try await AsrModels.downloadAndLoad(version: .v3)
+            let asr = AsrManager(config: .default)
+            try await asr.loadModels(tdtModels)
+            var decoderState = TdtDecoderState.make(decoderLayers: await asr.decoderLayerCount)
+            let tdtStart = Date()
+            let tdtResult = try await asr.transcribe(samples, decoderState: &decoderState)
+            let tdtSeconds = Date().timeIntervalSince(tdtStart)
+
+            let unifiedArtifacts = seamArtifacts(in: unifiedText)
+            let tdtArtifacts = seamArtifacts(in: tdtResult.text)
+
+            let unifiedOut = url.deletingPathExtension().lastPathComponent + ".unified.txt"
+            let tdtOut = url.deletingPathExtension().lastPathComponent + ".tdtv3.txt"
+            try? unifiedText.write(toFile: unifiedOut, atomically: true, encoding: .utf8)
+            try? tdtResult.text.write(toFile: tdtOut, atomically: true, encoding: .utf8)
+
+            print("\n" + String(repeating: "=", count: 64))
+            print("SEAM ARTIFACT COMPARISON — \(url.lastPathComponent)")
+            print(String(repeating: "=", count: 64))
+            print(String(format: "Audio: %.1fs", audioSeconds))
+            print("")
+            printArtifactRow(
+                label: "Unified batch",
+                artifacts: unifiedArtifacts,
+                seconds: unifiedSeconds,
+                audioSeconds: audioSeconds)
+            printArtifactRow(
+                label: "Parakeet TDT v3",
+                artifacts: tdtArtifacts,
+                seconds: tdtSeconds,
+                audioSeconds: audioSeconds)
+            print("")
+            print("Transcripts written to:\n  \(unifiedOut)\n  \(tdtOut)")
+            if !unifiedArtifacts.examples.isEmpty {
+                print("\nUnified seam examples (up to 10):")
+                for ex in unifiedArtifacts.examples.prefix(10) { print("  • \(ex)") }
+            }
+            print(String(repeating: "=", count: 64))
+        } catch {
+            logger.error("Seam comparison failed: \(error)")
+        }
+    }
+
+    // MARK: - Long-Form WER Benchmark (Earnings-22)
+
+    /// Transcribe every `{id}.wav` (with sibling `{id}.txt` reference) in a
+    /// directory of full-length recordings with both Unified batch and Parakeet
+    /// TDT v3, scoring long-form WER (normalized like `asr-benchmark`) plus the
+    /// seam case-duplicate count. This exercises chunk merging end-to-end —
+    /// each file spans many 15 s windows — which the short LibriSpeech /
+    /// earnings22-kws clips cannot.
+    private static func runLongformBenchmark(dir: String, precision: UnifiedEncoderPrecision, maxFiles: Int?) async {
+        let dirURL = URL(fileURLWithPath: dir)
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(at: dirURL, includingPropertiesForKeys: nil) else {
+            logger.error("Long-form directory not found: \(dir)")
+            return
+        }
+        var wavs = entries.filter { $0.pathExtension.lowercased() == "wav" }.sorted { $0.path < $1.path }
+        if let maxFiles { wavs = Array(wavs.prefix(maxFiles)) }
+        guard !wavs.isEmpty else {
+            logger.error("No .wav files in \(dir)")
+            return
+        }
+
+        do {
+            let converter = AudioConverter()
+            let batch = UnifiedAsrManager(encoderPrecision: precision)
+            try await batch.loadModels()
+            let tdtModels = try await AsrModels.downloadAndLoad(version: .v3)
+            let asr = AsrManager(config: .default)
+            try await asr.loadModels(tdtModels)
+
+            var rows: [(id: String, words: Int, uniWer: Double, tdtWer: Double)] = []
+            var uniErrors = 0
+            var tdtErrors = 0
+            var refWords = 0
+            var uniAudio = 0.0
+            var tdtAudio = 0.0
+            var uniProc = 0.0
+            var tdtProc = 0.0
+            var uniDupes = 0
+            var tdtDupes = 0
+
+            for wav in wavs {
+                let id = wav.deletingPathExtension().lastPathComponent
+                let refURL = wav.deletingPathExtension().appendingPathExtension("txt")
+                guard let reference = try? String(contentsOf: refURL, encoding: .utf8) else {
+                    logger.info("Skipping \(id): no reference .txt")
+                    continue
+                }
+                let samples = try converter.resampleAudioFile(wav)
+                let seconds = Double(samples.count) / 16000.0
+
+                let uniStart = Date()
+                let uniText = try await batch.transcribe(samples)
+                uniProc += Date().timeIntervalSince(uniStart)
+
+                var decoderState = TdtDecoderState.make(decoderLayers: await asr.decoderLayerCount)
+                let tdtStart = Date()
+                let tdtText = try await asr.transcribe(samples, decoderState: &decoderState).text
+                tdtProc += Date().timeIntervalSince(tdtStart)
+
+                let uni = WERCalculator.calculateWERMetrics(hypothesis: uniText, reference: reference)
+                let tdt = WERCalculator.calculateWERMetrics(hypothesis: tdtText, reference: reference)
+
+                uniErrors += uni.insertions + uni.deletions + uni.substitutions
+                tdtErrors += tdt.insertions + tdt.deletions + tdt.substitutions
+                refWords += uni.totalWords
+                uniAudio += seconds
+                tdtAudio += seconds
+                uniDupes += seamArtifacts(in: uniText).caseDuplicates
+                tdtDupes += seamArtifacts(in: tdtText).caseDuplicates
+                rows.append((id, uni.totalWords, uni.wer, tdt.wer))
+
+                print(
+                    String(
+                        format: "%-22@  %.1fs  ref=%5d  Unified WER %.2f%%   TDT v3 WER %.2f%%",
+                        id as NSString, seconds, uni.totalWords, uni.wer * 100, tdt.wer * 100))
+            }
+
+            guard !rows.isEmpty else {
+                logger.error("No scorable files (missing references).")
+                return
+            }
+
+            let uniAvg = rows.map(\.uniWer).reduce(0, +) / Double(rows.count) * 100
+            let tdtAvg = rows.map(\.tdtWer).reduce(0, +) / Double(rows.count) * 100
+            let uniAgg = refWords > 0 ? Double(uniErrors) / Double(refWords) * 100 : 0
+            let tdtAgg = refWords > 0 ? Double(tdtErrors) / Double(refWords) * 100 : 0
+
+            print("\n" + String(repeating: "=", count: 72))
+            print("EARNINGS-22 LONG-FORM WER — \(rows.count) files, \(String(format: "%.1f", uniAudio / 60))min audio")
+            print(String(repeating: "=", count: 72))
+            print(
+                String(
+                    format: "Unified batch     Avg WER %.2f%%   Aggregate WER %.2f%%   case-dupes %d   %.0fx",
+                    uniAvg, uniAgg, uniDupes, uniProc > 0 ? uniAudio / uniProc : 0))
+            print(
+                String(
+                    format: "Parakeet TDT v3   Avg WER %.2f%%   Aggregate WER %.2f%%   case-dupes %d   %.0fx",
+                    tdtAvg, tdtAgg, tdtDupes, tdtProc > 0 ? tdtAudio / tdtProc : 0))
+            print(String(repeating: "=", count: 72))
+        } catch {
+            logger.error("Long-form benchmark failed: \(error)")
+        }
+    }
+
+    private struct SeamArtifacts {
+        var caseDuplicates: Int
+        var midSentenceCaps: Int
+        var examples: [String]
+    }
+
+    private static func printArtifactRow(
+        label: String, artifacts: SeamArtifacts, seconds: Double, audioSeconds: Double
+    ) {
+        let rtfx = seconds > 0 ? audioSeconds / seconds : 0
+        let padded = label.padding(toLength: 18, withPad: " ", startingAt: 0)
+        print(
+            padded
+                + String(
+                    format: "case-dupes: %3d   mid-sentence caps: %4d   (%.1fs, %.0fx)",
+                    artifacts.caseDuplicates, artifacts.midSentenceCaps, seconds, rtfx))
+    }
+
+    /// Count seam artifacts in a transcript. `caseDuplicates` are adjacent words
+    /// equal up to case ("meeting Meeting"); `midSentenceCaps` are capitalized
+    /// words that don't follow sentence-ending punctuation (excluding the
+    /// pronoun "I" and all-caps acronyms).
+    private static func seamArtifacts(in text: String) -> SeamArtifacts {
+        let rawWords = text.split(whereSeparator: { $0 == " " || $0 == "\n" || $0 == "\t" }).map(String.init)
+        var caseDuplicates = 0
+        var midSentenceCaps = 0
+        var examples: [String] = []
+
+        func core(_ w: String) -> String {
+            w.trimmingCharacters(in: CharacterSet.punctuationCharacters)
+        }
+        func endsSentence(_ w: String) -> Bool {
+            guard let last = w.last else { return false }
+            return last == "." || last == "?" || last == "!" || last == ":"
+        }
+
+        for index in 1..<max(rawWords.count, 1) {
+            let prev = core(rawWords[index - 1])
+            let cur = core(rawWords[index])
+            guard !cur.isEmpty, !prev.isEmpty else { continue }
+
+            if cur != prev, cur.lowercased() == prev.lowercased(),
+                cur.first?.isLetter == true
+            {
+                caseDuplicates += 1
+                if examples.count < 20 {
+                    examples.append("…\(rawWords[index - 1]) \(rawWords[index])… (case duplicate)")
+                }
+            }
+
+            if let first = cur.first, first.isUppercase, first.isLetter,
+                cur != "I", cur != cur.uppercased(),  // skip ALL-CAPS acronyms
+                !endsSentence(rawWords[index - 1])
+            {
+                midSentenceCaps += 1
+                if examples.count < 20 {
+                    examples.append("…\(rawWords[index - 1]) \(rawWords[index])… (mid-sentence cap)")
+                }
+            }
+        }
+        return SeamArtifacts(caseDuplicates: caseDuplicates, midSentenceCaps: midSentenceCaps, examples: examples)
     }
 }
 

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessorTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessorTests.swift
@@ -787,6 +787,149 @@ final class ChunkProcessorTests: XCTestCase {
         XCTAssertEqual(ids, [10, 20, 24, 27, 30, 40, 60])
     }
 
+    // MARK: - Seam Case Artifacts (Issue #706)
+
+    /// Vocabulary with case-only twins: `▁meeting`/`▁Meeting` and `▁the`/`▁The`.
+    private let caseTestVocabulary: [Int: String] = [
+        10: "▁the",
+        11: "▁The",
+        20: "▁meeting",
+        21: "▁Meeting",
+        30: "▁was",
+        40: "▁good",
+        50: "▁here",
+    ]
+
+    private var caseTestSafeIds: Set<Int> {
+        ChunkProcessor.spliceSafeTokenIds(vocabulary: caseTestVocabulary)!
+    }
+
+    private var caseTestVariantIds: [Int: Int] {
+        ChunkProcessor.caseVariantCanonicalIds(vocabulary: caseTestVocabulary)!
+    }
+
+    func testCaseVariantCanonicalIdsMapsTwinsToLowercaseId() {
+        XCTAssertNil(ChunkProcessor.caseVariantCanonicalIds(vocabulary: [:]))
+
+        let canon = ChunkProcessor.caseVariantCanonicalIds(vocabulary: caseTestVocabulary)
+        // Only the case twins are present; each maps to its lower-case ID.
+        XCTAssertEqual(canon, [10: 10, 11: 10, 20: 20, 21: 20])
+    }
+
+    func testSeamWordCapitalizationCollapsesToLeftCasing() {
+        // The longest contiguous run is BEFORE the seam word, so the merge
+        // splices right's tail in — which starts with the capitalized
+        // `▁Meeting` the right window emitted as a false sentence start.
+        // Case-folded matching anchors the whole overlap and keeps left's
+        // lower-cased `▁meeting`.
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+
+        let left: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 10, timestamp: 128, confidence: 0.98, duration: 1),  // ▁the
+            (token: 30, timestamp: 130, confidence: 0.97, duration: 1),  // ▁was
+            (token: 20, timestamp: 132, confidence: 0.96, duration: 1),  // ▁meeting
+            (token: 40, timestamp: 134, confidence: 0.95, duration: 1),  // ▁good
+        ]
+        let right: [(token: Int, timestamp: Int, confidence: Float, duration: Int)] = [
+            (token: 10, timestamp: 128, confidence: 0.98, duration: 1),  // ▁the
+            (token: 30, timestamp: 130, confidence: 0.97, duration: 1),  // ▁was
+            (token: 21, timestamp: 132, confidence: 0.96, duration: 1),  // ▁Meeting (capitalized)
+            (token: 40, timestamp: 134, confidence: 0.95, duration: 1),  // ▁good
+        ]
+
+        let withFold = processor.mergeTokenWindowsForTesting(
+            left: left, right: right, spliceSafeTokenIds: caseTestSafeIds, caseVariantIds: caseTestVariantIds
+        ).map(\.token)
+        XCTAssertEqual(withFold, [10, 30, 20, 40], "Case-folded matching keeps left's lower-case ▁meeting")
+
+        // Without the case map the exact-ID matcher misses the seam word and
+        // the spliced tail carries the spurious capital.
+        let withoutFold = processor.mergeTokenWindowsForTesting(
+            left: left, right: right, spliceSafeTokenIds: caseTestSafeIds
+        ).map(\.token)
+        XCTAssertEqual(withoutFold, [10, 30, 21, 40], "Legacy matcher leaves the mid-sentence capital")
+    }
+
+    // Subword vocab (mirrors the 1024-piece Unified vocab): whole words are
+    // multiple pieces. "have"=[1,2], "Have"=[3,2], "either"=[4,5], "Either"=[6,5].
+    private let subwordVocabulary: [Int: String] = [
+        1: "▁ha", 2: "ve",
+        3: "▁Ha",
+        4: "▁ei", 5: "ther",
+        6: "▁Ei",
+        7: "▁a",
+        8: "▁the",
+        9: ".",
+    ]
+
+    private func word(_ ids: [Int], from start: Int) -> [(token: Int, timestamp: Int, confidence: Float, duration: Int)]
+    {
+        ids.enumerated().map { (token: $0.element, timestamp: start + $0.offset, confidence: 0.95, duration: 1) }
+    }
+
+    func testCollapseSeamWordDuplicatesRemovesMultiTokenDuplicate() {
+        // "...have Have a" — the Unified artifact: a multi-token word the
+        // token-level check could never see as a unit.
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+        let tokens =
+            word([1, 2], from: 100)  // have
+            + word([3, 2], from: 102)  // Have (seam dupe)
+            + word([7], from: 104)  // a
+
+        let collapsed = processor.collapseSeamWordDuplicates(tokens, vocabulary: subwordVocabulary).map(\.token)
+        XCTAssertEqual(collapsed, [1, 2, 7], "Capitalized multi-token seam dupe dropped, lower-case kept")
+    }
+
+    func testCollapseSeamWordDuplicatesKeepsLowercaseWhenCapitalFirst() {
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+        let tokens =
+            word([6, 5], from: 100)  // Either (capital first)
+            + word([4, 5], from: 102)  // either
+            + word([7], from: 104)  // a
+
+        let collapsed = processor.collapseSeamWordDuplicates(tokens, vocabulary: subwordVocabulary).map(\.token)
+        XCTAssertEqual(collapsed, [4, 5, 7], "Lower-case copy survives even when the capital comes first")
+    }
+
+    func testCollapseSeamWordDuplicatesKeepsGenuineRepeats() {
+        // "have have" — same case is a real disfluency, not a seam artifact.
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+        let tokens = word([1, 2], from: 100) + word([1, 2], from: 102)
+
+        let collapsed = processor.collapseSeamWordDuplicates(tokens, vocabulary: subwordVocabulary).map(\.token)
+        XCTAssertEqual(collapsed, [1, 2, 1, 2])
+    }
+
+    func testCollapseSeamWordDuplicatesKeepsDistantRepeats() {
+        // The two casings are far apart in time — separate occurrences.
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+        let tokens = word([1, 2], from: 100) + word([3, 2], from: 200)
+
+        let collapsed = processor.collapseSeamWordDuplicates(tokens, vocabulary: subwordVocabulary).map(\.token)
+        XCTAssertEqual(collapsed, [1, 2, 3, 2])
+    }
+
+    func testCollapseSeamWordDuplicatesKeepsSentenceBoundary() {
+        // "have. Have a" — the earlier word ends a sentence, so the capital is a
+        // legitimate sentence start, not a seam artifact.
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+        let tokens =
+            word([1, 2, 9], from: 100)  // have.
+            + word([3, 2], from: 103)  // Have
+            + word([7], from: 105)  // a
+
+        let collapsed = processor.collapseSeamWordDuplicates(tokens, vocabulary: subwordVocabulary).map(\.token)
+        XCTAssertEqual(collapsed, [1, 2, 9, 3, 2, 7])
+    }
+
+    func testCollapseSeamWordDuplicatesNoOpWithoutVocabulary() {
+        let processor = ChunkProcessor(audioSamples: createMockAudioSamples(durationSeconds: 22.0))
+        let tokens = word([1, 2], from: 100) + word([3, 2], from: 102)
+
+        let collapsed = processor.collapseSeamWordDuplicates(tokens, vocabulary: [:]).map(\.token)
+        XCTAssertEqual(collapsed, [1, 2, 3, 2], "No vocabulary → nothing collapsed")
+    }
+
     // MARK: - Chunk Count Prediction with Overlap
 
     func testPredictableChunkCountWithOverlap() {


### PR DESCRIPTION
## Problem (#706)

Long-form offline audio is transcribed in overlapping 15 s windows whose token streams are merged on a 2 s overlap. A window that begins mid-sentence biases the RNNT decoder to capitalize its first word as a *false sentence start*. The exact-token-ID overlap matcher couldn't align that with the previous window's lower-cased copy, leaving **duplicated, mis-cased words at chunk seams** — e.g. `...the meeting Meeting was...` or a word capitalized in the middle of a sentence.

## Fix

Two merge-level changes, shared across the Unified, TDT and dual-decode paths:

1. **Case-folded overlap matching** (`caseVariantCanonicalIds` + `tokenIdsMatch`) — case-only token twins (`Meeting`≈`meeting`) align at the seam, so the word collapses to the left window's contextually-correct casing.
2. **Word-level seam-duplicate collapse** (`collapseSeamWordDuplicates`) — reconstructs SentencePiece words from the token stream and drops an adjacent case-only duplicate within the overlap window. Word-level is required for the **1024-piece Unified subword vocab**, where whole words span several tokens and a token-level check never sees them as a unit. Genuine repeats (`that that`), same-case duplicates and legitimate sentence boundaries (`...thank you. You said...`) are left untouched.

**Silence-aligned chunk starts were prototyped and dropped:** on the 15 s offline encoder they measured as a **~1 WER point regression** (Earnings-22 long-form) with no artifact benefit. The chunk grid is therefore identical to baseline, so short-form WER is unaffected — the merge fixes only ever *remove* duplicate/mis-cased seam words.

## Validation — Earnings-22 long-form (45 files / 44 h, scored vs references)

| Path | Aggregate WER | seam case-dupes (before→after, 5-file subset) |
|---|---|---|
| Unified batch | **13.01%** (beats TDT v3) | 16 → 2 |
| Parakeet TDT v3 | 14.46% | 66 → 4 |

- No WER regression on either path; remaining "dupes" are sentence-boundary false-positives of the metric, not artifacts.
- Spot-checked: `have Have`→`have`, `either Either`→`either`, `implementation Implementation`→clean.

## Also included

- Reproducible long-form benchmark: `unified-benchmark --longform-dir <dir>` (WER + seam artifacts vs TDT v3) and `--input <file>` (single-file seam comparison).
- `Scripts/materialize_earnings22_longform.py` to fetch full-length Earnings-22 audio + references.
- Unit tests for the matcher, the word-level collapse (incl. multi-token words, sentence boundaries, genuine repeats), and the case-variant builder.

## Notes

- Unit tests are compile-checked and hand-traced locally (no Xcode/XCTest on the dev machine) — they execute in CI.