### PR TITLE
Added Feature Provider Classes for unified parakeet ASR

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
@@ -267,10 +267,7 @@ public actor StreamingUnifiedAsrManager {
 
         // 3. Streaming encoder (chunked attention mask baked in)
         let encoderOutput = try await encoder.prediction(
-            from: MLDictionaryFeatureProvider(dictionary: [
-                "mel": MLFeatureValue(multiArray: mel),
-                "mel_length": MLFeatureValue(multiArray: melLength),
-            ])
+            from: UnifiedEncoderFeatureProvider(mel: mel, melLength: melLength)
         )
         guard let encoded = encoderOutput.featureValue(for: "encoder")?.multiArrayValue,
             let encodedLength = encoderOutput.featureValue(for: "encoder_length")?.multiArrayValue

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
@@ -217,10 +217,7 @@ public actor UnifiedAsrManager {
         let (mel, melLength) = try swiftMel.features(window: buffer, validCount: validCount)
 
         let encoderOutput = try await encoder.prediction(
-            from: MLDictionaryFeatureProvider(dictionary: [
-                "mel": MLFeatureValue(multiArray: mel),
-                "mel_length": MLFeatureValue(multiArray: melLength),
-            ])
+            from: UnifiedEncoderFeatureProvider(mel: mel, melLength: melLength)
         )
         guard let encoded = encoderOutput.featureValue(for: "encoder")?.multiArrayValue,
             let encodedLength = encoderOutput.featureValue(for: "encoder_length")?.multiArrayValue

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedFeatureProviders.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedFeatureProviders.swift
@@ -1,12 +1,5 @@
-//
-//  File.swift
-//  FluidAudio
-//
-//  Created by Benjamin Lee on 6/17/26.
-//
-
-import Foundation
 @preconcurrency import CoreML
+import Foundation
 
 /// Hyperoptimized Mel Feature Provider
 final class UnifiedEncoderFeatureProvider: MLFeatureProvider {

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedFeatureProviders.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedFeatureProviders.swift
@@ -1,0 +1,75 @@
+//
+//  File.swift
+//  FluidAudio
+//
+//  Created by Benjamin Lee on 6/17/26.
+//
+
+import Foundation
+@preconcurrency import CoreML
+
+/// Hyperoptimized Mel Feature Provider
+final class UnifiedEncoderFeatureProvider: MLFeatureProvider {
+    let featureNames: Set<String> = ["mel", "mel_length"]
+
+    let mel: MLFeatureValue
+    let melLength: MLFeatureValue
+
+    func featureValue(for featureName: String) -> MLFeatureValue? {
+        if featureName.count == 3 { return mel }
+        return melLength
+    }
+
+    init(mel: MLMultiArray, melLength: MLMultiArray) {
+        self.mel = MLFeatureValue(multiArray: mel)
+        self.melLength = MLFeatureValue(multiArray: melLength)
+    }
+}
+
+/// Hyperoptimized Decoder Model Feature Provider
+final class UnifiedDecoderFeatureProvider: MLFeatureProvider {
+    let featureNames: Set<String> = ["targets", "target_length", "h_in", "c_in"]
+
+    let hIn: MLFeatureValue
+    let cIn: MLFeatureValue
+    let targets: MLFeatureValue
+    let targetLength: MLFeatureValue
+
+    func featureValue(for featureName: String) -> MLFeatureValue? {
+        switch featureName.count {
+        case 4: return featureName.first == "h" ? hIn : cIn
+        case 7: return targets
+        default: return targetLength
+        }
+    }
+
+    init(
+        targets: MLMultiArray,
+        targetLength: MLMultiArray,
+        hIn: MLMultiArray,
+        cIn: MLMultiArray
+    ) {
+        self.targets = MLFeatureValue(multiArray: targets)
+        self.targetLength = MLFeatureValue(multiArray: targetLength)
+        self.hIn = MLFeatureValue(multiArray: hIn)
+        self.cIn = MLFeatureValue(multiArray: cIn)
+    }
+}
+
+/// Hyperoptimized Joint Decision Model Feature Provider
+final class UnifiedJointDecisionFeatureProvider: MLFeatureProvider {
+    let featureNames: Set<String> = ["encoder_step", "decoder_step"]
+
+    let encoderStep: MLFeatureValue
+    let decoderStep: MLFeatureValue
+
+    func featureValue(for featureName: String) -> MLFeatureValue? {
+        if featureName.first == "e" { return encoderStep }
+        return decoderStep
+    }
+
+    init(encoderStep: MLMultiArray, decoderStep: MLMultiArray) {
+        self.encoderStep = MLFeatureValue(multiArray: encoderStep)
+        self.decoderStep = MLFeatureValue(multiArray: decoderStep)
+    }
+}

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedRnntDecoder.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedRnntDecoder.swift
@@ -74,7 +74,7 @@ final class UnifiedRnntDecoder {
                 let jointOutput = try jointDecisionModel.prediction(
                     from: UnifiedJointDecisionFeatureProvider(
                         encoderStep: encStep,
-                        decoderStep: decoderStep.output,
+                        decoderStep: decoderStep.output
                     )
                 )
                 guard let tokenArray = jointOutput.featureValue(for: "token_id")?.multiArrayValue else {

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedRnntDecoder.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedRnntDecoder.swift
@@ -72,10 +72,10 @@ final class UnifiedRnntDecoder {
 
             for _ in 0..<config.maxSymbolsPerFrame {
                 let jointOutput = try jointDecisionModel.prediction(
-                    from: MLDictionaryFeatureProvider(dictionary: [
-                        "encoder_step": MLFeatureValue(multiArray: encStep),
-                        "decoder_step": MLFeatureValue(multiArray: decoderStep.output),
-                    ])
+                    from: UnifiedJointDecisionFeatureProvider(
+                        encoderStep: encStep,
+                        decoderStep: decoderStep.output,
+                    )
                 )
                 guard let tokenArray = jointOutput.featureValue(for: "token_id")?.multiArrayValue else {
                     throw ASRError.processingFailed("Unified joint decision missing token_id")
@@ -116,12 +116,12 @@ final class UnifiedRnntDecoder {
         targetLength[0] = 1
 
         let output = try decoderModel.prediction(
-            from: MLDictionaryFeatureProvider(dictionary: [
-                "targets": MLFeatureValue(multiArray: targets),
-                "target_length": MLFeatureValue(multiArray: targetLength),
-                "h_in": MLFeatureValue(multiArray: h),
-                "c_in": MLFeatureValue(multiArray: c),
-            ])
+            from: UnifiedDecoderFeatureProvider(
+                targets: targets,
+                targetLength: targetLength,
+                hIn: h,
+                cIn: c
+            )
         )
         guard let decoderOut = output.featureValue(for: "decoder")?.multiArrayValue,
             let hOut = output.featureValue(for: "h_out")?.multiArrayValue,


### PR DESCRIPTION
Dictionary Feature Providers are slow. I added overly optimized feature provider classes for the Parakeet Unified model to replace them. This will probably reduce inference times by a few nanoseconds to a few hundred microseconds.