### PR TITLE
feat(tts): auto-chunk long text in KokoroAne high-level synthesize (#712)

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -15,7 +15,11 @@ import Foundation
 ///   * One default voice per variant (`af_heart` for English, `zf_001` for
 ///     Mandarin); additional voices download on demand via ``setDefaultVoice``
 ///     / `voice:` / `initialize(preloadVoices:)`.
-///   * IPA input capped at 512 tokens — chunk longer prompts upstream.
+///   * IPA input capped at 512 tokens. The high-level text API
+///     (``synthesize(text:voice:speed:)`` / ``synthesizeDetailed(text:voice:speed:)``)
+///     auto-chunks longer prompts at whitespace / pause punctuation (#712);
+///     the low-level ``synthesizeFromPhonemes(_:voice:speed:)`` stays strict
+///     and throws ``KokoroAneError/phonemeSequenceTooLong(_:)`` past the cap.
 ///   * Loads from HF path `kokoro-82m-coreml/ANE/` (English) or
 ///     `ANE-zh/` (Mandarin).
 ///
@@ -176,7 +180,52 @@ public actor KokoroAneManager {
         speed: Float = KokoroAneConstants.defaultSpeed
     ) async throws -> KokoroAneSynthesisResult {
         let resolved = try await phonemes(for: text)
-        return try await runChain(phonemes: resolved, voice: voice, speed: speed)
+
+        // High-level text API owns chunking: if the resolved phoneme string
+        // exceeds the chain's input cap, split it at whitespace / pause
+        // punctuation and synthesize each chunk, instead of throwing and
+        // making every caller write its own chunker (issue #712). The
+        // low-level `synthesizeFromPhonemes(_:)` stays strict. Chunking runs
+        // on the resolved phonemes, so normalization / G2P already happened.
+        let chunks = PhonemeChunker.chunk(resolved, maxLength: KokoroAneConstants.maxPhonemeLength)
+        guard chunks.count > 1 else {
+            return try await runChain(phonemes: resolved, voice: voice, speed: speed)
+        }
+        return try await synthesizeChunks(chunks, voice: voice, speed: speed)
+    }
+
+    /// Synthesize each chunk and concatenate into one result. Samples are
+    /// joined in order; per-stage timings and token/frame counts are summed.
+    /// Per-variant audio normalization is unchanged — it runs once over the
+    /// concatenated samples at WAV conversion (``wavData(from:)``), so levels
+    /// stay consistent across the join rather than being normalized per chunk.
+    private func synthesizeChunks(
+        _ chunks: [String],
+        voice: String?,
+        speed: Float
+    ) async throws -> KokoroAneSynthesisResult {
+        var samples: [Float] = []
+        var sampleRate = KokoroAneConstants.sampleRate
+        var encoderTokens = 0
+        var acousticFrames = 0
+        var timings = KokoroAneStageTimings()
+
+        for chunk in chunks {
+            let result = try await runChain(phonemes: chunk, voice: voice, speed: speed)
+            samples.append(contentsOf: result.samples)
+            sampleRate = result.sampleRate
+            encoderTokens += result.encoderTokens
+            acousticFrames += result.acousticFrames
+            timings.add(result.timings)
+        }
+
+        return KokoroAneSynthesisResult(
+            samples: samples,
+            sampleRate: sampleRate,
+            encoderTokens: encoderTokens,
+            acousticFrames: acousticFrames,
+            timings: timings
+        )
     }
 
     /// Resolve the exact phoneme string ``synthesize(text:voice:speed:)``

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer+Types.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer+Types.swift
@@ -16,6 +16,18 @@ public struct KokoroAneStageTimings: Sendable, Equatable {
     }
 
     public init() {}
+
+    /// Accumulate another call's per-stage timings into this one — used when
+    /// a long prompt is synthesized in several chunks (issue #712).
+    mutating func add(_ other: KokoroAneStageTimings) {
+        albert += other.albert
+        postAlbert += other.postAlbert
+        alignment += other.alignment
+        prosody += other.prosody
+        noise += other.noise
+        vocoder += other.vocoder
+        tail += other.tail
+    }
 }
 
 /// Detailed result of a `KokoroAneManager.synthesizeDetailed` call.

