### PR TITLE
feat(tts/styletts2): adopt shared text utilities — number normalization, initialisms, long-text chunking (#716, #712)

### DIFF
--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/Tokenizer/StyleTTS2Phonemizer.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/Tokenizer/StyleTTS2Phonemizer.swift
@@ -8,12 +8,19 @@ import Foundation
 /// vocabulary at load time, so anything that comes back is directly
 /// encodable by `StyleTTS2TextCleaner`.
 ///
-/// Resolution order:
-///   1. case-sensitive lexicon hit on the original spelling (proper nouns,
-///      abbreviations like `AI`, `NATO`)
-///   2. case-sensitive lexicon hit on the normalized lower-case form
-///   3. lower-case lexicon hit
-///   4. BART grapheme-to-phoneme CoreML model
+/// Raw text is first passed through `EnglishTextNormalizer` (strict
+/// standalone numbers / ordinals / decimals / 12-hour times → words, #711).
+///
+/// Per-word resolution order:
+///   1. letter-name overrides for bundled entries that don't read as letter
+///      names (`AI`, `US`) — spelled from per-letter entries (#710)
+///   2. case-sensitive lexicon hit on the original spelling (proper nouns,
+///      abbreviations like `NATO`)
+///   3. case-sensitive lexicon hit on the normalized lower-case form
+///   4. lower-case lexicon hit
+///   5. strict ASCII all-caps initialisms (`FBI`, `ATP`) spelled as letter
+///      names after a full lexicon miss (#710)
+///   6. BART grapheme-to-phoneme CoreML model
 ///      (`G2PEncoder.mlmodelc` / `G2PDecoder.mlmodelc`, fetched from the
 ///      kokoro repo) — last resort for OOV words.
 ///
@@ -62,7 +69,13 @@ public struct StyleTTS2Phonemizer: Sendable {
             return ""
         }
 
-        let words = splitWords(trimmed)
+        // Conservative raw-text normalization first (issue #711): strict
+        // standalone numbers, ordinals, decimals, and 12-hour times become
+        // spoken words before tokenization. Ambiguous/structured forms are
+        // left untouched. Shared with KokoroAne via `EnglishTextNormalizer`.
+        let normalized = EnglishTextNormalizer.normalize(trimmed)
+
+        let words = splitWords(normalized)
         var ipaParts: [String] = []
         ipaParts.reserveCapacity(words.count)
 
@@ -82,7 +95,24 @@ public struct StyleTTS2Phonemizer: Sendable {
                 continue
             }
 
-            // 1. Misaki lexicon-cache lookup (Kokoro pattern).
+            // 1. Letter-name overrides for bundled entries that don't read
+            //    as letter names (`AI` → blended, `US` → pronoun shape).
+            //    Spell from the per-letter entries before the lexicon so they
+            //    sound like `A I` / `U S` (issue #710). Lowercase `us`/`ai`
+            //    are untouched — the override is exact-uppercase only.
+            if EnglishInitialisms.letterNameOverrides.contains(word) {
+                if let spelled = spellAsLetterNames(word) {
+                    ipaParts.append(spelled)
+                    anyResolved = true
+                    lexiconHits += 1
+                    continue
+                }
+                logger.notice(
+                    "Letter-name override '\(word)' unspellable (missing per-letter lexicon "
+                        + "entries); falling back to the bundled pronunciation")
+            }
+
+            // 2. Misaki lexicon-cache lookup (Kokoro pattern).
             if let phonemes = lookupLexicon(word: word), !phonemes.isEmpty {
                 ipaParts.append(Self.expandMisakiShorthand(phonemes.joined()))
                 anyResolved = true
@@ -90,7 +120,18 @@ public struct StyleTTS2Phonemizer: Sendable {
                 continue
             }
 
-            // 2. BART G2P CoreML fallback for OOV words (Kokoro's
+            // 3. Strict ASCII all-caps initialisms (`FBI`, `ATP`) spelled as
+            //    letter names after a full lexicon miss, before G2P sounds
+            //    them out as a word (issue #710). Lexicon-backed acronyms
+            //    (`NASA`, `FIFA`) keep their bundled pronunciation above.
+            if EnglishInitialisms.isCandidate(word), let spelled = spellAsLetterNames(word) {
+                ipaParts.append(spelled)
+                anyResolved = true
+                lexiconHits += 1
+                continue
+            }
+
+            // 4. BART G2P CoreML fallback for OOV words (Kokoro's
             //    `G2PEncoder.mlmodelc` + `G2PDecoder.mlmodelc`).
             do {
                 let phonemes = try await G2PModel.shared.phonemize(word: word)
@@ -155,6 +196,22 @@ public struct StyleTTS2Phonemizer: Sendable {
             }
         }
         return out
+    }
+
+    // MARK: - Letter-name initialisms (issue #710)
+
+    /// Spell `word` as a sequence of letter names using the per-letter
+    /// entries in the case-sensitive lexicon (`FBI` → `ˈɛf bˈi ˈaɪ`). The
+    /// single-letter entries carry Misaki shorthand (`I` for /aɪ/), so each
+    /// letter is run through ``expandMisakiShorthand(_:)`` like every other
+    /// lexicon hit. Returns `nil` if any letter is missing so the caller
+    /// falls through rather than emitting a partial word.
+    private func spellAsLetterNames(_ word: String) -> String? {
+        EnglishInitialisms.spell(
+            word,
+            letterTokens: { caseSensitiveWordToPhonemes[$0] },
+            render: { Self.expandMisakiShorthand($0.joined()) }
+        )
     }
 
     // MARK: - Lexicon lookup

--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/Tokenizer/StyleTTS2Phonemizer.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/Tokenizer/StyleTTS2Phonemizer.swift
@@ -100,13 +100,15 @@ public struct StyleTTS2Phonemizer: Sendable {
             //    Spell from the per-letter entries before the lexicon so they
             //    sound like `A I` / `U S` (issue #710). Lowercase `us`/`ai`
             //    are untouched — the override is exact-uppercase only.
+            if EnglishInitialisms.letterNameOverrides.contains(word),
+                let spelled = spellAsLetterNames(word)
+            {
+                ipaParts.append(spelled)
+                anyResolved = true
+                lexiconHits += 1
+                continue
+            }
             if EnglishInitialisms.letterNameOverrides.contains(word) {
-                if let spelled = spellAsLetterNames(word) {
-                    ipaParts.append(spelled)
-                    anyResolved = true
-                    lexiconHits += 1
-                    continue
-                }
                 logger.notice(
                     "Letter-name override '\(word)' unspellable (missing per-letter lexicon "
                         + "entries); falling back to the bundled pronunciation")

--- a/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Constants.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Constants.swift
@@ -27,6 +27,13 @@ public enum StyleTTS2Constants {
     /// loader can pick the smallest bucket that fits.
     public static let bucketTokenSizes: [Int] = [64, 128, 256]
 
+    /// Max phoneme-string characters per chunk for the high-level text
+    /// API's auto-chunking (#712). `StyleTTS2TextCleaner.encode` prepends
+    /// one pad token and maps each kept character to at most one token, so
+    /// staying one under the largest bucket keeps the encoded sequence
+    /// within `resolveBucket`'s ceiling without overflowing.
+    public static let maxPhonemeChunkChars: Int = (bucketTokenSizes.max() ?? 256) - 1
+
     // MARK: - Reference-audio mel filterbank
     /// `torchaudio.transforms.MelSpectrogram` argument set used at training
     /// time. Note: the upstream `make_preprocess()` does **not** override

--- a/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Manager.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/StyleTTS2Manager.swift
@@ -156,11 +156,59 @@ public actor StyleTTS2Manager {
         guard let phonemizer = phonemizer else {
             throw StyleTTS2Error.notInitialized
         }
-        let tokenIds = try await phonemizer.encode(text)
-        return try await synthesize(
-            tokenIds: tokenIds,
+        let ipa = try await phonemizer.phonemize(text)
+
+        // High-level text API owns chunking: if the phonemes won't fit the
+        // largest bert/sampler bucket, split at whitespace / pause
+        // punctuation and synthesize each chunk against the same reference,
+        // instead of throwing `textTooLong` (#712). The low-level `ipa:` and
+        // `tokenIds:` paths stay strict. Chunking runs on the resolved
+        // phonemes, so normalization / G2P already happened.
+        let chunks = PhonemeChunker.chunk(ipa, maxLength: StyleTTS2Constants.maxPhonemeChunkChars)
+        guard chunks.count > 1 else {
+            let tokenIds = StyleTTS2TextCleaner.encode(ipa)
+            return try await synthesize(
+                tokenIds: tokenIds,
+                referenceAudioURL: referenceAudioURL,
+                alpha: alpha, beta: beta, noiseSeed: noiseSeed)
+        }
+        return try await synthesizeChunked(
+            chunks,
             referenceAudioURL: referenceAudioURL,
             alpha: alpha, beta: beta, noiseSeed: noiseSeed)
+    }
+
+    /// Synthesize each phoneme chunk against the *same* reference mel
+    /// (computed once) and concatenate the samples in order. Reusing one mel
+    /// keeps the speaker style consistent across the join and skips repeated
+    /// FFT / mel work.
+    private func synthesizeChunked(
+        _ chunks: [String],
+        referenceAudioURL: URL,
+        alpha: Float,
+        beta: Float,
+        noiseSeed: UInt64
+    ) async throws -> [Float] {
+        guard let melExtractor = melExtractor else {
+            throw StyleTTS2Error.notInitialized
+        }
+        let refSamples = try loadReferenceAudio(url: referenceAudioURL)
+        let (mel, frames) = melExtractor.compute(audio: refSamples)
+        guard frames > 0 else {
+            throw StyleTTS2Error.unsupportedReferenceAudio(
+                "reference audio at \(referenceAudioURL.lastPathComponent) yielded 0 mel frames")
+        }
+
+        var samples: [Float] = []
+        for chunk in chunks {
+            let tokenIds = StyleTTS2TextCleaner.encode(chunk)
+            let chunkSamples = try await synthesize(
+                tokenIds: tokenIds,
+                referenceMel: mel, referenceMelFrames: frames,
+                alpha: alpha, beta: beta, noiseSeed: noiseSeed)
+            samples.append(contentsOf: chunkSamples)
+        }
+        return samples
     }
 
     // MARK: - Synthesis: IPA path (espeak-parity escape hatch)

--- a/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2ChunkingTests.swift
+++ b/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2ChunkingTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Tests for StyleTTS2's high-level long-text auto-chunking (issue #712).
+///
+/// The full `synthesize(text:)` path needs the CoreML chain + reference
+/// audio, so these cover the model-free correctness claim: chunking the
+/// phoneme string at `maxPhonemeChunkChars` keeps every chunk within the
+/// largest bert/sampler bucket once encoded. The chunk-splitting mechanics
+/// themselves live in `PhonemeChunkerTests`.
+final class StyleTTS2ChunkingTests: XCTestCase {
+
+    func testMaxPhonemeChunkCharsStaysUnderLargestBucket() {
+        let largestBucket = StyleTTS2Constants.bucketTokenSizes.max()!
+        // One pad token + one token per kept char ≤ bucket capacity.
+        XCTAssertEqual(StyleTTS2Constants.maxPhonemeChunkChars, largestBucket - 1)
+    }
+
+    func testEveryChunkEncodesWithinTheLargestBucket() {
+        let largestBucket = StyleTTS2Constants.bucketTokenSizes.max()!
+        // A long phoneme-like string of encodable chars + word boundaries.
+        let longPhonemes = Array(repeating: "həlo wɝld", count: 80).joined(separator: " ")
+        XCTAssertGreaterThan(longPhonemes.count, largestBucket)
+
+        let chunks = PhonemeChunker.chunk(
+            longPhonemes, maxLength: StyleTTS2Constants.maxPhonemeChunkChars)
+        XCTAssertGreaterThan(chunks.count, 1)
+
+        for chunk in chunks {
+            XCTAssertLessThanOrEqual(chunk.count, StyleTTS2Constants.maxPhonemeChunkChars)
+            // The encoded sequence (pad + tokens) must fit the bucket so
+            // `resolveBucket` never throws `noBucketAvailable`.
+            let tokenCount = StyleTTS2TextCleaner.encode(chunk).count
+            XCTAssertLessThanOrEqual(tokenCount, largestBucket)
+        }
+    }
+
+    func testShortTextProducesAtMostOneChunk() {
+        let chunks = PhonemeChunker.chunk(
+            "həlo wɝld", maxLength: StyleTTS2Constants.maxPhonemeChunkChars)
+        XCTAssertEqual(chunks, ["həlo wɝld"])
+    }
+}

--- a/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2PhonemizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/StyleTTS2/StyleTTS2PhonemizerTests.swift
@@ -58,15 +58,16 @@ final class StyleTTS2PhonemizerTests: XCTestCase {
     // MARK: - Case-sensitive precedence
 
     func testCaseSensitiveOriginalSpellingWinsOverLower() async throws {
-        // "AI" exists case-sensitively as a proper noun pronunciation.
-        // The lower-case map has a different (wrong) pronunciation. The
-        // resolver must hit the case-sensitive entry first.
+        // "Read" (past tense, /rɛd/) exists case-sensitively; the lower-case
+        // map has the present tense /riːd/. The resolver must hit the
+        // case-sensitive entry first. (A non-acronym word avoids the #710
+        // initialism path.)
         let phonemizer = StyleTTS2Phonemizer(
-            wordToPhonemes: ["ai": ["a", "i"]],
-            caseSensitiveWordToPhonemes: ["AI": ["e", "ɪ", "a", "ɪ"]]
+            wordToPhonemes: ["read": ["r", "i", "d"]],
+            caseSensitiveWordToPhonemes: ["Read": ["r", "ˈ", "ɛ", "d"]]
         )
-        let phonemes = try await phonemizer.phonemize("AI")
-        XCTAssertEqual(phonemes, "eɪaɪ")
+        let phonemes = try await phonemizer.phonemize("Read")
+        XCTAssertEqual(phonemes, "rˈɛd")
     }
 
     func testCaseSensitiveNormalizedFallback() async throws {
@@ -149,6 +150,85 @@ final class StyleTTS2PhonemizerTests: XCTestCase {
         )
         let phonemes = try await phonemizer.phonemize("foo")
         XCTAssertEqual(phonemes, "foo")
+    }
+
+    // MARK: - Letter-name initialisms (issue #710)
+
+    /// Single-letter entries carry Misaki shorthand (`A`→/eɪ/, `I`→/aɪ/),
+    /// expanded on output like every other lexicon hit; plus the blended
+    /// `AI`/`US` shapes the overrides bypass and a lexicon-backed acronym.
+    private func makeInitialismPhonemizer() -> StyleTTS2Phonemizer {
+        StyleTTS2Phonemizer(
+            wordToPhonemes: ["us": ["ˌ", "ʌ", "s"]],
+            caseSensitiveWordToPhonemes: [
+                "AI": ["e", "ɪ", "a", "ɪ"],
+                "US": ["ˌ", "ʌ", "s"],
+                "A": ["ˈ", "A"],
+                "I": ["ˈ", "I"],
+                "U": ["j", "ˈ", "u"],
+                "S": ["ˈ", "ɛ", "s"],
+                "F": ["ˈ", "ɛ", "f"],
+                "B": ["b", "ˈ", "i"],
+                "NASA": ["n", "ˈ", "a", "s", "ə"],
+            ]
+        )
+    }
+
+    func testAIOverrideSpellsLetterNames() async throws {
+        let phonemes = try await makeInitialismPhonemizer().phonemize("AI")
+        XCTAssertEqual(phonemes, "ˈeɪ ˈaɪ")
+    }
+
+    func testUSOverrideSpellsLetterNamesNotPronoun() async throws {
+        let phonemes = try await makeInitialismPhonemizer().phonemize("US")
+        XCTAssertEqual(phonemes, "jˈu ˈɛs")
+    }
+
+    func testLowercaseUsStaysPronoun() async throws {
+        let phonemes = try await makeInitialismPhonemizer().phonemize("us")
+        XCTAssertEqual(phonemes, "ˌʌs")
+    }
+
+    func testUnknownAllCapsInitialismSpelledAsLetterNames() async throws {
+        // `FBI` misses the lexicon → spelled letter by letter, `I`→/aɪ/.
+        let phonemes = try await makeInitialismPhonemizer().phonemize("FBI")
+        XCTAssertEqual(phonemes, "ˈɛf bˈi ˈaɪ")
+    }
+
+    func testKnownAcronymStaysLexiconBacked() async throws {
+        let phonemes = try await makeInitialismPhonemizer().phonemize("NASA")
+        XCTAssertEqual(phonemes, "nˈasə")
+    }
+
+    func testOverrideFallsBackToLexiconWhenLettersMissing() async throws {
+        // No per-letter entries → override can't spell `AI`, falls through to
+        // the bundled blended shape (logged, never dropped).
+        let phonemizer = StyleTTS2Phonemizer(
+            caseSensitiveWordToPhonemes: ["AI": ["e", "ɪ", "a", "ɪ"]]
+        )
+        let phonemes = try await phonemizer.phonemize("AI")
+        XCTAssertEqual(phonemes, "eɪaɪ")
+    }
+
+    // MARK: - Raw-text number normalization (issue #711)
+
+    func testStandaloneNumberIsNormalizedBeforeLexicon() async throws {
+        // `26` → `twenty six` before tokenization, then each word resolves.
+        let phonemizer = StyleTTS2Phonemizer(
+            wordToPhonemes: ["twenty": ["t"], "six": ["s"]]
+        )
+        let phonemes = try await phonemizer.phonemize("26")
+        XCTAssertEqual(phonemes, "t s")
+    }
+
+    func testEmbeddedDigitsAreNotNormalized() async throws {
+        // `word26` is ambiguous → left intact; reaches G2P/grapheme path as
+        // one token (no "twenty six" split).
+        let phonemizer = StyleTTS2Phonemizer(
+            wordToPhonemes: ["word26": ["w"]]
+        )
+        let phonemes = try await phonemizer.phonemize("word26")
+        XCTAssertEqual(phonemes, "w")
     }
 
     // MARK: - OOV without G2P model raises (only-resolved-token check)


### PR DESCRIPTION
Brings the StyleTTS2 English frontend up to parity with KokoroAne by adopting the shared TTS text utilities. Supersedes #718 and #719 (combined into one PR per review preference).

Two independent, complementary changes:

## 1. Number normalization + initialisms in the phonemizer (#716)

`StyleTTS2Phonemizer` now reuses the shared utilities from #715:

- **`EnglishTextNormalizer`** runs before tokenization — standalone numbers/ordinals/decimals/12-hour times → words (`26` → `twenty six`, `3.14` → `three point one four`, `1:49 PM` → `one forty nine p m`); ambiguous/structured forms (`1.2.3`, `1,234`, `word26`, loose `1:49`, …) left untouched.
- **`EnglishInitialisms`** in the per-word order: `AI`/`US` overrides before the lexicon, all-caps spell-out (`FBI`, `ATP`) after a lexicon miss before G2P. The spell-out passes `expandMisakiShorthand` as the render closure so single-letter entries expand correctly (`I` → /aɪ/):

| Input | Output |
|-------|--------|
| `AI` | `ˈeɪ ˈaɪ` |
| `US` | `jˈu ˈɛs` |
| `FBI` | `ˈɛf bˈi ˈaɪ` |
| `us` (lowercase) | `ˌʌs` (pronoun, unchanged) |
| `NASA` | `nˈasə` (lexicon-backed, unchanged) |

A missing per-letter entry logs and falls through to the bundled pronunciation. All outputs verified end-to-end through the public `phonemize` API.

## 2. Long-text auto-chunking in the high-level synthesize (#712)

StyleTTS2 caps at its largest bert/sampler bucket — **256 tokens** (`resolveBucket` throws `noBucketAvailable`; the synthesizer throws `textTooLong`), so `synthesize(text:referenceAudioURL:)` failed on long input.

- New `StyleTTS2Constants.maxPhonemeChunkChars` = `bucketTokenSizes.max() − 1` (255). `TextCleaner.encode` prepends one pad + ≤1 token/char, so a ≤255-char chunk always fits the bucket.
- `synthesize(text:)` phonemizes, then `PhonemeChunker.chunk(...)` (the shared chunker from #717). Single chunk → existing path. Multiple chunks → compute the reference mel **once**, reuse it for every chunk (consistent speaker style, no repeated FFT/mel work), concatenate samples in order.
- The low-level `ipa:` and `tokenIds:` paths stay strict.

## Tests

- `StyleTTS2PhonemizerTests` — initialism + normalization cases; case-sensitive-precedence test retargeted off the now-overridden `AI` example onto a `Read`/`read` homograph.
- `StyleTTS2ChunkingTests` — the char cap stays under the largest bucket and every chunk of a long string encodes within it (`resolveBucket` never throws). Split mechanics covered by the existing `PhonemeChunkerTests`.

Builds cleanly; swift-format passes. XCTest can't run in my local env (CommandLineTools only); the phonemizer outputs were verified via the public API and the chunk/encode invariant is asserted directly.