### PR TITLE
fix(offline-diarizer): re-embed zero-vote spans instead of arbitrary cluster-0 tie-break

### DIFF
--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -321,11 +321,34 @@ public final class OfflineDiarizerManager {
             logger.debug("Clustering completed in \(clusteringTime)s with no assignments")
         }
 
+        // Zero-vote runs carry no clustering evidence, so reconstruction re-embeds their
+        // exact audio span to pick a speaker. Extraction needs models + audio, which the
+        // reconstruction helper doesn't own — hand it a closure instead.
+        let spanEmbedder: ((Double, Double) -> [Float]?)?
+        if config.zeroVoteReembed.enabled, !centroids.isEmpty {
+            let extractor = OfflineEmbeddingExtractor(
+                fbankModel: models.fbankModel,
+                embeddingModel: models.embeddingModel,
+                pldaTransform: pldaTransform,
+                config: config
+            )
+            spanEmbedder = { startSeconds, endSeconds in
+                try? extractor.embedSpan(
+                    audioSource: audioSource,
+                    startSeconds: startSeconds,
+                    endSeconds: endSeconds
+                )
+            }
+        } else {
+            spanEmbedder = nil
+        }
+
         let reconstruction = OfflineReconstruction(config: config)
         let segments = reconstruction.buildSegments(
             segmentation: segmentation,
             hardClusters: chunkAssignments,
-            centroids: centroids
+            centroids: centroids,
+            spanEmbedder: spanEmbedder
         )
 
         let speakerDatabase = reconstruction.buildSpeakerDatabase(segments: segments)

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
@@ -199,6 +199,32 @@ public struct OfflineDiarizerConfig: Sendable {
         }
     }
 