--- a/Sources/FluidAudio/TTS/Shared/PhonemeChunker.swift
+++ b/Sources/FluidAudio/TTS/Shared/PhonemeChunker.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Splits a phoneme / IPA string into chunks that each fit a model's input
+/// cap, preferring to break at whitespace or pause punctuation so words and
+/// prosody cues stay intact.
+///
+/// Frontend-agnostic — both ``KokoroAneManager`` and (in a follow-up) the
+/// StyleTTS2 high-level text API can share it so long multi-sentence input
+/// is handled by the manager instead of every downstream caller writing its
+/// own chunker (issue #712).
+///
+/// Chunking operates on the already-resolved phoneme string, so it runs
+/// *after* text normalization / G2P — decimals, abbreviations, and quote
+/// delimiters are never split at the raw-text layer.
+enum PhonemeChunker {
+
+    /// Pause / prosody punctuation that marks a natural break point. These
+    /// match the tokens TTS vocabularies encode as their own pause cues, so
+    /// breaking right after one keeps clause boundaries with the preceding
+    /// chunk.
+    static let defaultBoundaryPunctuation: Set<Character> = [
+        ",", ".", ";", ":", "!", "?", "…", "—",
+    ]
+
+    /// Split `phonemes` into chunks of at most `maxLength` characters each.
+    ///
+    /// Each break is taken at the latest whitespace or pause-punctuation
+    /// boundary within the `maxLength` window, so chunks stay as full as
+    /// possible without splitting a word and punctuation stays attached to
+    /// the preceding chunk. A run longer than `maxLength` with no boundary
+    /// is hard-split at the cap (rare for real phoneme strings). Leading and
+    /// trailing whitespace is trimmed from every chunk.
+    ///
+    /// - Returns: `[phonemes]` (trimmed) when the input already fits,
+    ///   `[]` for blank input, and otherwise the ordered chunks. Length is
+    ///   counted in `Character`s to match the cap TTS vocabularies enforce.
+    static func chunk(
+        _ phonemes: String,
+        maxLength: Int,
+        boundaryPunctuation: Set<Character> = defaultBoundaryPunctuation
+    ) -> [String] {
+        precondition(maxLength > 0, "maxLength must be positive")
+
+        let characters = Array(phonemes)
+        let count = characters.count
+        if count == 0 { return [] }
+
+        // Fast path: already within the cap (the common case).
+        if count <= maxLength {
+            let trimmed = phonemes.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? [] : [trimmed]
+        }
+
+        func isBoundary(_ character: Character) -> Bool {
+            character.isWhitespace || boundaryPunctuation.contains(character)
+        }
+
+        var chunks: [String] = []
+        var start = 0
+
+        // Skip any leading whitespace so the first window is fully usable.
+        while start < count, characters[start].isWhitespace { start += 1 }
+
+        while count - start > maxLength {
+            let windowEnd = start + maxLength  // exclusive upper bound
+
+            // Latest boundary in [start, windowEnd): break right after it.
+            var breakAt = -1
+            var index = windowEnd - 1
+            while index > start {
+                if isBoundary(characters[index]) {
+                    breakAt = index + 1
+                    break
+                }
+                index -= 1
+            }
+            // No usable boundary in the window → hard-split at the cap.
+            if breakAt <= start { breakAt = windowEnd }
+
+            appendChunk(characters[start..<breakAt], to: &chunks)
+
+            start = breakAt
+            while start < count, characters[start].isWhitespace { start += 1 }
+        }
+
+        if start < count {
+            appendChunk(characters[start..<count], to: &chunks)
+        }
+        return chunks
+    }
+
+    private static func appendChunk(_ slice: ArraySlice<Character>, to chunks: inout [String]) {
+        let text = String(slice).trimmingCharacters(in: .whitespacesAndNewlines)
+        if !text.isEmpty { chunks.append(text) }
+    }
+}

