### PR TITLE
feat(asr/vocab): per-term custom vocabulary CTC thresholds (#647)

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/BKTree/VocabularyRescorer+CandidateMatching.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/BKTree/VocabularyRescorer+CandidateMatching.swift
@@ -19,14 +19,30 @@ extension VocabularyRescorer {
     /// - Parameters:
     ///   - normalizedWord: The normalized TDT word
     ///   - adjacentNormalized: Array of normalized adjacent words (for compound detection)
-    ///   - minSimilarity: Minimum similarity threshold
+    ///   - minSimilarity: Vocabulary-level fallback similarity threshold. Each
+    ///     candidate is filtered against its own `term.minSimilarity` when set,
+    ///     otherwise against this value.
+    ///   - searchFloor: Lowest threshold across the vocabulary, used to widen
+    ///     the BK-tree edit-distance bound so per-term overrides are not pruned
+    ///     before filtering. Defaults to `minSimilarity` when omitted.
     /// - Returns: Array of candidate matches sorted by similarity (descending)
     func findCandidateTermsForWord(
         normalizedWord: String,
         adjacentNormalized: [String],
-        minSimilarity: Float
+        minSimilarity: Float,
+        searchFloor: Float? = nil
     ) -> [CandidateMatch] {
         guard !normalizedWord.isEmpty else { return [] }
+
+        // Distance bound uses the most permissive threshold so a low per-term
+        // override still surfaces from the BK-tree; per-candidate filtering
+        // applies each term's own threshold below.
+        let distanceFloor = min(searchFloor ?? minSimilarity, minSimilarity)
+
+        // Effective per-candidate threshold (term override or vocab fallback).
+        func threshold(for term: CustomVocabularyTerm) -> Float {
+            term.minSimilarity ?? minSimilarity
+        }
 
         var candidates: [CandidateMatch] = []
 
@@ -35,12 +51,12 @@ extension VocabularyRescorer {
 
             // 1. Single word query
             let maxLen1 = max(normalizedWord.count, 3)
-            let maxDist1 = min(bkTreeMaxDistance, Int((1.0 - minSimilarity) * Float(maxLen1)))
+            let maxDist1 = min(bkTreeMaxDistance, Int((1.0 - distanceFloor) * Float(maxLen1)))
             let results1 = tree.search(query: normalizedWord, maxDistance: maxDist1)
 
             for result in results1 {
                 let similarity = Self.stringSimilarity(normalizedWord, result.normalizedText)
-                if similarity >= minSimilarity {
+                if similarity >= threshold(for: result.term) {
                     candidates.append(
                         CandidateMatch(
                             term: result.term,
@@ -54,13 +70,13 @@ extension VocabularyRescorer {
             if !adjacentNormalized.isEmpty, let word2 = adjacentNormalized.first, !word2.isEmpty {
                 let compound2 = normalizedWord + word2
                 let maxLen2 = max(compound2.count, 3)
-                let maxDist2 = min(bkTreeMaxDistance, Int((1.0 - minSimilarity) * Float(maxLen2)))
+                let maxDist2 = min(bkTreeMaxDistance, Int((1.0 - distanceFloor) * Float(maxLen2)))
                 let results2 = tree.search(query: compound2, maxDistance: maxDist2)
 
                 for result in results2 {
                     // Use length-penalized similarity to prevent prefix/suffix mismatches
                     let similarity = Self.lengthPenalizedSimilarity(compound2, result.normalizedText)
-                    if similarity >= minSimilarity {
+                    if similarity >= threshold(for: result.term) {
                         candidates.append(
                             CandidateMatch(
                                 term: result.term,
@@ -80,13 +96,13 @@ extension VocabularyRescorer {
                 // Only search for 3-word compounds if the compound is long enough
                 if compound3.count >= 6 {
                     let maxLen3 = compound3.count
-                    let maxDist3 = min(bkTreeMaxDistance, Int((1.0 - minSimilarity) * Float(maxLen3)))
+                    let maxDist3 = min(bkTreeMaxDistance, Int((1.0 - distanceFloor) * Float(maxLen3)))
                     let results3 = tree.search(query: compound3, maxDistance: maxDist3)
 
                     for result in results3 {
                         // Use length-penalized similarity to prevent prefix/suffix mismatches
                         let similarity = Self.lengthPenalizedSimilarity(compound3, result.normalizedText)
-                        if similarity >= minSimilarity {
+                        if similarity >= threshold(for: result.term) {
                             candidates.append(
                                 CandidateMatch(
                                     term: result.term,
@@ -107,12 +123,12 @@ extension VocabularyRescorer {
                     let phrase = phraseWords.joined(separator: " ")
                     let maxLenPhrase = max(phrase.count, 3)
                     let maxDistPhrase = min(
-                        bkTreeMaxDistance + 1, Int((1.0 - minSimilarity) * Float(maxLenPhrase)))
+                        bkTreeMaxDistance + 1, Int((1.0 - distanceFloor) * Float(maxLenPhrase)))
                     let resultsPhrase = tree.search(query: phrase, maxDistance: maxDistPhrase)
 
                     for result in resultsPhrase {
                         let similarity = Self.stringSimilarity(phrase, result.normalizedText)
-                        if similarity >= minSimilarity {
+                        if similarity >= threshold(for: result.term) {
                             candidates.append(
                                 CandidateMatch(
                                     term: result.term,
@@ -132,10 +148,12 @@ extension VocabularyRescorer {
 
                 let termWordCount = termNormalized.split(separator: " ").count
 
+                let termThreshold = threshold(for: term)
+
                 if termWordCount == 1 {
                     // Single word term - check single word and compounds
                     let similarity1 = Self.stringSimilarity(normalizedWord, termNormalized)
-                    if similarity1 >= minSimilarity {
+                    if similarity1 >= termThreshold {
                         candidates.append(
                             CandidateMatch(
                                 term: term,
@@ -149,7 +167,7 @@ extension VocabularyRescorer {
                         let compound2 = normalizedWord + word2
                         // Use length-penalized similarity to prevent prefix/suffix mismatches
                         let similarity2 = Self.lengthPenalizedSimilarity(compound2, termNormalized)
-                        if similarity2 >= minSimilarity {
+                        if similarity2 >= termThreshold {
                             candidates.append(
                                 CandidateMatch(
                                     term: term,
@@ -168,7 +186,7 @@ extension VocabularyRescorer {
                             if compound3.count >= 6 {
                                 // Use length-penalized similarity to prevent prefix/suffix mismatches
                                 let similarity3 = Self.lengthPenalizedSimilarity(compound3, termNormalized)
-                                if similarity3 >= minSimilarity {
+                                if similarity3 >= termThreshold {
                                     candidates.append(
                                         CandidateMatch(
                                             term: term,
@@ -187,7 +205,7 @@ extension VocabularyRescorer {
                             let phraseWords = [normalizedWord] + Array(adjacentNormalized.prefix(spanLen - 1))
                             let phrase = phraseWords.joined(separator: " ")
                             let similarity = Self.stringSimilarity(phrase, termNormalized)
-                            if similarity >= minSimilarity {
+                            if similarity >= termThreshold {
                                 candidates.append(
                                     CandidateMatch(
                                         term: term,

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyContext.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyContext.swift
@@ -258,11 +258,15 @@ public struct CustomVocabularyContext: Sendable {
 
     /// Load vocabulary from file and tokenize with CTC tokenizer.
     ///
-    /// This is a convenience method that combines loading vocabulary from a simple text file
-    /// and tokenizing each term with the CTC tokenizer for use with vocabulary boosting.
+    /// This is a convenience method that loads a vocabulary file and tokenizes
+    /// each term with the CTC tokenizer for use with vocabulary boosting. The
+    /// file may be either the structured JSON config (which supports per-term
+    /// `minSimilarity` and vocabulary-level thresholds, see ``load(from:)``) or
+    /// the simple one-term-per-line text format (see ``loadFromSimpleFormat(from:)``).
+    /// The format is detected from the file contents.
     ///
     /// - Parameters:
-    ///   - path: Path to the vocabulary file (one term per line)
+    ///   - path: Path to the vocabulary file (JSON config or simple text list)
     ///   - ctcVariant: CTC model variant to use for tokenization (default: .ctc110m)
     /// - Returns: Tuple of tokenized vocabulary context and loaded CTC models
     /// - Throws: Error if vocabulary file cannot be read or CTC models fail to load
@@ -273,16 +277,16 @@ public struct CustomVocabularyContext: Sendable {
         // Load CTC models
         let ctcModels = try await CtcModels.downloadAndLoad(variant: ctcVariant)
 
-        // Load vocabulary from file
+        // Load vocabulary from file (JSON config or simple text list).
         let vocabURL = URL(fileURLWithPath: path)
-        let loadedVocab = try loadFromSimpleFormat(from: vocabURL)
+        let loadedVocab = try loadVocabularyFile(at: vocabURL)
 
         // Load CTC tokenizer
         let ctcTokenizer = try await CtcTokenizer.load(
             from: CtcModels.defaultCacheDirectory(for: ctcVariant)
         )
 
-        // Tokenize each term with CTC tokenizer
+        // Tokenize each term with CTC tokenizer, preserving per-term settings.
         let tokenizedTerms = loadedVocab.terms.compactMap { term -> CustomVocabularyTerm? in
             let tokenIds = ctcTokenizer.encode(term.text)
             guard !tokenIds.isEmpty else { return nil }
@@ -296,7 +300,31 @@ public struct CustomVocabularyContext: Sendable {
             )
         }
 
-        let tokenizedVocab = CustomVocabularyContext(terms: tokenizedTerms)
+        // Preserve vocabulary-level thresholds parsed from the JSON config so
+        // a structured file is honored end-to-end (the simple-text path keeps
+        // the defaults it always used).
+        let tokenizedVocab = CustomVocabularyContext(
+            terms: tokenizedTerms,
+            alpha: loadedVocab.alpha,
+            minCtcScore: loadedVocab.minCtcScore,
+            minSimilarity: loadedVocab.minSimilarity,
+            minCombinedConfidence: loadedVocab.minCombinedConfidence,
+            minTermLength: loadedVocab.minTermLength
+        )
         return (tokenizedVocab, ctcModels)
+    }
+
+    /// Load a vocabulary file, auto-detecting the structured JSON config vs the
+    /// simple one-term-per-line text format. JSON config files begin with `{`
+    /// (after optional leading whitespace); anything else is treated as simple
+    /// text.
+    static func loadVocabularyFile(at url: URL) throws -> CustomVocabularyContext {
+        let data = try Data(contentsOf: url)
+        let whitespace: Set<UInt8> = [0x20, 0x09, 0x0a, 0x0d]  // space, tab, LF, CR
+        let firstMeaningfulByte = data.first { !whitespace.contains($0) }
+        if firstMeaningfulByte == UInt8(ascii: "{") {
+            return try load(from: url)
+        }
+        return try loadFromSimpleFormat(from: url)
     }
 }

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyContext.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyContext.swift
@@ -13,12 +13,23 @@ public struct CustomVocabularyTerm: Codable, Sendable {
     /// the Parakeet TDT token IDs above.
     public let ctcTokenIds: [Int]?
 
+    /// Optional per-term minimum string similarity for CTC rescoring.
+    ///
+    /// Overrides the vocabulary-level `CustomVocabularyContext.minSimilarity`
+    /// for this term only. Lower values widen recall (more aggressive
+    /// correction); higher values demand a closer match (fewer false
+    /// replacements). When `nil`, the vocabulary-level / size-aware default is
+    /// used. Vocabulary-wide safety guards (short-word, stopword-span, and
+    /// length-ratio floors) still apply on top of this value, so a per-term
+    /// override can only loosen matching down to those guards.
+    public let minSimilarity: Float?
+
     /// Pre-computed lowercased text for efficient comparison (not serialized).
     public let textLowercased: String
 
     // Only encode/decode the original properties, not the cached ones
     private enum CodingKeys: String, CodingKey {
-        case text, weight, aliases, tokenIds, ctcTokenIds
+        case text, weight, aliases, tokenIds, ctcTokenIds, minSimilarity
     }
 
     /// Create a custom vocabulary term.
@@ -28,18 +39,22 @@ public struct CustomVocabularyTerm: Codable, Sendable {
     ///   - aliases: Optional alternative spellings
     ///   - tokenIds: Optional pre-tokenized Parakeet TDT token IDs
     ///   - ctcTokenIds: Optional pre-tokenized CTC token IDs
+    ///   - minSimilarity: Optional per-term minimum string similarity override
+    ///     (falls back to the vocabulary-level threshold when `nil`)
     public init(
         text: String,
         weight: Float? = nil,
         aliases: [String]? = nil,
         tokenIds: [Int]? = nil,
-        ctcTokenIds: [Int]? = nil
+        ctcTokenIds: [Int]? = nil,
+        minSimilarity: Float? = nil
     ) {
         self.text = text
         self.weight = weight
         self.aliases = aliases
         self.tokenIds = tokenIds
         self.ctcTokenIds = ctcTokenIds
+        self.minSimilarity = minSimilarity.map { Self.clampSimilarity($0) }
         self.textLowercased = text.lowercased()
     }
 
@@ -50,7 +65,15 @@ public struct CustomVocabularyTerm: Codable, Sendable {
         aliases = try container.decodeIfPresent([String].self, forKey: .aliases)
         tokenIds = try container.decodeIfPresent([Int].self, forKey: .tokenIds)
         ctcTokenIds = try container.decodeIfPresent([Int].self, forKey: .ctcTokenIds)
+        minSimilarity = try container.decodeIfPresent(Float.self, forKey: .minSimilarity)
+            .map { Self.clampSimilarity($0) }
         textLowercased = text.lowercased()
+    }
+
+    /// Clamp a similarity threshold into the valid [0, 1] range so malformed
+    /// config values cannot disable or invert the rescoring gate.
+    private static func clampSimilarity(_ value: Float) -> Float {
+        min(1.0, max(0.0, value))
     }
 }
 
@@ -138,7 +161,8 @@ public struct CustomVocabularyContext: Sendable {
                 weight: term.weight,
                 aliases: sanitizedAliases?.isEmpty == true ? nil : sanitizedAliases,
                 tokenIds: term.tokenIds,
-                ctcTokenIds: term.ctcTokenIds
+                ctcTokenIds: term.ctcTokenIds,
+                minSimilarity: term.minSimilarity
             )
             validatedTerms.append(sanitizedTerm)
         }
@@ -267,7 +291,8 @@ public struct CustomVocabularyContext: Sendable {
                 weight: term.weight,
                 aliases: term.aliases,
                 tokenIds: nil,
-                ctcTokenIds: tokenIds
+                ctcTokenIds: tokenIds,
+                minSimilarity: term.minSimilarity
             )
         }
 

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
@@ -924,6 +924,20 @@ extension VocabularyRescorer {
                 bestSimilarity = max(bestSimilarity, Self.stringSimilarity(normalizedPhrase, form.normalized))
             }
 
+            // Honor an EXPLICIT per-term similarity override even on this
+            // acoustic rescue path. A term that opts into a stricter threshold
+            // (issue #647 — e.g. a short/common-sounding name) should not be
+            // force-replaced over a low-similarity span purely on spotter
+            // evidence. Terms without an override keep the prior behavior
+            // (similarity is for ranking only).
+            if let termMinSimilarity = term.minSimilarity, bestSimilarity < termMinSimilarity {
+                debugLog(
+                    "  [SPOTTER-RESCUE] Skipping '\(vocabTerm)': similarity "
+                        + "\(String(format: "%.2f", bestSimilarity)) < per-term min "
+                        + "\(String(format: "%.2f", termMinSimilarity))")
+                continue
+            }
+
             let firstIdx = span.first!
             let lastIdx = span.last!
             let candidate = CTCMatchCandidate(

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
@@ -272,6 +272,12 @@ extension VocabularyRescorer {
         // Build normalized vocabulary set for guard checks
         let vocabularyNormalizedSet = buildVocabularyNormalizedSet()
 
+        // Lowest per-term similarity across the vocabulary. The BK-tree search
+        // bound is derived from this floor so that terms with a lower per-term
+        // `minSimilarity` are not pruned before per-candidate filtering applies
+        // each term's own threshold.
+        let searchFloor = vocabulary.terms.reduce(minSimilarity) { min($0, $1.minSimilarity ?? minSimilarity) }
+
         // Pre-compute normalized words for all timings
         let normalizedWords = wordTimings.map { Self.normalizeForSimilarity($0.word) }
 
@@ -299,11 +305,15 @@ extension VocabularyRescorer {
                 }
             }
 
-            // Find candidate vocabulary terms using BK-tree or linear scan
+            // Find candidate vocabulary terms using BK-tree or linear scan.
+            // `searchFloor` widens the BK-tree edit-distance bound to cover the
+            // most permissive per-term override; each candidate is then filtered
+            // against its own threshold inside the helper.
             let candidates = findCandidateTermsForWord(
                 normalizedWord: normalizedWord,
                 adjacentNormalized: adjacentNormalized,
-                minSimilarity: minSimilarity
+                minSimilarity: minSimilarity,
+                searchFloor: searchFloor
             )
 
             if !candidates.isEmpty {
@@ -359,9 +369,12 @@ extension VocabularyRescorer {
                     continue
                 }
 
-                // Apply similarity threshold adjustments
+                // Apply similarity threshold adjustments. Per-term override
+                // falls back to the vocabulary-level threshold; guards below
+                // still clamp it upward for short/stopword spans.
+                let termMinSimilarity = term.minSimilarity ?? minSimilarity
                 var minSimilarityForSpan = requiredSimilarity(
-                    minSimilarity: minSimilarity,
+                    minSimilarity: termMinSimilarity,
                     spanLength: spanLength
                 )
 
@@ -477,6 +490,11 @@ extension VocabularyRescorer {
         for term in vocabulary.terms {
             let vocabTerm = term.text
 
+            // Per-term similarity override (falls back to the vocabulary-level
+            // threshold). Safety guards in requiredSimilarity/checkStopwordRules/
+            // checkLengthRatioRules still clamp this upward for short/stopword spans.
+            let termMinSimilarity = term.minSimilarity ?? minSimilarity
+
             // Skip short vocabulary terms (per NeMo CTC-WS paper)
             guard vocabTerm.count >= vocabulary.minTermLength else {
                 debugLog(
@@ -546,7 +564,7 @@ extension VocabularyRescorer {
 
                         // Use adaptive similarity threshold
                         let minSimilarityForSpan = requiredSimilarity(
-                            minSimilarity: minSimilarity,
+                            minSimilarity: termMinSimilarity,
                             spanLength: spanLength
                         )
                         if bestSimilarity < minSimilarityForSpan { continue }
@@ -680,7 +698,7 @@ extension VocabularyRescorer {
 
                     // Use adaptive similarity threshold
                     var minSimilarityForSpan = requiredSimilarity(
-                        minSimilarity: minSimilarity,
+                        minSimilarity: termMinSimilarity,
                         spanLength: matchedSpanLength
                     )
 

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -491,8 +491,12 @@ enum TranscribeCommand {
                         ctcModelDirectory: ctcModelDir
                     )
 
-                    // Vocabulary-size-aware defaults, overridable via CLI
-                    let minSimilarity: Float = args.vocabMinSimilarity ?? vocabConfig.minSimilarity
+                    // Vocabulary-size-aware defaults, overridable via CLI.
+                    // Honor a vocabulary-level minSimilarity from a JSON config
+                    // as a floor (mirrors SlidingWindowAsrManager); per-term
+                    // overrides are applied inside the rescorer regardless.
+                    let minSimilarity: Float =
+                        args.vocabMinSimilarity ?? max(vocabConfig.minSimilarity, customVocab.minSimilarity)
                     let cbw: Float = args.vocabCbw ?? vocabConfig.cbw
                     let marginSeconds: Double = args.vocabMargin ?? ContextBiasingConstants.defaultMarginSeconds
 

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -491,12 +491,10 @@ enum TranscribeCommand {
                         ctcModelDirectory: ctcModelDir
                     )
 
-                    // Vocabulary-size-aware defaults, overridable via CLI.
-                    // Honor a vocabulary-level minSimilarity from a JSON config
-                    // as a floor (mirrors SlidingWindowAsrManager); per-term
-                    // overrides are applied inside the rescorer regardless.
-                    let minSimilarity: Float =
-                        args.vocabMinSimilarity ?? max(vocabConfig.minSimilarity, customVocab.minSimilarity)
+                    // Vocabulary-size-aware default, overridable via CLI.
+                    // Per-term minSimilarity overrides are applied inside the
+                    // rescorer regardless of this global value.
+                    let minSimilarity: Float = args.vocabMinSimilarity ?? vocabConfig.minSimilarity
                     let cbw: Float = args.vocabCbw ?? vocabConfig.cbw
                     let marginSeconds: Double = args.vocabMargin ?? ContextBiasingConstants.defaultMarginSeconds
 

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyTests.swift
@@ -170,6 +170,64 @@ final class CustomVocabularyTests: XCTestCase {
         XCTAssertNil(mobius.minSimilarity)
     }
 
+    // MARK: - loadVocabularyFile Format Detection (JSON vs simple text)
+
+    func testLoadVocabularyFileDetectsJSON() throws {
+        let json = """
+            {
+              "minSimilarity": 0.6,
+              "terms": [
+                {"text": "Caivex", "minSimilarity": 0.40},
+                {"text": "Andre"}
+              ]
+            }
+            """
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocab-647-json-\(UUID().uuidString).json")
+        try json.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let context = try CustomVocabularyContext.loadVocabularyFile(at: url)
+        XCTAssertEqual(context.terms.count, 2)
+        // Vocabulary-level threshold from JSON is honored.
+        XCTAssertEqual(context.minSimilarity, 0.6, accuracy: 0.001)
+        let byText = Dictionary(uniqueKeysWithValues: context.terms.map { ($0.text, $0) })
+        XCTAssertEqual(byText["Caivex"]?.minSimilarity ?? -1, 0.40, accuracy: 0.001)
+        XCTAssertNil(try XCTUnwrap(byText["Andre"]).minSimilarity)
+    }
+
+    func testLoadVocabularyFileDetectsJSONWithLeadingWhitespace() throws {
+        let json = "\n\n   {\"terms\": [{\"text\": \"Caivex\", \"minSimilarity\": 0.4}]}"
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocab-647-ws-\(UUID().uuidString).json")
+        try json.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let context = try CustomVocabularyContext.loadVocabularyFile(at: url)
+        XCTAssertEqual(context.terms.count, 1)
+        XCTAssertEqual(context.terms.first?.minSimilarity ?? -1, 0.4, accuracy: 0.001)
+    }
+
+    func testLoadVocabularyFileDetectsSimpleText() throws {
+        let text = """
+            # comment line
+            NVIDIA
+            Bose: boz, boss
+            """
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocab-647-txt-\(UUID().uuidString).txt")
+        try text.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let context = try CustomVocabularyContext.loadVocabularyFile(at: url)
+        XCTAssertEqual(context.terms.count, 2)
+        let byText = Dictionary(uniqueKeysWithValues: context.terms.map { ($0.text, $0) })
+        XCTAssertNotNil(byText["NVIDIA"])
+        XCTAssertEqual(byText["Bose"]?.aliases, ["boz", "boss"])
+        // Simple text format has no per-term threshold field.
+        XCTAssertNil(try XCTUnwrap(byText["NVIDIA"]).minSimilarity)
+    }
+
     // MARK: - Edge Cases
 
     func testTermWithEmptyAliases() {

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyTests.swift
@@ -13,6 +13,7 @@ final class CustomVocabularyTests: XCTestCase {
         XCTAssertNil(term.aliases)
         XCTAssertNil(term.tokenIds)
         XCTAssertNil(term.ctcTokenIds)
+        XCTAssertNil(term.minSimilarity)
     }
 
     func testTermFullInit() {
@@ -21,13 +22,25 @@ final class CustomVocabularyTests: XCTestCase {
             weight: 5.0,
             aliases: ["boz", "boss"],
             tokenIds: [100, 200],
-            ctcTokenIds: [50, 60]
+            ctcTokenIds: [50, 60],
+            minSimilarity: 0.45
         )
         XCTAssertEqual(term.text, "Bose")
         XCTAssertEqual(term.weight, 5.0)
         XCTAssertEqual(term.aliases, ["boz", "boss"])
         XCTAssertEqual(term.tokenIds, [100, 200])
         XCTAssertEqual(term.ctcTokenIds, [50, 60])
+        XCTAssertEqual(term.minSimilarity ?? -1, 0.45, accuracy: 0.001)
+    }
+
+    // MARK: - Per-Term minSimilarity (#647)
+
+    func testTermMinSimilarityClampedToRange() {
+        XCTAssertEqual(
+            CustomVocabularyTerm(text: "Caivex", minSimilarity: -0.5).minSimilarity ?? -1, 0.0, accuracy: 0.001)
+        XCTAssertEqual(
+            CustomVocabularyTerm(text: "Andre", minSimilarity: 1.7).minSimilarity ?? -1, 1.0, accuracy: 0.001)
+        XCTAssertEqual(CustomVocabularyTerm(text: "Mid", minSimilarity: 0.6).minSimilarity ?? -1, 0.6, accuracy: 0.001)
     }
 
     func testTextLowercased() {
@@ -47,7 +60,8 @@ final class CustomVocabularyTests: XCTestCase {
             weight: 3.0,
             aliases: ["tensor-rt"],
             tokenIds: [10, 20],
-            ctcTokenIds: [30, 40]
+            ctcTokenIds: [30, 40],
+            minSimilarity: 0.52
         )
 
         let data = try JSONEncoder().encode(original)
@@ -58,6 +72,7 @@ final class CustomVocabularyTests: XCTestCase {
         XCTAssertEqual(decoded.aliases, original.aliases)
         XCTAssertEqual(decoded.tokenIds, original.tokenIds)
         XCTAssertEqual(decoded.ctcTokenIds, original.ctcTokenIds)
+        XCTAssertEqual(decoded.minSimilarity ?? -1, 0.52, accuracy: 0.001)
         XCTAssertEqual(decoded.textLowercased, "tensorrt")
     }
 
@@ -71,6 +86,15 @@ final class CustomVocabularyTests: XCTestCase {
         XCTAssertNil(decoded.aliases)
         XCTAssertNil(decoded.tokenIds)
         XCTAssertNil(decoded.ctcTokenIds)
+        XCTAssertNil(decoded.minSimilarity)
+    }
+
+    func testTermDecodeMinSimilarityFromJSON() throws {
+        let json = """
+            {"text": "Caivex", "minSimilarity": 0.42}
+            """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(CustomVocabularyTerm.self, from: json)
+        XCTAssertEqual(decoded.minSimilarity ?? -1, 0.42, accuracy: 0.001)
     }
 
     func testTermDecodeSetsLowercased() throws {
@@ -116,6 +140,34 @@ final class CustomVocabularyTests: XCTestCase {
     func testContextMinTermLengthDefault() {
         let context = CustomVocabularyContext(terms: [])
         XCTAssertEqual(context.minTermLength, 3)
+    }
+
+    // MARK: - load(from:) Per-Term minSimilarity
+
+    func testLoadPreservesPerTermMinSimilarity() throws {
+        let json = """
+            {
+              "terms": [
+                {"text": "Caivex", "minSimilarity": 0.40, "ctcTokenIds": [1, 2, 3]},
+                {"text": "Andre", "minSimilarity": 0.80, "ctcTokenIds": [4, 5]},
+                {"text": "Mobius", "ctcTokenIds": [6, 7]}
+              ]
+            }
+            """
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vocab-647-\(UUID().uuidString).json")
+        try json.write(to: url, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let context = try CustomVocabularyContext.load(from: url)
+        XCTAssertEqual(context.terms.count, 3)
+
+        let byText = Dictionary(uniqueKeysWithValues: context.terms.map { ($0.text, $0) })
+        XCTAssertEqual(byText["Caivex"]?.minSimilarity ?? -1, 0.40, accuracy: 0.001)
+        XCTAssertEqual(byText["Andre"]?.minSimilarity ?? -1, 0.80, accuracy: 0.001)
+        // Term without an override keeps nil → falls back to vocabulary-level threshold.
+        let mobius = try XCTUnwrap(byText["Mobius"])
+        XCTAssertNil(mobius.minSimilarity)
     }
 
     // MARK: - Edge Cases


### PR DESCRIPTION
Closes #647.

## Summary

Adds an optional per-term `minSimilarity` to `CustomVocabularyTerm`, so each
vocabulary term can tune its own recall/precision tradeoff instead of sharing a
single vocabulary-wide threshold. Additive and fully backward compatible: omit
the field and behavior is unchanged; existing simple-text and JSON vocab files
keep decoding.

This lets one vocabulary mix aggressive and strict terms — the issue's use case:
- `Caivex`: low threshold for aggressive correction of a distinctive name.
- `Andre`: high threshold so short/common-sounding spans don't over-match.

```json
{
  "terms": [
    { "text": "Caivex", "minSimilarity": 0.45 },
    { "text": "Andre",  "minSimilarity": 0.85 },
    { "text": "Mobius" }
  ]
}
```
```bash
fluidaudiocli transcribe audio.wav --custom-vocab vocab.json
```

## Changes

- **`CustomVocabularyTerm`**: new optional `minSimilarity: Float?` (Codable,
  clamped to `[0, 1]`); falls back to the vocabulary-level / size-aware default
  when nil.
- **Rescoring**: per-term threshold resolved in the term-centric path, the
  word-centric/BK-tree path (with a vocabulary-wide *search floor* so a lower
  per-term override widens recall instead of being pruned), the linear-scan
  fallback, and the acoustic spotter-rescue path (the last only when an
  override is explicitly set).
- **Loader / CLI**: `loadWithCtcTokens` now auto-detects structured JSON config
  vs simple text, so `transcribe --custom-vocab` can pass per-term thresholds
  (previously JSON was never read on this path). JSON vocabulary-level
  thresholds are preserved; the CLI honors a JSON vocab-level `minSimilarity` as
  a floor (mirrors `SlidingWindowAsrManager`).
- **Safety guards unchanged**: short-word, stopword-span, multi-word, and
  `minTermLength` floors still clamp on top, so an override can only loosen
  matching down to those floors.

## Verification

Verified end-to-end via `transcribe --custom-vocab` on real audio + models. Same
audio, same term `Arnav`, conservative global `0.80` — only the per-term value
differs:

| per-term `minSimilarity` | output |
|---|---|
| `0.50` | "Today we're here with **Arnav** and Chas Englander" (corrected) |
| `0.90` | "Today we're here with **Arnie** and Chas Englander" (suppressed) |

No collateral over-matching in either run. Achieving the same correction by
lowering the *global* threshold instead smears the term over unrelated words;
per-term gets the one correction without the damage.

## Tests

Unit tests for per-term init/clamping, Codable round-trip, JSON decode (present
+ omitted), `load(from:)` preservation, and JSON-vs-simple format detection
(incl. leading whitespace) + vocabulary-level threshold preservation. Build and
swift-format lint pass.