### PR TITLE
fix(tts/kokoro-ane): read uppercase initialisms as letter names (#710)

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
@@ -5,13 +5,18 @@ import Foundation
 /// Word resolution order (mirrors `StyleTTS2Phonemizer` and Kokoro's
 /// Misaki frontend):
 ///   1. caller-supplied custom lexicon (case-sensitive, then lower-cased)
-///   2. case-sensitive Misaki lexicon hit on the original spelling
-///      (proper nouns, abbreviations like `AI`, `NATO`)
-///   3. case-sensitive hit on the normalized lower-case form
-///   4. lower-cased Misaki lexicon hit — this is what gives function
+///   2. letter-name overrides for bundled entries that don't read as
+///      letter names (`AI`, `US`) — spelled out from per-letter entries
+///      (issue #710)
+///   3. case-sensitive Misaki lexicon hit on the original spelling
+///      (proper nouns, abbreviations like `NATO`)
+///   4. case-sensitive hit on the normalized lower-case form
+///   5. lower-cased Misaki lexicon hit — this is what gives function
 ///      words their weak forms (`to` → `tu`), instead of the BART G2P
 ///      citation form (`tˈO`) that over-stresses them (issue #691)
-///   5. BART G2P CoreML fallback for OOV words (injected by the caller)
+///   6. strict ASCII all-caps initialisms (`FBI`, `ATP`) spelled as
+///      letter names after a full lexicon miss (issue #710)
+///   7. BART G2P CoreML fallback for OOV words (injected by the caller)
 ///
 /// Punctuation supported by the chain's `vocab.json` (`, . ! ? ; …` etc.)
 /// is preserved and attached to the preceding word — Kokoro treats those
@@ -112,12 +117,31 @@ struct KokoroAneEnglishPhonemizer: Sendable {
             return custom
         }
 
+        // A few bundled case-sensitive entries don't read as letter names
+        // even though uppercase callers expect them to (`AI` → blended
+        // `ˈAˌI`, `US` → the lowercase-pronoun `ʌs` shape). Spell those out
+        // before consulting the lexicon so they sound like `A I` / `U S`
+        // (issue #710). Lowercase `us`/`ai` are untouched — the override
+        // only matches the exact uppercase spelling.
+        if Self.letterNameOverrides.contains(word), let spelled = spellAsLetterNames(word) {
+            return spelled
+        }
+
         if let phonemes = caseSensitiveWordToPhonemes[word]
             ?? caseSensitiveWordToPhonemes[normalized]
             ?? wordToPhonemes[normalized],
             !phonemes.isEmpty
         {
             return phonemes.joined()
+        }
+
+        // After a full lexicon miss, read strict ASCII all-caps tokens of a
+        // small length range as letter-name initialisms (`FBI`, `ATP`)
+        // instead of letting BART G2P sound them out as a word (issue #710).
+        // Known acronyms (`NASA`, `FIFA`, `OK`, `COVID`) keep their bundled
+        // pronunciations because they're resolved above as lexicon hits.
+        if Self.isInitialismCandidate(word), let spelled = spellAsLetterNames(word) {
+            return spelled
         }
 
         guard !normalized.isEmpty else { return nil }
@@ -131,6 +155,44 @@ struct KokoroAneEnglishPhonemizer: Sendable {
             Self.logger.warning("G2P failed on word '\(normalized)': \(error.localizedDescription)")
             throw error
         }
+    }
+
+    // MARK: - Letter-name initialisms (issue #710)
+
+    /// Exact uppercase spellings whose bundled lexicon entry is not the
+    /// letter-name reading callers expect. These bypass the Misaki lexicon
+    /// and are spelled out from the per-letter entries instead.
+    private static let letterNameOverrides: Set<String> = ["AI", "US"]
+
+    /// Length bounds for spelling unknown all-caps tokens as letter names.
+    private static let initialismLengthRange = 2...5
+
+    /// A strict ASCII all-caps token (`FBI`, `ATP`) within the length range
+    /// — the only shape we spell out after a lexicon miss. Anything with a
+    /// digit, hyphen, apostrophe, or non-ASCII letter is excluded so brand
+    /// and proper-name pronunciations aren't disturbed.
+    static func isInitialismCandidate(_ word: String) -> Bool {
+        guard Self.initialismLengthRange.contains(word.count) else { return false }
+        return word.allSatisfy { $0.isASCII && $0.isUppercase && $0.isLetter }
+    }
+
+    /// Spell a token as a sequence of letter names, reading each uppercase
+    /// letter's pronunciation from the case-sensitive lexicon and joining
+    /// them with spaces so each letter is its own prosodic unit (`FBI` →
+    /// `ˈɛf bˈi ˈI`). Returns `nil` if any letter is missing from the
+    /// lexicon (e.g. the G2P-only degraded path) so the caller falls
+    /// through to its normal fallback rather than emitting a partial word.
+    private func spellAsLetterNames(_ word: String) -> String? {
+        var letters: [String] = []
+        letters.reserveCapacity(word.count)
+        for ch in word {
+            guard let phonemes = caseSensitiveWordToPhonemes[String(ch)], !phonemes.isEmpty else {
+                return nil
+            }
+            letters.append(phonemes.joined())
+        }
+        guard !letters.isEmpty else { return nil }
+        return letters.joined(separator: " ")
     }
 
     /// Lowercase + strip non-letter/digit/apostrophe chars so we hit the