--- a/Tests/FluidAudioTests/TTS/Shared/PhonemeChunkerTests.swift
+++ b/Tests/FluidAudioTests/TTS/Shared/PhonemeChunkerTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Tests for the shared phoneme-string chunker (issue #712): long input is
+/// split at whitespace / pause punctuation into chunks under the cap, with
+/// words kept intact and punctuation attached to the preceding chunk.
+final class PhonemeChunkerTests: XCTestCase {
+
+    private func chunk(_ text: String, _ maxLength: Int) -> [String] {
+        PhonemeChunker.chunk(text, maxLength: maxLength)
+    }
+
+    // MARK: - Fast path
+
+    func testWithinCapReturnsSingleTrimmedChunk() {
+        XCTAssertEqual(chunk("hello world", 100), ["hello world"])
+        XCTAssertEqual(chunk("  hello world  ", 100), ["hello world"])
+    }
+
+    func testBlankInputReturnsEmpty() {
+        XCTAssertEqual(chunk("", 100), [])
+        XCTAssertEqual(chunk("   ", 100), [])
+    }
+
+    func testExactlyAtCapIsNotSplit() {
+        let text = String(repeating: "a", count: 10)
+        XCTAssertEqual(chunk(text, 10), [text])
+    }
+
+    // MARK: - Splitting
+
+    func testSplitsAtWhitespaceWithoutBreakingWords() {
+        // 4 words of 5 chars + spaces = "aaaaa bbbbb ccccc ddddd" (23 chars).
+        let text = "aaaaa bbbbb ccccc ddddd"
+        let chunks = chunk(text, 12)
+        for piece in chunks {
+            XCTAssertLessThanOrEqual(piece.count, 12)
+        }
+        // No word is split across chunks.
+        XCTAssertEqual(chunks.joined(separator: " "), text)
+    }
+
+    func testEveryChunkWithinCap() {
+        let words = (0..<60).map { "w\($0)" }.joined(separator: " ")
+        let chunks = chunk(words, 20)
+        XCTAssertGreaterThan(chunks.count, 1)
+        for piece in chunks {
+            XCTAssertLessThanOrEqual(piece.count, 20)
+            XCTAssertFalse(piece.hasPrefix(" "))
+            XCTAssertFalse(piece.hasSuffix(" "))
+        }
+    }
+
+    func testPrefersLatestBoundaryToFillChunks() {
+        // "one two three four" — cap 9 should pack "one two" (7), not stop at "one".
+        let chunks = chunk("one two three four", 9)
+        XCTAssertEqual(chunks.first, "one two")
+    }
+
+    func testPunctuationStaysWithPrecedingChunk() {
+        // Break should land after the comma's following space, keeping the
+        // comma attached to the first clause.
+        let chunks = chunk("hello there, friend over yonder", 14)
+        XCTAssertEqual(chunks.first, "hello there,")
+    }
+
+    func testHardSplitsWordLongerThanCap() {
+        // A single 25-char run with no boundary is split at the cap.
+        let text = String(repeating: "x", count: 25)
+        let chunks = chunk(text, 10)
+        XCTAssertEqual(chunks, ["xxxxxxxxxx", "xxxxxxxxxx", "xxxxx"])
+    }
+
+    func testReassemblyPreservesAllNonWhitespaceContent() {
+        let text = "the quick brown fox jumps over the lazy dog repeatedly today"
+        let chunks = chunk(text, 13)
+        let original = text.split(separator: " ").joined()
+        let roundTrip = chunks.joined().replacingOccurrences(of: " ", with: "")
+        XCTAssertEqual(roundTrip, original)
+    }
+}


### PR DESCRIPTION
Closes #712.

The high-level KokoroAne **text** API now handles moderately long input itself instead of throwing `phonemeSequenceTooLong` and making each downstream caller (chat assistant, reading app) reimplement its own chunker.

## Shared, frontend-agnostic chunker

New `PhonemeChunker` under `Sources/FluidAudio/TTS/Shared/` (alongside the `EnglishTextNormalizer` / `EnglishInitialisms` shared utils from #715). It's pure string logic, so **StyleTTS2 can adopt it** for its own long-text path in a follow-up — that's why it lives in `Shared/` rather than inside KokoroAne.

- Splits at the **latest** whitespace / pause-punctuation boundary within the cap window → chunks stay as full as possible without splitting a word.
- Punctuation stays attached to the preceding chunk (clause boundaries kept as prosody cues).
- A boundary-less run longer than the cap is hard-split at the cap (rare for real phoneme strings).
- Returns the input unchanged when it already fits; length counted in `Character`s to match the cap TTS vocabs enforce.

## KokoroAne wiring

- `synthesizeDetailed(text:)` resolves the full phoneme string, then chunks with `maxLength: KokoroAneConstants.maxPhonemeLength` (510). One chunk → existing path untouched; multiple chunks → synthesize each and concatenate.
- **Chunking runs after normalization / G2P**, so decimals, abbreviations, and quote delimiters are never split at the raw-text layer (per the issue's constraint).
- Sample concatenation joins in order; per-stage timings and token/frame counts are summed.
- **Per-variant audio normalization is preserved** — it still runs once over the *concatenated* samples at WAV conversion (`wavData(from:)`), so English/Mandarin peak-normalization stays consistent across the join and Japanese keeps its native level. No per-chunk normalization that would cause level jumps.
- `synthesizeFromPhonemes(_:)` (low-level IPA API) **stays strict** and throws past the cap — unchanged contract, as the issue requested.

## Tests

`PhonemeChunkerTests` — fast path (within cap / blank / exactly at cap), whitespace splitting without breaking words, latest-boundary fill preference, punctuation attachment, per-chunk cap invariant, hard-split of an over-long run, and content round-trip.

Builds cleanly; swift-format passes. XCTest can't run in my local env (CommandLineTools only, no full Xcode); the chunker outputs were verified out-of-band against an exact algorithm replica and assertions hand-traced.