### PR TITLE
Update Silero VAD CoreML artifact to v6.2.1

### DIFF
--- a/Documentation/Benchmarks.md
+++ b/Documentation/Benchmarks.md
@@ -311,6 +311,17 @@ Model is nearly identical to the base model in terms of quality, performance wis
 ![VAD/speed.png](VAD/speed.png)
 ![VAD/correlation.png](VAD/correlation.png)
 
+Silero VAD v6.2.1 Core ML preflight benchmark on an Apple M1 MacBook Air (`macOS 26.5.1`), using the same `mini50` dataset and threshold as the VAD CI workflow:
+
+```text
+swift run -c release fluidaudiocli vad-benchmark --dataset mini50 --all-files --threshold 0.5 --output musan_vad_results.json
+```
+
+| Model | Accuracy | Precision | Recall | F1-Score | Total time | RTFx |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Upstream baseline | 92.0% | 86.2% | 100.0% | 92.6% | 2.19s | 1117.2x |
+| Silero VAD v6.2.1 | 94.0% | 89.3% | 100.0% | 94.3% | 2.27s | 1077.9x |
+
 Dataset: https://github.com/Lab41/VOiCES-subset
 
 ```text

--- a/Documentation/VAD/GettingStarted.md
+++ b/Documentation/VAD/GettingStarted.md
@@ -4,7 +4,8 @@ Fluid Audio ships the Silero VAD converted for Core ML together with Silero-styl
 timestamp extraction and streaming hysteresis. If you need help tuning the
 parameters for your use case, reach out on Discord.
 
-For comparison of Silero-VAD compared to other models, see this. We are running v6
+For comparison of Silero-VAD compared to other models, see this. We are running
+the 256 ms unified Silero v6.2.1 Core ML artifact.
 
 https://github.com/snakers4/silero-vad/wiki/Quality-Metrics
 
@@ -33,7 +34,7 @@ Stage the Core ML bundle yourself when the runtime cannot reach HuggingFace.
 
 ### Required asset
 
-- `silero-vad-unified-256ms-v6.0.0.mlmodelc`
+- `silero-vad-unified-256ms-v6.2.1.mlmodelc`
 
 The bundle lives in the `FluidInference/silero-vad-coreml` repo. Keep the folder name intact so `coremldata.bin` remains discoverable.
 
@@ -42,7 +43,7 @@ The bundle lives in the `FluidInference/silero-vad-coreml` repo. Keep the folder
 ```
 /opt/models
 └── silero-vad-coreml
-    └── silero-vad-unified-256ms-v6.0.0.mlmodelc
+    └── silero-vad-unified-256ms-v6.2.1.mlmodelc
         ├── coremldata.bin
         └── ...
 ```
@@ -59,7 +60,7 @@ import CoreML
 
 Task {
     do {
-        let modelURL = URL(fileURLWithPath: "/opt/models/silero-vad-coreml/silero-vad-unified-256ms-v6.0.0.mlmodelc", isDirectory: true)
+        let modelURL = URL(fileURLWithPath: "/opt/models/silero-vad-coreml/silero-vad-unified-256ms-v6.2.1.mlmodelc", isDirectory: true)
 
         var configuration = MLModelConfiguration()
         configuration.computeUnits = .cpuOnly

--- a/Documentation/VAD/GettingStarted.md
+++ b/Documentation/VAD/GettingStarted.md
@@ -48,7 +48,7 @@ The bundle lives in the `FluidInference/silero-vad-coreml` repo. Keep the folder
         └── ...
 ```
 
-Clone with Git LFS, download the archive from the HuggingFace UI, or copy from a machine that already initialized `VadManager()` (cache path: `~/Library/Application Support/FluidAudio/Models/silero-vad-coreml`).
+Clone with Git LFS, download the archive from the HuggingFace UI, or copy from a machine that already initialized `VadManager()` (default cache path: `~/Library/Application Support/FluidAudio/Models/silero-vad`).
 
 ### Loading without downloads
 

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -488,7 +488,7 @@ public enum ModelNames {
 
     /// VAD model names
     public enum VAD {
-        public static let sileroVad = "silero-vad-unified-256ms-v6.0.0"
+        public static let sileroVad = "silero-vad-unified-256ms-v6.2.1"
 
         public static let sileroVadFile = sileroVad + ".mlmodelc"
 


### PR DESCRIPTION
## Summary

- update the built-in Silero VAD Core ML model name from `silero-vad-unified-256ms-v6.0.0` to `silero-vad-unified-256ms-v6.2.1`
- update the VAD manual-loading documentation to use the v6.2.1 `.mlmodelc` folder name

## Dependency

This PR depends on the matching Hugging Face model repo PR landing first:

- https://huggingface.co/FluidInference/silero-vad-coreml/discussions/2

The PR is intentionally draft because merging this before the Hugging Face artifact is available on the model repo main branch would make the default download path request a missing bundle.

Refs #733.

## Verification

- `git diff --check`
- `swift build --target FluidAudio`

I also tried `swift test --filter VadSegmentationTests`, but the package build currently stops on an unrelated existing CLI type-checking issue in `Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronMultilingualFleursBenchmark.swift:790` before the VAD tests can run.
