### PR TITLE
fix(diarization): deterministic & robust offline VBx re-clustering (K-Means n_init)

### DIFF
--- a/Sources/FluidAudio/Diarizer/Offline/Clustering/KMeansClustering.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Clustering/KMeansClustering.swift
@@ -61,7 +61,7 @@ struct KMeansClustering {
             return (Array(0..<count), embeddings)
         }
 
-        var rng = SeededRNG(seed: seed ?? UInt64.random(in: 0...UInt64.max))
+        var rng = SeededRNG(seed: seed ?? 0)
         let normalized = normalizeEmbeddings(embeddings)
         var centroids = initializeCentroids(from: normalized, k: k, rng: &rng)
         var assignments = [Int](repeating: 0, count: count)
@@ -87,6 +87,45 @@ struct KMeansClustering {
         }
 
         return (assignments, centroids)
+    }
+
+    /// Runs K-Means `nInit` times with deterministic seeds (baseSeed, baseSeed+1, …) and returns
+    /// the lowest-inertia result (sklearn-style `n_init`). Single random-seed init is both
+    /// non-deterministic and fragile: it collapses small/边界 speakers run-to-run (ICT 4-spk
+    /// 小牧 が kept↔collapse で揺れ、~10%↔~30% を実証)。Best-of-N with fixed seeds makes the
+    /// re-clustering both reproducible and robust.
+    static func clusterWithCentroidsNInit(
+        embeddings: [[Double]],
+        numClusters: Int,
+        maxIterations: Int = 300,
+        nInit: Int = 10,
+        baseSeed: UInt64 = 0
+    ) -> (clusters: [Int], centroids: [[Double]]) {
+        guard embeddings.count > numClusters, nInit > 1 else {
+            return clusterWithCentroids(
+                embeddings: embeddings, numClusters: numClusters,
+                maxIterations: maxIterations, seed: baseSeed)
+        }
+        let normalized = normalizeEmbeddings(embeddings)
+        var best: (clusters: [Int], centroids: [[Double]])?
+        var bestInertia = Double.greatestFiniteMagnitude
+        for i in 0..<nInit {
+            let result = clusterWithCentroids(
+                embeddings: embeddings, numClusters: numClusters,
+                maxIterations: maxIterations, seed: baseSeed &+ UInt64(i))
+            // inertia = Σ ‖normalized(emb) − assignedCentroid‖²(centroids も normalized 空間)
+            var inertia: Double = 0
+            for (idx, c) in result.clusters.enumerated() where c >= 0 && c < result.centroids.count {
+                inertia += euclideanDistanceSquared(normalized[idx], result.centroids[c])
+            }
+            if inertia < bestInertia {
+                bestInertia = inertia
+                best = result
+            }
+        }
+        return best ?? clusterWithCentroids(
+            embeddings: embeddings, numClusters: numClusters,
+            maxIterations: maxIterations, seed: baseSeed)
     }
 
     private static func normalizeEmbeddings(_ embeddings: [[Double]]) -> [[Double]] {

--- a/Sources/FluidAudio/Diarizer/Offline/Clustering/VBxClustering.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Clustering/VBxClustering.swift
@@ -704,10 +704,14 @@ struct VBxClustering {
             "Speaker count \(detectedCount) outside bounds [\(constraints.minSpeakers), \(constraints.maxSpeakers)]; re-clustering to \(targetCount)"
         )
 
-        let (kmeansClusters, centroids) = KMeansClustering.clusterWithCentroids(
+        // n_init=10 の決定的初期化から最小 inertia を採用(sklearn 流)。単一ランダム初期化は
+        // 脆い話者を非決定的に collapse させる(ICT 小牧で実証、~10%↔~30% の揺れ)。
+        let (kmeansClusters, centroids) = KMeansClustering.clusterWithCentroidsNInit(
             embeddings: trainingEmbeddings,
             numClusters: targetCount,
-            maxIterations: 100
+            maxIterations: 100,
+            nInit: 10,
+            baseSeed: 0
         )
 
         return VBxOutput(


### PR DESCRIPTION
## Summary

The offline diarization speaker-count adjustment — re-clustering VBx-detected clusters down to the constrained count (`numSpeakers` / `min`–`max`) — calls `KMeansClustering` with a **random seed** and a **single initialization**. This makes the result both **non-deterministic** and **fragile**: small / boundary speakers collapse run-to-run.

## Reproduction

A 4-speaker Japanese meeting clip (~7 min, 16 kHz mono), `process --mode offline --num-speakers 4 --step-ratio 0.1`, repeated runs on **identical audio + config**:

| run | speaker confusion vs hand-corrected reference | smallest speaker (~41 s) recall |
|-----|-----------------------------------------------|----------------------------------|
| 1   | ~10.9%                                        | ~80% (kept)                      |
| 2   | ~32.0%                                        | ~15% (collapsed)                 |
| 3   | ~10.9%                                        | ~80% (kept)                      |

The only thing varying between runs is the K-Means random seed; the smallest speaker flips between kept and merged-away.

## Root cause

- `KMeansClustering.clusterWithCentroids` initializes its RNG as `SeededRNG(seed: seed ?? UInt64.random(in: 0...UInt64.max))` → a random seed whenever the caller doesn't pass one.
- The `VBxClustering` speaker-count re-clustering (`Speaker count N outside bounds […]; re-clustering to K`) calls `KMeansClustering.clusterWithCentroids(...)` **without a seed and with a single init** (no `n_init` / best-of-N inertia selection).

So the final hard assignment of an over-segmented frame set down to `K` speakers depends on one random K-Means initialization, which is unstable for fragile / imbalanced speaker sets.

This re-clustering path was introduced in #236 (which made the `numSpeakers` constraint actually apply the K-Means centroids); it simply never seeded the K-Means or used `n_init`, so the constrained result was left non-deterministic.

## Fix

- `KMeansClustering`:
  - The unseeded fallback now uses a fixed seed (`0`) instead of `UInt64.random` → deterministic by default.
  - Added `clusterWithCentroidsNInit(embeddings:numClusters:maxIterations:nInit:baseSeed:)` which runs `nInit` deterministic initializations (seeds `baseSeed … baseSeed+nInit-1`) and returns the lowest-inertia result (sklearn-style `n_init`).
- `VBxClustering`: the speaker-count re-clustering now calls `clusterWithCentroidsNInit(nInit: 10, baseSeed: 0)`.

No breaking API changes — `clusterWithCentroids` keeps its signature (its unseeded path is just deterministic now); `clusterWithCentroidsNInit` is additive.

## Result

Re-clustering is now fully deterministic and robustly retains fragile speakers. The 4-speaker clip scores **~9.2% consistently across 5+ CLI runs and on-device (CoreML / ANE, sandboxed macOS app)**.

## Related

- **#236** introduced this K-Means re-clustering path (applying the speaker-count constraint via K-Means centroids); this PR makes that path deterministic and robust.
- **#523** fixed a different cause of single-speaker collapse (transpose / mask bugs); this PR is orthogonal — it addresses the run-to-run *non-determinism* of the constrained re-clustering.
- **#393** (closed, not merged) already used a fixed seed to make a Sortformer test reproducible — the same underlying concern (time/random seeds break reproducibility), here applied to the production offline re-clustering.
