### PR TITLE
feat(tts/styletts2): auto-chunk long text in high-level synthesize (#712)

### DIFF
--- a/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Constants.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Constants.swift
@@ -27,6 +27,13 @@ public enum StyleTTS2Constants {
     /// loader can pick the smallest bucket that fits.
     public static let bucketTokenSizes: [Int] = [64, 128, 256]
 
+    /// Max phoneme-string characters per chunk for the high-level text
+    /// API's auto-chunking (#712). `StyleTTS2TextCleaner.encode` prepends
+    /// one pad token and maps each kept character to at most one token, so
+    /// staying one under the largest bucket keeps the encoded sequence
+    /// within `resolveBucket`'s ceiling without overflowing.
+    public static let maxPhonemeChunkChars: Int = (bucketTokenSizes.max() ?? 256) - 1
+
     // MARK: - Reference-audio mel filterbank
     /// `torchaudio.transforms.MelSpectrogram` argument set used at training
     /// time. Note: the upstream `make_preprocess()` does **not** override

--- a/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Manager.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Manager.swift
@@ -156,11 +156,59 @@ public actor StyleTTS2Manager {
         guard let phonemizer = phonemizer else {
             throw StyleTTS2Error.notInitialized
         }
-        let tokenIds = try await phonemizer.encode(text)
-        return try await synthesize(
-            tokenIds: tokenIds,
+        let ipa = try await phonemizer.phonemize(text)
+
+        // High-level text API owns chunking: if the phonemes won't fit the
+        // largest bert/sampler bucket, split at whitespace / pause
+        // punctuation and synthesize each chunk against the same reference,
+        // instead of throwing `textTooLong` (#712). The low-level `ipa:` and
+        // `tokenIds:` paths stay strict. Chunking runs on the resolved
+        // phonemes, so normalization / G2P already happened.
+        let chunks = PhonemeChunker.chunk(ipa, maxLength: StyleTTS2Constants.maxPhonemeChunkChars)
+        guard chunks.count > 1 else {
+            let tokenIds = StyleTTS2TextCleaner.encode(ipa)
+            return try await synthesize(
+                tokenIds: tokenIds,
+                referenceAudioURL: referenceAudioURL,
+                alpha: alpha, beta: beta, noiseSeed: noiseSeed)
+        }
+        return try await synthesizeChunked(
+            chunks,
             referenceAudioURL: referenceAudioURL,
             alpha: alpha, beta: beta, noiseSeed: noiseSeed)
+    }
+
+    /// Synthesize each phoneme chunk against the *same* reference mel
+    /// (computed once) and concatenate the samples in order. Reusing one mel
+    /// keeps the speaker style consistent across the join and skips repeated
+    /// FFT / mel work.
+    private func synthesizeChunked(
+        _ chunks: [String],
+        referenceAudioURL: URL,
+        alpha: Float,
+        beta: Float,
+        noiseSeed: UInt64
+    ) async throws -> [Float] {
+        guard let melExtractor = melExtractor else {
+            throw StyleTTS2Error.notInitialized
+        }
+        let refSamples = try loadReferenceAudio(url: referenceAudioURL)
+        let (mel, frames) = melExtractor.compute(audio: refSamples)
+        guard frames > 0 else {
+            throw StyleTTS2Error.unsupportedReferenceAudio(
+                "reference audio at \(referenceAudioURL.lastPathComponent) yielded 0 mel frames")
+        }
+
+        var samples: [Float] = []
+        for chunk in chunks {
+            let tokenIds = StyleTTS2TextCleaner.encode(chunk)
+            let chunkSamples = try await synthesize(
+                tokenIds: tokenIds,
+                referenceMel: mel, referenceMelFrames: frames,
+                alpha: alpha, beta: beta, noiseSeed: noiseSeed)
+            samples.append(contentsOf: chunkSamples)
+        }
+        return samples
     }
 
     // MARK: - Synthesis: IPA path (espeak-parity escape hatch)

--- a/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2ChunkingTests.swift
+++ b/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2ChunkingTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Tests for StyleTTS2's high-level long-text auto-chunking (issue #712).
+///
+/// The full `synthesize(text:)` path needs the CoreML chain + reference
+/// audio, so these cover the model-free correctness claim: chunking the
+/// phoneme string at `maxPhonemeChunkChars` keeps every chunk within the
+/// largest bert/sampler bucket once encoded. The chunk-splitting mechanics
+/// themselves live in `PhonemeChunkerTests`.
+final class StyleTTS2ChunkingTests: XCTestCase {
+
+    func testMaxPhonemeChunkCharsStaysUnderLargestBucket() {
+        let largestBucket = StyleTTS2Constants.bucketTokenSizes.max()!
+        // One pad token + one token per kept char ≤ bucket capacity.
+        XCTAssertEqual(StyleTTS2Constants.maxPhonemeChunkChars, largestBucket - 1)
+    }
+
+    func testEveryChunkEncodesWithinTheLargestBucket() {
+        let largestBucket = StyleTTS2Constants.bucketTokenSizes.max()!
+        // A long phoneme-like string of encodable chars + word boundaries.
+        let longPhonemes = Array(repeating: "həlo wɝld", count: 80).joined(separator: " ")
+        XCTAssertGreaterThan(longPhonemes.count, largestBucket)
+
+        let chunks = PhonemeChunker.chunk(
+            longPhonemes, maxLength: StyleTTS2Constants.maxPhonemeChunkChars)
+        XCTAssertGreaterThan(chunks.count, 1)
+
+        for chunk in chunks {
+            XCTAssertLessThanOrEqual(chunk.count, StyleTTS2Constants.maxPhonemeChunkChars)
+            // The encoded sequence (pad + tokens) must fit the bucket so
+            // `resolveBucket` never throws `noBucketAvailable`.
+            let tokenCount = StyleTTS2TextCleaner.encode(chunk).count
+            XCTAssertLessThanOrEqual(tokenCount, largestBucket)
+        }
+    }
+
+    func testShortTextProducesAtMostOneChunk() {
+        let chunks = PhonemeChunker.chunk(
+            "həlo wɝld", maxLength: StyleTTS2Constants.maxPhonemeChunkChars)
+        XCTAssertEqual(chunks, ["həlo wɝld"])
+    }
+}


### PR DESCRIPTION
Adopts the shared `PhonemeChunker` (introduced for KokoroAne in #717) in StyleTTS2's high-level text API, completing the #712 direction for both frontends.

## Why

StyleTTS2 caps at its largest bert/sampler bucket — **256 tokens** (`resolveBucket` throws `noBucketAvailable` above that, and `StyleTTS2Synthesizer` throws `textTooLong` when `realN > chosenT`). So `synthesize(text:referenceAudioURL:)` fails on a normal multi-sentence reply unless the caller pre-chunks. This is a tighter limit than KokoroAne's 510, so it bites sooner.

## Change

- **`StyleTTS2Constants.maxPhonemeChunkChars`** = `bucketTokenSizes.max() - 1` (255). `StyleTTS2TextCleaner.encode` prepends one pad token and maps each kept character to *at most* one token, so a chunk of ≤255 chars always encodes to ≤256 tokens and fits the largest bucket.
- **`synthesize(text:)`** now phonemizes, then `PhonemeChunker.chunk(...)`. Single chunk → existing path untouched. Multiple chunks → `synthesizeChunked`: compute the reference mel **once** and reuse it for every chunk (consistent speaker style across the join, no repeated FFT/mel work), concatenating samples in order.
- Chunking runs on the **resolved phonemes**, so normalization / G2P already happened — nothing is split at the raw-text layer.
- The low-level `ipa:` (espeak escape hatch) and `tokenIds:` paths **stay strict**, mirroring KokoroAne's `synthesizeFromPhonemes`.

## Tests

`StyleTTS2ChunkingTests` — model-free correctness: the char cap stays one under the largest bucket, every chunk of a long string encodes within the bucket (so `resolveBucket` never throws), and short text stays a single chunk. The split mechanics themselves are covered by the existing `PhonemeChunkerTests`; the full audio path needs the CoreML chain + reference audio and isn't unit-testable in CI.

Builds cleanly; swift-format passes.

## Relationship to other PRs

- Uses `PhonemeChunker` from #712/#717 (already merged to `main`).
- Independent of #718 (StyleTTS2 normalization + initialisms, #716) — different methods, no conflict.