### PR TITLE
Validate downloaded model artifacts before caching (#740)

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -100,8 +100,6 @@ public class DownloadUtils {
         }
     }
 
-    /// True if `data` begins with HTML/XML markup (proxy / captive-portal error
-    /// page served as a normal 200 body under the requested filename).
     static func looksLikeHTML(_ data: Data) -> Bool {
         let prefix = data.prefix(512)
         let text = String(data: prefix, encoding: .utf8) ?? String(decoding: prefix, as: UTF8.self)
@@ -109,10 +107,6 @@ public class DownloadUtils {
         return lowered.hasPrefix("<!doctype html") || lowered.hasPrefix("<html") || lowered.hasPrefix("<?xml")
     }
 
-    /// Validate a downloaded artifact at `tempURL` before it is moved into the
-    /// cache. Rejects HTML error pages and truncated bodies, throwing
-    /// `HuggingFaceDownloadError.invalidArtifact` (retryable) so a bad fetch
-    /// never poisons the cache. `expectedSize <= 0` skips the size check.
     static func validateDownloadedArtifact(
         at tempURL: URL,
         response: HTTPURLResponse,
@@ -154,9 +148,6 @@ public class DownloadUtils {
         case downloadFailed(path: String, underlying: Error)
         case modelNotFound(path: String)
         case htmlErrorResponse(path: String, snippet: String)
-        /// A downloaded artifact failed validation before being cached (HTML
-        /// error page, empty body, or size mismatch). The bad bytes are
-        /// discarded so the cache is never poisoned.
         case invalidArtifact(path: String, reason: String)
 
         public var errorDescription: String? {

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -100,12 +100,100 @@ public class DownloadUtils {
         }
     }
 
+    /// True if `data` begins with HTML markup (after leading whitespace / BOM).
+    /// Catches captive-portal and proxy error pages served as a normal 200 body
+    /// under the requested filename.
+    static func looksLikeHTML(_ data: Data) -> Bool {
+        // Only the leading bytes matter; decode lossily so a binary tail can't
+        // hide an HTML preamble.
+        let prefix = data.prefix(512)
+        guard var text = String(data: prefix, encoding: .utf8) else {
+            // Try lossy ASCII for bodies with a stray non-UTF8 byte further in.
+            let ascii = String(decoding: prefix, as: UTF8.self)
+            return htmlPrefixMatch(ascii)
+        }
+        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return htmlPrefixMatch(text)
+    }
+
+    private static func htmlPrefixMatch(_ text: String) -> Bool {
+        let lowered = text.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        return lowered.hasPrefix("<!doctype html")
+            || lowered.hasPrefix("<html")
+            || lowered.hasPrefix("<?xml")  // proxy SOAP/XML error envelopes
+    }
+
+    /// Validate a freshly-downloaded artifact at `tempURL` *before* it is moved
+    /// into the cache. Rejects HTML/error-page bodies (captive portals, proxies,
+    /// HF rate-limit pages served with 200) and truncated files (size mismatch
+    /// vs. the size HuggingFace reported for the object). Throws
+    /// `HuggingFaceDownloadError.invalidArtifact` on failure so a transient bad
+    /// fetch is retried and never poisons the cache directory.
+    ///
+    /// - Parameters:
+    ///   - tempURL: Location of the just-downloaded temporary file.
+    ///   - response: The HTTP response, for the `Content-Type` check.
+    ///   - path: Remote path, used for log/error context.
+    ///   - expectedSize: Size HuggingFace reported (the LFS object size for large
+    ///     weights). `<= 0` means unknown — the exact-size check is skipped.
+    static func validateDownloadedArtifact(
+        at tempURL: URL,
+        response: HTTPURLResponse,
+        path: String,
+        expectedSize: Int
+    ) throws {
+        // 1. Content-Type: model artifacts are binary octet-streams. An HTML
+        //    content type means the body is an error page, not the file.
+        if let contentType = response.value(forHTTPHeaderField: "Content-Type")?.lowercased(),
+            contentType.contains("text/html")
+        {
+            throw HuggingFaceDownloadError.invalidArtifact(
+                path: path, reason: "server returned Content-Type: \(contentType)")
+        }
+
+        let fm = FileManager.default
+        let actualSize = ((try? fm.attributesOfItem(atPath: tempURL.path))?[.size] as? Int) ?? 0
+
+        // 2. Empty body — a download that produced no bytes is never valid.
+        if actualSize == 0 {
+            throw HuggingFaceDownloadError.invalidArtifact(path: path, reason: "empty file")
+        }
+
+        // 3. Sniff the leading bytes for HTML markup — a 200 OK proxy / captive
+        //    portal error page is served under the model's filename.
+        if let handle = try? FileHandle(forReadingFrom: tempURL) {
+            defer { try? handle.close() }
+            let head = handle.readData(ofLength: 512)
+            if looksLikeHTML(head) {
+                throw HuggingFaceDownloadError.invalidArtifact(
+                    path: path, reason: "response body begins with HTML markup")
+            }
+        }
+
+        // 4. Truncation: HuggingFace's tree listing reports the exact byte size
+        //    for each file (the resolved LFS object size for large weights). A
+        //    short body means a dropped connection or proxy truncation. Require
+        //    an exact match when the expected size is known.
+        if expectedSize > 0 && actualSize != expectedSize {
+            throw HuggingFaceDownloadError.invalidArtifact(
+                path: path,
+                reason: "size mismatch (expected \(expectedSize) bytes, got \(actualSize))")
+        }
+    }
+
     public enum HuggingFaceDownloadError: LocalizedError {
         case invalidResponse
         case rateLimited(statusCode: Int, message: String)
         case downloadFailed(path: String, underlying: Error)
         case modelNotFound(path: String)
         case htmlErrorResponse(path: String, snippet: String)
+        /// A downloaded artifact failed validation before being cached — e.g. an
+        /// HTML error page (captive portal / proxy / HF rate-limit page served
+        /// with 200), an empty body, or a truncated file whose size does not
+        /// match the size HuggingFace reported. The bad bytes are discarded
+        /// rather than written under the model's filename, so the cache is never
+        /// poisoned and a later load does not surface a confusing CoreML error.
+        case invalidArtifact(path: String, reason: String)
 
         public var errorDescription: String? {
             switch self {
@@ -119,6 +207,8 @@ public class DownloadUtils {
                 return "HuggingFace returned HTML instead of JSON for \(path) (rate limit or server issue): \(snippet)"
             case .modelNotFound(let path):
                 return "Model file not found: \(path)"
+            case .invalidArtifact(let path, let reason):
+                return "Downloaded artifact for \(path) is invalid (\(reason)); refusing to cache it."
             }
         }
     }
@@ -581,6 +671,7 @@ public class DownloadUtils {
             let tempFileURL = try await downloadFileWithRetry(
                 request: request,
                 path: file.path,
+                expectedSize: file.size,
                 onProgress: onProgress
             )
 
@@ -714,6 +805,7 @@ public class DownloadUtils {
     private static func downloadFileWithRetry(
         request: URLRequest,
         path: String,
+        expectedSize: Int,
         onProgress: (@Sendable (Int64, Int64) -> Void)?,
         maxAttempts: Int = 4,
         minBackoff: TimeInterval = 1.0
@@ -749,6 +841,13 @@ public class DownloadUtils {
                         underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
                     )
                 }
+
+                // Validate the body before handing the temp file back to be
+                // cached. A bad fetch (HTML error page, truncation) throws
+                // `invalidArtifact`, which is retryable, so a transient proxy
+                // hiccup is retried instead of poisoning the cache.
+                try validateDownloadedArtifact(
+                    at: tempURL, response: httpResponse, path: path, expectedSize: expectedSize)
 
                 return tempURL
             } catch {
@@ -786,6 +885,11 @@ public class DownloadUtils {
 
         switch error {
         case HuggingFaceDownloadError.rateLimited:
+            return true
+        case HuggingFaceDownloadError.invalidArtifact:
+            // HTML error pages / truncation are usually a transient unhealthy
+            // network path (captive portal, proxy, mirror 5xx) — retry rather
+            // than fail the whole repo download on the first blip.
             return true
         case HuggingFaceDownloadError.downloadFailed(_, let underlying):
             let nsError = underlying as NSError
@@ -916,6 +1020,10 @@ public class DownloadUtils {
                     underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
                 )
             }
+
+            // Reject HTML error pages / truncated bodies before caching.
+            try validateDownloadedArtifact(
+                at: tempURL, response: httpResponse, path: file.path, expectedSize: file.size)
 
             if FileManager.default.fileExists(atPath: destPath.path) {
                 try? FileManager.default.removeItem(at: destPath)

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -100,50 +100,25 @@ public class DownloadUtils {
         }
     }
 
-    /// True if `data` begins with HTML markup (after leading whitespace / BOM).
-    /// Catches captive-portal and proxy error pages served as a normal 200 body
-    /// under the requested filename.
+    /// True if `data` begins with HTML/XML markup (proxy / captive-portal error
+    /// page served as a normal 200 body under the requested filename).
     static func looksLikeHTML(_ data: Data) -> Bool {
-        // Only the leading bytes matter; decode lossily so a binary tail can't
-        // hide an HTML preamble.
         let prefix = data.prefix(512)
-        guard var text = String(data: prefix, encoding: .utf8) else {
-            // Try lossy ASCII for bodies with a stray non-UTF8 byte further in.
-            let ascii = String(decoding: prefix, as: UTF8.self)
-            return htmlPrefixMatch(ascii)
-        }
-        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        return htmlPrefixMatch(text)
-    }
-
-    private static func htmlPrefixMatch(_ text: String) -> Bool {
+        let text = String(data: prefix, encoding: .utf8) ?? String(decoding: prefix, as: UTF8.self)
         let lowered = text.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-        return lowered.hasPrefix("<!doctype html")
-            || lowered.hasPrefix("<html")
-            || lowered.hasPrefix("<?xml")  // proxy SOAP/XML error envelopes
+        return lowered.hasPrefix("<!doctype html") || lowered.hasPrefix("<html") || lowered.hasPrefix("<?xml")
     }
 
-    /// Validate a freshly-downloaded artifact at `tempURL` *before* it is moved
-    /// into the cache. Rejects HTML/error-page bodies (captive portals, proxies,
-    /// HF rate-limit pages served with 200) and truncated files (size mismatch
-    /// vs. the size HuggingFace reported for the object). Throws
-    /// `HuggingFaceDownloadError.invalidArtifact` on failure so a transient bad
-    /// fetch is retried and never poisons the cache directory.
-    ///
-    /// - Parameters:
-    ///   - tempURL: Location of the just-downloaded temporary file.
-    ///   - response: The HTTP response, for the `Content-Type` check.
-    ///   - path: Remote path, used for log/error context.
-    ///   - expectedSize: Size HuggingFace reported (the LFS object size for large
-    ///     weights). `<= 0` means unknown — the exact-size check is skipped.
+    /// Validate a downloaded artifact at `tempURL` before it is moved into the
+    /// cache. Rejects HTML error pages and truncated bodies, throwing
+    /// `HuggingFaceDownloadError.invalidArtifact` (retryable) so a bad fetch
+    /// never poisons the cache. `expectedSize <= 0` skips the size check.
     static func validateDownloadedArtifact(
         at tempURL: URL,
         response: HTTPURLResponse,
         path: String,
         expectedSize: Int
     ) throws {
-        // 1. Content-Type: model artifacts are binary octet-streams. An HTML
-        //    content type means the body is an error page, not the file.
         if let contentType = response.value(forHTTPHeaderField: "Content-Type")?.lowercased(),
             contentType.contains("text/html")
         {
@@ -151,29 +126,21 @@ public class DownloadUtils {
                 path: path, reason: "server returned Content-Type: \(contentType)")
         }
 
-        let fm = FileManager.default
-        let actualSize = ((try? fm.attributesOfItem(atPath: tempURL.path))?[.size] as? Int) ?? 0
-
-        // 2. Empty body — a download that produced no bytes is never valid.
+        let actualSize =
+            ((try? FileManager.default.attributesOfItem(atPath: tempURL.path))?[.size] as? Int) ?? 0
         if actualSize == 0 {
             throw HuggingFaceDownloadError.invalidArtifact(path: path, reason: "empty file")
         }
 
-        // 3. Sniff the leading bytes for HTML markup — a 200 OK proxy / captive
-        //    portal error page is served under the model's filename.
         if let handle = try? FileHandle(forReadingFrom: tempURL) {
             defer { try? handle.close() }
-            let head = handle.readData(ofLength: 512)
-            if looksLikeHTML(head) {
+            if looksLikeHTML(handle.readData(ofLength: 512)) {
                 throw HuggingFaceDownloadError.invalidArtifact(
                     path: path, reason: "response body begins with HTML markup")
             }
         }
 
-        // 4. Truncation: HuggingFace's tree listing reports the exact byte size
-        //    for each file (the resolved LFS object size for large weights). A
-        //    short body means a dropped connection or proxy truncation. Require
-        //    an exact match when the expected size is known.
+        // HuggingFace reports the exact (LFS-resolved) object size; a short body is truncation.
         if expectedSize > 0 && actualSize != expectedSize {
             throw HuggingFaceDownloadError.invalidArtifact(
                 path: path,
@@ -187,12 +154,9 @@ public class DownloadUtils {
         case downloadFailed(path: String, underlying: Error)
         case modelNotFound(path: String)
         case htmlErrorResponse(path: String, snippet: String)
-        /// A downloaded artifact failed validation before being cached — e.g. an
-        /// HTML error page (captive portal / proxy / HF rate-limit page served
-        /// with 200), an empty body, or a truncated file whose size does not
-        /// match the size HuggingFace reported. The bad bytes are discarded
-        /// rather than written under the model's filename, so the cache is never
-        /// poisoned and a later load does not surface a confusing CoreML error.
+        /// A downloaded artifact failed validation before being cached (HTML
+        /// error page, empty body, or size mismatch). The bad bytes are
+        /// discarded so the cache is never poisoned.
         case invalidArtifact(path: String, reason: String)
 
         public var errorDescription: String? {
@@ -842,10 +806,7 @@ public class DownloadUtils {
                     )
                 }
 
-                // Validate the body before handing the temp file back to be
-                // cached. A bad fetch (HTML error page, truncation) throws
-                // `invalidArtifact`, which is retryable, so a transient proxy
-                // hiccup is retried instead of poisoning the cache.
+                // Validate before the caller moves the temp file into the cache.
                 try validateDownloadedArtifact(
                     at: tempURL, response: httpResponse, path: path, expectedSize: expectedSize)
 
@@ -887,9 +848,7 @@ public class DownloadUtils {
         case HuggingFaceDownloadError.rateLimited:
             return true
         case HuggingFaceDownloadError.invalidArtifact:
-            // HTML error pages / truncation are usually a transient unhealthy
-            // network path (captive portal, proxy, mirror 5xx) — retry rather
-            // than fail the whole repo download on the first blip.
+            // Usually a transient unhealthy network path (proxy, mirror 5xx) — retry.
             return true
         case HuggingFaceDownloadError.downloadFailed(_, let underlying):
             let nsError = underlying as NSError

--- a/Tests/FluidAudioTests/Shared/DownloadArtifactValidationTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadArtifactValidationTests.swift
@@ -2,11 +2,8 @@ import XCTest
 
 @testable import FluidAudio
 
-/// Validation of downloaded model artifacts before they are committed to the
-/// cache (issue #740). An unhealthy network path — captive portal, corporate
-/// proxy, mirror 5xx — can return an HTML error page or a truncated body under
-/// the model's filename. `DownloadUtils.validateDownloadedArtifact` rejects
-/// those so a later CoreML load does not surface a confusing, far-removed error.
+/// `DownloadUtils.validateDownloadedArtifact` rejects HTML error pages and
+/// truncated bodies before they reach the cache (issue #740).
 final class DownloadArtifactValidationTests: XCTestCase {
 
     private var tempDir: URL!
@@ -77,8 +74,8 @@ final class DownloadArtifactValidationTests: XCTestCase {
     }
 
     func testLooksLikeHTMLAllowsBinaryWeights() {
-        // A CoreML weight blob starts with arbitrary bytes, not markup.
-        let binary = Data([0x00, 0x01, 0x02, 0xFF, 0xFE, 0x3C, 0x68])  // contains '<h' mid-stream
+        // Markup-like bytes mid-stream ('<h') must not trip the leading-byte check.
+        let binary = Data([0x00, 0x01, 0x02, 0xFF, 0xFE, 0x3C, 0x68])
         XCTAssertFalse(DownloadUtils.looksLikeHTML(binary))
     }
 
@@ -99,7 +96,6 @@ final class DownloadArtifactValidationTests: XCTestCase {
 
     func testValidArtifactWithUnknownSizeSkipsSizeCheck() throws {
         let url = try writeTemp(Data(repeating: 0x01, count: 50))
-        // expectedSize <= 0 means "unknown" — must not reject on size.
         XCTAssertNoThrow(
             try DownloadUtils.validateDownloadedArtifact(
                 at: url, response: response(), path: "file.json", expectedSize: -1))
@@ -123,8 +119,6 @@ final class DownloadArtifactValidationTests: XCTestCase {
     }
 
     func testRejectsHTMLBodyServedAsBinaryContentType() throws {
-        // Proxy/captive-portal page served with a 200 and a non-HTML content
-        // type but an HTML body — the body sniff must still catch it.
         let html = Data("<!DOCTYPE html>\n<html><body>Proxy error</body></html>".utf8)
         let url = try writeTemp(html)
         assertInvalid(
@@ -135,7 +129,6 @@ final class DownloadArtifactValidationTests: XCTestCase {
     }
 
     func testRejectsTruncatedBody() throws {
-        // Body shorter than the size HuggingFace reported → truncation.
         let url = try writeTemp(Data(repeating: 0x7F, count: 500))
         assertInvalid(
             try DownloadUtils.validateDownloadedArtifact(
@@ -145,7 +138,6 @@ final class DownloadArtifactValidationTests: XCTestCase {
     }
 
     func testRejectsOversizedBody() throws {
-        // An over-long body is also a mismatch (e.g. error page padded out).
         let url = try writeTemp(Data(repeating: 0x7F, count: 2000))
         assertInvalid(
             try DownloadUtils.validateDownloadedArtifact(

--- a/Tests/FluidAudioTests/Shared/DownloadArtifactValidationTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadArtifactValidationTests.swift
@@ -1,0 +1,166 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Validation of downloaded model artifacts before they are committed to the
+/// cache (issue #740). An unhealthy network path — captive portal, corporate
+/// proxy, mirror 5xx — can return an HTML error page or a truncated body under
+/// the model's filename. `DownloadUtils.validateDownloadedArtifact` rejects
+/// those so a later CoreML load does not surface a confusing, far-removed error.
+final class DownloadArtifactValidationTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fluidaudio-artifact-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+    }
+
+    // MARK: - helpers
+
+    private func writeTemp(_ data: Data, name: String = UUID().uuidString) throws -> URL {
+        let url = tempDir.appendingPathComponent(name)
+        try data.write(to: url)
+        return url
+    }
+
+    private func response(
+        contentType: String? = "application/octet-stream"
+    ) -> HTTPURLResponse {
+        var headers: [String: String] = [:]
+        if let contentType { headers["Content-Type"] = contentType }
+        return HTTPURLResponse(
+            url: URL(string: "https://huggingface.co/test/file")!,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: headers
+        )!
+    }
+
+    private func assertInvalid(
+        _ body: @autoclosure () throws -> Void,
+        reasonContains: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        do {
+            try body()
+            XCTFail("expected invalidArtifact to be thrown", file: file, line: line)
+        } catch let DownloadUtils.HuggingFaceDownloadError.invalidArtifact(_, reason) {
+            XCTAssertTrue(
+                reason.lowercased().contains(reasonContains.lowercased()),
+                "reason \"\(reason)\" should mention \"\(reasonContains)\"",
+                file: file, line: line
+            )
+        } catch {
+            XCTFail("expected invalidArtifact, got: \(error)", file: file, line: line)
+        }
+    }
+
+    // MARK: - looksLikeHTML
+
+    func testLooksLikeHTMLDetectsDoctype() {
+        XCTAssertTrue(DownloadUtils.looksLikeHTML(Data("<!DOCTYPE html><html></html>".utf8)))
+    }
+
+    func testLooksLikeHTMLDetectsLeadingWhitespaceAndCasing() {
+        XCTAssertTrue(DownloadUtils.looksLikeHTML(Data("\n\n   <HTML lang=\"en\">".utf8)))
+    }
+
+    func testLooksLikeHTMLDetectsXMLProxyEnvelope() {
+        XCTAssertTrue(DownloadUtils.looksLikeHTML(Data("<?xml version=\"1.0\"?><error/>".utf8)))
+    }
+
+    func testLooksLikeHTMLAllowsBinaryWeights() {
+        // A CoreML weight blob starts with arbitrary bytes, not markup.
+        let binary = Data([0x00, 0x01, 0x02, 0xFF, 0xFE, 0x3C, 0x68])  // contains '<h' mid-stream
+        XCTAssertFalse(DownloadUtils.looksLikeHTML(binary))
+    }
+
+    func testLooksLikeHTMLAllowsJSON() {
+        XCTAssertFalse(DownloadUtils.looksLikeHTML(Data("{\"vocab\": 1}".utf8)))
+    }
+
+    // MARK: - validateDownloadedArtifact
+
+    func testValidArtifactPasses() throws {
+        let payload = Data(repeating: 0xAB, count: 1024)
+        let url = try writeTemp(payload)
+        XCTAssertNoThrow(
+            try DownloadUtils.validateDownloadedArtifact(
+                at: url, response: response(), path: "Model.mlmodelc/weights/weight.bin",
+                expectedSize: 1024))
+    }
+
+    func testValidArtifactWithUnknownSizeSkipsSizeCheck() throws {
+        let url = try writeTemp(Data(repeating: 0x01, count: 50))
+        // expectedSize <= 0 means "unknown" — must not reject on size.
+        XCTAssertNoThrow(
+            try DownloadUtils.validateDownloadedArtifact(
+                at: url, response: response(), path: "file.json", expectedSize: -1))
+    }
+
+    func testRejectsHTMLContentType() throws {
+        let url = try writeTemp(Data(repeating: 0xAB, count: 1024))
+        assertInvalid(
+            try DownloadUtils.validateDownloadedArtifact(
+                at: url, response: response(contentType: "text/html; charset=utf-8"),
+                path: "Model.mlmodelc/coremldata.bin", expectedSize: 1024),
+            reasonContains: "content-type")
+    }
+
+    func testRejectsEmptyBody() throws {
+        let url = try writeTemp(Data())
+        assertInvalid(
+            try DownloadUtils.validateDownloadedArtifact(
+                at: url, response: response(), path: "file.bin", expectedSize: 0),
+            reasonContains: "empty")
+    }
+
+    func testRejectsHTMLBodyServedAsBinaryContentType() throws {
+        // Proxy/captive-portal page served with a 200 and a non-HTML content
+        // type but an HTML body — the body sniff must still catch it.
+        let html = Data("<!DOCTYPE html>\n<html><body>Proxy error</body></html>".utf8)
+        let url = try writeTemp(html)
+        assertInvalid(
+            try DownloadUtils.validateDownloadedArtifact(
+                at: url, response: response(contentType: "application/octet-stream"),
+                path: "Model.mlmodelc/weights/weight.bin", expectedSize: -1),
+            reasonContains: "html")
+    }
+
+    func testRejectsTruncatedBody() throws {
+        // Body shorter than the size HuggingFace reported → truncation.
+        let url = try writeTemp(Data(repeating: 0x7F, count: 500))
+        assertInvalid(
+            try DownloadUtils.validateDownloadedArtifact(
+                at: url, response: response(), path: "Model.mlmodelc/weights/weight.bin",
+                expectedSize: 1000),
+            reasonContains: "size mismatch")
+    }
+
+    func testRejectsOversizedBody() throws {
+        // An over-long body is also a mismatch (e.g. error page padded out).
+        let url = try writeTemp(Data(repeating: 0x7F, count: 2000))
+        assertInvalid(
+            try DownloadUtils.validateDownloadedArtifact(
+                at: url, response: response(), path: "file.bin", expectedSize: 1000),
+            reasonContains: "size mismatch")
+    }
+
+    // MARK: - error description
+
+    func testInvalidArtifactErrorDescription() {
+        let err = DownloadUtils.HuggingFaceDownloadError.invalidArtifact(
+            path: "Encoder.mlmodelc/weights/weight.bin", reason: "empty file")
+        XCTAssertEqual(
+            err.errorDescription,
+            "Downloaded artifact for Encoder.mlmodelc/weights/weight.bin is invalid (empty file); refusing to cache it."
+        )
+    }
+}


### PR DESCRIPTION
Closes #740.

## Problem

`AsrModels.download(...)` / `DiarizerModels.downloadIfNeeded()` write HuggingFace artifacts straight into the cache. When the network path is unhealthy (captive portal, corporate proxy, mirror 5xx/redirects), the HTTP body can be an **HTML error page** or a **truncated** file rather than the real artifact. It gets written under the expected filename, so the presence-based `modelsExist(at:version:)` check reports the model as installed. The failure only surfaces later at load/compile time as an opaque CoreML error, far from the root cause.

## Change

All model downloads route through `DownloadUtils`. Each file is fetched to a temp path and validated **before** it is moved into the cache, so a bad fetch never poisons the cache dir. Validation is wired into both download paths — `downloadRepo` (via `downloadFileWithRetry`) and `downloadSubdirectory`:

- Reject `Content-Type: text/html` responses (proxy / captive-portal pages).
- Reject empty bodies.
- Sniff leading bytes for `<!DOCTYPE html` / `<html` / `<?xml` markup (error pages served with `200` under the model's filename).
- Exact size match against the size HuggingFace reports for the object, to catch truncation.

Failures throw a distinct `HuggingFaceDownloadError.invalidArtifact(path:reason:)` so callers can present "download corrupt — retry" instead of a downstream load crash. The error is classified **retryable**, so a transient bad fetch is retried with the existing bounded backoff rather than failing the whole repo download on the first blip.

### Size check is safe for LFS

Verified against the HF tree API that the `size` field is the **resolved LFS object size**, not the 130-byte pointer (e.g. `Encoder.mlmodelc/weights/weight.bin` reports `445187200`, matching `lfs.size`). So the exact-match truncation check won't false-positive on large weights. Legitimately-empty files (API `size == 0`) are still created directly and bypass validation.

## Tests

Adds `DownloadArtifactValidationTests` (13 cases): HTML/XML/doctype detection, binary/JSON pass-through, content-type rejection, empty / truncated / oversized bodies, unknown-size skip, and the error description.

> Note: tests were not run locally — this machine has only CommandLineTools (no full Xcode), so `XCTest` is unavailable and `swift test` can't compile any test target here. `swift build` is clean and `swift format lint` passes on the changed files; the new tests run in CI.