### PR TITLE
Fix type-checker timeout in NemotronMultilingualFleursBenchmark

### DIFF
--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronMultilingualFleursBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronMultilingualFleursBenchmark.swift
@@ -788,14 +788,16 @@ extension NemotronMultilingualFleursBenchmark {
             // Print summary table
             print("")
             print(
-                "Language".padding(toLength: 12, withPad: " ", startingAt: 0) + " | "
-                    + "Prompt".padding(toLength: 8, withPad: " ", startingAt: 0) + " | "
-                    + "WER%".padding(toLength: 6, withPad: " ", startingAt: 0) + " | "
-                    + "CER%".padding(toLength: 6, withPad: " ", startingAt: 0) + " | "
-                    + "RTFx".padding(toLength: 6, withPad: " ", startingAt: 0) + " | "
-                    + "Duration".padding(toLength: 9, withPad: " ", startingAt: 0) + " | "
-                    + "Processed".padding(toLength: 9, withPad: " ", startingAt: 0) + " | "
-                    + "Skipped"
+                [
+                    "Language".padding(toLength: 12, withPad: " ", startingAt: 0),
+                    "Prompt".padding(toLength: 8, withPad: " ", startingAt: 0),
+                    "WER%".padding(toLength: 6, withPad: " ", startingAt: 0),
+                    "CER%".padding(toLength: 6, withPad: " ", startingAt: 0),
+                    "RTFx".padding(toLength: 6, withPad: " ", startingAt: 0),
+                    "Duration".padding(toLength: 9, withPad: " ", startingAt: 0),
+                    "Processed".padding(toLength: 9, withPad: " ", startingAt: 0),
+                    "Skipped",
+                ].joined(separator: " | ")
             )
             print(String(repeating: "-", count: 80))
 
@@ -807,14 +809,16 @@ extension NemotronMultilingualFleursBenchmark {
                 let procStr = String(r.samplesProcessed)
                 let skipStr = r.samplesSkipped > 0 ? String(r.samplesSkipped) : "-"
                 print(
-                    r.language.padding(toLength: 12, withPad: " ", startingAt: 0) + " | "
-                        + r.promptLanguageCode.padding(toLength: 8, withPad: " ", startingAt: 0) + " | "
-                        + werStr.padding(toLength: 6, withPad: " ", startingAt: 0) + " | "
-                        + cerStr.padding(toLength: 6, withPad: " ", startingAt: 0) + " | "
-                        + rtfxStr.padding(toLength: 6, withPad: " ", startingAt: 0) + " | "
-                        + durStr.padding(toLength: 9, withPad: " ", startingAt: 0) + " | "
-                        + procStr.padding(toLength: 9, withPad: " ", startingAt: 0) + " | "
-                        + skipStr
+                    [
+                        r.language.padding(toLength: 12, withPad: " ", startingAt: 0),
+                        r.promptLanguageCode.padding(toLength: 8, withPad: " ", startingAt: 0),
+                        werStr.padding(toLength: 6, withPad: " ", startingAt: 0),
+                        cerStr.padding(toLength: 6, withPad: " ", startingAt: 0),
+                        rtfxStr.padding(toLength: 6, withPad: " ", startingAt: 0),
+                        durStr.padding(toLength: 9, withPad: " ", startingAt: 0),
+                        procStr.padding(toLength: 9, withPad: " ", startingAt: 0),
+                        skipStr,
+                    ].joined(separator: " | ")
                 )
             }
 
@@ -824,11 +828,13 @@ extension NemotronMultilingualFleursBenchmark {
                 let avgRTFx = results.reduce(0.0) { $0 + $1.rtfx } / Double(results.count)
                 print(String(repeating: "-", count: 80))
                 print(
-                    "AVERAGE".padding(toLength: 12, withPad: " ", startingAt: 0) + " | "
-                        + "—".padding(toLength: 8, withPad: " ", startingAt: 0) + " | "
-                        + String(format: "%.1f", avgWER * 100).padding(toLength: 6, withPad: " ", startingAt: 0) + " | "
-                        + String(format: "%.1f", avgCER * 100).padding(toLength: 6, withPad: " ", startingAt: 0) + " | "
-                        + String(format: "%.1f", avgRTFx).padding(toLength: 6, withPad: " ", startingAt: 0)
+                    [
+                        "AVERAGE".padding(toLength: 12, withPad: " ", startingAt: 0),
+                        "—".padding(toLength: 8, withPad: " ", startingAt: 0),
+                        String(format: "%.1f", avgWER * 100).padding(toLength: 6, withPad: " ", startingAt: 0),
+                        String(format: "%.1f", avgCER * 100).padding(toLength: 6, withPad: " ", startingAt: 0),
+                        String(format: "%.1f", avgRTFx).padding(toLength: 6, withPad: " ", startingAt: 0),
+                    ].joined(separator: " | ")
                 )
             }
         } catch {


### PR DESCRIPTION
Fixes #731.

## Problem
`swift build` fails to compile the `FluidAudioCLI` target:

```
Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronMultilingualFleursBenchmark.swift:790:13:
error: the compiler is unable to type-check this expression in reasonable time;
try breaking up the expression into distinct sub-expressions
```

The summary-table printing used long chains of `+`-concatenated `String.padding(...)` calls (header row, per-result row, and average row), which are heavy for Swift type inference and trip the type-checker timeout. Because `FluidAudioCLI` is a single target, this blocked the entire CLI — including unrelated commands like `transcribe`.

## Fix
Replace each `a + " | " + b + " | " + …` chain with an array of the padded column strings joined via `.joined(separator: " | ")`. Output is byte-for-byte identical; only the expression shape changes so the type-checker resolves it instantly.

## Verification
- `swift build` completes cleanly (no errors).
- `swift run fluidaudiocli transcribe <file>.wav` runs end-to-end (verified on a 5.5s French clip, RTFx ~44x).
- `swift format lint` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)