### PR TITLE
fix(asr/vocab): opt-in controls for short-term CTC over-firing (#702)

### DIFF
--- a/Documentation/ASR/CustomVocabulary.md
+++ b/Documentation/ASR/CustomVocabulary.md
@@ -430,6 +430,66 @@ minimum string similarity before the acoustic-only rescue path may fire
 (higher for multi-word spans, which are the most error-prone). Tune these for
 short-keyword KWS; leave them off for distinctive-name vocabularies.
 
+#### When to enable
+
+Turn these on when **all** of the following hold; otherwise leave them off:
+
+- the vocabulary is small and made of **short** terms (≤ ~5 chars / a few
+  CTC tokens), and
+- those terms **collide acoustically with ordinary English** (brand names,
+  acronyms, function-word homophones), and
+- you observe ordinary words being replaced by keywords that were not spoken.
+
+For vocabularies of long, distinctive names (company/drug names, the
+earnings22 profile) leave them **off** — enabling them costs KWS recall
+(see below).
+
+#### Enabling
+
+```bash
+# CLI (batch) — recommended short-vocab settings
+fluidaudio transcribe audio.wav \
+    --custom-vocab short_terms.txt \
+    --vocab-short-term-taper-pivot 5 \
+    --vocab-spotter-min-sim 0.30 \
+    --vocab-spotter-min-sim-multi 0.50
+```
+
+```swift
+// API — pass an opt-in Config to the rescorer
+let config = VocabularyRescorer.Config(
+    shortTermCbwTaperPivot: 5,            // taper boost for terms < 5 tokens
+    spotterRescueMinSimilarity: 0.30,     // single-word acoustic-rescue floor
+    spotterRescueMultiWordMinSimilarity: 0.50  // multi-word floor
+)
+let rescorer = try await VocabularyRescorer.create(
+    spotter: ctcSpotter,
+    vocabulary: vocabulary,
+    config: config
+)
+```
+
+```bash
+# Env overrides (handy for parameter sweeps; apply to any entry point)
+export FLUID_CBW_TAPER_PIVOT=5
+export FLUID_SPOTTER_MIN_SIM=0.30
+export FLUID_SPOTTER_MIN_SIM_MULTI=0.50
+```
+
+#### Measured effect
+
+Repro: 8 short brand/acronym distractors (none spoken) over one minute of
+ordinary speech, plus the earnings22-kws KWS set (200 files) as the recall
+guard.
+
+| Setting | distractor false positives | earnings22 recall |
+|---|---|---|
+| **off (default)** | 12 | 95.7% |
+| recommended opt-in (pivot 5, floors 0.30 / 0.50) | **0** | (lower — only enable for short-vocab KWS) |
+
+The defaults are byte-for-byte identical to the pre-#702 behavior; the floors
+and taper only change scoring when explicitly enabled.
+
 ## Usage Example
 
 ```swift

--- a/Documentation/ASR/CustomVocabulary.md
+++ b/Documentation/ASR/CustomVocabulary.md
@@ -400,6 +400,36 @@ The thresholds, the size buckets (`largeVocabThreshold = 10`,
 `extraLargeVocabThreshold = 100`), and the dispatch logic live in
 `ContextBiasingConstants.rescorerConfig(forVocabSize:)`.
 
+### Short-Term Over-Fire Controls (opt-in, #702)
+
+The blank-aware DP score is a per-token average log-prob. A **short** keyword
+(few tokens) can free-start align to its single best-matching frame-run and
+score close to zero per token, so it can beat a correctly transcribed common
+word. With vocabularies of short terms that collide acoustically with ordinary
+English (`CRAN`~"ran", `Snyk`~"sync", a 3-letter acronym ~ a function word),
+the rescorer over-fires — replacing ordinary words that are none of the
+keywords.
+
+Benchmarking shows the over-fire and the genuine KWS recall on
+distinctive-name vocabularies (earnings22) come from the *same* mechanisms
+(the flat `cbw` boost and the acoustic spotter-rescue), and neither string
+similarity nor token length separates them — gating hard enough to suppress
+the false positives also costs recall. These controls are therefore **opt-in
+and default to disabled (no behavior change)**:
+
+| `VocabularyRescorer.Config` field | CLI flag | Env | Default | Recommended (short-vocab) |
+|---|---|---|---|---|
+| `shortTermCbwTaperPivot` | `--vocab-short-term-taper-pivot` | `FLUID_CBW_TAPER_PIVOT` | `1` (off) | `5` |
+| `shortTermCbwTaperExponent` | — | `FLUID_CBW_TAPER_EXP` | `2.0` | `2.0` |
+| `spotterRescueMinSimilarity` | `--vocab-spotter-min-sim` | `FLUID_SPOTTER_MIN_SIM` | `0.0` (off) | `0.30` |
+| `spotterRescueMultiWordMinSimilarity` | `--vocab-spotter-min-sim-multi` | `FLUID_SPOTTER_MIN_SIM_MULTI` | `0.0` (off) | `0.50` |
+
+The taper scales the `cbw` boost down for terms with fewer than `pivot` tokens
+(`cbw * (tokenCount / pivot) ** exponent`). The spotter floors require a
+minimum string similarity before the acoustic-only rescue path may fire
+(higher for multi-word spans, which are the most error-prone). Tune these for
+short-keyword KWS; leave them off for distinctive-name vocabularies.
+
 ## Usage Example
 
 ```swift

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/ContextBiasingConstants.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/ContextBiasingConstants.swift
@@ -287,6 +287,62 @@ public enum ContextBiasingConstants {
     /// - Used in: `VocabularyRescorer.Config.default` and init
     public static let defaultReferenceTokenCount: Int = 3
 
+    // MARK: - Short-Term Over-Fire Controls (#702, opt-in)
+    //
+    // The blank-aware DP score is a per-token average log-prob. A short
+    // keyword (few tokens) can free-start align to its single best-matching
+    // frame-run and score close to zero per token, so it can beat a correctly
+    // transcribed common word — short distractors over-fire (`ran` → `CRAN`,
+    // `Hall of Q4.` → `Snyk`). Benchmarking shows that gating this hard enough
+    // to suppress short-vocab false positives also costs KWS recall on
+    // distinctive-name vocabularies (earnings22), because the same mechanisms
+    // produce both. These controls therefore DEFAULT TO DISABLED (no behavior
+    // change) and are opt-in for short-keyword KWS via `VocabularyRescorer.Config`,
+    // the `transcribe` CLI flags, or the `FLUID_*` env overrides below.
+    //
+    // Recommended short-vocab opt-in values: taper pivot 5 / exponent 2.0,
+    // spotter floors 0.30 (single) / 0.50 (multi-word).
+
+    /// Default token-count pivot for the short-term cbw taper. A value `<= 1`
+    /// disables the taper (the default). When enabled (e.g. 5), terms with
+    /// fewer tokens than the pivot have their boost scaled by
+    /// `(tokenCount / pivot) ** exponent`. Env: `FLUID_CBW_TAPER_PIVOT`.
+    public static var defaultShortTermCbwTaperPivot: Int {
+        envInt("FLUID_CBW_TAPER_PIVOT") ?? 1
+    }
+
+    /// Default exponent for the short-term cbw taper. Higher = more
+    /// conservative on short terms. Env: `FLUID_CBW_TAPER_EXP`.
+    public static var defaultShortTermCbwTaperExponent: Float {
+        envFloat("FLUID_CBW_TAPER_EXP") ?? 2.0
+    }
+
+    /// Default minimum string similarity for a single-word spotter-anchored
+    /// rescue. `0.0` disables the floor (the default), preserving the
+    /// acoustic-only rescue. Env: `FLUID_SPOTTER_MIN_SIM`.
+    public static var defaultSpotterRescueMinSimilarity: Float {
+        envFloat("FLUID_SPOTTER_MIN_SIM") ?? 0.0
+    }
+
+    /// Default minimum string similarity for a multi-word spotter-anchored
+    /// rescue (replacing several words with one term is more error-prone).
+    /// `0.0` disables. Env: `FLUID_SPOTTER_MIN_SIM_MULTI`.
+    public static var defaultSpotterRescueMultiWordMinSimilarity: Float {
+        envFloat("FLUID_SPOTTER_MIN_SIM_MULTI") ?? 0.0
+    }
+
+    /// Read a `Float` tuning override from the environment, if present and valid.
+    private static func envFloat(_ name: String) -> Float? {
+        guard let raw = ProcessInfo.processInfo.environment[name], let value = Float(raw) else { return nil }
+        return value
+    }
+
+    /// Read an `Int` tuning override from the environment, if present and valid.
+    private static func envInt(_ name: String) -> Int? {
+        guard let raw = ProcessInfo.processInfo.environment[name], let value = Int(raw) else { return nil }
+        return value
+    }
+
     /// Default setting for adaptive thresholds.
     ///
     /// When enabled, similarity thresholds scale based on token count,

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
@@ -917,24 +917,31 @@ extension VocabularyRescorer {
                 if allStopwords { continue }
             }
 
-            // Compute similarity for ranking only — the gate is CTC
-            // evidence, not similarity.
+            // Compute similarity (best over canonical + aliases).
             var bestSimilarity: Float = 0
             for form in normalizedForms {
                 bestSimilarity = max(bestSimilarity, Self.stringSimilarity(normalizedPhrase, form.normalized))
             }
 
-            // Honor an EXPLICIT per-term similarity override even on this
-            // acoustic rescue path. A term that opts into a stricter threshold
-            // (issue #647 — e.g. a short/common-sounding name) should not be
-            // force-replaced over a low-similarity span purely on spotter
-            // evidence. Terms without an override keep the prior behavior
-            // (similarity is for ranking only).
-            if let termMinSimilarity = term.minSimilarity, bestSimilarity < termMinSimilarity {
+            // SIMILARITY FLOOR for the acoustic rescue path. The spotter
+            // rescue is acoustic-evidence driven and otherwise ignores
+            // similarity, which lets it force-replace low-similarity spans.
+            // The effective floor is the stricter of:
+            //   - the term's EXPLICIT per-term override (#647), and
+            //   - the opt-in span-aware config floor (#702; higher for
+            //     multi-word spans, which are the most error-prone).
+            // Both sources default to disabled, so by default this is a no-op
+            // and similarity stays "for ranking only".
+            let configSpotterFloor =
+                span.count >= 2
+                ? config.spotterRescueMultiWordMinSimilarity
+                : config.spotterRescueMinSimilarity
+            let spotterSimFloor = max(term.minSimilarity ?? 0, configSpotterFloor)
+            if bestSimilarity < spotterSimFloor {
                 debugLog(
-                    "  [SPOTTER-RESCUE] Skipping '\(vocabTerm)': similarity "
-                        + "\(String(format: "%.2f", bestSimilarity)) < per-term min "
-                        + "\(String(format: "%.2f", termMinSimilarity))")
+                    "  [SPOTTER-RESCUE] Skipping '\(vocabTerm)' over '\(originalPhrase)': "
+                        + "similarity \(String(format: "%.2f", bestSimilarity)) < floor "
+                        + "\(String(format: "%.2f", spotterSimFloor)) (span=\(span.count))")
                 continue
             }
 

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer.swift
@@ -34,38 +34,86 @@ public struct VocabularyRescorer: Sendable {
         /// Reference token count for adaptive scaling (tokens beyond this get adjusted thresholds)
         public let referenceTokenCount: Int
 
-        public static let `default` = Config(
-            useAdaptiveThresholds: ContextBiasingConstants.defaultUseAdaptiveThresholds,
-            referenceTokenCount: ContextBiasingConstants.defaultReferenceTokenCount
-        )
+        /// Token-count pivot for the short-term cbw taper (#702, opt-in).
+        /// A value `<= 1` disables the taper (default). When enabled (e.g. 5),
+        /// terms with fewer tokens than the pivot get a reduced boost so they
+        /// can't beat a correctly transcribed common word on the flat boost
+        /// alone. Trades short-vocab precision for some recall on
+        /// distinctive-name vocabularies — see #702.
+        public let shortTermCbwTaperPivot: Int
+
+        /// Exponent for the short-term cbw taper. Higher = more conservative.
+        public let shortTermCbwTaperExponent: Float
+
+        /// Minimum string similarity for a single-word spotter-anchored rescue
+        /// (#702, opt-in). `0.0` disables (default), preserving the
+        /// acoustic-only rescue; a positive value (e.g. 0.30) suppresses
+        /// near-zero-similarity over-fires at some recall cost.
+        public let spotterRescueMinSimilarity: Float
+
+        /// Minimum string similarity for a multi-word spotter-anchored rescue.
+        /// `0.0` disables (default). Recommended opt-in: 0.50.
+        public let spotterRescueMultiWordMinSimilarity: Float
+
+        public static let `default` = Config()
 
         public init(
             useAdaptiveThresholds: Bool = ContextBiasingConstants.defaultUseAdaptiveThresholds,
-            referenceTokenCount: Int = ContextBiasingConstants.defaultReferenceTokenCount
+            referenceTokenCount: Int = ContextBiasingConstants.defaultReferenceTokenCount,
+            shortTermCbwTaperPivot: Int = ContextBiasingConstants.defaultShortTermCbwTaperPivot,
+            shortTermCbwTaperExponent: Float = ContextBiasingConstants.defaultShortTermCbwTaperExponent,
+            spotterRescueMinSimilarity: Float = ContextBiasingConstants.defaultSpotterRescueMinSimilarity,
+            spotterRescueMultiWordMinSimilarity: Float = ContextBiasingConstants
+                .defaultSpotterRescueMultiWordMinSimilarity
         ) {
             self.useAdaptiveThresholds = useAdaptiveThresholds
             self.referenceTokenCount = referenceTokenCount
+            self.shortTermCbwTaperPivot = shortTermCbwTaperPivot
+            self.shortTermCbwTaperExponent = shortTermCbwTaperExponent
+            self.spotterRescueMinSimilarity = spotterRescueMinSimilarity
+            self.spotterRescueMultiWordMinSimilarity = spotterRescueMultiWordMinSimilarity
         }
 
         // MARK: - Adaptive Threshold Functions
 
         /// Compute adaptive context-biasing weight based on token count.
-        /// Longer keywords need more boost to compensate for accumulated scoring error.
         ///
-        /// Formula: `cbw * (1 + log2(tokenCount / referenceTokenCount) * 0.3)`
-        /// - 3 tokens: cbw * 1.0 (reference)
-        /// - 6 tokens: cbw * 1.3
-        /// - 12 tokens: cbw * 1.6
+        /// Longer keywords need more boost to compensate for accumulated
+        /// scoring error; shorter keywords need *less* boost because their
+        /// per-token DP score is inflated by free-start alignment (#702).
+        ///
+        /// - Long terms (`tokenCount > referenceTokenCount`):
+        ///   `cbw * (1 + log2(tokenCount / referenceTokenCount) * 0.3)`
+        ///   - 6 tokens: cbw * 1.3, 12 tokens: cbw * 1.6
+        /// - Reference length (`== referenceTokenCount`): `cbw` unchanged.
+        /// - Short terms (`tokenCount < referenceTokenCount`):
+        ///   `cbw * (tokenCount / referenceTokenCount) ** shortTermCbwTaperExponent`,
+        ///   tapering the boost toward zero so a short keyword cannot beat a
+        ///   correctly transcribed common word on the flat boost alone — it
+        ///   must earn the margin from acoustic evidence.
         ///
         /// - Parameters:
         ///   - baseCbw: Base context-biasing weight
         ///   - tokenCount: Number of tokens in the vocabulary term
         /// - Returns: Adjusted context-biasing weight
         public func adaptiveCbw(baseCbw: Float, tokenCount: Int) -> Float {
-            guard useAdaptiveThresholds, tokenCount > referenceTokenCount else { return baseCbw }
+            guard useAdaptiveThresholds else { return baseCbw }
+
+            // Short-term taper (#702, opt-in): below the pivot, scale the
+            // boost down toward zero so a short keyword cannot beat a correctly
+            // transcribed common word on the flat boost alone. Disabled when
+            // pivot <= 1 (default), which leaves the original behavior intact.
+            let pivot = shortTermCbwTaperPivot
+            if pivot > 1 && tokenCount < pivot {
+                let ratio = Float(max(1, tokenCount)) / Float(pivot)
+                return baseCbw * pow(ratio, shortTermCbwTaperExponent)
+            }
+
+            // Long terms: boost grows to compensate for accumulated per-token
+            // scoring error.
+            guard tokenCount > referenceTokenCount else { return baseCbw }
             let ratio = Float(tokenCount) / Float(referenceTokenCount)
-            let scaleFactor = 1.0 + log2(ratio) * 0.3
-            return baseCbw * scaleFactor
+            return baseCbw * (1.0 + log2(ratio) * 0.3)
         }
     }
 

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -228,6 +228,10 @@ enum TranscribeCommand {
         var vocabMinSimilarity: Float?
         var vocabCbw: Float?
         var vocabMargin: Double?
+        // #702 opt-in short-term over-fire controls (nil = library default = disabled).
+        var vocabShortTermTaperPivot: Int?
+        var vocabSpotterMinSim: Float?
+        var vocabSpotterMinSimMulti: Float?
     }
 
     private static func parseArguments(_ args: [String]) -> ParsedArgs? {
@@ -367,6 +371,21 @@ enum TranscribeCommand {
                     parsed.vocabMargin = Double(args[i + 1])
                     i += 1
                 }
+            case "--vocab-short-term-taper-pivot":
+                if i + 1 < args.count {
+                    parsed.vocabShortTermTaperPivot = Int(args[i + 1])
+                    i += 1
+                }
+            case "--vocab-spotter-min-sim":
+                if i + 1 < args.count {
+                    parsed.vocabSpotterMinSim = Float(args[i + 1])
+                    i += 1
+                }
+            case "--vocab-spotter-min-sim-multi":
+                if i + 1 < args.count {
+                    parsed.vocabSpotterMinSimMulti = Float(args[i + 1])
+                    i += 1
+                }
 
             default:
                 fputs("WARNING: Unknown option: \(args[i])\n", stderr)
@@ -482,7 +501,16 @@ enum TranscribeCommand {
                     let ctcModelDir = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
 
                     let vocabConfig = ContextBiasingConstants.rescorerConfig(forVocabSize: customVocab.terms.count)
-                    let rescorerConfig = VocabularyRescorer.Config.default
+                    // #702: opt-in short-term over-fire controls. Each flag
+                    // falls back to the library default (disabled) when unset.
+                    let rescorerConfig = VocabularyRescorer.Config(
+                        shortTermCbwTaperPivot: args.vocabShortTermTaperPivot
+                            ?? ContextBiasingConstants.defaultShortTermCbwTaperPivot,
+                        spotterRescueMinSimilarity: args.vocabSpotterMinSim
+                            ?? ContextBiasingConstants.defaultSpotterRescueMinSimilarity,
+                        spotterRescueMultiWordMinSimilarity: args.vocabSpotterMinSimMulti
+                            ?? ContextBiasingConstants.defaultSpotterRescueMultiWordMinSimilarity
+                    )
 
                     let rescorer = try await VocabularyRescorer.create(
                         spotter: spotter,
@@ -986,6 +1014,13 @@ enum TranscribeCommand {
                 --vocab-min-similarity <0-1>     Minimum string similarity for replacement (default: auto)
                 --vocab-cbw <float>              Context-biasing weight boost (default: auto)
                 --vocab-margin <sec>             CTC frame alignment margin (default: 0.5)
+
+              Short-term over-fire controls (#702, opt-in; default off — these
+              improve precision on SHORT keyword vocabularies at some recall
+              cost on distinctive-name vocabularies):
+                --vocab-short-term-taper-pivot <n>   Reduce boost for terms with < n tokens (e.g. 5)
+                --vocab-spotter-min-sim <0-1>        Min similarity for acoustic single-word rescue (e.g. 0.30)
+                --vocab-spotter-min-sim-multi <0-1>  Min similarity for multi-word rescue (e.g. 0.50)
 
             PARAKEET VARIANT MODE (--parakeet-variant):
                 --parakeet-variant <variant>     Engine: parakeet-eou-160ms, nemotron-560ms, …

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyRescorerUtilsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyRescorerUtilsTests.swift
@@ -118,6 +118,42 @@ final class VocabularyRescorerUtilsTests: XCTestCase {
         XCTAssertEqual(config.adaptiveCbw(baseCbw: 3.0, tokenCount: 10), 3.0, accuracy: 0.01)
     }
 
+    // MARK: - Short-Term cbw Taper (#702, opt-in)
+
+    func testShortTermTaperDisabledByDefault() {
+        // Default config must NOT taper short terms (zero behavior change).
+        let config = VocabularyRescorer.Config.default
+        XCTAssertEqual(config.shortTermCbwTaperPivot <= 1, true, "taper disabled by default")
+        XCTAssertEqual(config.adaptiveCbw(baseCbw: 4.5, tokenCount: 1), 4.5, accuracy: 0.01)
+        XCTAssertEqual(config.adaptiveCbw(baseCbw: 4.5, tokenCount: 2), 4.5, accuracy: 0.01)
+        XCTAssertEqual(config.adaptiveCbw(baseCbw: 4.5, tokenCount: 3), 4.5, accuracy: 0.01)
+    }
+
+    func testShortTermTaperWhenEnabled() {
+        // pivot=5, exponent=2: terms below 5 tokens get a quadratic-tapered
+        // boost. referenceTokenCount=5 too, so tokenCount=5 is the clean
+        // boundary (full boost, no long-term scale-up).
+        let config = VocabularyRescorer.Config(
+            referenceTokenCount: 5,
+            shortTermCbwTaperPivot: 5,
+            shortTermCbwTaperExponent: 2.0
+        )
+        // tokenCount=1: (1/5)^2 = 0.04 → 4.5 * 0.04 = 0.18
+        XCTAssertEqual(config.adaptiveCbw(baseCbw: 4.5, tokenCount: 1), 0.18, accuracy: 0.01)
+        // tokenCount=3: (3/5)^2 = 0.36 → 4.5 * 0.36 = 1.62
+        XCTAssertEqual(config.adaptiveCbw(baseCbw: 4.5, tokenCount: 3), 1.62, accuracy: 0.01)
+        // tokenCount=4: (4/5)^2 = 0.64 → 4.5 * 0.64 = 2.88
+        XCTAssertEqual(config.adaptiveCbw(baseCbw: 4.5, tokenCount: 4), 2.88, accuracy: 0.01)
+        // At the pivot (== reference) the full boost applies.
+        XCTAssertEqual(config.adaptiveCbw(baseCbw: 4.5, tokenCount: 5), 4.5, accuracy: 0.01)
+    }
+
+    func testSpotterRescueFloorsDisabledByDefault() {
+        let config = VocabularyRescorer.Config.default
+        XCTAssertEqual(config.spotterRescueMinSimilarity, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(config.spotterRescueMultiWordMinSimilarity, 0.0, accuracy: 0.0001)
+    }
+
     // MARK: - Config Defaults
 
     func testConfigDefaultValues() {


### PR DESCRIPTION
Addresses #702.

## Problem

PR #634's blank-aware DP returns a **per-token-normalized** score, and the replacement gate adds a flat `cbw` boost (`vocabScore + cbw > originalScore`). A **short** keyword (few tokens) can free-start align to its single best-matching frame-run and score close to zero per token, so the flat boost lets it beat a correctly transcribed common word. Vocabularies of short terms that collide acoustically with ordinary English over-fire badly (`ran` → `CRAN`, `Hall of Q4.` → `Snyk`). The dominant source is the **spotter-anchored rescue**, which fires on acoustic evidence with *no* similarity gate (observed matches at similarity 0.00).

## Why this is opt-in, not a default-on fix

I reproduced the over-fire and validated candidate fixes on the cached **earnings22-kws** set (200 files; baseline **F 97.8% / recall 95.7% / precision 100%**). A short-distractor repro on ordinary speech starts at **12 false-positive insertions**.

| Default-on lever | repro FP | earnings22 recall |
|---|---|---|
| baseline | 12 | 95.7% |
| cbw taper (pivot 4 / 5) | 8 / 6 | 92.0% / 90.5% |
| spotter sim-floor 0.30/0.50 | **0** | 86.5% |
| spotter floor, multi-word only | 7 | 92.6% |

**Every default-on gate trades earnings22 recall ~1:1**, because the over-fire and the genuine KWS recall on distinctive-name vocabularies come from the *same* mechanisms (the flat boost + acoustic rescue), and neither string similarity nor token length separates them. This matches the reporter's own sweep conclusion ("nothing approaches 0.14.5; tightening the gates only destroys recall") and their diagnosis that the real fix is the DP score scale (their ask #3 — a larger, separately-benchmarked effort needing the FDA + FDA-extended suites).

So this PR ships the reporter's ask #1/#2: the levers as **opt-in config, defaulting to disabled (zero behavior change)**.

## Changes

- `VocabularyRescorer.Config`:
  - `shortTermCbwTaperPivot` / `shortTermCbwTaperExponent` — taper the cbw boost down for terms with fewer than `pivot` tokens (`cbw * (tokenCount/pivot) ** exponent`). Disabled when `pivot <= 1` (default).
  - `spotterRescueMinSimilarity` / `spotterRescueMultiWordMinSimilarity` — require a minimum string similarity before the acoustic spotter-rescue may fire (higher for multi-word spans). Disabled at `0.0` (default).
- `transcribe` CLI flags: `--vocab-short-term-taper-pivot`, `--vocab-spotter-min-sim`, `--vocab-spotter-min-sim-multi`.
- `FLUID_CBW_TAPER_PIVOT` / `FLUID_CBW_TAPER_EXP` / `FLUID_SPOTTER_MIN_SIM` / `FLUID_SPOTTER_MIN_SIM_MULTI` env overrides for sweeps.
- Docs section in `Documentation/ASR/CustomVocabulary.md`.

## Verification

- **Defaults reproduce baseline earnings22 exactly**: F 97.8%, recall 95.7%, precision 100%, FP 0 (200 files).
- **Recommended short-vocab opt-in** (taper pivot 5, spotter floors 0.30/0.50): short-distractor repro **12 → 0** false-positive insertions.
- Unit tests for the taper math and the disabled-by-default guarantee.

## Not included (follow-up)

The deeper score-scale rework (ask #3) and exposing `TDT_EMISSION_DELAY_FRAMES` as proper API (the reporter's bonus) are left for a separate change; the score-scale fix needs the full FDA / FDA-extended benchmark suites to validate safely.