--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
@@ -123,8 +123,17 @@ struct KokoroAneEnglishPhonemizer: Sendable {
         // before consulting the lexicon so they sound like `A I` / `U S`
         // (issue #710). Lowercase `us`/`ai` are untouched — the override
         // only matches the exact uppercase spelling.
-        if Self.letterNameOverrides.contains(word), let spelled = spellAsLetterNames(word) {
-            return spelled
+        if Self.letterNameOverrides.contains(word) {
+            if let spelled = spellAsLetterNames(word) {
+                return spelled
+            }
+            // Per-letter entries should always be present when the full
+            // lexicon is loaded; if they aren't (e.g. a letter was filtered
+            // out of the cache) the override below silently becomes the
+            // blended shape it was meant to bypass — log so it isn't silent.
+            Self.logger.warning(
+                "Letter-name override '\(word)' unspellable (missing per-letter lexicon entries); "
+                    + "falling back to the bundled pronunciation")
         }
 
         if let phonemes = caseSensitiveWordToPhonemes[word]

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
@@ -22,10 +22,26 @@ final class KokoroAneEnglishPhonemizerTests: XCTestCase {
         "hello": ["h", "ə", "l", "ˈ", "O"],
         "there's": ["ð", "ɛ", "ɹ", "z"],
         "world": ["w", "ˈ", "ɜ", "ɹ", "l", "d"],
+        // Lowercase pronoun must stay the weak `ʌs` shape (issue #710).
+        "us": ["ˌ", "ʌ", "s"],
     ]
 
+    /// Mirrors the real `us_lexicon_cache.json`: the blended `AI`/`US`
+    /// shapes the #710 overrides bypass, the per-letter names the spell-out
+    /// reads, and known acronyms that must stay lexicon-backed.
     private let caseSensitive: [String: [String]] = [
-        "AI": ["ˈ", "A", "ˈ", "I"]
+        "AI": ["ˈ", "A", "ˌ", "I"],
+        "US": ["ˌ", "ʌ", "s"],
+        "A": ["ˈ", "A"],
+        "I": ["ˈ", "I"],
+        "U": ["j", "ˈ", "u"],
+        "S": ["ˈ", "ɛ", "s"],
+        "F": ["ˈ", "ɛ", "f"],
+        "B": ["b", "ˈ", "i"],
+        "T": ["t", "ˈ", "i"],
+        "P": ["p", "ˈ", "i"],
+        "NASA": ["n", "ˈ", "æ", "s", "ə"],
+        "OK": ["ˌ", "O", "k", "ˈ", "A"],
     ]
 
     /// Punctuation present in the real `ANE/vocab.json`.
@@ -77,9 +93,68 @@ final class KokoroAneEnglishPhonemizerTests: XCTestCase {
 
     // MARK: - Resolution order
 
-    func testCaseSensitiveLexiconWinsForAbbreviations() async throws {
+    func testCaseSensitiveLexiconWinsForProperNouns() async throws {
+        // `NASA` is a lexicon-backed acronym, not spelled out.
+        let result = try await makePhonemizer().phonemize("NASA") { _ in nil }
+        XCTAssertEqual(result, "nˈæsə")
+    }
+
+    // MARK: - Letter-name initialisms (issue #710)
+
+    func testAIOverrideSpellsLetterNamesNotBlendedShape() async throws {
+        // `AI` bypasses the blended `ˈAˌI` lexicon entry and reads `A I`.
         let result = try await makePhonemizer().phonemize("AI") { _ in nil }
-        XCTAssertEqual(result, "ˈAˈI")
+        XCTAssertEqual(result, "ˈA ˈI")
+    }
+
+    func testUSOverrideSpellsLetterNamesNotPronoun() async throws {
+        // Uppercase `US` reads `U S`, not the lowercase pronoun `ʌs`.
+        let result = try await makePhonemizer().phonemize("US") { _ in nil }
+        XCTAssertEqual(result, "jˈu ˈɛs")
+    }
+
+    func testLowercaseUsStaysPronoun() async throws {
+        // The override only matches the exact uppercase spelling.
+        let result = try await makePhonemizer().phonemize("us") { _ in nil }
+        XCTAssertEqual(result, "ˌʌs")
+    }
+
+    func testUnknownAllCapsInitialismSpelledAsLetterNames() async throws {
+        // `FBI`/`ATP` miss the lexicon and spell out instead of reaching G2P.
+        let recorder = FallbackRecorder()
+        let fbi = try await makePhonemizer().phonemize("FBI") { await recorder.g2p($0) }
+        XCTAssertEqual(fbi, "ˈɛf bˈi ˈI")
+        let atp = try await makePhonemizer().phonemize("ATP") { await recorder.g2p($0) }
+        XCTAssertEqual(atp, "ˈA tˈi pˈi")
+        let recorded = await recorder.words
+        XCTAssertTrue(recorded.isEmpty, "initialisms must not reach BART G2P")
+    }
+
+    func testKnownAcronymStaysLexiconBackedNotSpelled() async throws {
+        // `OK` is a lexicon hit (2-5 all-caps) — it keeps its bundled shape
+        // rather than spelling `O K`.
+        let result = try await makePhonemizer().phonemize("OK") { _ in nil }
+        XCTAssertEqual(result, "ˌOkˈA")
+    }
+
+    func testInitialismSpellOutFallsThroughToG2PWithoutLetterEntries() async throws {
+        // G2P-only degraded path: no per-letter lexicon entries, so the
+        // all-caps token must reach the fallback rather than emit a partial.
+        let phonemizer = KokoroAneEnglishPhonemizer(allowedPunctuation: punctuation)
+        let recorder = FallbackRecorder()
+        let result = try await phonemizer.phonemize("FBI") { await recorder.g2p($0) }
+        XCTAssertEqual(result, "<g2p:fbi>")
+        let recorded = await recorder.words
+        XCTAssertEqual(recorded, ["fbi"])
+    }
+
+    func testLongAllCapsWordIsNotSpelled() async throws {
+        // Outside the 2-5 length range → not an initialism candidate.
+        XCTAssertFalse(KokoroAneEnglishPhonemizer.isInitialismCandidate("ABCDEF"))
+        XCTAssertFalse(KokoroAneEnglishPhonemizer.isInitialismCandidate("A"))
+        XCTAssertTrue(KokoroAneEnglishPhonemizer.isInitialismCandidate("FBI"))
+        // Digits/hyphens disqualify it (`COVID-19`, `MP3`).
+        XCTAssertFalse(KokoroAneEnglishPhonemizer.isInitialismCandidate("MP3"))
     }
 
     func testOOVWordFallsBackToG2PWithNormalizedSpelling() async throws {

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
@@ -148,6 +148,21 @@ final class KokoroAneEnglishPhonemizerTests: XCTestCase {
         XCTAssertEqual(recorded, ["fbi"])
     }
 
+    func testOverrideFallsBackToLexiconWhenLettersMissing() async throws {
+        // Degraded lexicon: `US` is present but the per-letter entries are
+        // not, so the override can't spell it and falls through to the
+        // bundled shape (logged, never silently dropped or sent to G2P).
+        let phonemizer = KokoroAneEnglishPhonemizer(
+            caseSensitiveWordToPhonemes: ["US": ["ˌ", "ʌ", "s"]],
+            allowedPunctuation: punctuation
+        )
+        let recorder = FallbackRecorder()
+        let result = try await phonemizer.phonemize("US") { await recorder.g2p($0) }
+        XCTAssertEqual(result, "ˌʌs")
+        let recorded = await recorder.words
+        XCTAssertTrue(recorded.isEmpty, "override fall-through must use the lexicon, not G2P")
+    }
+
     func testLongAllCapsWordIsNotSpelled() async throws {
         // Outside the 2-5 length range → not an initialism candidate.
         XCTAssertFalse(KokoroAneEnglishPhonemizer.isInitialismCandidate("ABCDEF"))


### PR DESCRIPTION
Closes #710.

## Problem

Uppercase initialisms read poorly through the KokoroAne English frontend (verified against the real `us_lexicon_cache.json`):

- `AI` hit the bundled blended entry `['ˈ','A','ˌ','I']` (`ˈAˌI`) and sounds too joined.
- `US` hit `['ˌ','ʌ','s']` — the lowercase-pronoun `ʌs` shape.
- `FBI` / `ATP` are absent from the lexicon and fell through to BART G2P, which sounds them out as a word.

## Change

`KokoroAneEnglishPhonemizer.resolveWord` now follows the safe rule proposed in #710, inserting two steps without disturbing existing behavior:

1. **Custom lexicon** — unchanged, still first authority.
2. **Letter-name overrides** (`AI`, `US`, exact uppercase only) — bypass the bad bundled entries and spell out from the per-letter lexicon names. Lowercase `us`/`ai` are untouched (override matches exact spelling only).
3. **Case-sensitive / lowercased Misaki lexicon** — unchanged. Keeps `NASA`, `NATO`, `FIFA`, `OK`, `COVID` lexicon-backed.
4. **Initialism spell-out** — after a *full* lexicon miss, strict ASCII all-caps tokens of length 2–5 (`FBI`, `ATP`) spell as letter names instead of reaching G2P. Digits/hyphens/non-ASCII disqualify (`MP3`, `COVID-19`).
5. **BART G2P fallback** — unchanged.

Spelling is data-driven from the loaded single-letter lexicon entries (no hardcoded IPA). `spellAsLetterNames` returns `nil` if any letter is missing (e.g. the G2P-only degraded path), so the word falls through cleanly rather than emitting a partial.

## Results

| Input | Before | After |
|-------|--------|-------|
| `AI`  | `ˈAˌI` | `ˈA ˈI` |
| `US`  | `ˌʌs` (pronoun) | `jˈu ˈɛs` |
| `FBI` | BART G2P (word) | `ˈɛf bˈi ˈI` |
| `ATP` | BART G2P (word) | `ˈA tˈi pˈi` |
| `us`  | `ˌʌs` | `ˌʌs` (unchanged) |
| `NASA`/`OK` | lexicon shape | unchanged |

## Tests

Updated `KokoroAneEnglishPhonemizerTests` fixtures to mirror the real lexicon (blended `AI`/`US`, per-letter names, `NASA`/`OK` acronyms) and added cases for: `AI`/`US` overrides, lowercase `us` pronoun, `FBI`/`ATP` spell-out, `NASA`/`OK` staying lexicon-backed, the G2P-only fall-through, and the `isInitialismCandidate` length/charset boundaries.

Library builds cleanly; swift-format passes. The XCTest suite could not be executed in my local environment (CommandLineTools only, no full Xcode, so `swift test` can't link `XCTest`) — assertions were hand-traced against the real lexicon values and the test file parses clean.