### PR TITLE
feat(tts): shared English text normalization for raw numbers/times (#711) + shared initialism helpers (#710)

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
@@ -123,7 +123,7 @@ struct KokoroAneEnglishPhonemizer: Sendable {
         // before consulting the lexicon so they sound like `A I` / `U S`
         // (issue #710). Lowercase `us`/`ai` are untouched — the override
         // only matches the exact uppercase spelling.
-        if Self.letterNameOverrides.contains(word) {
+        if EnglishInitialisms.letterNameOverrides.contains(word) {
             if let spelled = spellAsLetterNames(word) {
                 return spelled
             }
@@ -149,7 +149,7 @@ struct KokoroAneEnglishPhonemizer: Sendable {
         // instead of letting BART G2P sound them out as a word (issue #710).
         // Known acronyms (`NASA`, `FIFA`, `OK`, `COVID`) keep their bundled
         // pronunciations because they're resolved above as lexicon hits.
-        if Self.isInitialismCandidate(word), let spelled = spellAsLetterNames(word) {
+        if EnglishInitialisms.isCandidate(word), let spelled = spellAsLetterNames(word) {
             return spelled
         }
 
@@ -168,40 +168,13 @@ struct KokoroAneEnglishPhonemizer: Sendable {
 
     // MARK: - Letter-name initialisms (issue #710)
 
-    /// Exact uppercase spellings whose bundled lexicon entry is not the
-    /// letter-name reading callers expect. These bypass the Misaki lexicon
-    /// and are spelled out from the per-letter entries instead.
-    private static let letterNameOverrides: Set<String> = ["AI", "US"]
-
-    /// Length bounds for spelling unknown all-caps tokens as letter names.
-    private static let initialismLengthRange = 2...5
-
-    /// A strict ASCII all-caps token (`FBI`, `ATP`) within the length range
-    /// — the only shape we spell out after a lexicon miss. Anything with a
-    /// digit, hyphen, apostrophe, or non-ASCII letter is excluded so brand
-    /// and proper-name pronunciations aren't disturbed.
-    static func isInitialismCandidate(_ word: String) -> Bool {
-        guard Self.initialismLengthRange.contains(word.count) else { return false }
-        return word.allSatisfy { $0.isASCII && $0.isUppercase && $0.isLetter }
-    }
-
-    /// Spell a token as a sequence of letter names, reading each uppercase
-    /// letter's pronunciation from the case-sensitive lexicon and joining
-    /// them with spaces so each letter is its own prosodic unit (`FBI` →
-    /// `ˈɛf bˈi ˈI`). Returns `nil` if any letter is missing from the
-    /// lexicon (e.g. the G2P-only degraded path) so the caller falls
-    /// through to its normal fallback rather than emitting a partial word.
+    /// Spell a token as a sequence of letter names using the per-letter
+    /// entries in the case-sensitive lexicon (`FBI` → `ˈɛf bˈi ˈI`). See
+    /// ``EnglishInitialisms/spell(_:letterTokens:render:separator:)`` —
+    /// returns `nil` if any letter is missing so the caller falls through
+    /// to its normal fallback rather than emitting a partial word.
     private func spellAsLetterNames(_ word: String) -> String? {
-        var letters: [String] = []
-        letters.reserveCapacity(word.count)
-        for ch in word {
-            guard let phonemes = caseSensitiveWordToPhonemes[String(ch)], !phonemes.isEmpty else {
-                return nil
-            }
-            letters.append(phonemes.joined())
-        }
-        guard !letters.isEmpty else { return nil }
-        return letters.joined(separator: " ")
+        EnglishInitialisms.spell(word) { caseSensitiveWordToPhonemes[$0] }
     }
 
     /// Lowercase + strip non-letter/digit/apostrophe chars so we hit the

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -264,13 +264,17 @@ public actor KokoroAneManager {
         )
     }
 
-    /// English text → Misaki-style IPA. Lexicon-first resolution (weak
-    /// function-word forms — `to` → `tu`, not the stressed BART citation
-    /// form `tˈO`, issue #691), per-word BART G2P fallback for OOV words,
-    /// and vocab-supported punctuation kept as prosody/pause tokens.
+    /// English text → Misaki-style IPA. A conservative normalization pass
+    /// first rewrites strict standalone numbers, ordinals, decimals, and
+    /// 12-hour times into spoken words (issue #711), then lexicon-first
+    /// resolution applies (weak function-word forms — `to` → `tu`, not the
+    /// stressed BART citation form `tˈO`, issue #691), with per-word BART
+    /// G2P fallback for OOV words and vocab-supported punctuation kept as
+    /// prosody/pause tokens.
     private func phonemize(text: String) async throws -> String {
+        let normalized = EnglishTextNormalizer.normalize(text)
         let phonemizer = await ensureEnglishPhonemizer()
-        return try await phonemizer.phonemize(text) { word in
+        return try await phonemizer.phonemize(normalized) { word in
             try await G2PModel.shared.phonemize(word: word)
         }
     }

--- a/Sources/FluidAudio/TTS/Shared/EnglishInitialisms.swift
+++ b/Sources/FluidAudio/TTS/Shared/EnglishInitialisms.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Shared helpers for reading uppercase initialisms as letter names in
+/// English TTS frontends (issue #710).
+///
+/// A few bundled Misaki entries don't read as letter names even though
+/// uppercase callers expect them to (`AI` → blended `ˈAˌI`, `US` → the
+/// lowercase-pronoun `ʌs` shape), and unknown all-caps tokens (`FBI`,
+/// `ATP`) miss the lexicon and fall through to BART G2P, which sounds them
+/// out as a word. Both ``KokoroAneEnglishPhonemizer`` and (in a follow-up)
+/// StyleTTS2 can use these helpers to spell such tokens from the per-letter
+/// lexicon entries instead.
+///
+/// The actual letter phonemes come from the caller's lexicon, so this type
+/// holds only the policy (which tokens to spell) and the spelling
+/// mechanics; the data stays with each frontend.
+enum EnglishInitialisms {
+
+    /// Exact uppercase spellings whose bundled lexicon entry is not the
+    /// letter-name reading callers expect. These should bypass the Misaki
+    /// lexicon and be spelled out from the per-letter entries instead.
+    /// Lowercase `us`/`ai` are intentionally absent — only the exact
+    /// uppercase spelling is overridden.
+    static let letterNameOverrides: Set<String> = ["AI", "US"]
+
+    /// Length bounds for spelling unknown all-caps tokens as letter names.
+    private static let lengthRange = 2...5
+
+    /// A strict ASCII all-caps token (`FBI`, `ATP`) within the length range
+    /// — the only shape worth spelling out after a lexicon miss. Anything
+    /// with a digit, hyphen, apostrophe, or non-ASCII letter is excluded so
+    /// brand and proper-name pronunciations aren't disturbed.
+    static func isCandidate(_ word: String) -> Bool {
+        guard lengthRange.contains(word.count) else { return false }
+        return word.allSatisfy { $0.isASCII && $0.isUppercase && $0.isLetter }
+    }
+
+    /// Spell `word` as a sequence of letter names, resolving each uppercase
+    /// letter to its phoneme tokens via `letterTokens` and joining the
+    /// rendered letters with `separator` so each is its own prosodic unit
+    /// (`FBI` → `ˈɛf bˈi ˈI`).
+    ///
+    /// - Parameters:
+    ///   - letterTokens: resolves a single-letter key (`"F"`) to its
+    ///     phoneme tokens, or `nil` if absent (e.g. a G2P-only degraded
+    ///     path, or a letter filtered out of the lexicon cache).
+    ///   - render: turns one letter's tokens into its IPA fragment.
+    ///     Defaults to a plain join; frontends that post-process Misaki
+    ///     shorthand can pass their own.
+    ///   - separator: inserted between letters (default a single space).
+    /// - Returns: the spelled string, or `nil` if any letter is missing —
+    ///   so the caller falls through to its normal fallback rather than
+    ///   emitting a partial word.
+    static func spell(
+        _ word: String,
+        letterTokens: (String) -> [String]?,
+        render: ([String]) -> String = { $0.joined() },
+        separator: String = " "
+    ) -> String? {
+        var letters: [String] = []
+        letters.reserveCapacity(word.count)
+        for character in word {
+            guard let tokens = letterTokens(String(character)), !tokens.isEmpty else {
+                return nil
+            }
+            letters.append(render(tokens))
+        }
+        guard !letters.isEmpty else { return nil }
+        return letters.joined(separator: separator)
+    }
+}

--- a/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
+++ b/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+/// Conservative pre-tokenization text normalization for English TTS
+/// raw-text frontends (issue #711).
+///
+/// Raw chat-style text often contains standalone numbers, ordinals, and
+/// clock times that tokenize poorly (`3.14` splits around `.` and reads
+/// closer to `three fourteen` than `three point one four`). This pass
+/// rewrites only *strict standalone* numeric forms into spoken words
+/// before a frontend tokenizes, reusing ``SayAsInterpreter`` for the
+/// actual spelling. It is frontend-agnostic — both ``KokoroAneManager``
+/// and (in a follow-up) StyleTTS2 can apply it.
+///
+/// Raw text carries no caller annotation, so the rules are deliberately
+/// stricter than SSML `<say-as>`: anything ambiguous or structured is left
+/// untouched. Handled forms:
+///   * cardinal integers — `26` → `twenty six`
+///   * valid ordinals — `13th` → `thirteenth` (suffix must match the number)
+///   * leading-zero digit strings — `007` → `zero zero seven`
+///   * decimals — `3.14` → `three point one four`
+///   * 12-hour meridiem times — `1:49 PM` → `one forty nine p m`
+///
+/// Left unchanged (ambiguous / structured): version strings (`1.2.3`),
+/// grouped numbers (`1,234`), embedded digits (`word26`, `26word`), loose
+/// colon numbers without a meridiem (`1:49`), invalid times (`1:99 PM`),
+/// and 24-hour forms (`13:49`).
+enum EnglishTextNormalizer {
+
+    /// Rewrite strict standalone numeric forms in `text` to spoken words.
+    /// Passes run in priority order so a token is consumed by the most
+    /// specific rule (a meridiem time before its bare digits, a decimal
+    /// before its integer part).
+    static func normalize(_ text: String) -> String {
+        var result = text
+        result = apply(Self.meridiemTimeRegex, to: result, transform: Self.spellMeridiemTime)
+        result = apply(Self.decimalRegex, to: result, transform: Self.spellDecimal)
+        result = apply(Self.ordinalRegex, to: result, transform: Self.spellOrdinal)
+        result = apply(Self.leadingZeroRegex, to: result, transform: Self.spellLeadingZero)
+        result = apply(Self.cardinalRegex, to: result, transform: Self.spellCardinal)
+        return result
+    }
+
+    // MARK: - Boundaries
+    //
+    // A standalone number must not be glued to a letter, another digit, or
+    // a `. , :` separator that would make it part of a word, version
+    // string, grouped number, or clock value. `leadBoundary` guards the
+    // left edge; `trailBoundary` guards the right edge while still allowing
+    // a trailing sentence period (`26.` / `3.14.`) — a `.`/`,`/`:` only
+    // disqualifies when it is itself followed by a digit.
+    private static let leadBoundary = #"(?<![A-Za-z0-9.,:])"#
+    private static let trailBoundary = #"(?![A-Za-z0-9])(?![.,:][0-9])"#
+
+    // MARK: - Compiled patterns
+
+    /// `1:49 PM`, `1:49 p.m.` — hour 1-12, minute 00-59, explicit meridiem.
+    private static let meridiemTimeRegex = regex(
+        leadBoundary + #"(1[0-2]|[1-9]):([0-5][0-9])\s*([AaPp])\.?[Mm]\.?"# + #"(?![A-Za-z])"#)
+
+    /// `3.14` — integer and fractional parts, not part of a version string.
+    private static let decimalRegex = regex(
+        leadBoundary + #"([0-9]+)\.([0-9]+)"# + trailBoundary)
+
+    /// `13th`, `21st` — digits immediately followed by an ordinal suffix.
+    private static let ordinalRegex = regex(
+        leadBoundary + #"([0-9]+)(st|nd|rd|th)"# + #"(?![A-Za-z])"#)
+
+    /// `007` — leading zero forces a digit-by-digit reading.
+    private static let leadingZeroRegex = regex(
+        leadBoundary + #"(0[0-9]+)"# + trailBoundary)
+
+    /// `26` — a plain standalone integer.
+    private static let cardinalRegex = regex(
+        leadBoundary + #"([0-9]+)"# + trailBoundary)
+
+    // MARK: - Per-match spelling (return nil to leave the match unchanged)
+
+    private static func spellMeridiemTime(_ groups: [String]) -> String? {
+        let clock = "\(groups[1]):\(groups[2])"
+        let spoken = spaced(SayAsInterpreter.interpret(content: clock, interpretAs: "time", format: nil))
+        guard !containsDigit(spoken) else { return nil }
+        let meridiem = groups[3].lowercased() == "p" ? "p m" : "a m"
+        return "\(spoken) \(meridiem)"
+    }
+
+    private static func spellDecimal(_ groups: [String]) -> String? {
+        guard let integerPart = cardinalWords(groups[1]) else { return nil }
+        let fractionalPart = SayAsInterpreter.interpret(
+            content: groups[2], interpretAs: "digits", format: nil)
+        guard !containsDigit(fractionalPart) else { return nil }
+        return "\(integerPart) point \(fractionalPart)"
+    }
+
+    private static func spellOrdinal(_ groups: [String]) -> String? {
+        // Only rewrite grammatically valid ordinals (`13th`, not `13st`).
+        guard let number = Int(groups[1]), expectedOrdinalSuffix(for: number) == groups[2].lowercased()
+        else { return nil }
+        let spoken = spaced(SayAsInterpreter.interpret(content: groups[1], interpretAs: "ordinal", format: nil))
+        return containsDigit(spoken) ? nil : spoken
+    }
+
+    private static func spellLeadingZero(_ groups: [String]) -> String? {
+        let spoken = SayAsInterpreter.interpret(content: groups[1], interpretAs: "digits", format: nil)
+        return containsDigit(spoken) ? nil : spoken
+    }
+
+    private static func spellCardinal(_ groups: [String]) -> String? {
+        cardinalWords(groups[1])
+    }
+
+    // MARK: - Helpers
+
+    /// Spell a non-negative integer string with spaces between words
+    /// (`twenty-six` → `twenty six`); `nil` if it overflows `Int` and the
+    /// interpreter hands the digits back unchanged.
+    private static func cardinalWords(_ digits: String) -> String? {
+        let spoken = spaced(SayAsInterpreter.interpret(content: digits, interpretAs: "cardinal", format: nil))
+        return containsDigit(spoken) ? nil : spoken
+    }
+
+    /// The grammatically correct ordinal suffix for `number`.
+    private static func expectedOrdinalSuffix(for number: Int) -> String {
+        if (11...13).contains(number % 100) { return "th" }
+        switch number % 10 {
+        case 1: return "st"
+        case 2: return "nd"
+        case 3: return "rd"
+        default: return "th"
+        }
+    }
+
+    private static func spaced(_ text: String) -> String {
+        text.replacingOccurrences(of: "-", with: " ")
+    }
+
+    private static func containsDigit(_ text: String) -> Bool {
+        text.contains { $0.isNumber }
+    }
+
+    private static func regex(_ pattern: String) -> NSRegularExpression {
+        // Patterns are compile-time constants; a failure is a programmer error
+        // (mirrors `SayAsInterpreter`'s regex initialization).
+        try! NSRegularExpression(pattern: pattern, options: [])
+    }
+
+    /// Apply `regex` to `text`, replacing each match with `transform`'s
+    /// result. Matches are spliced in reverse so earlier ranges stay valid.
+    /// `transform` receives the full match plus capture groups (index 0 is
+    /// the whole match); returning `nil` leaves that match untouched.
+    private static func apply(
+        _ regex: NSRegularExpression,
+        to text: String,
+        transform: ([String]) -> String?
+    ) -> String {
+        let ns = text as NSString
+        let matches = regex.matches(in: text, range: NSRange(location: 0, length: ns.length))
+        guard !matches.isEmpty else { return text }
+
+        let mutable = NSMutableString(string: text)
+        for match in matches.reversed() {
+            var groups: [String] = []
+            groups.reserveCapacity(match.numberOfRanges)
+            for index in 0..<match.numberOfRanges {
+                let range = match.range(at: index)
+                groups.append(range.location == NSNotFound ? "" : ns.substring(with: range))
+            }
+            if let replacement = transform(groups) {
+                mutable.replaceCharacters(in: match.range, with: replacement)
+            }
+        }
+        return mutable as String
+    }
+}

--- a/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
+++ b/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
@@ -54,8 +54,11 @@ enum EnglishTextNormalizer {
     // MARK: - Compiled patterns
 
     /// `1:49 PM`, `1:49 p.m.` — hour 1-12, minute 00-59, explicit meridiem.
+    /// The `m` half is an explicit alternation (`.m`/`.m.` for the dotted
+    /// form, bare `m` otherwise) so a sentence period after `PM` is left as
+    /// punctuation instead of being swallowed (`1:49 PM.`).
     private static let meridiemTimeRegex = regex(
-        leadBoundary + #"(1[0-2]|[1-9]):([0-5][0-9])\s*([AaPp])\.?[Mm]\.?"# + #"(?![A-Za-z])"#)
+        leadBoundary + #"(1[0-2]|[1-9]):([0-5][0-9])\s*([AaPp])(?:\.[Mm]\.?|[Mm])"# + #"(?![A-Za-z])"#)
 
     /// `3.14` — integer and fractional parts, not part of a version string.
     private static let decimalRegex = regex(

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
@@ -163,13 +163,15 @@ final class KokoroAneEnglishPhonemizerTests: XCTestCase {
         XCTAssertTrue(recorded.isEmpty, "override fall-through must use the lexicon, not G2P")
     }
 
-    func testLongAllCapsWordIsNotSpelled() async throws {
-        // Outside the 2-5 length range → not an initialism candidate.
-        XCTAssertFalse(KokoroAneEnglishPhonemizer.isInitialismCandidate("ABCDEF"))
-        XCTAssertFalse(KokoroAneEnglishPhonemizer.isInitialismCandidate("A"))
-        XCTAssertTrue(KokoroAneEnglishPhonemizer.isInitialismCandidate("FBI"))
-        // Digits/hyphens disqualify it (`COVID-19`, `MP3`).
-        XCTAssertFalse(KokoroAneEnglishPhonemizer.isInitialismCandidate("MP3"))
+    func testLongAllCapsWordIsNotSpelledButReachesG2P() async throws {
+        // Outside the 2-5 length range → not an initialism; reaches G2P
+        // instead of being spelled letter by letter. (Candidate boundaries
+        // are unit-tested in EnglishInitialismsTests.)
+        let recorder = FallbackRecorder()
+        let result = try await makePhonemizer().phonemize("ABCDEF") { await recorder.g2p($0) }
+        XCTAssertEqual(result, "<g2p:abcdef>")
+        let recorded = await recorder.words
+        XCTAssertEqual(recorded, ["abcdef"])
     }
 
     func testOOVWordFallsBackToG2PWithNormalizedSpelling() async throws {

--- a/Tests/FluidAudioTests/TTS/Shared/EnglishInitialismsTests.swift
+++ b/Tests/FluidAudioTests/TTS/Shared/EnglishInitialismsTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Unit tests for the shared letter-name initialism helpers (issue #710):
+/// candidate boundaries and the lexicon-driven spell-out mechanics that
+/// English TTS frontends share.
+final class EnglishInitialismsTests: XCTestCase {
+
+    // MARK: - Candidate boundaries
+
+    func testCandidateLengthRange() {
+        // 2-5 strict ASCII uppercase letters.
+        XCTAssertTrue(EnglishInitialisms.isCandidate("FBI"))
+        XCTAssertTrue(EnglishInitialisms.isCandidate("US"))
+        XCTAssertTrue(EnglishInitialisms.isCandidate("ABCDE"))
+        XCTAssertFalse(EnglishInitialisms.isCandidate("A"))
+        XCTAssertFalse(EnglishInitialisms.isCandidate("ABCDEF"))
+    }
+
+    func testCandidateRejectsNonStrictAllCaps() {
+        XCTAssertFalse(EnglishInitialisms.isCandidate("MP3"))  // digit
+        XCTAssertFalse(EnglishInitialisms.isCandidate("iOS"))  // mixed case
+        XCTAssertFalse(EnglishInitialisms.isCandidate("A-B"))  // hyphen
+        XCTAssertFalse(EnglishInitialisms.isCandidate("ÉÀ"))  // non-ASCII
+    }
+
+    // MARK: - Spelling
+
+    private let letters: [String: [String]] = [
+        "F": ["ˈ", "ɛ", "f"],
+        "B": ["b", "ˈ", "i"],
+        "I": ["ˈ", "I"],
+    ]
+
+    func testSpellJoinsLetterNamesWithSpaces() {
+        let spelled = EnglishInitialisms.spell("FBI") { letters[$0] }
+        XCTAssertEqual(spelled, "ˈɛf bˈi ˈI")
+    }
+
+    func testSpellReturnsNilWhenAnyLetterMissing() {
+        // `X` isn't in the map → nil so the caller can fall through.
+        XCTAssertNil(EnglishInitialisms.spell("FXB") { letters[$0] })
+    }
+
+    func testSpellHonorsCustomRenderAndSeparator() {
+        let spelled = EnglishInitialisms.spell(
+            "FB",
+            letterTokens: { letters[$0] },
+            render: { "[" + $0.joined() + "]" },
+            separator: "-"
+        )
+        XCTAssertEqual(spelled, "[ˈɛf]-[bˈi]")
+    }
+
+    func testLetterNameOverridesAreUppercaseOnly() {
+        XCTAssertTrue(EnglishInitialisms.letterNameOverrides.contains("AI"))
+        XCTAssertTrue(EnglishInitialisms.letterNameOverrides.contains("US"))
+        XCTAssertFalse(EnglishInitialisms.letterNameOverrides.contains("ai"))
+        XCTAssertFalse(EnglishInitialisms.letterNameOverrides.contains("us"))
+    }
+}

--- a/Tests/FluidAudioTests/TTS/Shared/EnglishTextNormalizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/Shared/EnglishTextNormalizerTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Tests for the shared conservative English raw-text normalization pass
+/// (issue #711): strict standalone numbers/ordinals/decimals/12-hour times
+/// are spelled out, while ambiguous or structured forms are left untouched.
+final class EnglishTextNormalizerTests: XCTestCase {
+
+    private func normalize(_ text: String) -> String {
+        EnglishTextNormalizer.normalize(text)
+    }
+
+    // MARK: - Supported standalone forms
+
+    func testCardinalInteger() {
+        XCTAssertEqual(normalize("I am 26 years old."), "I am twenty six years old.")
+        XCTAssertEqual(normalize("100"), "one hundred")
+    }
+
+    func testOrdinal() {
+        XCTAssertEqual(normalize("Today is June 13th."), "Today is June thirteenth.")
+        XCTAssertEqual(normalize("the 21st"), "the twenty first")
+    }
+
+    func testDecimal() {
+        XCTAssertEqual(normalize("The score is 3.14."), "The score is three point one four.")
+        XCTAssertEqual(normalize("0.5"), "zero point five")
+    }
+
+    func testLeadingZeroDigitString() {
+        XCTAssertEqual(normalize("Agent 007"), "Agent zero zero seven")
+    }
+
+    func testTwelveHourMeridiemTime() {
+        XCTAssertEqual(
+            normalize("The current time is 1:49 PM."),
+            "The current time is one forty nine p m.")
+        XCTAssertEqual(normalize("1:49 p.m."), "one forty nine p m")
+        XCTAssertEqual(normalize("meet at 9:00 AM"), "meet at nine o'clock a m")
+        XCTAssertEqual(normalize("3:05 pm"), "three oh five p m")
+    }
+
+    func testMultipleFormsInOneSentence() {
+        XCTAssertEqual(
+            normalize("At 1:49 PM on the 13th I scored 3.14 in 26 tries."),
+            "At one forty nine p m on the thirteenth I scored three point one four in twenty six tries.")
+    }
+
+    // MARK: - Ambiguous / structured forms left unchanged
+
+    func testVersionStringUnchanged() {
+        XCTAssertEqual(normalize("Install 1.2.3 now"), "Install 1.2.3 now")
+    }
+
+    func testGroupedNumberUnchanged() {
+        XCTAssertEqual(normalize("It costs 1,234 dollars"), "It costs 1,234 dollars")
+    }
+
+    func testEmbeddedDigitsUnchanged() {
+        XCTAssertEqual(normalize("word26 and 26word"), "word26 and 26word")
+    }
+
+    func testLooseColonNumberUnchanged() {
+        // No meridiem → not a time we rewrite.
+        XCTAssertEqual(normalize("ratio 1:49 here"), "ratio 1:49 here")
+    }
+
+    func testInvalidTimeUnchanged() {
+        // Minute out of range → left as-is.
+        XCTAssertEqual(normalize("1:99 PM"), "1:99 PM")
+    }
+
+    func testTwentyFourHourTimeUnchanged() {
+        XCTAssertEqual(normalize("13:49"), "13:49")
+        XCTAssertEqual(normalize("13:49 PM"), "13:49 PM")
+    }
+
+    func testInvalidOrdinalSuffixUnchanged() {
+        // `1th`/`2th` aren't grammatical ordinals → not rewritten.
+        XCTAssertEqual(normalize("1th"), "1th")
+        XCTAssertEqual(normalize("2th"), "2th")
+    }
+
+    // MARK: - Boundary details
+
+    func testTrailingSentencePunctuationPreserved() {
+        XCTAssertEqual(normalize("I scored 26."), "I scored twenty six.")
+        XCTAssertEqual(normalize("pi is 3.14, roughly"), "pi is three point one four, roughly")
+    }
+
+    func testDecimalNotConfusedWithVersionPrefix() {
+        // `3.14` inside `3.14.2` (version-like) must stay untouched.
+        XCTAssertEqual(normalize("v3.14.2"), "v3.14.2")
+    }
+
+    func testNoDigitsIsUnchanged() {
+        XCTAssertEqual(normalize("Hello world"), "Hello world")
+    }
+
+    func testEmptyStringIsUnchanged() {
+        XCTAssertEqual(normalize(""), "")
+    }
+}


### PR DESCRIPTION
Closes #711. Refactors the #710 letter-name initialism logic into a shared module so both KokoroAne and (in a follow-up) StyleTTS2 English frontends can reuse it.

Per maintainer guidance on #711, both utilities now live under `Sources/FluidAudio/TTS/Shared/` (alongside `LexiconAssetCache`, already shared by both frontends).

## New shared modules

**`EnglishTextNormalizer` (#711)** — a conservative pre-tokenization pass for the English raw-text path. Raw chat text carries no caller annotation, so it rewrites only *strict standalone* numeric forms and leaves anything ambiguous/structured alone. Reuses `SayAsInterpreter` for the actual spelling.

| Input | Output |
|-------|--------|
| `I am 26 years old.` | `I am twenty six years old.` |
| `Today is June 13th.` | `Today is June thirteenth.` |
| `The score is 3.14.` | `The score is three point one four.` |
| `The current time is 1:49 PM.` | `The current time is one forty nine p m.` |
| `Agent 007` | `Agent zero zero seven` |

Left **unchanged**: version strings (`1.2.3`), grouped numbers (`1,234`), embedded digits (`word26`, `26word`), loose colon numbers without a meridiem (`1:49`), invalid times (`1:99 PM`), and 24-hour forms (`13:49`).

**`EnglishInitialisms` (#710)** — the `AI`/`US` override set, the strict all-caps candidate check, and the lexicon-driven letter-name spell-out, extracted from `KokoroAneEnglishPhonemizer`. Now parameterized over a per-letter lookup + render closure so each frontend supplies its own lexicon and IPA rendering; KokoroAne delegates to it (behavior unchanged from #710).

## Wiring

`KokoroAneManager.phonemize(text:)` runs `EnglishTextNormalizer.normalize` before tokenization. `KokoroAneEnglishPhonemizer` delegates initialism handling to `EnglishInitialisms`.

**StyleTTS2 is unchanged here** — structure-only, as requested. A follow-up issue (#716) tracks wiring the StyleTTS2 English frontend to both shared utilities.

## Tests

- `EnglishTextNormalizerTests` — supported forms + negative cases for every ambiguous/structured shape above.
- `EnglishInitialismsTests` — candidate boundaries (length 2–5, strict ASCII all-caps) and spell mechanics (custom render/separator, nil on missing letter).
- `KokoroAneEnglishPhonemizerTests` — updated for the delegated path.

Builds cleanly; swift-format passes. XCTest can't run in my local env (CommandLineTools only, no full Xcode), so regex boundaries and `SayAsInterpreter` spellings were verified out-of-band against the real lexicon and assertions hand-traced.
