### PR TITLE
fix(tts/supertonic): lower inter-chunk silence 0.3s→0.05s + add --silence flag

### DIFF
--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Constants.swift
@@ -69,8 +69,14 @@ public enum Supertonic3Constants {
     public static let defaultSpeed: Float = 1.05
 
     /// Default silence inserted between text chunks when synthesizing long
-    /// utterances. 0.3 s mirrors the reference CLI default.
-    public static let defaultSilenceDuration: Float = 0.3
+    /// utterances. The 70-char chunk cap (#669) splits a paragraph into many
+    /// chunks; the reference CLI's 0.3 s pad stacks on top of the model's own
+    /// trailing sentence silence, inflating natural ~0.5–1.0 s sentence pauses
+    /// to ~1.1–1.2 s (the "unintended pauses" of #736). 0.05 s keeps the seams
+    /// from butting tokens together while letting the model's intrinsic
+    /// sentence prosody come through. Override via the synthesize parameter
+    /// (CLI `--silence`).
+    public static let defaultSilenceDuration: Float = 0.05
 
     /// Max characters per chunk when synthesizing long English/Latin text.
     /// Although `textTFixed = 128` would *fit* ~110 chars, the model's output

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Manager.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Manager.swift
@@ -107,7 +107,8 @@ public actor Supertonic3Manager {
     ///   - speed: Speech-rate multiplier (default 1.05). Divides the
     ///     predicted duration vector.
     ///   - silenceDuration: Silence inserted between chunks when the text
-    ///     is split into multiple chunks. Default 0.3 s.
+    ///     is split into multiple chunks. Default 0.05 s — see
+    ///     `Supertonic3Constants.defaultSilenceDuration`.
     public func synthesize(
         text: String,
         language: String,

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -92,6 +92,7 @@ public struct TTS {
         var supertonicVoiceStylePath: String? = nil
         var supertonicTotalSteps: Int = Supertonic3Constants.defaultTotalSteps
         var supertonicSpeed: Float = Supertonic3Constants.defaultSpeed
+        var supertonicSilence: Float = Supertonic3Constants.defaultSilenceDuration
         // VectorEstimator build: fp16 | int8/int6/int4 (ANE-bucketed) |
         // dyn-int8/dyn-int6/dyn-int4 (dynamic CPU/GPU). Default fp16.
         var supertonicVE: Supertonic3VectorEstimator = .aneBucketed(.int4)
@@ -187,6 +188,11 @@ public struct TTS {
             case "--speed":
                 if i + 1 < arguments.count, let v = Float(arguments[i + 1]) {
                     supertonicSpeed = v
+                    i += 1
+                }
+            case "--silence":
+                if i + 1 < arguments.count, let v = Float(arguments[i + 1]) {
+                    supertonicSilence = v
                     i += 1
                 }
             case "--alpha":
@@ -314,6 +320,7 @@ public struct TTS {
                 text: text, output: output, language: supertonicLanguage,
                 voiceStylePath: supertonicVoiceStylePath, voiceName: voice,
                 totalSteps: supertonicTotalSteps, speed: supertonicSpeed,
+                silenceDuration: supertonicSilence,
                 vectorEstimator: supertonicVE,
                 metricsPath: metricsPath, cpuOnly: cpuOnly)
         }
@@ -803,6 +810,7 @@ public struct TTS {
         text: String, output: String, language: String,
         voiceStylePath: String?, voiceName: String,
         totalSteps: Int, speed: Float,
+        silenceDuration: Float,
         vectorEstimator: Supertonic3VectorEstimator,
         metricsPath: String?, cpuOnly: Bool
     ) async {
@@ -844,7 +852,8 @@ public struct TTS {
             let tSynth0 = Date()
             let result = try await manager.synthesize(
                 text: text, language: language, style: style,
-                totalSteps: totalSteps, speed: speed)
+                totalSteps: totalSteps, speed: speed,
+                silenceDuration: silenceDuration)
             let tSynth1 = Date()
 
             let outURL = resolveInputURL(output)
@@ -925,6 +934,7 @@ public struct TTS {
                                      --lang en                  ISO-639-1 language code (default en)
                                      --total-steps 8            denoising step count (default 8)
                                      --speed 1.05               duration multiplier (default 1.05)
+                                     --silence 0.05             inter-chunk silence seconds (default 0.05)
                                      --cpu-only                 disable Neural Engine
               --lexicon, -l        Custom pronunciation lexicon file (KokoroAne --variant zh only):
                                      word  pinyin1 pinyin2   (e.g. zi4 jie2)


### PR DESCRIPTION
## Problem (#736)

Supertonic-3 reads short sentences naturally and fast, but full paragraphs get **unintended pauses** between chunks. Root cause: the 70-char chunk cap (#669) splits a paragraph into several chunks, and a fixed **0.3 s of silence is concatenated at every seam**. That pad stacks on top of the model's own trailing sentence silence, inflating natural ~0.5–1.0 s sentence pauses to ~1.1–1.2 s.

## Change

- `Supertonic3Constants.defaultSilenceDuration` **0.3 → 0.05**
- Expose `silenceDuration` through the CLI **`--silence`** flag (the `tts` command was calling `synthesize` without it, so CLI users were pinned to the default)

## Measured

Same 4-sentence (351-char) paragraph, ~8 chunks:

| `--silence` | total duration | largest internal gaps |
|---|---|---|
| 0.3 (old default) | 25.44 s | 0.9–1.2 s (robotic) |
| 0.05 (new default) | 23.69 s | 0.5–1.0 s (natural sentence pauses) |
| 0.0 | 23.34 s | 0.5–1.0 s |

Dropping the pad removes ~2.1 s of dead air across the paragraph; remaining gaps land at sentence/comma boundaries (the chunker splits there first), so there are no mid-word cuts.

## Not addressed (intrinsic to the base model)

The 70-char cap can't be raised without a WER cost — the base Supertone `supertonic-3` weights degrade past ~90 chars (relative-position attention trained at sentence scale: ~0% WER ≤70 chars → ~6% by ~100 chars). Supertonic-3 is a per-sentence/streaming TTS by design; for seamless long-form, PocketTTS is the better fit. This PR only fixes the avoidable silence artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)