### PR TITLE
docs: add evoglyph to the Showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Make a PR if you want to add your app, please keep it in chronological order.
 | **[Hedy](https://hedy.ai)** | Privacy-first AI meeting coach for iOS, macOS, Android, and Windows. Real-time, fully on-device transcription with speaker diarization and AI-powered conversation insights. Uses Parakeet and Nemotron streaming ASR and speaker diarization on the Apple Neural Engine. |
 | **[Parakey](https://github.com/rcourtman/parakey)** | Open-source (MIT) menu-bar push-to-talk dictation for macOS — hold a key, speak, release; the transcript pastes at the cursor in about 100 ms. Uses Parakeet TDT v3 ASR on the Apple Neural Engine via FluidAudio. |
 | **[TypeWhisper](https://www.typewhisper.com/)** | Speech-to-text and AI text processing for macOS. Uses FluidAudio's Parakeet ASR for local transcription. |
+| **[evoglyph](https://evoglyph.com)** | Lightweight, privacy-first macOS menu-bar dictation — press a hotkey, speak, and cleaned-up text is injected at your cursor. Fully local: Parakeet TDT ASR with CTC vocabulary boosting and Silero VAD via FluidAudio on the Apple Neural Engine, plus on-device LLM cleanup. Audio never leaves the Mac. |
 
 ## Installation
 


### PR DESCRIPTION
Adds [evoglyph](https://evoglyph.com) to the Showcase table (chronological, at the end), matching the recent Parakey/TypeWhisper PRs — README-only, no edit to the maintainer-curated logo strip.

evoglyph is a lightweight, privacy-first macOS menu-bar dictation app: press a hotkey, speak, and cleaned-up text is injected at your cursor. It runs fully on-device — audio never leaves the Mac.

FluidAudio is the entire speech stack:
- **Parakeet TDT ASR** on the Apple Neural Engine for local transcription
- **CtcKeywordSpotter (CTC-110M)** for vocabulary boosting
- **Silero VAD** (VadManager) for speech detection

On-device LLM cleanup (LFM2 via MLX) then polishes the transcript before injection. Thanks for the library — the low-latency ANE path is what makes the whole product feel instant.

Happy to adjust the wording if you'd prefer something shorter.