### PR TITLE
LS-EEND Speaker Pre-Enrollment Bugfixes

### DIFF
--- a/Sources/FluidAudio/Diarizer/DiarizerTimeline.swift
+++ b/Sources/FluidAudio/Diarizer/DiarizerTimeline.swift
@@ -1086,8 +1086,8 @@ public class DiarizerTimeline {
     ) -> DiarizerSpeaker? {
         lock.lock()
         defer { lock.unlock() }
-        guard config.storeSegments else { return nil }
-        // Ensure index is within bounds
+        // Speaker identity registration is independent of `storeSegments` (mirrors the
+        // `named:` overload) so enrollment can register a speaker even in emit-only mode.
         let index = index ?? (0..<speakerCapacity).first { _speakers[$0] == nil }
 
         guard let index, index >= 0, index < speakerCapacity else {

--- a/Sources/FluidAudio/Diarizer/DiarizerTimeline.swift
+++ b/Sources/FluidAudio/Diarizer/DiarizerTimeline.swift
@@ -667,7 +667,7 @@ public class DiarizerTimeline {
     private let lock = NSLock()
 
     /// Post-processing configuration
-    public private(set) var config: DiarizerTimelineConfig
+    public let config: DiarizerTimelineConfig
 
     /// Finalized frame-wise speaker predictions.
     /// Flat array of shape [numFrames, numSpeakers].
@@ -933,21 +933,6 @@ public class DiarizerTimeline {
         }
     }
 
-    // MARK: - Configuration
-
-    /// Temporarily override whether committed segments are persisted on speakers,
-    /// returning the previous value. Enrollment forces this on because it must read
-    /// the detected speaker back from the timeline to map it to a slot; callers are
-    /// responsible for restoring the configured value when finished.
-    @discardableResult
-    public func setStoreSegments(_ enabled: Bool) -> Bool {
-        lock.withLock {
-            let previous = config.storeSegments
-            config.storeSegments = enabled
-            return previous
-        }
-    }
-
     // MARK: - Rebuild Timeline
 
     /// Rebuild the timeline from initial predictions. This is equivalent to reinitializing the timeline.
@@ -1054,7 +1039,11 @@ public class DiarizerTimeline {
 
     // MARK: - Timeline Speaker Management
 
-    /// Add a speaker to the timeline at a given slot, or update their name if one already exists
+    /// Add a speaker to the timeline at a given slot, or update their name if one already exists.
+    ///
+    /// Registers speaker *identity* and is intentionally independent of
+    /// `config.storeSegments`: enrollment derives the slot from a `DiarizerTimelineUpdate`
+    /// and must be able to persist the named speaker even when segments aren't stored.
     /// - Parameters:
     ///   - name: The speaker's name
     ///   - index: The diarizer index of the speaker. If left as `nil`, the first unused index will be chosen.
@@ -1066,7 +1055,6 @@ public class DiarizerTimeline {
     ) -> DiarizerSpeaker? {
         lock.lock()
         defer { lock.unlock() }
-        guard config.storeSegments else { return nil }
         let index = index ?? (0..<speakerCapacity).first { _speakers[$0] == nil }
 
         // Ensure index is within bounds

--- a/Sources/FluidAudio/Diarizer/DiarizerTimeline.swift
+++ b/Sources/FluidAudio/Diarizer/DiarizerTimeline.swift
@@ -667,7 +667,7 @@ public class DiarizerTimeline {
     private let lock = NSLock()
 
     /// Post-processing configuration
-    public let config: DiarizerTimelineConfig
+    public private(set) var config: DiarizerTimelineConfig
 
     /// Finalized frame-wise speaker predictions.
     /// Flat array of shape [numFrames, numSpeakers].
@@ -930,6 +930,21 @@ public class DiarizerTimeline {
             }
         } else {
             _speakers.removeAll(keepingCapacity: true)
+        }
+    }
+
+    // MARK: - Configuration
+
+    /// Temporarily override whether committed segments are persisted on speakers,
+    /// returning the previous value. Enrollment forces this on because it must read
+    /// the detected speaker back from the timeline to map it to a slot; callers are
+    /// responsible for restoring the configured value when finished.
+    @discardableResult
+    public func setStoreSegments(_ enabled: Bool) -> Bool {
+        lock.withLock {
+            let previous = config.storeSegments
+            config.storeSegments = enabled
+            return previous
         }
     }
 

--- a/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDDiarizer.swift
+++ b/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDDiarizer.swift
@@ -342,7 +342,7 @@ public final class LSEENDDiarizer: Diarizer {
         // Get the new/unnamed speaker with the most speech if any exist.
         // Fallback to old speaker with the most speech if overwrites are allowed.
         var speechActivities: [Int: Float] = [:]
-        for segment in update.finalizedSegments {
+        for segment in update.finalizedSegments + update.tentativeSegments {
             speechActivities[segment.speakerIndex, default: 0] += segment.activity * Float(segment.length)
         }
 
@@ -359,8 +359,6 @@ public final class LSEENDDiarizer: Diarizer {
         guard let bestSlot,
             !requireNewSpeaker || !oldSlots.contains(bestSlot),
             // Register the enrolled speaker at the slot identified from the update.
-            // Derived from the update rather than persisted timeline segments, so it
-            // works even when the timeline is configured not to store segments.
             let enrolledSpeaker = timeline.upsertSpeaker(named: name, atIndex: bestSlot)
         else {
             session.rollback(to: sessionSnapshot)
@@ -371,10 +369,7 @@ public final class LSEENDDiarizer: Diarizer {
 
         timeline.reset(keepingSpeakers: true)
 
-        // Re-arm the right-context warmup strip for the live stream. The timeline
-        // origin is now frame 0, but the encoder's convDelay look-ahead still holds
-        // the enrollment drain silence; resetting the counter makes the first live
-        // chunk strip those frames so reported timestamps stay aligned to real time.
+        // Re-arm the right-context warmup strip for the live stream to timestamp drift.
         framesFedToModel = 0
 
         return enrolledSpeaker

--- a/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDDiarizer.swift
+++ b/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDDiarizer.swift
@@ -299,6 +299,13 @@ public final class LSEENDDiarizer: Diarizer {
         let sessionSnapshot = try session.takeSnapshot()
         let timelineSnapshot = timeline.takeSnapshot()
         let framesFedSnapshot = framesFedToModel
+
+        // Enrollment identifies the new speaker by reading it back from the timeline,
+        // which requires segments to be stored. Force storage on for the duration and
+        // restore the configured value when finished (the caller may have disabled it).
+        let storeSegmentsSnapshot = timeline.setStoreSegments(true)
+        defer { timeline.setStoreSegments(storeSegmentsSnapshot) }
+
         let isNamed = name != nil
 
         let requireNewSpeaker = isNamed && !overwriteAssignedSpeakerName

--- a/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDDiarizer.swift
+++ b/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDDiarizer.swift
@@ -298,6 +298,7 @@ public final class LSEENDDiarizer: Diarizer {
 
         let sessionSnapshot = try session.takeSnapshot()
         let timelineSnapshot = timeline.takeSnapshot()
+        let framesFedSnapshot = framesFedToModel
         let isNamed = name != nil
 
         let requireNewSpeaker = isNamed && !overwriteAssignedSpeakerName
@@ -334,6 +335,7 @@ public final class LSEENDDiarizer: Diarizer {
         else {
             session.rollback(to: sessionSnapshot)
             timeline.rollback(to: timelineSnapshot)
+            framesFedToModel = framesFedSnapshot
             return nil
         }
 
@@ -360,12 +362,19 @@ public final class LSEENDDiarizer: Diarizer {
         else {
             session.rollback(to: sessionSnapshot)
             timeline.rollback(to: timelineSnapshot)
+            framesFedToModel = framesFedSnapshot
             return nil
         }
 
         // Rename speaker and report success
         enrolledSpeaker.name = name
         timeline.reset(keepingSpeakers: true)
+
+        // Re-arm the right-context warmup strip for the live stream. The timeline
+        // origin is now frame 0, but the encoder's convDelay look-ahead still holds
+        // the enrollment drain silence; resetting the counter makes the first live
+        // chunk strip those frames so reported timestamps stay aligned to real time.
+        framesFedToModel = 0
 
         return enrolledSpeaker
     }

--- a/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDDiarizer.swift
+++ b/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDDiarizer.swift
@@ -299,13 +299,6 @@ public final class LSEENDDiarizer: Diarizer {
         let sessionSnapshot = try session.takeSnapshot()
         let timelineSnapshot = timeline.takeSnapshot()
         let framesFedSnapshot = framesFedToModel
-
-        // Enrollment identifies the new speaker by reading it back from the timeline,
-        // which requires segments to be stored. Force storage on for the duration and
-        // restore the configured value when finished (the caller may have disabled it).
-        let storeSegmentsSnapshot = timeline.setStoreSegments(true)
-        defer { timeline.setStoreSegments(storeSegmentsSnapshot) }
-
         let isNamed = name != nil
 
         let requireNewSpeaker = isNamed && !overwriteAssignedSpeakerName
@@ -364,8 +357,11 @@ public final class LSEENDDiarizer: Diarizer {
         }?.key
 
         guard let bestSlot,
-            let enrolledSpeaker = timeline.speakers[bestSlot],
-            !requireNewSpeaker || !oldSlots.contains(bestSlot)
+            !requireNewSpeaker || !oldSlots.contains(bestSlot),
+            // Register the enrolled speaker at the slot identified from the update.
+            // Derived from the update rather than persisted timeline segments, so it
+            // works even when the timeline is configured not to store segments.
+            let enrolledSpeaker = timeline.upsertSpeaker(named: name, atIndex: bestSlot)
         else {
             session.rollback(to: sessionSnapshot)
             timeline.rollback(to: timelineSnapshot)
@@ -373,8 +369,6 @@ public final class LSEENDDiarizer: Diarizer {
             return nil
         }
 
-        // Rename speaker and report success
-        enrolledSpeaker.name = name
         timeline.reset(keepingSpeakers: true)
 
         // Re-arm the right-context warmup strip for the live stream. The timeline

--- a/Sources/FluidAudio/Diarizer/Sortformer/SortformerDiarizer.swift
+++ b/Sources/FluidAudio/Diarizer/Sortformer/SortformerDiarizer.swift
@@ -244,12 +244,6 @@ public final class SortformerDiarizer: Diarizer {
                 throw SortformerError.notInitialized
             }
 
-            // Enrollment identifies the new speaker by reading it back from the timeline,
-            // which requires segments to be stored. Force storage on for the duration and
-            // restore the configured value when finished (the caller may have disabled it).
-            let storeSegmentsSnapshot = _timeline.setStoreSegments(true)
-            defer { _timeline.setStoreSegments(storeSegmentsSnapshot) }
-
             if _timeline.hasSegments {
                 logger.warning("Trying to enroll a speaker while timeline has segments; timeline will be reset")
             }
@@ -268,8 +262,19 @@ public final class SortformerDiarizer: Diarizer {
 
             preprocessAudioToFeaturesLocked()
 
+            // Accumulate per-slot speech frames from the diarizer updates rather than
+            // from persisted timeline segments, so enrollment works even when the
+            // timeline is configured not to store segments.
+            var speechFrames: [Int: Int] = [:]
+            var lastUpdate: DiarizerTimelineUpdate?
             var didProcess: Bool = false
-            while let _ = try processLocked(updateTimeline: true) { didProcess = true }
+            while let update = try processLocked(updateTimeline: true) {
+                didProcess = true
+                for segment in update.finalizedSegments {
+                    speechFrames[segment.speakerIndex, default: 0] += segment.length
+                }
+                lastUpdate = update
+            }
 
             guard didProcess else {
                 let minDuration = Float(config.chunkLen + config.chunkRightContext) * config.frameDurationSeconds
@@ -279,15 +284,20 @@ public final class SortformerDiarizer: Diarizer {
                 return nil
             }
 
-            let speaker = _timeline.speakers.values.max { $0.numSpeechFrames < $1.numSpeechFrames }
+            // Include the trailing still-open (tentative) segment from the final update.
+            for segment in lastUpdate?.tentativeSegments ?? [] {
+                speechFrames[segment.speakerIndex, default: 0] += segment.length
+            }
+
+            let bestSlot = speechFrames.max { $0.value < $1.value }?.key
             let enrolledSpeaker: DiarizerSpeaker?
-            if let speaker, speaker.hasSegments {
+            if let bestSlot, (speechFrames[bestSlot] ?? 0) > 0 {
                 // Provide warnings if the diarizer failed to recognize this person as a new speaker
-                if let oldName = speaker.name {
+                if let oldName = _timeline.speakers[bestSlot]?.name {
                     guard overwriteAssignedSpeakerName else {
                         logger.warning(
                             "Failed to enroll speaker \(description): diarizer matched existing speaker '\(oldName)' "
-                                + "at index \(speaker.index) and overwritingAssignedSpeakerName=false"
+                                + "at index \(bestSlot) and overwritingAssignedSpeakerName=false"
                         )
                         _timeline.reset(keepingSpeakersWhere: { occupiedIndices.contains($0.index) })
                         _numFramesProcessed = 0
@@ -300,12 +310,15 @@ public final class SortformerDiarizer: Diarizer {
                         return nil
                     }
                     logger.warning(
-                        "Newly-enrolled speaker \(description) will overwrite the old one named \(oldName) at index \(speaker.index)"
+                        "Newly-enrolled speaker \(description) will overwrite the old one named \(oldName) at index \(bestSlot)"
                     )
                 }
-                speaker.name = name
-                occupiedIndices.insert(speaker.index)
-                enrolledSpeaker = speaker
+                // Register the enrolled speaker at the chosen slot regardless of whether
+                // segments are persisted; the slot came from the updates above.
+                enrolledSpeaker = _timeline.upsertSpeaker(named: name, atIndex: bestSlot)
+                if enrolledSpeaker != nil {
+                    occupiedIndices.insert(bestSlot)
+                }
             } else {
                 logger.warning("Failed to enroll speaker \(description) because no speech detected")
                 enrolledSpeaker = nil

--- a/Sources/FluidAudio/Diarizer/Sortformer/SortformerDiarizer.swift
+++ b/Sources/FluidAudio/Diarizer/Sortformer/SortformerDiarizer.swift
@@ -244,6 +244,12 @@ public final class SortformerDiarizer: Diarizer {
                 throw SortformerError.notInitialized
             }
 
+            // Enrollment identifies the new speaker by reading it back from the timeline,
+            // which requires segments to be stored. Force storage on for the duration and
+            // restore the configured value when finished (the caller may have disabled it).
+            let storeSegmentsSnapshot = _timeline.setStoreSegments(true)
+            defer { _timeline.setStoreSegments(storeSegmentsSnapshot) }
+
             if _timeline.hasSegments {
                 logger.warning("Trying to enroll a speaker while timeline has segments; timeline will be reset")
             }

--- a/Tests/FluidAudioTests/Diarizer/Sortformer/SortformerTimelineTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Sortformer/SortformerTimelineTests.swift
@@ -388,14 +388,19 @@ final class SortformerTimelineTests: XCTestCase {
         XCTAssertTrue(timeline.speakers.isEmpty, "Tentative segments must not create speakers")
     }
 
-    func testUpsertSpeakerRefusedInEmitOnlyMode() {
+    func testUpsertSpeakerAllowedInEmitOnlyMode() {
         var config = DiarizerTimelineConfig.sortformerDefault
         config.storeSegments = false
         let timeline = DiarizerTimeline(config: config)
 
-        XCTAssertNil(timeline.upsertSpeaker(named: "Alice", atIndex: 0))
-        XCTAssertNil(timeline.upsertSpeaker(DiarizerSpeaker(index: 1, name: "Bob"), atIndex: 1))
-        XCTAssertTrue(timeline.speakers.isEmpty)
+        // Speaker identity registration is independent of segment storage: enrollment
+        // must be able to register a named speaker even when the timeline only emits
+        // segments via updates. Auto-tracking of speakers from processing stays off.
+        let alice = timeline.upsertSpeaker(named: "Alice", atIndex: 0)
+        XCTAssertEqual(alice?.name, "Alice")
+        let bob = timeline.upsertSpeaker(DiarizerSpeaker(index: 1, name: "Bob"), atIndex: 1)
+        XCTAssertEqual(bob?.name, "Bob")
+        XCTAssertEqual(Set(timeline.speakers.keys), [0, 1])
     }
 
     func testSnapshotInitDropsSpeakersInEmitOnlyMode() throws {

--- a/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
@@ -328,6 +328,38 @@ final class SpeakerEnrollmentTests: XCTestCase {
         XCTAssertEqual(namedSpeakerNames(in: diarizer.timeline), ["Alice"])
     }
 
+    func testSortformerEnrollmentWorksWhenTimelineDoesNotStoreSegments() async throws {
+        XCTExpectFailure("Download might fail in CI environment", strict: false)
+
+        let config = SortformerConfig.default
+        let models = try await loadSortformerModelsForTest(config: config)
+        let enrollmentAudio = try DiarizationTestFixtures.fixtureAudio(
+            sampleRate: config.sampleRate, startSeconds: 0.0, durationSeconds: 5.0)
+
+        // Control: confirm the fixture yields a confident speaker with storage on.
+        let control = SortformerDiarizer(config: config)
+        control.initialize(models: models)
+        let controlSpeaker = try control.enrollSpeaker(withAudio: enrollmentAudio, named: "Alice")
+        try XCTSkipIf(
+            controlSpeaker == nil, "Fixture did not produce a confident Sortformer speaker segment on this host.")
+
+        // Timeline configured NOT to store segments: enrollment must still succeed by
+        // temporarily storing segments, then fall back to the configured value.
+        let diarizer = SortformerDiarizer(
+            config: config, timelineConfig: DiarizerTimelineConfig(storeSegments: false))
+        diarizer.initialize(models: models)
+        XCTAssertFalse(diarizer.timeline.config.storeSegments)
+
+        let speaker = try diarizer.enrollSpeaker(withAudio: enrollmentAudio, named: "Alice")
+
+        XCTAssertNotNil(
+            speaker, "Enrollment must work even when the timeline is configured not to store segments")
+        XCTAssertEqual(speaker?.name, "Alice")
+        XCTAssertFalse(
+            diarizer.timeline.config.storeSegments,
+            "store-segments must fall back to its configured value after enrollment")
+    }
+
     // MARK: - LS-EEND enrollSpeaker: Error Cases
 
     func testLseendEnrollSpeakerThrowsWhenNotInitialized() {
@@ -444,6 +476,35 @@ final class SpeakerEnrollmentTests: XCTestCase {
         XCTAssertEqual(
             enrolled.timeline.numFinalizedFrames, baselineFrames,
             "Enrollment must not offset the streaming timeline by the right-context lag")
+    }
+
+    func testLseendEnrollmentWorksWhenTimelineDoesNotStoreSegments() async throws {
+        let model = try await loadLseendModelForTest()
+
+        // Control: with segment storage on (default), confirm the fixture yields a
+        // confident speaker on this host; otherwise the host can't exercise enrollment.
+        let control = try LSEENDDiarizer(model: model)
+        let sampleRate = control.targetSampleRate ?? 16_000
+        let enrollmentAudio = try DiarizationTestFixtures.fixtureAudio(
+            sampleRate: sampleRate, startSeconds: 0.0, durationSeconds: 3.0)
+        let controlSpeaker = try control.enrollSpeaker(withAudio: enrollmentAudio, named: "Alice")
+        try XCTSkipIf(
+            controlSpeaker == nil, "Fixture did not produce a confident LS-EEND speaker segment on this host.")
+
+        // Timeline configured NOT to store segments: enrollment must still succeed by
+        // temporarily storing segments, then fall back to the configured value.
+        let config = DiarizerTimelineConfig(storeSegments: false)
+        let diarizer = try LSEENDDiarizer(model: model, timelineConfig: config)
+        XCTAssertFalse(diarizer.timeline.config.storeSegments)
+
+        let speaker = try diarizer.enrollSpeaker(withAudio: enrollmentAudio, named: "Alice")
+
+        XCTAssertNotNil(
+            speaker, "Enrollment must work even when the timeline is configured not to store segments")
+        XCTAssertEqual(speaker?.name, "Alice")
+        XCTAssertFalse(
+            diarizer.timeline.config.storeSegments,
+            "store-segments must fall back to its configured value after enrollment")
     }
 
     func testLseendMultipleEnrollmentsRetainNamedSpeakersAndSession() async throws {

--- a/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
@@ -407,6 +407,45 @@ final class SpeakerEnrollmentTests: XCTestCase {
         }
     }
 
+    /// Enrollment resets the visible timeline to frame 0, but must not shift the
+    /// streaming timeline relative to real audio. Regression test for the
+    /// right-context (convDelay) offset: an enrolled stream must finalize the same
+    /// number of frames as a baseline stream of identical live audio. Before the
+    /// fix, the enrolled stream skipped the convDelay output strip on its first
+    /// live chunk and ran convDelay frames long, shifting every reported timestamp
+    /// later by the right-context lag.
+    func testLseendEnrollmentDoesNotOffsetStreamingTimeline() async throws {
+        let model = try await loadLseendModelForTest()
+        let chunkSizes = [977, 1231, 1607]
+
+        // Baseline: stream live audio with no enrollment.
+        let baseline = try LSEENDDiarizer(model: model)
+        let sampleRate = baseline.targetSampleRate ?? 16_000
+        let liveAudio = try DiarizationTestFixtures.fixtureAudio(
+            sampleRate: sampleRate, startSeconds: 3.0, durationSeconds: 3.0)
+        for chunk in DiarizationTestFixtures.chunk(liveAudio, sizes: chunkSizes) {
+            _ = try baseline.process(samples: chunk, sourceSampleRate: nil)
+        }
+        _ = try baseline.finalizeSession()
+        let baselineFrames = baseline.timeline.numFinalizedFrames
+        XCTAssertGreaterThan(baselineFrames, 0)
+
+        // Enrolled: enroll a speaker, then stream the identical live audio.
+        let enrolled = try LSEENDDiarizer(model: model)
+        let enrollmentAudio = try DiarizationTestFixtures.fixtureAudio(
+            sampleRate: sampleRate, startSeconds: 0.0, durationSeconds: 3.0)
+        _ = try enrolled.enrollSpeaker(
+            withAudio: enrollmentAudio, sourceSampleRate: nil, named: "Alice")
+        for chunk in DiarizationTestFixtures.chunk(liveAudio, sizes: chunkSizes) {
+            _ = try enrolled.process(samples: chunk, sourceSampleRate: nil)
+        }
+        _ = try enrolled.finalizeSession()
+
+        XCTAssertEqual(
+            enrolled.timeline.numFinalizedFrames, baselineFrames,
+            "Enrollment must not offset the streaming timeline by the right-context lag")
+    }
+
     func testLseendMultipleEnrollmentsRetainNamedSpeakersAndSession() async throws {
         let model = try await loadLseendModelForTest()
         let diarizer = try LSEENDDiarizer(model: model)

--- a/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
@@ -355,9 +355,10 @@ final class SpeakerEnrollmentTests: XCTestCase {
         XCTAssertNotNil(
             speaker, "Enrollment must work even when the timeline is configured not to store segments")
         XCTAssertEqual(speaker?.name, "Alice")
-        XCTAssertFalse(
-            diarizer.timeline.config.storeSegments,
-            "store-segments must fall back to its configured value after enrollment")
+        // The enrolled speaker identity persists (derived from the update, not stored
+        // segments) and the configured store-segments value is left untouched.
+        XCTAssertEqual(namedSpeakerNames(in: diarizer.timeline), ["Alice"])
+        XCTAssertFalse(diarizer.timeline.config.storeSegments)
     }
 
     // MARK: - LS-EEND enrollSpeaker: Error Cases
@@ -502,9 +503,10 @@ final class SpeakerEnrollmentTests: XCTestCase {
         XCTAssertNotNil(
             speaker, "Enrollment must work even when the timeline is configured not to store segments")
         XCTAssertEqual(speaker?.name, "Alice")
-        XCTAssertFalse(
-            diarizer.timeline.config.storeSegments,
-            "store-segments must fall back to its configured value after enrollment")
+        // The enrolled speaker identity persists (derived from the update, not stored
+        // segments) and the configured store-segments value is left untouched.
+        XCTAssertEqual(namedSpeakerNames(in: diarizer.timeline), ["Alice"])
+        XCTAssertFalse(diarizer.timeline.config.storeSegments)
     }
 
     func testLseendMultipleEnrollmentsRetainNamedSpeakersAndSession() async throws {


### PR DESCRIPTION
# Summary:
Fixed two issues with issues with LS-EEND speaker pre-enrollment:

# Issue 1: Pre-Enrollment Offsets `DiarizerTimeline` Timestamps
## Cause:
Pre-enrollment offsets timestamps. The silence frames that pad the pre-enrollment audio are counted as valid frames in the `DiarizerTimeline`, sample count, pushing all actual audio frames about 1 second into the future. 

## Solution:
Reset LS-EEND's sample counter after pre-enrollment to make it exclude the warmup audio from the output. When the actual session starts, the silent frames will be skipped. This will not corrupt the recurrent state because it simply affects which frames are selected from the model's output. Additionally, when pre-enrolling back-to-back speakers, their audio is separated by a silence gap that is double the right context size (i.e., twice the number of frames it will skip), ensuring that no part of the enrollment output is cut off.

# Issue 2: Pre-Enrollment Fails When No Segments Can Be Saved

## Cause:
Disabling segment saving in the DiarizerTimeline prevents pre-enrollment from working because it counts the number of saved new segments for each speaker.

## Solution:
Use the `DiarizerUpdate` object emitted by the flush instead, since it will contain the detected segments regardless of whether the timeline can save segments. Also removed the unit test enforcing this incorrect behavior.

Note: this was also an issue for Sortformer and was fixed in a similar way.