### PR TITLE
feat(diarizer): optional progressHandler on performCompleteDiarization

### DIFF
--- a/Sources/FluidAudio/Diarizer/Core/DiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Core/DiarizerManager.swift
@@ -130,6 +130,9 @@ public final class DiarizerManager {
     ///   - samples: Audio samples (16kHz mono) - accepts any RandomAccessCollection of Float
     ///             (Array, ArraySlice, ContiguousArray, or custom collections)
     ///   - sampleRate: Sample rate (default: 16000)
+    ///   - progressHandler: Optional callback invoked after each processed audio chunk with
+    ///             overall progress in the range `0.0...1.0`. Called synchronously on the
+    ///             calling thread; the final call reports `1.0` once processing completes.
     /// - Returns: `DiarizationResult` containing:
     ///   - `segments`: Array of speaker segments with speaker IDs, timestamps, and embeddings
     ///   - `speakerDatabase`: Dictionary mapping speaker IDs to embeddings (only when debugMode enabled)
@@ -151,7 +154,8 @@ public final class DiarizerManager {
     /// let result = try diarizer.performCompleteDiarization(audioContiguous)
     /// ```
     public func performCompleteDiarization<C>(
-        _ samples: C, sampleRate: Int = 16000, atTime startTime: TimeInterval = 0
+        _ samples: C, sampleRate: Int = 16000, atTime startTime: TimeInterval = 0,
+        progressHandler: ((Double) -> Void)? = nil
     ) throws -> DiarizationResult
     where C: RandomAccessCollection, C.Element == Float, C.Index == Int {
         guard let models else {
@@ -196,7 +200,11 @@ public final class DiarizerManager {
             segmentationTime += chunkTimings.segmentationTime
             embeddingTime += chunkTimings.embeddingTime
             clusteringTime += chunkTimings.clusteringTime
+
+            progressHandler?(
+                Double(min(chunkStartOffset + stepSize, totalSamples)) / Double(totalSamples))
         }
+        progressHandler?(1.0)
 
         let postProcessingStartTime = Date()
         let filteredSegments = allSegments  // No post-processing


### PR DESCRIPTION
## What

Adds an optional `progressHandler: ((Double) -> Void)? = nil` to `DiarizerManager.performCompleteDiarization`. It reports overall progress in `0.0...1.0` after each processed audio chunk, ending at `1.0`.

## Why

`performCompleteDiarization` already loops over the audio in chunks, but exposes no way to observe progress, so a host app can only show an indeterminate spinner (or a fake full bar) during a long offline diarization. This lets callers drive a real progress bar.

## Notes

- Default `nil` — every existing call site is unaffected (fully source-compatible).
- The closure is non-escaping and invoked synchronously on the calling thread, so it adds no `Sendable`/concurrency requirements.
- The progress fraction is derived from the existing `stepSize` stride over `totalSamples`; no behavioral change to segmentation, embedding, or clustering.
- `swift format lint` clean; `swift build` green.