+    /// Optional post-pass that re-embeds aggregated timeline spans whose per-cluster vote
+    /// sums are all zero and assigns them to the closest speaker centroid.
+    ///
+    /// A frame ends up with zero votes when the active local speaker slot received no
+    /// embedding in any covering window (assignment −2 everywhere). Reconstruction would
+    /// otherwise tie-break such frames arbitrarily to cluster 0, silently absorbing whole
+    /// speaker turns into the surrounding speaker's segment. Since zero votes means there
+    /// is no incumbent evidence at all, the re-embedded span is assigned to the best
+    /// centroid regardless of margin.
+    public struct ZeroVoteReembed: Sendable {
+        /// Whether the post-pass runs. `false` by default — upstream behavior unchanged.
+        public var enabled: Bool
+
+        /// Minimum duration (seconds) of a contiguous zero-vote run eligible for re-embed.
+        /// Shorter runs keep the existing tie-break behavior.
+        public var minDurationSeconds: Double
+
+        /// Post-pass disabled (FluidAudio default).
+        public static let disabled = ZeroVoteReembed()
+
+        public init(enabled: Bool = false, minDurationSeconds: Double = 0.4) {
+            self.enabled = enabled
+            self.minDurationSeconds = minDurationSeconds
+        }
+    }
+
     public struct Export: Sendable {
         public var embeddingsPath: String?
 
@@ -214,6 +240,7 @@ public struct OfflineDiarizerConfig: Sendable {
     public var clustering: Clustering
     public var vbx: VBx
     public var postProcessing: PostProcessing
+    public var zeroVoteReembed: ZeroVoteReembed
     public var export: Export
 
     /// When true, populate `DiarizationResult.chunkEmbeddings` with per-chunk
@@ -228,6 +255,7 @@ public struct OfflineDiarizerConfig: Sendable {
         clustering: Clustering = .community,
         vbx: VBx = .community,
         postProcessing: PostProcessing = .community,
+        zeroVoteReembed: ZeroVoteReembed = .disabled,
         export: Export = .none,
         exposeChunkEmbeddings: Bool = false
     ) {
@@ -236,6 +264,7 @@ public struct OfflineDiarizerConfig: Sendable {
         self.clustering = clustering
         self.vbx = vbx
         self.postProcessing = postProcessing
+        self.zeroVoteReembed = zeroVoteReembed
         self.export = export
         self.exposeChunkEmbeddings = exposeChunkEmbeddings
     }
@@ -365,6 +394,12 @@ public struct OfflineDiarizerConfig: Sendable {
         guard postProcessing.minGapDurationSeconds >= 0 else {
             throw OfflineDiarizationError.invalidConfiguration(
                 "minGapDuration must be >= 0"
+            )
+        }
+
+        guard zeroVoteReembed.minDurationSeconds >= 0 else {
+            throw OfflineDiarizationError.invalidConfiguration(
+                "zeroVoteReembed.minDurationSeconds must be >= 0, got \(zeroVoteReembed.minDurationSeconds)"
             )
         }
 

--- a/Sources/FluidAudio/Diarizer/Offline/Extraction/OfflineEmbeddingExtractor.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Extraction/OfflineEmbeddingExtractor.swift
@@ -226,6 +226,71 @@ struct OfflineEmbeddingExtractor {
         )
     }
 
+    /// Extract a single raw 256-dim embedding over an exact time span of the audio.
+    ///
+    /// Used by the short-segment relabel post-pass: the span's samples are placed at the
+    /// start of a zero-padded model window and an all-active weight mask covering only the
+    /// span's frames is applied, so the embedding reflects the span's speaker exclusively
+    /// (neighboring audio never leaks in through the mask).
+    ///
+    /// - Parameters:
+    ///   - audioSource: Full-session audio source (same one used by the main pipeline).
+    ///   - startSeconds: Span start, in seconds.
+    ///   - endSeconds: Span end, in seconds. Spans longer than one model window are
+    ///     truncated to the window duration.
+    /// - Returns: Raw embedding vector (not L2-normalized).
+    func embedSpan(
+        audioSource: AudioSampleSource,
+        startSeconds: Double,
+        endSeconds: Double
+    ) throws -> [Float] {
+        let sampleRate = Double(config.sampleRate)
+        let startSample = max(0, Int((startSeconds * sampleRate).rounded()))
+        let endSample = min(audioSource.sampleCount, Int((endSeconds * sampleRate).rounded()))
+        let spanLength = min(endSample - startSample, config.samplesPerWindow)
+        guard spanLength > 0 else {
+            throw OfflineDiarizationError.processingFailed(
+                "embedSpan: empty span [\(startSeconds)s, \(endSeconds)s)"
+            )
+        }
+
+        var buffer = [Float](repeating: 0, count: config.samplesPerWindow)
+        try buffer.withUnsafeMutableBufferPointer { pointer in
+            guard let baseAddress = pointer.baseAddress else { return }
+            try audioSource.copySamples(
+                into: baseAddress,
+                offset: startSample,
+                count: spanLength
+            )
+        }
+
+        let fbankInput = try buffer.withUnsafeBufferPointer { pointer -> MLMultiArray in
+            guard let baseAddress = pointer.baseAddress else {
+                throw OfflineDiarizationError.processingFailed("embedSpan: failed to access span buffer")
+            }
+            return try prepareFbankInput(chunkPointer: baseAddress, length: spanLength)
+        }
+        let fbankFeatures = try runFbankModel(audioArray: fbankInput)
+
+        // All-active mask over exactly the frames covering the span; zero elsewhere so the
+        // zero-padded tail of the window contributes nothing to the pooled embedding.
+        let spanFraction = Double(spanLength) / Double(config.samplesPerWindow)
+        let activeFrames = max(
+            1,
+            min(weightFrameCount, Int((spanFraction * Double(weightFrameCount)).rounded()))
+        )
+        var weights = [Float](repeating: 0, count: weightFrameCount)
+        for frame in 0..<activeFrames {
+            weights[frame] = 1
+        }
+        let weightsArray = try prepareWeightsInput(weights: weights)
+
+        return try runEmbeddingModel(
+            fbankFeatures: fbankFeatures,
+            weightsArray: weightsArray
+        )
+    }
+
     func extractEmbeddings<S: AsyncSequence>(
         audioSource: AudioSampleSource,
         segmentationStream: S

--- a/Sources/FluidAudio/Diarizer/Offline/Extraction/OfflineEmbeddingExtractor.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Extraction/OfflineEmbeddingExtractor.swift
@@ -228,7 +228,8 @@ struct OfflineEmbeddingExtractor {
 
     /// Extract a single raw 256-dim embedding over an exact time span of the audio.
     ///
-    /// Used by the short-segment relabel post-pass: the span's samples are placed at the
+    /// Used by span re-embedding post-passes (zero-vote re-embed; the fork's
+    /// short-segment relabel): the span's samples are placed at the
     /// start of a zero-padded model window and an all-active weight mask covering only the
     /// span's frames is applied, so the embedding reflects the span's speaker exclusively
     /// (neighboring audio never leaks in through the mask).
@@ -256,7 +257,11 @@ struct OfflineEmbeddingExtractor {
 
         var buffer = [Float](repeating: 0, count: config.samplesPerWindow)
         try buffer.withUnsafeMutableBufferPointer { pointer in
-            guard let baseAddress = pointer.baseAddress else { return }
+            guard let baseAddress = pointer.baseAddress else {
+                throw OfflineDiarizationError.processingFailed(
+                    "embedSpan: failed to access span buffer"
+                )
+            }
             try audioSource.copySamples(
                 into: baseAddress,
                 offset: startSample,

--- a/Sources/FluidAudio/Diarizer/Offline/Utils/OfflineReconstruction.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Utils/OfflineReconstruction.swift
@@ -16,10 +16,16 @@ struct OfflineReconstruction {
         self.config = config
     }
 
+    /// - Parameters:
+    ///   - spanEmbedder: Optional closure that extracts an embedding over an exact audio
+    ///     span `(startSeconds, endSeconds)`, returning `nil` on failure. Required by the
+    ///     zero-vote re-embed post-pass (`config.zeroVoteReembed.enabled`); when absent
+    ///     the pass is skipped and zero-vote frames keep the tie-break behavior.
     func buildSegments(
         segmentation: SegmentationOutput,
         hardClusters: [[Int]],
-        centroids: [[Double]]
+        centroids: [[Double]],
+        spanEmbedder: ((_ startSeconds: Double, _ endSeconds: Double) -> [Float]?)? = nil
     ) -> [TimedSpeakerSegment] {
         guard segmentation.numChunks > 0, segmentation.numFrames > 0 else { return [] }
 
@@ -167,6 +173,17 @@ struct OfflineReconstruction {
             perFrameClusters[frame] = selected
         }
 
+        if config.zeroVoteReembed.enabled, let spanEmbedder, !centroids.isEmpty {
+            applyZeroVoteReembed(
+                perFrameClusters: &perFrameClusters,
+                speakerCountPerFrame: speakerCountPerFrame,
+                activationSums: activationSums,
+                frameDuration: frameDuration,
+                centroids: centroids,
+                spanEmbedder: spanEmbedder
+            )
+        }
+
         var activeSegments: [Int: Accumulator] = [:]
         var rawSegments: [TimedSpeakerSegment] = []
 
@@ -216,8 +233,73 @@ struct OfflineReconstruction {
         }
 
         let merged = mergeSegments(rawSegments, gapThreshold: gapThreshold)
-        return sanitize(segments: merged)
+        let output = sanitize(segments: merged)
+
+
+        return output
     }
+
+    /// Zero-vote re-embed post-pass over the aggregated frame timeline.
+    ///
+    /// Speech-active frames whose vote sums are zero across all clusters carry no
+    /// clustering evidence at all (the active local speaker slot got assignment −2 in
+    /// every covering window), so the per-frame ranking tie-breaks them arbitrarily to
+    /// cluster 0. For each maximal contiguous zero-vote run of at least
+    /// `config.zeroVoteReembed.minDurationSeconds`, re-embed the run's exact audio span
+    /// and assign its frames to the closest speaker centroid regardless of margin.
+    /// Segment boundaries then follow the run boundaries via the normal accumulator
+    /// machinery. A failed/NaN embedding keeps the tie-break behavior for that run.
+    private func applyZeroVoteReembed(
+        perFrameClusters: inout [[Int]],
+        speakerCountPerFrame: [Int],
+        activationSums: [[Double]],
+        frameDuration: Double,
+        centroids: [[Double]],
+        spanEmbedder: (_ startSeconds: Double, _ endSeconds: Double) -> [Float]?
+    ) {
+        let runs = ZeroVoteReembedder.detectRuns(
+            speakerCountPerFrame: speakerCountPerFrame,
+            activationSums: activationSums,
+            frameDuration: frameDuration,
+            minDurationSeconds: config.zeroVoteReembed.minDurationSeconds
+        )
+        guard !runs.isEmpty else { return }
+
+        for run in runs {
+            let startSeconds = Double(run.lowerBound) * frameDuration
+            let endSeconds = Double(run.upperBound) * frameDuration
+            let startString = String(format: "%.2f", startSeconds)
+            let endString = String(format: "%.2f", endSeconds)
+
+            guard
+                let embedding = spanEmbedder(startSeconds, endSeconds),
+                let assignment = ZeroVoteReembedder.assignment(
+                    embedding: embedding.map(Double.init),
+                    centroids: centroids
+                )
+            else {
+                logger.warning(
+                    "Zero-vote re-embed [\(startString)s–\(endString)s]: embedding failed; keeping tie-break assignment"
+                )
+                continue
+            }
+
+            for frame in run {
+                perFrameClusters[frame] = [assignment.cluster]
+            }
+
+            let cosineString = assignment.cosines
+                .map { String(format: "%.3f", $0) }
+                .joined(separator: ", ")
+            logger.info(
+                "Zero-vote re-embed [\(startString)s–\(endString)s]: assigned S\(assignment.cluster + 1) (cosines [\(cosineString)])"
+            )
+        }
+    }
+
+    /// Debug-only dump of the aggregated global frame timeline (post-window-aggregation,
+    /// post cluster assignment). No-op unless FLUID_OFFLINE_POSTERIOR_DUMP is set.
+
 
     func buildSpeakerDatabase(
         segments: [TimedSpeakerSegment]

--- a/Sources/FluidAudio/Diarizer/Offline/Utils/OfflineReconstruction.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Utils/OfflineReconstruction.swift
@@ -297,7 +297,6 @@ struct OfflineReconstruction {
     /// Debug-only dump of the aggregated global frame timeline (post-window-aggregation,
     /// post cluster assignment). No-op unless FLUID_OFFLINE_POSTERIOR_DUMP is set.
 
-
     func buildSpeakerDatabase(
         segments: [TimedSpeakerSegment]
     ) -> [String: [Float]] {

--- a/Sources/FluidAudio/Diarizer/Offline/Utils/OfflineReconstruction.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Utils/OfflineReconstruction.swift
@@ -233,10 +233,7 @@ struct OfflineReconstruction {
         }
 
         let merged = mergeSegments(rawSegments, gapThreshold: gapThreshold)
-        let output = sanitize(segments: merged)
-
-
-        return output
+        return sanitize(segments: merged)
     }
 
     /// Zero-vote re-embed post-pass over the aggregated frame timeline.

--- a/Sources/FluidAudio/Diarizer/Offline/Utils/ZeroVoteReembedder.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Utils/ZeroVoteReembedder.swift
@@ -53,8 +53,11 @@ enum ZeroVoteReembedder {
         var runStart: Int? = nil
 
         for frame in 0..<frameCount {
+            // Single-speaker frames only: an overlap frame (2+ active speakers) with zero
+            // votes must keep the existing behavior — re-embedding would collapse the
+            // overlap to one speaker and silently change overlap semantics.
             let isZeroVote =
-                speakerCountPerFrame[frame] > 0
+                speakerCountPerFrame[frame] == 1
                 && activationSums[frame].allSatisfy { $0 == 0 }
 
             if isZeroVote {

--- a/Sources/FluidAudio/Diarizer/Offline/Utils/ZeroVoteReembedder.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Utils/ZeroVoteReembedder.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// Pure decision logic for the zero-vote re-embed post-pass.
+///
+/// During reconstruction, aggregated timeline frames collect per-cluster "votes"
+/// (activation sums) from every covering window. When the active local speaker slot
+/// received no embedding in any covering window (assignment −2 everywhere), a
+/// speech-active frame ends up with zero votes across all clusters and the per-frame
+/// cluster ranking tie-breaks it arbitrarily to cluster 0 — silently absorbing whole
+/// speaker turns into the surrounding speaker's segment.
+///
+/// This type detects maximal contiguous zero-vote runs and, given a fresh embedding
+/// extracted over the run's exact audio span, picks the closest speaker centroid.
+/// Because zero votes means there is no incumbent evidence at all, assignment ignores
+/// any margin — the best centroid simply wins.
+///
+/// All CoreML-dependent extraction lives in `OfflineEmbeddingExtractor.embedSpan`;
+/// keeping the decision pure makes it unit-testable without models.
+enum ZeroVoteReembedder {
+
+    /// Outcome of assigning a re-embedded zero-vote run to a speaker centroid.
+    struct Assignment: Equatable {
+        /// Zero-based cluster index of the winning centroid.
+        let cluster: Int
+        /// Cosine similarity between the span embedding and each centroid, by index.
+        let cosines: [Double]
+    }
+
+    /// Detect maximal contiguous zero-vote runs over the aggregated frame timeline.
+    ///
+    /// A frame belongs to a run when it is speech-active (`speakerCountPerFrame > 0`)
+    /// and its vote sums are zero for every cluster. Runs are naturally bounded by
+    /// non-speech gaps and voted frames. Only runs spanning at least
+    /// `minDurationSeconds` of audio are returned.
+    ///
+    /// - Parameters:
+    ///   - speakerCountPerFrame: Estimated speaker count for each aggregated frame.
+    ///   - activationSums: Per-frame, per-cluster vote sums (`[frame][cluster]`).
+    ///   - frameDuration: Duration of one aggregated frame in seconds.
+    ///   - minDurationSeconds: Minimum run duration; shorter runs are dropped.
+    /// - Returns: Frame-index ranges of qualifying runs, in ascending order.
+    static func detectRuns(
+        speakerCountPerFrame: [Int],
+        activationSums: [[Double]],
+        frameDuration: Double,
+        minDurationSeconds: Double
+    ) -> [Range<Int>] {
+        guard frameDuration > 0 else { return [] }
+        let frameCount = min(speakerCountPerFrame.count, activationSums.count)
+        guard frameCount > 0 else { return [] }
+
+        var runs: [Range<Int>] = []
+        var runStart: Int? = nil
+
+        for frame in 0..<frameCount {
+            let isZeroVote =
+                speakerCountPerFrame[frame] > 0
+                && activationSums[frame].allSatisfy { $0 == 0 }
+
+            if isZeroVote {
+                if runStart == nil {
+                    runStart = frame
+                }
+            } else if let start = runStart {
+                runs.append(start..<frame)
+                runStart = nil
+            }
+        }
+        if let start = runStart {
+            runs.append(start..<frameCount)
+        }
+
+        return runs.filter { run in
+            Double(run.count) * frameDuration >= minDurationSeconds
+        }
+    }
+
+    /// Assign a re-extracted span embedding to the closest speaker centroid.
+    ///
+    /// Unlike `ShortSegmentRelabeler.decision`, there is no incumbent label to defend:
+    /// the best centroid wins regardless of margin. Ties resolve to the lowest cluster
+    /// index for determinism.
+    ///
+    /// - Returns: The winning cluster plus all per-centroid cosines, or `nil` when the
+    ///   embedding is empty/non-finite or the centroids are empty/dimension-mismatched
+    ///   (callers should fall back to the existing tie-break behavior).
+    static func assignment(
+        embedding: [Double],
+        centroids: [[Double]]
+    ) -> Assignment? {
+        guard !embedding.isEmpty, !centroids.isEmpty else { return nil }
+        guard embedding.allSatisfy({ $0.isFinite }) else { return nil }
+
+        var cosines: [Double] = []
+        cosines.reserveCapacity(centroids.count)
+        var bestIndex = -1
+        var bestCosine = -Double.infinity
+
+        for (index, centroid) in centroids.enumerated() {
+            guard centroid.count == embedding.count else { return nil }
+            let cosine = Self.cosineSimilarity(embedding, centroid)
+            guard cosine.isFinite else { return nil }
+            cosines.append(cosine)
+            if cosine > bestCosine {
+                bestCosine = cosine
+                bestIndex = index
+            }
+        }
+
+        guard bestIndex >= 0 else { return nil }
+        return Assignment(cluster: bestIndex, cosines: cosines)
+    }
+    /// Cosine similarity between an embedding and a centroid. Scale-invariant; returns
+    /// a non-finite value when either vector has zero magnitude.
+    static func cosineSimilarity(_ a: [Double], _ b: [Double]) -> Double {
+        var dot = 0.0
+        var normA = 0.0
+        var normB = 0.0
+        for index in a.indices {
+            let x = a[index]
+            let y = b[index]
+            dot += x * y
+            normA += x * x
+            normB += y * y
+        }
+        return dot / ((normA * normB).squareRoot())
+    }
+}

--- a/Tests/FluidAudioTests/Diarizer/Offline/ZeroVoteReembedderTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Offline/ZeroVoteReembedderTests.swift
@@ -32,6 +32,26 @@ final class ZeroVoteReembedderTests: XCTestCase {
         XCTAssertEqual(runs, [2..<7])
     }
 
+    func testOverlapFramesAreNeverDetectedAsZeroVoteRuns() {
+        // Frames 2-6 have zero votes but 2+ active speakers (overlap): re-embedding would
+        // collapse the overlap to one speaker, so they must keep the existing tie-break.
+        let speakerCount = [1, 1, 2, 2, 2, 2, 2, 1]
+        let sums: [[Double]] = [
+            [0.9, 0], [0.8, 0],
+            [0, 0], [0, 0], [0, 0], [0, 0], [0, 0],
+            [0.7, 0],
+        ]
+
+        let runs = ZeroVoteReembedder.detectRuns(
+            speakerCountPerFrame: speakerCount,
+            activationSums: sums,
+            frameDuration: 0.1,
+            minDurationSeconds: 0.4
+        )
+
+        XCTAssertEqual(runs, [])
+    }
+
     func testDetectsRunBoundedByNonSpeechGaps() {
         // Non-speech frames (speakerCount 0) delimit the run even with zero sums everywhere.
         let speakerCount = [0, 1, 1, 1, 1, 1, 0, 0]

--- a/Tests/FluidAudioTests/Diarizer/Offline/ZeroVoteReembedderTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Offline/ZeroVoteReembedderTests.swift
@@ -1,0 +1,282 @@
+import XCTest
+
+@testable import FluidAudio
+
+final class ZeroVoteReembedderTests: XCTestCase {
+
+    // Orthogonal unit centroids: cosine(embedding, centroid) is trivially predictable.
+    private let centroids: [[Double]] = [
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+    ]
+
+    // MARK: - Run detection
+
+    func testDetectsRunBoundedByVotedFrames() {
+        // Frames 0–1 voted, 2–6 speech-active with zero votes, 7 voted.
+        let speakerCount = [1, 1, 1, 1, 1, 1, 1, 1]
+        let sums: [[Double]] = [
+            [0.9, 0], [0.8, 0],
+            [0, 0], [0, 0], [0, 0], [0, 0], [0, 0],
+            [0.7, 0],
+        ]
+
+        let runs = ZeroVoteReembedder.detectRuns(
+            speakerCountPerFrame: speakerCount,
+            activationSums: sums,
+            frameDuration: 0.1,
+            minDurationSeconds: 0.4
+        )
+
+        XCTAssertEqual(runs, [2..<7])
+    }
+
+    func testDetectsRunBoundedByNonSpeechGaps() {
+        // Non-speech frames (speakerCount 0) delimit the run even with zero sums everywhere.
+        let speakerCount = [0, 1, 1, 1, 1, 1, 0, 0]
+        let sums = [[Double]](repeating: [0, 0], count: 8)
+
+        let runs = ZeroVoteReembedder.detectRuns(
+            speakerCountPerFrame: speakerCount,
+            activationSums: sums,
+            frameDuration: 0.1,
+            minDurationSeconds: 0.4
+        )
+
+        XCTAssertEqual(runs, [1..<6])
+    }
+
+    func testDropsRunsShorterThanMinDuration() {
+        // 3 zero-vote frames at 0.1 s each = 0.3 s < 0.4 s minimum.
+        let speakerCount = [1, 1, 1, 1, 1]
+        let sums: [[Double]] = [[0.9, 0], [0, 0], [0, 0], [0, 0], [0.9, 0]]
+
+        let runs = ZeroVoteReembedder.detectRuns(
+            speakerCountPerFrame: speakerCount,
+            activationSums: sums,
+            frameDuration: 0.1,
+            minDurationSeconds: 0.4
+        )
+
+        XCTAssertTrue(runs.isEmpty)
+    }
+
+    func testDetectsMultipleMaximalRuns() {
+        let speakerCount = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        var sums = [[Double]](repeating: [0, 0], count: 14)
+        sums[0] = [0.9, 0]
+        sums[5] = [0, 0.8]
+        sums[6] = [0, 0.8]
+        // Zero-vote runs: 1..<5 (0.4 s) and 7..<14 (0.7 s).
+
+        let runs = ZeroVoteReembedder.detectRuns(
+            speakerCountPerFrame: speakerCount,
+            activationSums: sums,
+            frameDuration: 0.1,
+            minDurationSeconds: 0.4
+        )
+
+        XCTAssertEqual(runs, [1..<5, 7..<14])
+    }
+
+    func testRunExtendingToTimelineEndIsDetected() {
+        let speakerCount = [1, 1, 1, 1, 1, 1]
+        let sums: [[Double]] = [[0.9, 0], [0, 0], [0, 0], [0, 0], [0, 0], [0, 0]]
+
+        let runs = ZeroVoteReembedder.detectRuns(
+            speakerCountPerFrame: speakerCount,
+            activationSums: sums,
+            frameDuration: 0.1,
+            minDurationSeconds: 0.4
+        )
+
+        XCTAssertEqual(runs, [1..<6])
+    }
+
+    func testEmptyTimelineAndInvalidFrameDurationYieldNoRuns() {
+        XCTAssertTrue(
+            ZeroVoteReembedder.detectRuns(
+                speakerCountPerFrame: [],
+                activationSums: [],
+                frameDuration: 0.1,
+                minDurationSeconds: 0.4
+            ).isEmpty
+        )
+        XCTAssertTrue(
+            ZeroVoteReembedder.detectRuns(
+                speakerCountPerFrame: [1, 1, 1, 1, 1],
+                activationSums: [[Double]](repeating: [0], count: 5),
+                frameDuration: 0,
+                minDurationSeconds: 0.4
+            ).isEmpty
+        )
+    }
+
+    // MARK: - Assignment
+
+    func testAssignsToClosestCentroidRegardlessOfMargin() {
+        // Nearly tied with cluster 0, but cluster 1 is best by a sliver — there is no
+        // incumbent to defend, so the best centroid wins outright.
+        let assignment = ZeroVoteReembedder.assignment(
+            embedding: [0.70, 0.71, 0.0],
+            centroids: centroids
+        )
+
+        XCTAssertEqual(assignment?.cluster, 1)
+        XCTAssertEqual(assignment?.cosines.count, 3)
+    }
+
+    func testExactTieResolvesToLowestClusterIndex() {
+        let assignment = ZeroVoteReembedder.assignment(
+            embedding: [1, 1, 0],
+            centroids: centroids
+        )
+
+        XCTAssertEqual(assignment?.cluster, 0)
+    }
+
+    func testNonFiniteEmbeddingReturnsNil() {
+        XCTAssertNil(
+            ZeroVoteReembedder.assignment(
+                embedding: [Double.nan, 0.5, 0.5],
+                centroids: centroids
+            )
+        )
+        XCTAssertNil(
+            ZeroVoteReembedder.assignment(
+                embedding: [Double.infinity, 0, 0],
+                centroids: centroids
+            )
+        )
+    }
+
+    func testEmptyInputsAndDimensionMismatchReturnNil() {
+        XCTAssertNil(ZeroVoteReembedder.assignment(embedding: [], centroids: centroids))
+        XCTAssertNil(ZeroVoteReembedder.assignment(embedding: [1, 0, 0], centroids: []))
+        XCTAssertNil(
+            ZeroVoteReembedder.assignment(embedding: [1, 0], centroids: centroids)
+        )
+    }
+
+    // MARK: - Config surface
+
+    func testZeroVoteReembedDisabledByDefault() {
+        let config = OfflineDiarizerConfig.default
+        XCTAssertFalse(config.zeroVoteReembed.enabled)
+        XCTAssertEqual(config.zeroVoteReembed.minDurationSeconds, 0.4)
+    }
+
+    func testValidateRejectsNegativeMinDuration() {
+        var config = OfflineDiarizerConfig.default
+        config.zeroVoteReembed.minDurationSeconds = -0.1
+        XCTAssertThrowsError(try config.validate())
+    }
+
+    // MARK: - Reconstruction integration (synthetic frames, injected embedder)
+
+    /// One chunk, two local speakers. Speaker 0 is voted to cluster 0 on both flanks;
+    /// speaker 1 is speech-active in the middle but carries assignment −2 (no embedding),
+    /// producing a zero-vote run that reconstruction must re-embed and emit as its own
+    /// S2 segment with boundaries on the frame-run edges.
+    private func makeZeroVoteScenario() -> (
+        config: OfflineDiarizerConfig,
+        segmentation: SegmentationOutput,
+        hardClusters: [[Int]],
+        centroids: [[Double]]
+    ) {
+        var config = OfflineDiarizerConfig(
+            minSegmentDuration: 0.1,
+            minGapDuration: 0.05,
+            segmentationMinDurationOn: 0.0,
+            segmentationMinDurationOff: 0.0
+        )
+        config.zeroVoteReembed = OfflineDiarizerConfig.ZeroVoteReembed(
+            enabled: true,
+            minDurationSeconds: 0.4
+        )
+
+        var weights = [[Float]]()
+        for frame in 0..<30 {
+            let middle = (10..<20).contains(frame)
+            weights.append(middle ? [0, 1] : [1, 0])
+        }
+        let segmentation = SegmentationOutput(
+            logProbs: [[[0]]],
+            speakerWeights: [weights],
+            numChunks: 1,
+            numFrames: 30,
+            numSpeakers: 2,
+            chunkOffsets: [0],
+            frameDuration: 0.1
+        )
+
+        return (config, segmentation, [[0, -2]], [[1, 0, 0], [0, 1, 0]])
+    }
+
+    func testReembeddedRunBecomesItsOwnSegmentOnFrameBoundaries() {
+        let scenario = makeZeroVoteScenario()
+        var embeddedSpans: [(Double, Double)] = []
+
+        let segments = OfflineReconstruction(config: scenario.config).buildSegments(
+            segmentation: scenario.segmentation,
+            hardClusters: scenario.hardClusters,
+            centroids: scenario.centroids,
+            spanEmbedder: { start, end in
+                embeddedSpans.append((start, end))
+                return [0.1, 0.9, 0.0]  // Clearly centroid 1.
+            }
+        )
+
+        XCTAssertEqual(embeddedSpans.count, 1)
+        XCTAssertEqual(embeddedSpans.first?.0 ?? -1, 1.0, accuracy: 1e-6)
+        XCTAssertEqual(embeddedSpans.first?.1 ?? -1, 2.0, accuracy: 1e-6)
+
+        let shape = segments.map { ($0.speakerId, $0.startTimeSeconds, $0.endTimeSeconds) }
+        XCTAssertEqual(shape.map { $0.0 }, ["S1", "S2", "S1"])
+        XCTAssertEqual(Double(shape[1].1), 1.0, accuracy: 1e-3)
+        XCTAssertEqual(Double(shape[1].2), 2.0, accuracy: 1e-3)
+    }
+
+    func testDisabledConfigNeverInvokesEmbedder() {
+        var scenario = makeZeroVoteScenario()
+        scenario.config.zeroVoteReembed.enabled = false
+        var invocationCount = 0
+
+        _ = OfflineReconstruction(config: scenario.config).buildSegments(
+            segmentation: scenario.segmentation,
+            hardClusters: scenario.hardClusters,
+            centroids: scenario.centroids,
+            spanEmbedder: { _, _ in
+                invocationCount += 1
+                return [0.1, 0.9, 0.0]
+            }
+        )
+
+        XCTAssertEqual(invocationCount, 0)
+    }
+
+    func testFailedEmbeddingFallsBackToTieBreakBehavior() {
+        let scenario = makeZeroVoteScenario()
+
+        let withFailingEmbedder = OfflineReconstruction(config: scenario.config).buildSegments(
+            segmentation: scenario.segmentation,
+            hardClusters: scenario.hardClusters,
+            centroids: scenario.centroids,
+            spanEmbedder: { _, _ in nil }
+        )
+
+        var disabledConfig = scenario.config
+        disabledConfig.zeroVoteReembed.enabled = false
+        let withoutPass = OfflineReconstruction(config: disabledConfig).buildSegments(
+            segmentation: scenario.segmentation,
+            hardClusters: scenario.hardClusters,
+            centroids: scenario.centroids
+        )
+
+        XCTAssertEqual(
+            withFailingEmbedder.map { "\($0.speakerId)|\($0.startTimeSeconds)|\($0.endTimeSeconds)" },
+            withoutPass.map { "\($0.speakerId)|\($0.startTimeSeconds)|\($0.endTimeSeconds)" }
+        )
+    }
+}


### PR DESCRIPTION
## Problem

In `OfflineReconstruction.buildSegments`, aggregated timeline frames whose per-cluster vote sums are **all zero** are tie-broken arbitrarily to cluster 0. A frame ends up with zero votes when the active local speaker slot received no embedding in any covering window (assignment −2 everywhere). The result: whole speaker turns silently absorbed into the surrounding speaker's segment.

Reproduced on a 97 s two-speaker fixture: a clean 1.6 s turn (segmentation gaps delimit it correctly at 26.88–28.46 s, verified from raw powerset activations) had zero cluster votes in all six covering windows and was emitted as part of the other speaker's 13 s segment.

## Fix

Optional post-pass (`OfflineDiarizerConfig.zeroVoteReembed`, **disabled by default** — no behavior change unless opted in):
- detect maximal contiguous zero-vote runs (speech-active frames, no cluster votes, bounded by gaps/voted frames) ≥ `minDurationSeconds` (default 0.4 s)
- re-embed each run's exact audio span (zero-padded window, weight mask covering only the span's frames so neighboring audio can't leak in)
- assign to the closest speaker centroid by cosine; a failed/NaN embedding falls back to the existing tie-break
- the run becomes its own segment when its assigned cluster differs from its neighbors

## Results (fixture A/B, community-1 preset, min-segment 0.5)

| config | DER | speaker-error |
|---|---|---|
| baseline | 0.0404 | 0.0200 |
| + zeroVoteReembed | **0.0216** | **0.0012** |

Three real turns recovered (26.9–28.4 s, 72.6–73.7 s, 87.3–87.9 s), all matching ground truth.

## Tests

`ZeroVoteReembedderTests`: 15 cases — run detection (voted/non-speech bounds, min-duration filter, multiple runs, timeline-end), assignment (no-margin win, tie → lowest index, NaN, dimension mismatch), disabled-by-default, and synthetic-frame reconstruction integration (segment split on run boundaries, disabled path never invokes the embedder, nil-embedding parity with disabled).

Pure decision logic lives in `ZeroVoteReembedder` (no RNG, stable iteration order) so it is testable without CoreML models.