### PR TITLE
feat(tts/styletts2): adopt shared number normalization + initialisms (#716)

### DIFF
--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/Tokenizer/StyleTTS2Phonemizer.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/Tokenizer/StyleTTS2Phonemizer.swift
@@ -8,12 +8,19 @@ import Foundation
 /// vocabulary at load time, so anything that comes back is directly
 /// encodable by `StyleTTS2TextCleaner`.
 ///
-/// Resolution order:
-///   1. case-sensitive lexicon hit on the original spelling (proper nouns,
-///      abbreviations like `AI`, `NATO`)
-///   2. case-sensitive lexicon hit on the normalized lower-case form
-///   3. lower-case lexicon hit
-///   4. BART grapheme-to-phoneme CoreML model
+/// Raw text is first passed through `EnglishTextNormalizer` (strict
+/// standalone numbers / ordinals / decimals / 12-hour times → words, #711).
+///
+/// Per-word resolution order:
+///   1. letter-name overrides for bundled entries that don't read as letter
+///      names (`AI`, `US`) — spelled from per-letter entries (#710)
+///   2. case-sensitive lexicon hit on the original spelling (proper nouns,
+///      abbreviations like `NATO`)
+///   3. case-sensitive lexicon hit on the normalized lower-case form
+///   4. lower-case lexicon hit
+///   5. strict ASCII all-caps initialisms (`FBI`, `ATP`) spelled as letter
+///      names after a full lexicon miss (#710)
+///   6. BART grapheme-to-phoneme CoreML model
 ///      (`G2PEncoder.mlmodelc` / `G2PDecoder.mlmodelc`, fetched from the
 ///      kokoro repo) — last resort for OOV words.
 ///
@@ -62,7 +69,13 @@ public struct StyleTTS2Phonemizer: Sendable {
             return ""
         }
 
-        let words = splitWords(trimmed)
+        // Conservative raw-text normalization first (issue #711): strict
+        // standalone numbers, ordinals, decimals, and 12-hour times become
+        // spoken words before tokenization. Ambiguous/structured forms are
+        // left untouched. Shared with KokoroAne via `EnglishTextNormalizer`.
+        let normalized = EnglishTextNormalizer.normalize(trimmed)
+
+        let words = splitWords(normalized)
         var ipaParts: [String] = []
         ipaParts.reserveCapacity(words.count)
 
@@ -82,7 +95,24 @@ public struct StyleTTS2Phonemizer: Sendable {
                 continue
             }
 
-            // 1. Misaki lexicon-cache lookup (Kokoro pattern).
+            // 1. Letter-name overrides for bundled entries that don't read
+            //    as letter names (`AI` → blended, `US` → pronoun shape).
+            //    Spell from the per-letter entries before the lexicon so they
+            //    sound like `A I` / `U S` (issue #710). Lowercase `us`/`ai`
+            //    are untouched — the override is exact-uppercase only.
+            if EnglishInitialisms.letterNameOverrides.contains(word) {
+                if let spelled = spellAsLetterNames(word) {
+                    ipaParts.append(spelled)
+                    anyResolved = true
+                    lexiconHits += 1
+                    continue
+                }
+                logger.notice(
+                    "Letter-name override '\(word)' unspellable (missing per-letter lexicon "
+                        + "entries); falling back to the bundled pronunciation")
+            }
+
+            // 2. Misaki lexicon-cache lookup (Kokoro pattern).
             if let phonemes = lookupLexicon(word: word), !phonemes.isEmpty {
                 ipaParts.append(Self.expandMisakiShorthand(phonemes.joined()))
                 anyResolved = true
@@ -90,7 +120,18 @@ public struct StyleTTS2Phonemizer: Sendable {
                 continue
             }
 
-            // 2. BART G2P CoreML fallback for OOV words (Kokoro's
+            // 3. Strict ASCII all-caps initialisms (`FBI`, `ATP`) spelled as
+            //    letter names after a full lexicon miss, before G2P sounds
+            //    them out as a word (issue #710). Lexicon-backed acronyms
+            //    (`NASA`, `FIFA`) keep their bundled pronunciation above.
+            if EnglishInitialisms.isCandidate(word), let spelled = spellAsLetterNames(word) {
+                ipaParts.append(spelled)
+                anyResolved = true
+                lexiconHits += 1
+                continue
+            }
+
+            // 4. BART G2P CoreML fallback for OOV words (Kokoro's
             //    `G2PEncoder.mlmodelc` + `G2PDecoder.mlmodelc`).
             do {
                 let phonemes = try await G2PModel.shared.phonemize(word: word)
@@ -155,6 +196,22 @@ public struct StyleTTS2Phonemizer: Sendable {
             }
         }
         return out
+    }
+
+    // MARK: - Letter-name initialisms (issue #710)
+
+    /// Spell `word` as a sequence of letter names using the per-letter
+    /// entries in the case-sensitive lexicon (`FBI` → `ˈɛf bˈi ˈaɪ`). The
+    /// single-letter entries carry Misaki shorthand (`I` for /aɪ/), so each
+    /// letter is run through ``expandMisakiShorthand(_:)`` like every other
+    /// lexicon hit. Returns `nil` if any letter is missing so the caller
+    /// falls through rather than emitting a partial word.
+    private func spellAsLetterNames(_ word: String) -> String? {
+        EnglishInitialisms.spell(
+            word,
+            letterTokens: { caseSensitiveWordToPhonemes[$0] },
+            render: { Self.expandMisakiShorthand($0.joined()) }
+        )
     }
 
     // MARK: - Lexicon lookup

--- a/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2PhonemizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2PhonemizerTests.swift
@@ -58,15 +58,16 @@ final class StyleTTS2PhonemizerTests: XCTestCase {
     // MARK: - Case-sensitive precedence
 
     func testCaseSensitiveOriginalSpellingWinsOverLower() async throws {
-        // "AI" exists case-sensitively as a proper noun pronunciation.
-        // The lower-case map has a different (wrong) pronunciation. The
-        // resolver must hit the case-sensitive entry first.
+        // "Read" (past tense, /rɛd/) exists case-sensitively; the lower-case
+        // map has the present tense /riːd/. The resolver must hit the
+        // case-sensitive entry first. (A non-acronym word avoids the #710
+        // initialism path.)
         let phonemizer = StyleTTS2Phonemizer(
-            wordToPhonemes: ["ai": ["a", "i"]],
-            caseSensitiveWordToPhonemes: ["AI": ["e", "ɪ", "a", "ɪ"]]
+            wordToPhonemes: ["read": ["r", "i", "d"]],
+            caseSensitiveWordToPhonemes: ["Read": ["r", "ˈ", "ɛ", "d"]]
         )
-        let phonemes = try await phonemizer.phonemize("AI")
-        XCTAssertEqual(phonemes, "eɪaɪ")
+        let phonemes = try await phonemizer.phonemize("Read")
+        XCTAssertEqual(phonemes, "rˈɛd")
     }
 
     func testCaseSensitiveNormalizedFallback() async throws {
@@ -149,6 +150,85 @@ final class StyleTTS2PhonemizerTests: XCTestCase {
         )
         let phonemes = try await phonemizer.phonemize("foo")
         XCTAssertEqual(phonemes, "foo")
+    }
+
+    // MARK: - Letter-name initialisms (issue #710)
+
+    /// Single-letter entries carry Misaki shorthand (`A`→/eɪ/, `I`→/aɪ/),
+    /// expanded on output like every other lexicon hit; plus the blended
+    /// `AI`/`US` shapes the overrides bypass and a lexicon-backed acronym.
+    private func makeInitialismPhonemizer() -> StyleTTS2Phonemizer {
+        StyleTTS2Phonemizer(
+            wordToPhonemes: ["us": ["ˌ", "ʌ", "s"]],
+            caseSensitiveWordToPhonemes: [
+                "AI": ["e", "ɪ", "a", "ɪ"],
+                "US": ["ˌ", "ʌ", "s"],
+                "A": ["ˈ", "A"],
+                "I": ["ˈ", "I"],
+                "U": ["j", "ˈ", "u"],
+                "S": ["ˈ", "ɛ", "s"],
+                "F": ["ˈ", "ɛ", "f"],
+                "B": ["b", "ˈ", "i"],
+                "NASA": ["n", "ˈ", "a", "s", "ə"],
+            ]
+        )
+    }
+
+    func testAIOverrideSpellsLetterNames() async throws {
+        let phonemes = try await makeInitialismPhonemizer().phonemize("AI")
+        XCTAssertEqual(phonemes, "ˈeɪ ˈaɪ")
+    }
+
+    func testUSOverrideSpellsLetterNamesNotPronoun() async throws {
+        let phonemes = try await makeInitialismPhonemizer().phonemize("US")
+        XCTAssertEqual(phonemes, "jˈu ˈɛs")
+    }
+
+    func testLowercaseUsStaysPronoun() async throws {
+        let phonemes = try await makeInitialismPhonemizer().phonemize("us")
+        XCTAssertEqual(phonemes, "ˌʌs")
+    }
+
+    func testUnknownAllCapsInitialismSpelledAsLetterNames() async throws {
+        // `FBI` misses the lexicon → spelled letter by letter, `I`→/aɪ/.
+        let phonemes = try await makeInitialismPhonemizer().phonemize("FBI")
+        XCTAssertEqual(phonemes, "ˈɛf bˈi ˈaɪ")
+    }
+
+    func testKnownAcronymStaysLexiconBacked() async throws {
+        let phonemes = try await makeInitialismPhonemizer().phonemize("NASA")
+        XCTAssertEqual(phonemes, "nˈasə")
+    }
+
+    func testOverrideFallsBackToLexiconWhenLettersMissing() async throws {
+        // No per-letter entries → override can't spell `AI`, falls through to
+        // the bundled blended shape (logged, never dropped).
+        let phonemizer = StyleTTS2Phonemizer(
+            caseSensitiveWordToPhonemes: ["AI": ["e", "ɪ", "a", "ɪ"]]
+        )
+        let phonemes = try await phonemizer.phonemize("AI")
+        XCTAssertEqual(phonemes, "eɪaɪ")
+    }
+
+    // MARK: - Raw-text number normalization (issue #711)
+
+    func testStandaloneNumberIsNormalizedBeforeLexicon() async throws {
+        // `26` → `twenty six` before tokenization, then each word resolves.
+        let phonemizer = StyleTTS2Phonemizer(
+            wordToPhonemes: ["twenty": ["t"], "six": ["s"]]
+        )
+        let phonemes = try await phonemizer.phonemize("26")
+        XCTAssertEqual(phonemes, "t s")
+    }
+
+    func testEmbeddedDigitsAreNotNormalized() async throws {
+        // `word26` is ambiguous → left intact; reaches G2P/grapheme path as
+        // one token (no "twenty six" split).
+        let phonemizer = StyleTTS2Phonemizer(
+            wordToPhonemes: ["word26": ["w"]]
+        )
+        let phonemes = try await phonemizer.phonemize("word26")
+        XCTAssertEqual(phonemes, "w")
     }
 
     // MARK: - OOV without G2P model raises (only-resolved-token check)


### PR DESCRIPTION
Closes #716.

Wires the StyleTTS2 English phonemizer to the shared utilities from #715, giving it the same raw-text handling KokoroAne already has. No new logic — it reuses `EnglishTextNormalizer` and `EnglishInitialisms` directly.

## Changes to `StyleTTS2Phonemizer`

**Number normalization (#711)** — `EnglishTextNormalizer.normalize` runs on the input before `splitWords`. Standalone numbers/ordinals/decimals/12-hour times become words; ambiguous/structured forms (`1.2.3`, `1,234`, `word26`, loose `1:49`, `1:99 PM`, `13:49`) are left untouched.

**Initialisms (#710)** — folded into the per-word resolution order:
1. `letterNameOverrides` (`AI`/`US`) before the lexicon
2. case-sensitive → normalized → lower lexicon (unchanged)
3. `isCandidate` all-caps spell-out (`FBI`, `ATP`) after a lexicon miss, before G2P
4. BART G2P fallback (unchanged)

The spell-out passes `expandMisakiShorthand` as the `render` closure, so single-letter entries expand correctly (`I` → /aɪ/):

| Input | Output |
|-------|--------|
| `AI` | `ˈeɪ ˈaɪ` |
| `US` | `jˈu ˈɛs` |
| `FBI` | `ˈɛf bˈi ˈaɪ` |
| `us` (lowercase) | `ˌʌs` (pronoun, unchanged) |
| `NASA` | `nˈasə` (lexicon-backed, unchanged) |
| `26` | normalized to `twenty six` before lexicon |

A missing per-letter entry logs and falls through to the bundled pronunciation (e.g. `AI` → blended `eɪaɪ`), never dropping the word.

## Tests

Added initialism + normalization cases to `StyleTTS2PhonemizerTests`, and retargeted the case-sensitive-precedence test off the now-overridden `AI` example onto a non-acronym homograph (`Read`/`read`). All outputs were verified end-to-end through the public `phonemize` API (none of the cases hit G2P).

Builds cleanly; swift-format passes. XCTest can't run in my local env (CommandLineTools only, no full Xcode), so I verified via the public API in a throwaway executable instead.

## Not included

StyleTTS2 long-text chunking (the shared `PhonemeChunker` from #712) is a separate concern and not part of #716 — can be a follow-up if StyleTTS2's high-level API wants the same auto-chunk behavior.