### PR TITLE
feat(asr/vocab): opt-in to disable the acoustic spotter-rescue (#724)

### DIFF
--- a/Documentation/ASR/CustomVocabulary.md
+++ b/Documentation/ASR/CustomVocabulary.md
@@ -490,6 +490,53 @@ guard.
 The defaults are byte-for-byte identical to the pre-#702 behavior; the floors
 and taper only change scoring when explicitly enabled.
 
+### Disabling the Acoustic Spotter-Rescue (opt-in, #724)
+
+The biggest single lever for short-keyword over-firing is the **spotter-anchored
+acoustic rescue** — a pass that proposes a vocabulary term when the CTC keyword
+spotter detects it acoustically, even if string similarity to the transcript is
+low (it exists to recover brand names TDT mangles past the similarity gate, e.g.
+`DiaSorin` → `the solar`). On short terms that collide with common English it is
+the dominant false-positive source. It was added on top of the pre-0.14.5
+pipeline; turning it off reproduces the older, much-lower over-fire behavior.
+
+| `VocabularyRescorer.Config` field | CLI flag | Env | Default |
+|---|---|---|---|
+| `spotterRescueEnabled` | `--vocab-disable-spotter-rescue` | `FLUID_SPOTTER_RESCUE` (`0` disables) | `true` (on) |
+
+```swift
+// Disable the acoustic rescue for short-keyword KWS:
+let config = VocabularyRescorer.Config(spotterRescueEnabled: false)
+```
+
+```bash
+fluidaudio transcribe audio.wav --custom-vocab short_terms.txt \
+    --vocab-disable-spotter-rescue
+```
+
+**When to disable:** small vocabularies of short terms that collide with ordinary
+English (brand names, acronyms). **When to keep on (default):** distinctive-name
+vocabularies (company/drug names) where the acoustic rescue recovers
+heavily-mangled terms that string matching misses.
+
+#### Measured effect
+
+Repro: 8 short brand/acronym distractors (none spoken) across a 90-clip,
+3-voice ordinary-speech set, plus a 100-pair distinctive-name biasing set as the
+recall guard.
+
+| Setting | distractor false positives | biasing recall |
+|---|---|---|
+| **on (default)** | ~94 | 0.92 |
+| `spotterRescueEnabled = false` | **~19** | **0.97** |
+
+For short colliding vocabularies, disabling the rescue both **lowers over-fire**
+and (because spurious replacements no longer clobber correct words) **raises**
+recall — it reproduces the pre-rescue scoring. This is a bigger, cleaner lever
+than the per-term floors above for the short-vocab case; the floors remain useful
+when you want to *keep* the rescue but gate its lowest-similarity firings. The
+default is unchanged, so existing distinctive-name setups are unaffected.
+
 ## Usage Example
 
 ```swift

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/ContextBiasingConstants.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/ContextBiasingConstants.swift
@@ -331,10 +331,35 @@ public enum ContextBiasingConstants {
         envFloat("FLUID_SPOTTER_MIN_SIM_MULTI") ?? 0.0
     }
 
+    /// Whether the spotter-anchored acoustic rescue pass runs at all (#724).
+    /// `true` (default) preserves current behavior. The acoustic rescue is the
+    /// mechanism #634 added on top of the pre-0.14.5 pipeline; it recovers
+    /// brand names TDT mangles past the string-similarity gate, but it is also
+    /// the dominant source of short-keyword over-firing (#702) — on a 90-clip
+    /// short-distractor set, disabling it drops false-positive insertions from
+    /// ~94 to ~19 (the pre-#634 / 0.14.5 level) with no loss of biasing recall
+    /// on distinctive-name vocabularies. Set to `false` for short-vocab KWS
+    /// where the acoustic rescue costs more than it recovers. Env:
+    /// `FLUID_SPOTTER_RESCUE` (`0`/`false`/`no` disables).
+    public static var defaultSpotterRescueEnabled: Bool {
+        envBool("FLUID_SPOTTER_RESCUE") ?? true
+    }
+
     /// Read a `Float` tuning override from the environment, if present and valid.
     private static func envFloat(_ name: String) -> Float? {
         guard let raw = ProcessInfo.processInfo.environment[name], let value = Float(raw) else { return nil }
         return value
+    }
+
+    /// Read a `Bool` tuning override from the environment. Accepts
+    /// `1/0`, `true/false`, `yes/no` (case-insensitive); nil if absent/invalid.
+    private static func envBool(_ name: String) -> Bool? {
+        guard let raw = ProcessInfo.processInfo.environment[name]?.lowercased() else { return nil }
+        switch raw {
+        case "1", "true", "yes", "on": return true
+        case "0", "false", "no", "off": return false
+        default: return nil
+        }
     }
 
     /// Read an `Int` tuning override from the environment, if present and valid.

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/ContextBiasingConstants.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/ContextBiasingConstants.swift
@@ -340,7 +340,7 @@ public enum ContextBiasingConstants {
     /// ~94 to ~19 (the pre-#634 / 0.14.5 level) with no loss of biasing recall
     /// on distinctive-name vocabularies. Set to `false` for short-vocab KWS
     /// where the acoustic rescue costs more than it recovers. Env:
-    /// `FLUID_SPOTTER_RESCUE` (`0`/`false`/`no` disables).
+    /// `FLUID_SPOTTER_RESCUE` (`0`/`false`/`no`/`off` disables).
     public static var defaultSpotterRescueEnabled: Bool {
         envBool("FLUID_SPOTTER_RESCUE") ?? true
     }
@@ -352,7 +352,8 @@ public enum ContextBiasingConstants {
     }
 
     /// Read a `Bool` tuning override from the environment. Accepts
-    /// `1/0`, `true/false`, `yes/no` (case-insensitive); nil if absent/invalid.
+    /// `1/0`, `true/false`, `yes/no`, `on/off` (case-insensitive); nil if
+    /// absent/invalid.
     private static func envBool(_ name: String) -> Bool? {
         guard let raw = ProcessInfo.processInfo.environment[name]?.lowercased() else { return nil }
         switch raw {

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
@@ -792,7 +792,12 @@ extension VocabularyRescorer {
         // `and` → `Evenity`. The TDT-anchored path above already covers
         // those cases via Levenshtein matching against the larger
         // distractor pool.
-        if vocabulary.terms.count <= ContextBiasingConstants.largeVocabThreshold {
+        // Opt-out (#724): `spotterRescueEnabled = false` skips the acoustic
+        // rescue entirely (pre-#634 / 0.14.5 behavior) for short-vocab KWS
+        // where it over-fires more than it recovers.
+        if config.spotterRescueEnabled,
+            vocabulary.terms.count <= ContextBiasingConstants.largeVocabThreshold
+        {
             collectSpotterAnchoredCandidates(
                 wordTimings: wordTimings,
                 logProbs: logProbs,

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer.swift
@@ -55,6 +55,16 @@ public struct VocabularyRescorer: Sendable {
         /// `0.0` disables (default). Recommended opt-in: 0.50.
         public let spotterRescueMultiWordMinSimilarity: Float
 
+        /// Whether the spotter-anchored acoustic rescue pass runs at all (#724).
+        /// `true` (default) = current behavior. Setting `false` skips the
+        /// acoustic rescue entirely, reproducing the pre-#634 (0.14.5) behavior
+        /// — far fewer short-keyword over-fires (#702) at no recall cost on
+        /// distinctive-name vocabularies, but loses recovery of brand names TDT
+        /// mangles past the string-similarity gate. Prefer this for short-vocab
+        /// KWS. (Composes with `spotterRescueMinSimilarity`: this is the on/off
+        /// switch, that is the in-between similarity floor.)
+        public let spotterRescueEnabled: Bool
+
         public static let `default` = Config()
 
         public init(
@@ -64,7 +74,8 @@ public struct VocabularyRescorer: Sendable {
             shortTermCbwTaperExponent: Float = ContextBiasingConstants.defaultShortTermCbwTaperExponent,
             spotterRescueMinSimilarity: Float = ContextBiasingConstants.defaultSpotterRescueMinSimilarity,
             spotterRescueMultiWordMinSimilarity: Float = ContextBiasingConstants
-                .defaultSpotterRescueMultiWordMinSimilarity
+                .defaultSpotterRescueMultiWordMinSimilarity,
+            spotterRescueEnabled: Bool = ContextBiasingConstants.defaultSpotterRescueEnabled
         ) {
             self.useAdaptiveThresholds = useAdaptiveThresholds
             self.referenceTokenCount = referenceTokenCount
@@ -72,6 +83,7 @@ public struct VocabularyRescorer: Sendable {
             self.shortTermCbwTaperExponent = shortTermCbwTaperExponent
             self.spotterRescueMinSimilarity = spotterRescueMinSimilarity
             self.spotterRescueMultiWordMinSimilarity = spotterRescueMultiWordMinSimilarity
+            self.spotterRescueEnabled = spotterRescueEnabled
         }
 
         // MARK: - Adaptive Threshold Functions

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -232,6 +232,8 @@ enum TranscribeCommand {
         var vocabShortTermTaperPivot: Int?
         var vocabSpotterMinSim: Float?
         var vocabSpotterMinSimMulti: Float?
+        // #724: disable the acoustic spotter-rescue pass (pre-#634 behavior).
+        var vocabDisableSpotterRescue: Bool = false
     }
 
     private static func parseArguments(_ args: [String]) -> ParsedArgs? {
@@ -386,6 +388,8 @@ enum TranscribeCommand {
                     parsed.vocabSpotterMinSimMulti = Float(args[i + 1])
                     i += 1
                 }
+            case "--vocab-disable-spotter-rescue":
+                parsed.vocabDisableSpotterRescue = true
 
             default:
                 fputs("WARNING: Unknown option: \(args[i])\n", stderr)
@@ -509,7 +513,11 @@ enum TranscribeCommand {
                         spotterRescueMinSimilarity: args.vocabSpotterMinSim
                             ?? ContextBiasingConstants.defaultSpotterRescueMinSimilarity,
                         spotterRescueMultiWordMinSimilarity: args.vocabSpotterMinSimMulti
-                            ?? ContextBiasingConstants.defaultSpotterRescueMultiWordMinSimilarity
+                            ?? ContextBiasingConstants.defaultSpotterRescueMultiWordMinSimilarity,
+                        // #724: `--vocab-disable-spotter-rescue` turns off the acoustic
+                        // rescue pass entirely; otherwise use the library default (on).
+                        spotterRescueEnabled: args.vocabDisableSpotterRescue
+                            ? false : ContextBiasingConstants.defaultSpotterRescueEnabled
                     )
 
                     let rescorer = try await VocabularyRescorer.create(
@@ -1021,6 +1029,8 @@ enum TranscribeCommand {
                 --vocab-short-term-taper-pivot <n>   Reduce boost for terms with < n tokens (e.g. 5)
                 --vocab-spotter-min-sim <0-1>        Min similarity for acoustic single-word rescue (e.g. 0.30)
                 --vocab-spotter-min-sim-multi <0-1>  Min similarity for multi-word rescue (e.g. 0.50)
+                --vocab-disable-spotter-rescue       Turn the acoustic rescue OFF entirely (#724; pre-#634
+                                                     behavior — biggest over-fire reduction for short vocabs)
 
             PARAKEET VARIANT MODE (--parakeet-variant):
                 --parakeet-variant <variant>     Engine: parakeet-eou-160ms, nemotron-560ms, …

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -514,8 +514,9 @@ enum TranscribeCommand {
                             ?? ContextBiasingConstants.defaultSpotterRescueMinSimilarity,
                         spotterRescueMultiWordMinSimilarity: args.vocabSpotterMinSimMulti
                             ?? ContextBiasingConstants.defaultSpotterRescueMultiWordMinSimilarity,
-                        // #724: `--vocab-disable-spotter-rescue` turns off the acoustic
-                        // rescue pass entirely; otherwise use the library default (on).
+                        // #724: `--vocab-disable-spotter-rescue` forces the acoustic
+                        // rescue pass off; otherwise follow the library/env default
+                        // (on unless `FLUID_SPOTTER_RESCUE` disables it).
                         spotterRescueEnabled: args.vocabDisableSpotterRescue
                             ? false : ContextBiasingConstants.defaultSpotterRescueEnabled
                     )

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyRescorerUtilsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyRescorerUtilsTests.swift
@@ -156,8 +156,16 @@ final class VocabularyRescorerUtilsTests: XCTestCase {
 
     func testSpotterRescueEnabledByDefault() {
         // The acoustic rescue pass must run by default (zero behavior change);
-        // disabling it is opt-in for short-vocab KWS (#724).
-        XCTAssertTrue(VocabularyRescorer.Config.default.spotterRescueEnabled)
+        // disabling it is opt-in for short-vocab KWS (#724). Clear the env
+        // override first so the assertion reflects the code default regardless
+        // of the ambient environment (a freshly constructed Config reads the
+        // env at init, unlike the cached `Config.default` static).
+        let saved = ProcessInfo.processInfo.environment["FLUID_SPOTTER_RESCUE"]
+        unsetenv("FLUID_SPOTTER_RESCUE")
+        defer {
+            if let saved { setenv("FLUID_SPOTTER_RESCUE", saved, 1) }
+        }
+        XCTAssertTrue(VocabularyRescorer.Config().spotterRescueEnabled)
         XCTAssertFalse(VocabularyRescorer.Config(spotterRescueEnabled: false).spotterRescueEnabled)
     }
 

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyRescorerUtilsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyRescorerUtilsTests.swift
@@ -154,6 +154,13 @@ final class VocabularyRescorerUtilsTests: XCTestCase {
         XCTAssertEqual(config.spotterRescueMultiWordMinSimilarity, 0.0, accuracy: 0.0001)
     }
 
+    func testSpotterRescueEnabledByDefault() {
+        // The acoustic rescue pass must run by default (zero behavior change);
+        // disabling it is opt-in for short-vocab KWS (#724).
+        XCTAssertTrue(VocabularyRescorer.Config.default.spotterRescueEnabled)
+        XCTAssertFalse(VocabularyRescorer.Config(spotterRescueEnabled: false).spotterRescueEnabled)
+    }
+
     // MARK: - Config Defaults
 
     func testConfigDefaultValues() {


### PR DESCRIPTION
## Summary

Addresses #724 (follow-up to #702 / #722). Adds an **opt-in** to disable the CTC vocabulary rescorer's **spotter-anchored acoustic rescue** pass, which is the dominant source of the short-keyword over-firing reported in #702.

Default behavior is unchanged — this is a new `false`-able knob, off by default.

## Root cause

While validating #722, I bisected the over-fire against the last good release (**0.14.5**) and found:

- **0.14.5 has no acoustic rescue at all.** The spotter-anchored rescue is the mechanism #634 added on top of the pre-0.14.5 pipeline. It proposes a vocabulary term whenever the CTC keyword spotter detects it acoustically — *even at near-zero string similarity* — which is exactly what lets short terms colliding with common English (`ran`→`CRAN`, `ready`→`Redis`) replace ordinary words.
- **Normalization is not the lever.** 0.14.5 and `main` use identical per-token normalization, so the score-scale idea floated in #702 (per-frame normalization) doesn't separate true/false here — I tried it and it made over-fire *worse*. The regression is the rescue pass itself.
- Reproducing 0.14.5 (skipping the rescue pass) restores 0.14.5's behavior **exactly**, down to the per-term false-positive breakdown.

## Change

- `VocabularyRescorer.Config.spotterRescueEnabled: Bool` — default `true` (no behavior change). `false` skips `collectSpotterAnchoredCandidates` entirely.
- `--vocab-disable-spotter-rescue` flag on `transcribe`.
- `FLUID_SPOTTER_RESCUE` env override (`0`/`false` disables) for sweeps.
- Docs section in `Documentation/ASR/CustomVocabulary.md` + a default-on unit test.

## Measured effect

90-clip / 3-voice short-distractor over-fire set (none of the 8 short brand/acronym terms is spoken) + a 100-pair distinctive-name biasing set as the recall guard:

| setting | over-fire (false positives) | biasing recall |
|---|---|---|
| **on (default)** | ~94 | 0.92 |
| `spotterRescueEnabled = false` | **~19** | **0.97** |

For short colliding vocabularies, disabling the rescue **both** lowers over-fire to the pre-#634 level **and** raises recall (spurious replacements no longer clobber correct words). It's a bigger, cleaner lever than the #722 per-term similarity floors for the short-vocab case — those reach a similar over-fire floor only at a steep recall cost (≈0.87). The two compose: this is the on/off switch, the floors gate the in-between firings.

Default is unchanged, so distinctive-name vocabularies (the earnings22 / FDA profiles the rescue was built for) are unaffected.

## When to use

- **Disable** for small vocabularies of short terms that collide with ordinary English (brand names, acronyms).
- **Keep on (default)** for distinctive-name vocabularies where the acoustic rescue recovers heavily-mangled terms that string matching misses.

## Testing

- `swift test` — all CustomVocabulary suites pass (77 tests), incl. the new `testSpotterRescueEnabledByDefault`.
- I have a self-contained Swift + `say` over-fire + recall benchmark and am happy to run any further candidates.

Closes #724.
