### PR TITLE
Seam-gap repair pass for long-form chunk-merge content drops

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift
@@ -61,6 +61,25 @@ public struct ASRConfig: Sendable {
     /// `melChunkContext = false` path.
     public let dualDecodeArbitration: Bool
 
+    /// Repair pass for chunk-seam content drops in long-form batch
+    /// transcription (issue #758). The chunk merger can deterministically
+    /// drop multi-second spans of clear speech at a chunk boundary when the
+    /// overlap region is low-SNR (crosstalk, applause, soft speech). After
+    /// merging, gaps between consecutive tokens longer than
+    /// `seamGapRepairMinGapSeconds` whose audio contains speech-level energy
+    /// are re-decoded with a single fresh window centred on the gap — the
+    /// seam does not exist in the re-decode — and only tokens that fall
+    /// strictly inside the gap are spliced in, starting at a word-initial
+    /// piece. Genuine silence yields no in-gap tokens and is left untouched.
+    ///
+    /// Cost: one extra window decode per probed gap (typically 0–3 per
+    /// half-hour file). Applies to the stateless chunked batch path only.
+    public let seamGapRepair: Bool
+
+    /// Minimum inter-token gap, in seconds, that triggers a seam-gap repair
+    /// probe when `seamGapRepair` is enabled.
+    public let seamGapRepairMinGapSeconds: Double
+
     public static let `default` = ASRConfig()
 
     public init(
@@ -71,7 +90,9 @@ public struct ASRConfig: Sendable {
         streamingEnabled: Bool = true,
         streamingThreshold: Int = 480_000,
         melChunkContext: Bool = true,
-        dualDecodeArbitration: Bool = false
+        dualDecodeArbitration: Bool = false,
+        seamGapRepair: Bool = true,
+        seamGapRepairMinGapSeconds: Double = 1.5
     ) {
         self.sampleRate = sampleRate
         self.tdtConfig = tdtConfig
@@ -81,6 +102,8 @@ public struct ASRConfig: Sendable {
         self.streamingThreshold = streamingThreshold
         self.melChunkContext = melChunkContext
         self.dualDecodeArbitration = dualDecodeArbitration
+        self.seamGapRepair = seamGapRepair
+        self.seamGapRepairMinGapSeconds = max(0.5, seamGapRepairMinGapSeconds)
     }
 }
 

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
@@ -46,6 +46,16 @@ public actor AsrManager {
         config.dualDecodeArbitration
     }
 
+    /// Seam-gap repair flag exposed to `ChunkProcessor` (issue #758).
+    internal var seamGapRepair: Bool {
+        config.seamGapRepair
+    }
+
+    /// Minimum inter-token gap that triggers a seam-gap repair probe.
+    internal var seamGapRepairMinGapSeconds: Double {
+        config.seamGapRepairMinGapSeconds
+    }
+
     /// Cached vocabulary loaded once during initialization
     internal var vocabulary: [Int: String] = [:]
     #if DEBUG

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
@@ -1152,6 +1152,118 @@ struct ChunkProcessor {
     /// probed. Genuine pauses with a stray cough stay untouched.
     private var seamGapMinSpeechSeconds: Double { 0.5 }
 
+    /// A piece consisting solely of punctuation/symbol scalars (e.g. the
+    /// "." in "else." = ▁else + .). Skipped when resolving the word bordering
+    /// a gap for edge dedupe.
+    static func isPunctuationOnlyPiece(_ id: Int, vocabulary: [Int: String]) -> Bool {
+        guard let piece = vocabulary[id], !piece.isEmpty else { return false }
+        return piece.unicodeScalars.allSatisfy { scalar in
+            CharacterSet.punctuationCharacters.contains(scalar)
+                || CharacterSet.symbols.contains(scalar)
+        }
+    }
+
+    /// The token of the word bordering a gap, walking past punctuation-only
+    /// pieces (`step` -1 walks left from the token before the gap, +1 walks
+    /// right from the token after it).
+    static func wordNeighbor(
+        in stream: [TokenWindow],
+        from index: Int,
+        step: Int,
+        vocabulary: [Int: String]
+    ) -> TokenWindow {
+        var neighborIndex = index
+        while neighborIndex + step >= 0,
+            neighborIndex + step < stream.count,
+            isPunctuationOnlyPiece(stream[neighborIndex].token, vocabulary: vocabulary)
+        {
+            neighborIndex += step
+        }
+        return stream[neighborIndex]
+    }
+
+    /// Filter a probe window's decoded tokens down to the run that may be
+    /// spliced into a gap:
+    ///
+    /// - only tokens strictly inside the gap (one-frame margins), so words
+    ///   the merged stream already has are never duplicated;
+    /// - never splice in mid-word — the run starts at a word-initial (or
+    ///   punctuation) piece (same rule as the seam merge, #683);
+    /// - edge dedupe: the probe can re-hear the word bordering the gap at a
+    ///   slightly shifted frame, sometimes with different capitalisation
+    ///   ("▁for" vs "▁For") — keep the merged stream's copy, not both. The
+    ///   tolerance is deliberately tight (6 frames = 0.48s): genuine
+    ///   stutters ("I I") re-heard by the probe sit at or beyond it.
+    static func spliceCandidate(
+        windowTokens: [Int],
+        windowTimestamps: [Int],
+        windowConfidences: [Float],
+        windowDurations: [Int],
+        gapStartFrame: Int,
+        gapEndFrame: Int,
+        leadNeighbor: TokenWindow,
+        tailNeighbor: TokenWindow,
+        spliceSafeTokenIds: Set<Int>?,
+        vocabulary: [Int: String]
+    ) -> [TokenWindow] {
+        let edgeToleranceFrames = 6
+        func samePiece(_ a: Int, _ b: Int) -> Bool {
+            if a == b { return true }
+            guard let pieceA = vocabulary[a], let pieceB = vocabulary[b] else { return false }
+            return pieceA.lowercased() == pieceB.lowercased()
+        }
+
+        var candidate: [TokenWindow] = []
+        for tokenIndex in 0..<windowTokens.count {
+            let timestamp = windowTimestamps[tokenIndex]
+            guard timestamp > gapStartFrame, timestamp < gapEndFrame - 1 else { continue }
+            candidate.append(
+                (
+                    token: windowTokens[tokenIndex],
+                    timestamp: timestamp,
+                    confidence: windowConfidences[tokenIndex],
+                    duration: windowDurations[tokenIndex]
+                )
+            )
+        }
+
+        if let safeIds = spliceSafeTokenIds {
+            while let first = candidate.first, !safeIds.contains(first.token) {
+                candidate.removeFirst()
+            }
+        }
+
+        while let first = candidate.first,
+            samePiece(first.token, leadNeighbor.token),
+            abs(first.timestamp - leadNeighbor.timestamp) <= edgeToleranceFrames
+        {
+            candidate.removeFirst()
+        }
+        while let last = candidate.last,
+            samePiece(last.token, tailNeighbor.token),
+            abs(tailNeighbor.timestamp - last.timestamp) <= edgeToleranceFrames
+        {
+            candidate.removeLast()
+        }
+        // Removing an edge token can expose continuation pieces (or orphaned
+        // punctuation) at the head — re-trim.
+        if let safeIds = spliceSafeTokenIds {
+            while let first = candidate.first,
+                !safeIds.contains(first.token) || isPunctuationOnlyPiece(first.token, vocabulary: vocabulary)
+            {
+                candidate.removeFirst()
+            }
+        }
+
+        return candidate
+    }
+
+    #if DEBUG
+    internal func speechLikeSecondsForTesting(from startSample: Int, to endSample: Int) throws -> Double {
+        try speechLikeSeconds(from: startSample, to: endSample)
+    }
+    #endif
+
     /// Detect inter-token gaps that plausibly contain dropped speech and
     /// re-decode each with a single fresh window centred on the gap. Because
     /// the window is decoded from silence-free state with no seam inside it,
@@ -1248,84 +1360,18 @@ struct ChunkProcessor {
                         windowDurations.count == windowTokens.count
                         ? windowDurations : Array(repeating: 0, count: windowTokens.count)
 
-                    // Keep only tokens strictly inside the gap (one-frame margins)
-                    // so words the merged stream already has are never duplicated.
-                    var candidate: [TokenWindow] = []
-                    for tokenIndex in 0..<windowTokens.count {
-                        let timestamp = windowTimestamps[tokenIndex]
-                        guard timestamp > gapStartFrame, timestamp < gapEndFrame - 1 else { continue }
-                        candidate.append(
-                            (
-                                token: windowTokens[tokenIndex],
-                                timestamp: timestamp,
-                                confidence: windowConfidences[tokenIndex],
-                                duration: durations[tokenIndex]
-                            )
-                        )
-                    }
-
-                    // Never splice in mid-word: drop leading continuation pieces
-                    // so the recovered run starts at a word-initial (or
-                    // punctuation) piece (same rule as the seam merge, #683).
-                    if let safeIds = spliceSafeTokenIds {
-                        while let first = candidate.first, !safeIds.contains(first.token) {
-                            candidate.removeFirst()
-                        }
-                    }
-
-                    // Edge dedupe: the probe can re-hear the word bordering the
-                    // gap at a slightly shifted frame (sometimes with different
-                    // capitalisation, i.e. a different token id — "▁for" vs
-                    // "▁For"); keep the merged stream's copy, not both. The
-                    // comparison must skip punctuation pieces on the merged
-                    // stream's side ("else." decodes as ▁else + .), else the
-                    // recovered ▁else is compared against "." and slips through.
-                    // The tolerance is deliberately tight (0.48s): genuine
-                    // stutters ("I I") re-heard by the probe sit further apart.
-                    let edgeToleranceFrames = 6
-                    func samePiece(_ a: Int, _ b: Int) -> Bool {
-                        if a == b { return true }
-                        guard let pieceA = vocabulary[a], let pieceB = vocabulary[b] else { return false }
-                        return pieceA.lowercased() == pieceB.lowercased()
-                    }
-                    func isPunctuationPiece(_ id: Int) -> Bool {
-                        guard let piece = vocabulary[id], !piece.isEmpty else { return false }
-                        return piece.unicodeScalars.allSatisfy { scalar in
-                            CharacterSet.punctuationCharacters.contains(scalar)
-                                || CharacterSet.symbols.contains(scalar)
-                        }
-                    }
-                    var leadNeighborIndex = index
-                    while leadNeighborIndex > 0, isPunctuationPiece(working[leadNeighborIndex].token) {
-                        leadNeighborIndex -= 1
-                    }
-                    let leadNeighbor = working[leadNeighborIndex]
-                    var tailNeighborIndex = index + 1
-                    while tailNeighborIndex < working.count - 1, isPunctuationPiece(working[tailNeighborIndex].token) {
-                        tailNeighborIndex += 1
-                    }
-                    let tailNeighbor = working[tailNeighborIndex]
-                    while let first = candidate.first,
-                        samePiece(first.token, leadNeighbor.token),
-                        abs(first.timestamp - leadNeighbor.timestamp) <= edgeToleranceFrames
-                    {
-                        candidate.removeFirst()
-                    }
-                    while let last = candidate.last,
-                        samePiece(last.token, tailNeighbor.token),
-                        abs(tailNeighbor.timestamp - last.timestamp) <= edgeToleranceFrames
-                    {
-                        candidate.removeLast()
-                    }
-                    // Removing an edge token can expose continuation pieces (or
-                    // orphaned punctuation) at the head — re-trim.
-                    if let safeIds = spliceSafeTokenIds {
-                        while let first = candidate.first,
-                            !safeIds.contains(first.token) || isPunctuationPiece(first.token)
-                        {
-                            candidate.removeFirst()
-                        }
-                    }
+                    let candidate = Self.spliceCandidate(
+                        windowTokens: windowTokens,
+                        windowTimestamps: windowTimestamps,
+                        windowConfidences: windowConfidences,
+                        windowDurations: durations,
+                        gapStartFrame: gapStartFrame,
+                        gapEndFrame: gapEndFrame,
+                        leadNeighbor: Self.wordNeighbor(in: working, from: index, step: -1, vocabulary: vocabulary),
+                        tailNeighbor: Self.wordNeighbor(in: working, from: index + 1, step: 1, vocabulary: vocabulary),
+                        spliceSafeTokenIds: spliceSafeTokenIds,
+                        vocabulary: vocabulary
+                    )
 
                     if !candidate.isEmpty {
                         recovered = candidate

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
@@ -598,6 +598,24 @@ struct ChunkProcessor {
             mergedTokens.sort { $0.timestamp < $1.timestamp }
         }
 
+        // Issue #758: the merge above can deterministically drop multi-second
+        // spans of clear speech at a chunk seam. Detect suspicious gaps and
+        // re-decode each with a fresh window centred on the gap, where the
+        // seam does not exist.
+        if orderedChunkOutputs.count > 1, mergedTokens.count > 1, await manager.seamGapRepair {
+            let vocabulary = await manager.vocabulary
+            mergedTokens = try await repairSeamGaps(
+                in: mergedTokens,
+                using: workers[0],
+                decoderLayers: decoderLayers,
+                maxModelSamples: maxModelSamples,
+                minGapSeconds: await manager.seamGapRepairMinGapSeconds,
+                spliceSafeTokenIds: Self.spliceSafeTokenIds(vocabulary: vocabulary),
+                vocabulary: vocabulary,
+                language: language
+            )
+        }
+
         let allTokens = mergedTokens.map { $0.token }
         let allTimestamps = mergedTokens.map { $0.timestamp }
         let allConfidences = mergedTokens.map { $0.confidence }
@@ -1115,5 +1133,207 @@ struct ChunkProcessor {
             }
         }
         return Array(left[..<leftEnd]) + Array(right[rightStart...])
+    }
+
+    // MARK: - Seam-gap repair (issue #758)
+
+    /// Maximum number of gap probes per file — a backstop against
+    /// pathological inputs (e.g. hours of intermittent noise). A half-hour
+    /// conference recording with applause breaks legitimately probes ~12
+    /// gaps, and iteration over residual gaps needs headroom beyond that.
+    private var maxSeamGapRepairs: Int { 32 }
+
+    /// Per-frame RMS above this counts as speech-like energy inside a gap.
+    /// Comfortably above the library's quiet threshold (0.003 in
+    /// `shouldUseWarmupPrefix`) so room tone and hiss do not trigger probes.
+    private var seamGapSpeechRmsThreshold: Float { 0.008 }
+
+    /// Minimum cumulative speech-like audio inside a gap before it is
+    /// probed. Genuine pauses with a stray cough stay untouched.
+    private var seamGapMinSpeechSeconds: Double { 0.5 }
+
+    /// Detect inter-token gaps that plausibly contain dropped speech and
+    /// re-decode each with a single fresh window centred on the gap. Because
+    /// the window is decoded from silence-free state with no seam inside it,
+    /// it recovers spans the chunk merger dropped (issue #758). Only tokens
+    /// strictly inside the gap are spliced in, starting at a word-initial
+    /// piece; a gap of genuine silence produces no in-gap tokens and the
+    /// stream is returned unchanged.
+    private func repairSeamGaps(
+        in tokens: [TokenWindow],
+        using manager: AsrManager,
+        decoderLayers: Int,
+        maxModelSamples: Int,
+        minGapSeconds: Double,
+        spliceSafeTokenIds: Set<Int>?,
+        vocabulary: [Int: String],
+        language: Language?
+    ) async throws -> [TokenWindow] {
+        let frameSamples = ASRConstants.samplesPerEncoderFrame
+        let frameDuration = ASRConstants.secondsPerEncoderFrame
+        let minGapFrames = max(2, Int(minGapSeconds / frameDuration))
+        // Same frame-aligned usable window size the chunker uses (no context
+        // reservation — the repair window is decoded standalone).
+        let windowSamples = max(
+            frameSamples,
+            (maxModelSamples - ASRConstants.melHopSize) / frameSamples * frameSamples
+        )
+
+        var working = tokens
+        var probes = 0
+        var probedGapStarts = Set<Int>()
+        // A successful repair can leave a residual gap (e.g. recovered
+        // speech, then applause, then more dropped speech): iterate so the
+        // residual — whose start has moved — gets its own probe. Gaps that
+        // yielded nothing keep the same start and are skipped via the memo.
+        for _ in 0..<3 {
+            var inserts: [TokenWindow] = []
+
+            for index in 0..<(working.count - 1) {
+                guard probes < maxSeamGapRepairs else { break }
+
+                let current = working[index]
+                let next = working[index + 1]
+                // Conservative end of the current token: its decoded duration
+                // when present, else one frame (mirrors mergeChunks).
+                let gapStartFrame = current.timestamp + max(1, current.duration)
+                let gapEndFrame = next.timestamp
+                guard gapEndFrame - gapStartFrame >= minGapFrames else { continue }
+                guard !probedGapStarts.contains(gapStartFrame) else { continue }
+
+                let gapStartSample = gapStartFrame * frameSamples
+                let gapEndSample = min(gapEndFrame * frameSamples, totalSamples)
+                guard gapEndSample > gapStartSample else { continue }
+
+                let speechSeconds = try speechLikeSeconds(from: gapStartSample, to: gapEndSample)
+                guard speechSeconds >= seamGapMinSpeechSeconds else { continue }
+                probedGapStarts.insert(gapStartFrame)
+                probes += 1
+
+            // Probe placement matters: the merger dropped this span because
+            // the decoder blanks after low-SNR audio, and a probe window that
+            // replays the same pre-gap audio can blank the same way. Start
+            // the fresh window AT the gap (the decoder cold-starts directly
+            // on the dropped speech, without the noise history); fall back
+            // to a gap-centred window for spans the first placement misses.
+            let gapCenterSample = (gapStartSample + gapEndSample) / 2
+            let placements = [gapStartSample, gapCenterSample - windowSamples / 2]
+            var recovered: [TokenWindow] = []
+
+            for placement in placements {
+                var windowStart = max(0, min(placement, totalSamples - windowSamples))
+                windowStart = windowStart / frameSamples * frameSamples
+                let windowEnd = min(windowStart + windowSamples, totalSamples)
+                guard windowEnd > windowStart else { continue }
+
+                var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
+                decoderState.reset()
+                let windowAudio = try readSamples(offset: windowStart, count: windowEnd - windowStart)
+                let (windowTokens, windowTimestamps, windowConfidences, windowDurations) =
+                    try await Self.transcribeChunk(
+                        samples: windowAudio,
+                        contextSamples: 0,
+                        chunkStart: windowStart,
+                        isLastChunk: windowEnd >= totalSamples,
+                        using: manager,
+                        decoderState: &decoderState,
+                        maxModelSamples: maxModelSamples,
+                        language: language
+                    )
+
+                guard windowTokens.count == windowTimestamps.count,
+                    windowTokens.count == windowConfidences.count
+                else { continue }
+                let durations =
+                    windowDurations.count == windowTokens.count
+                    ? windowDurations : Array(repeating: 0, count: windowTokens.count)
+
+                // Keep only tokens strictly inside the gap (one-frame margins)
+                // so words the merged stream already has are never duplicated.
+                var candidate: [TokenWindow] = []
+                for tokenIndex in 0..<windowTokens.count {
+                    let timestamp = windowTimestamps[tokenIndex]
+                    guard timestamp > gapStartFrame, timestamp < gapEndFrame - 1 else { continue }
+                    candidate.append(
+                        (
+                            token: windowTokens[tokenIndex],
+                            timestamp: timestamp,
+                            confidence: windowConfidences[tokenIndex],
+                            duration: durations[tokenIndex]
+                        )
+                    )
+                }
+
+                // Never splice in mid-word: drop leading continuation pieces
+                // so the recovered run starts at a word-initial (or
+                // punctuation) piece (same rule as the seam merge, #683).
+                if let safeIds = spliceSafeTokenIds {
+                    while let first = candidate.first, !safeIds.contains(first.token) {
+                        candidate.removeFirst()
+                    }
+                }
+
+                // Edge dedupe: the probe can re-hear the word bordering the
+                // gap at a slightly shifted frame (sometimes with different
+                // capitalisation, i.e. a different token id — "▁for" vs
+                // "▁For"); keep the merged stream's copy, not both.
+                let edgeToleranceFrames = 6
+                func samePiece(_ a: Int, _ b: Int) -> Bool {
+                    if a == b { return true }
+                    guard let pieceA = vocabulary[a], let pieceB = vocabulary[b] else { return false }
+                    return pieceA.lowercased() == pieceB.lowercased()
+                }
+                while let first = candidate.first, samePiece(first.token, current.token),
+                    abs(first.timestamp - current.timestamp) <= edgeToleranceFrames
+                {
+                    candidate.removeFirst()
+                }
+                while let last = candidate.last, samePiece(last.token, next.token),
+                    abs(next.timestamp - last.timestamp) <= edgeToleranceFrames
+                {
+                    candidate.removeLast()
+                }
+
+                if !candidate.isEmpty {
+                    recovered = candidate
+                    break
+                }
+            }
+
+                guard !recovered.isEmpty else { continue }
+                logger.info(
+                    "Seam-gap repair: recovered \(recovered.count) tokens in "
+                        + String(format: "%.2fs", Double(gapStartFrame) * frameDuration) + "–"
+                        + String(format: "%.2fs", Double(gapEndFrame) * frameDuration) + " gap"
+                )
+                inserts.append(contentsOf: recovered)
+            }
+
+            guard !inserts.isEmpty else { break }
+            working.append(contentsOf: inserts)
+            working.sort { $0.timestamp < $1.timestamp }
+        }
+
+        return working
+    }
+
+    /// Cumulative duration of speech-like audio (per-frame RMS above
+    /// `seamGapSpeechRmsThreshold`) between two sample offsets.
+    private func speechLikeSeconds(from startSample: Int, to endSample: Int) throws -> Double {
+        let frameSamples = ASRConstants.samplesPerEncoderFrame
+        var speechFrames = 0
+        var offset = startSample
+        while offset + frameSamples <= endSample {
+            let samples = try readSamples(offset: offset, count: frameSamples)
+            var sum: Float = 0
+            for sample in samples {
+                sum += sample * sample
+            }
+            if sqrt(sum / Float(samples.count)) > seamGapSpeechRmsThreshold {
+                speechFrames += 1
+            }
+            offset += frameSamples
+        }
+        return Double(speechFrames) * ASRConstants.secondsPerEncoderFrame
     }
 }

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
@@ -1276,22 +1276,55 @@ struct ChunkProcessor {
                 // Edge dedupe: the probe can re-hear the word bordering the
                 // gap at a slightly shifted frame (sometimes with different
                 // capitalisation, i.e. a different token id — "▁for" vs
-                // "▁For"); keep the merged stream's copy, not both.
+                // "▁For"); keep the merged stream's copy, not both. The
+                // comparison must skip punctuation pieces on the merged
+                // stream's side ("else." decodes as ▁else + .), else the
+                // recovered ▁else is compared against "." and slips through.
+                // The tolerance is deliberately tight (0.48s): genuine
+                // stutters ("I I") re-heard by the probe sit further apart.
                 let edgeToleranceFrames = 6
                 func samePiece(_ a: Int, _ b: Int) -> Bool {
                     if a == b { return true }
                     guard let pieceA = vocabulary[a], let pieceB = vocabulary[b] else { return false }
                     return pieceA.lowercased() == pieceB.lowercased()
                 }
-                while let first = candidate.first, samePiece(first.token, current.token),
-                    abs(first.timestamp - current.timestamp) <= edgeToleranceFrames
+                func isPunctuationPiece(_ id: Int) -> Bool {
+                    guard let piece = vocabulary[id], !piece.isEmpty else { return false }
+                    return piece.unicodeScalars.allSatisfy { scalar in
+                        CharacterSet.punctuationCharacters.contains(scalar)
+                            || CharacterSet.symbols.contains(scalar)
+                    }
+                }
+                var leadNeighborIndex = index
+                while leadNeighborIndex > 0, isPunctuationPiece(working[leadNeighborIndex].token) {
+                    leadNeighborIndex -= 1
+                }
+                let leadNeighbor = working[leadNeighborIndex]
+                var tailNeighborIndex = index + 1
+                while tailNeighborIndex < working.count - 1, isPunctuationPiece(working[tailNeighborIndex].token) {
+                    tailNeighborIndex += 1
+                }
+                let tailNeighbor = working[tailNeighborIndex]
+                while let first = candidate.first,
+                    samePiece(first.token, leadNeighbor.token),
+                    abs(first.timestamp - leadNeighbor.timestamp) <= edgeToleranceFrames
                 {
                     candidate.removeFirst()
                 }
-                while let last = candidate.last, samePiece(last.token, next.token),
-                    abs(next.timestamp - last.timestamp) <= edgeToleranceFrames
+                while let last = candidate.last,
+                    samePiece(last.token, tailNeighbor.token),
+                    abs(tailNeighbor.timestamp - last.timestamp) <= edgeToleranceFrames
                 {
                     candidate.removeLast()
+                }
+                // Removing an edge token can expose continuation pieces (or
+                // orphaned punctuation) at the head — re-trim.
+                if let safeIds = spliceSafeTokenIds {
+                    while let first = candidate.first,
+                        !safeIds.contains(first.token) || isPunctuationPiece(first.token)
+                    {
+                        candidate.removeFirst()
+                    }
                 }
 
                 if !candidate.isEmpty {

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
@@ -1210,128 +1210,128 @@ struct ChunkProcessor {
                 probedGapStarts.insert(gapStartFrame)
                 probes += 1
 
-            // Probe placement matters: the merger dropped this span because
-            // the decoder blanks after low-SNR audio, and a probe window that
-            // replays the same pre-gap audio can blank the same way. Start
-            // the fresh window AT the gap (the decoder cold-starts directly
-            // on the dropped speech, without the noise history); fall back
-            // to a gap-centred window for spans the first placement misses.
-            let gapCenterSample = (gapStartSample + gapEndSample) / 2
-            let placements = [gapStartSample, gapCenterSample - windowSamples / 2]
-            var recovered: [TokenWindow] = []
+                // Probe placement matters: the merger dropped this span because
+                // the decoder blanks after low-SNR audio, and a probe window that
+                // replays the same pre-gap audio can blank the same way. Start
+                // the fresh window AT the gap (the decoder cold-starts directly
+                // on the dropped speech, without the noise history); fall back
+                // to a gap-centred window for spans the first placement misses.
+                let gapCenterSample = (gapStartSample + gapEndSample) / 2
+                let placements = [gapStartSample, gapCenterSample - windowSamples / 2]
+                var recovered: [TokenWindow] = []
 
-            for placement in placements {
-                var windowStart = max(0, min(placement, totalSamples - windowSamples))
-                windowStart = windowStart / frameSamples * frameSamples
-                let windowEnd = min(windowStart + windowSamples, totalSamples)
-                guard windowEnd > windowStart else { continue }
+                for placement in placements {
+                    var windowStart = max(0, min(placement, totalSamples - windowSamples))
+                    windowStart = windowStart / frameSamples * frameSamples
+                    let windowEnd = min(windowStart + windowSamples, totalSamples)
+                    guard windowEnd > windowStart else { continue }
 
-                var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
-                decoderState.reset()
-                let windowAudio = try readSamples(offset: windowStart, count: windowEnd - windowStart)
-                let (windowTokens, windowTimestamps, windowConfidences, windowDurations) =
-                    try await Self.transcribeChunk(
-                        samples: windowAudio,
-                        contextSamples: 0,
-                        chunkStart: windowStart,
-                        isLastChunk: windowEnd >= totalSamples,
-                        using: manager,
-                        decoderState: &decoderState,
-                        maxModelSamples: maxModelSamples,
-                        language: language
-                    )
-
-                guard windowTokens.count == windowTimestamps.count,
-                    windowTokens.count == windowConfidences.count
-                else { continue }
-                let durations =
-                    windowDurations.count == windowTokens.count
-                    ? windowDurations : Array(repeating: 0, count: windowTokens.count)
-
-                // Keep only tokens strictly inside the gap (one-frame margins)
-                // so words the merged stream already has are never duplicated.
-                var candidate: [TokenWindow] = []
-                for tokenIndex in 0..<windowTokens.count {
-                    let timestamp = windowTimestamps[tokenIndex]
-                    guard timestamp > gapStartFrame, timestamp < gapEndFrame - 1 else { continue }
-                    candidate.append(
-                        (
-                            token: windowTokens[tokenIndex],
-                            timestamp: timestamp,
-                            confidence: windowConfidences[tokenIndex],
-                            duration: durations[tokenIndex]
+                    var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
+                    decoderState.reset()
+                    let windowAudio = try readSamples(offset: windowStart, count: windowEnd - windowStart)
+                    let (windowTokens, windowTimestamps, windowConfidences, windowDurations) =
+                        try await Self.transcribeChunk(
+                            samples: windowAudio,
+                            contextSamples: 0,
+                            chunkStart: windowStart,
+                            isLastChunk: windowEnd >= totalSamples,
+                            using: manager,
+                            decoderState: &decoderState,
+                            maxModelSamples: maxModelSamples,
+                            language: language
                         )
-                    )
-                }
 
-                // Never splice in mid-word: drop leading continuation pieces
-                // so the recovered run starts at a word-initial (or
-                // punctuation) piece (same rule as the seam merge, #683).
-                if let safeIds = spliceSafeTokenIds {
-                    while let first = candidate.first, !safeIds.contains(first.token) {
-                        candidate.removeFirst()
-                    }
-                }
+                    guard windowTokens.count == windowTimestamps.count,
+                        windowTokens.count == windowConfidences.count
+                    else { continue }
+                    let durations =
+                        windowDurations.count == windowTokens.count
+                        ? windowDurations : Array(repeating: 0, count: windowTokens.count)
 
-                // Edge dedupe: the probe can re-hear the word bordering the
-                // gap at a slightly shifted frame (sometimes with different
-                // capitalisation, i.e. a different token id — "▁for" vs
-                // "▁For"); keep the merged stream's copy, not both. The
-                // comparison must skip punctuation pieces on the merged
-                // stream's side ("else." decodes as ▁else + .), else the
-                // recovered ▁else is compared against "." and slips through.
-                // The tolerance is deliberately tight (0.48s): genuine
-                // stutters ("I I") re-heard by the probe sit further apart.
-                let edgeToleranceFrames = 6
-                func samePiece(_ a: Int, _ b: Int) -> Bool {
-                    if a == b { return true }
-                    guard let pieceA = vocabulary[a], let pieceB = vocabulary[b] else { return false }
-                    return pieceA.lowercased() == pieceB.lowercased()
-                }
-                func isPunctuationPiece(_ id: Int) -> Bool {
-                    guard let piece = vocabulary[id], !piece.isEmpty else { return false }
-                    return piece.unicodeScalars.allSatisfy { scalar in
-                        CharacterSet.punctuationCharacters.contains(scalar)
-                            || CharacterSet.symbols.contains(scalar)
+                    // Keep only tokens strictly inside the gap (one-frame margins)
+                    // so words the merged stream already has are never duplicated.
+                    var candidate: [TokenWindow] = []
+                    for tokenIndex in 0..<windowTokens.count {
+                        let timestamp = windowTimestamps[tokenIndex]
+                        guard timestamp > gapStartFrame, timestamp < gapEndFrame - 1 else { continue }
+                        candidate.append(
+                            (
+                                token: windowTokens[tokenIndex],
+                                timestamp: timestamp,
+                                confidence: windowConfidences[tokenIndex],
+                                duration: durations[tokenIndex]
+                            )
+                        )
                     }
-                }
-                var leadNeighborIndex = index
-                while leadNeighborIndex > 0, isPunctuationPiece(working[leadNeighborIndex].token) {
-                    leadNeighborIndex -= 1
-                }
-                let leadNeighbor = working[leadNeighborIndex]
-                var tailNeighborIndex = index + 1
-                while tailNeighborIndex < working.count - 1, isPunctuationPiece(working[tailNeighborIndex].token) {
-                    tailNeighborIndex += 1
-                }
-                let tailNeighbor = working[tailNeighborIndex]
-                while let first = candidate.first,
-                    samePiece(first.token, leadNeighbor.token),
-                    abs(first.timestamp - leadNeighbor.timestamp) <= edgeToleranceFrames
-                {
-                    candidate.removeFirst()
-                }
-                while let last = candidate.last,
-                    samePiece(last.token, tailNeighbor.token),
-                    abs(tailNeighbor.timestamp - last.timestamp) <= edgeToleranceFrames
-                {
-                    candidate.removeLast()
-                }
-                // Removing an edge token can expose continuation pieces (or
-                // orphaned punctuation) at the head — re-trim.
-                if let safeIds = spliceSafeTokenIds {
+
+                    // Never splice in mid-word: drop leading continuation pieces
+                    // so the recovered run starts at a word-initial (or
+                    // punctuation) piece (same rule as the seam merge, #683).
+                    if let safeIds = spliceSafeTokenIds {
+                        while let first = candidate.first, !safeIds.contains(first.token) {
+                            candidate.removeFirst()
+                        }
+                    }
+
+                    // Edge dedupe: the probe can re-hear the word bordering the
+                    // gap at a slightly shifted frame (sometimes with different
+                    // capitalisation, i.e. a different token id — "▁for" vs
+                    // "▁For"); keep the merged stream's copy, not both. The
+                    // comparison must skip punctuation pieces on the merged
+                    // stream's side ("else." decodes as ▁else + .), else the
+                    // recovered ▁else is compared against "." and slips through.
+                    // The tolerance is deliberately tight (0.48s): genuine
+                    // stutters ("I I") re-heard by the probe sit further apart.
+                    let edgeToleranceFrames = 6
+                    func samePiece(_ a: Int, _ b: Int) -> Bool {
+                        if a == b { return true }
+                        guard let pieceA = vocabulary[a], let pieceB = vocabulary[b] else { return false }
+                        return pieceA.lowercased() == pieceB.lowercased()
+                    }
+                    func isPunctuationPiece(_ id: Int) -> Bool {
+                        guard let piece = vocabulary[id], !piece.isEmpty else { return false }
+                        return piece.unicodeScalars.allSatisfy { scalar in
+                            CharacterSet.punctuationCharacters.contains(scalar)
+                                || CharacterSet.symbols.contains(scalar)
+                        }
+                    }
+                    var leadNeighborIndex = index
+                    while leadNeighborIndex > 0, isPunctuationPiece(working[leadNeighborIndex].token) {
+                        leadNeighborIndex -= 1
+                    }
+                    let leadNeighbor = working[leadNeighborIndex]
+                    var tailNeighborIndex = index + 1
+                    while tailNeighborIndex < working.count - 1, isPunctuationPiece(working[tailNeighborIndex].token) {
+                        tailNeighborIndex += 1
+                    }
+                    let tailNeighbor = working[tailNeighborIndex]
                     while let first = candidate.first,
-                        !safeIds.contains(first.token) || isPunctuationPiece(first.token)
+                        samePiece(first.token, leadNeighbor.token),
+                        abs(first.timestamp - leadNeighbor.timestamp) <= edgeToleranceFrames
                     {
                         candidate.removeFirst()
                     }
-                }
+                    while let last = candidate.last,
+                        samePiece(last.token, tailNeighbor.token),
+                        abs(tailNeighbor.timestamp - last.timestamp) <= edgeToleranceFrames
+                    {
+                        candidate.removeLast()
+                    }
+                    // Removing an edge token can expose continuation pieces (or
+                    // orphaned punctuation) at the head — re-trim.
+                    if let safeIds = spliceSafeTokenIds {
+                        while let first = candidate.first,
+                            !safeIds.contains(first.token) || isPunctuationPiece(first.token)
+                        {
+                            candidate.removeFirst()
+                        }
+                    }
 
-                if !candidate.isEmpty {
-                    recovered = candidate
-                    break
+                    if !candidate.isEmpty {
+                        recovered = candidate
+                        break
+                    }
                 }
-            }
 
                 guard !recovered.isEmpty else { continue }
                 logger.info(

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -211,6 +211,7 @@ enum TranscribeCommand {
         var encoderPrecision: ParakeetEncoderPrecision = .int8
         var melChunkContext = true
         var dualDecodeArbitration = false
+        var seamGapRepair = true
         var streamingMode = false
 
         // Streaming mode (SlidingWindowAsrConfig)
@@ -317,6 +318,8 @@ enum TranscribeCommand {
                 parsed.melChunkContext = false
             case "--dual-decode-arbitration":
                 parsed.dualDecodeArbitration = true
+            case "--no-seam-gap-repair":
+                parsed.seamGapRepair = false
 
             // Streaming mode config
             case "--chunk-seconds":
@@ -453,7 +456,8 @@ enum TranscribeCommand {
                 tdtConfig: tdtConfig,
                 encoderHiddenSize: args.modelVersion.encoderHiddenSize,
                 melChunkContext: args.melChunkContext,
-                dualDecodeArbitration: args.dualDecodeArbitration
+                dualDecodeArbitration: args.dualDecodeArbitration,
+                seamGapRepair: args.seamGapRepair
             )
             let asrManager = AsrManager(config: asrConfig)
             try await asrManager.loadModels(models)

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/SeamGapRepairTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/SeamGapRepairTests.swift
@@ -1,0 +1,217 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Unit tests for the seam-gap repair pass (issue #758): the pure splice
+/// logic that decides which probe-decoded tokens may be inserted into a
+/// detected gap. The cases mirror artifacts observed on real conference
+/// audio during validation.
+final class SeamGapRepairTests: XCTestCase {
+
+    // Small SentencePiece-style vocabulary. "▁" marks word-initial pieces.
+    private let vocabulary: [Int: String] = [
+        1: "▁for",
+        2: "▁For",
+        3: "▁else",
+        4: ".",
+        5: "▁and",
+        6: "ing",
+        7: "▁science",
+        8: "▁I",
+        9: "▁So",
+        10: "▁examples",
+    ]
+
+    private var safeIds: Set<Int>? {
+        ChunkProcessor.spliceSafeTokenIds(vocabulary: vocabulary)
+    }
+
+    private func token(_ id: Int, _ timestamp: Int) -> ChunkProcessor.TokenWindow {
+        (token: id, timestamp: timestamp, confidence: 0.9, duration: 1)
+    }
+
+    private func splice(
+        tokens: [(Int, Int)],
+        gap: (Int, Int),
+        lead: ChunkProcessor.TokenWindow,
+        tail: ChunkProcessor.TokenWindow,
+        vocabulary: [Int: String]? = nil
+    ) -> [ChunkProcessor.TokenWindow] {
+        let vocab = vocabulary ?? self.vocabulary
+        return ChunkProcessor.spliceCandidate(
+            windowTokens: tokens.map { $0.0 },
+            windowTimestamps: tokens.map { $0.1 },
+            windowConfidences: tokens.map { _ in 0.9 },
+            windowDurations: tokens.map { _ in 1 },
+            gapStartFrame: gap.0,
+            gapEndFrame: gap.1,
+            leadNeighbor: lead,
+            tailNeighbor: tail,
+            spliceSafeTokenIds: ChunkProcessor.spliceSafeTokenIds(vocabulary: vocab),
+            vocabulary: vocab
+        )
+    }
+
+    // MARK: - Config
+
+    func testSeamGapRepairDefaults() {
+        XCTAssertTrue(ASRConfig.default.seamGapRepair)
+        XCTAssertEqual(ASRConfig.default.seamGapRepairMinGapSeconds, 1.5)
+    }
+
+    func testMinGapSecondsClampedToHalfSecond() {
+        let config = ASRConfig(seamGapRepairMinGapSeconds: 0.1)
+        XCTAssertEqual(config.seamGapRepairMinGapSeconds, 0.5)
+    }
+
+    // MARK: - In-gap filtering
+
+    func testOnlyTokensStrictlyInsideGapAreKept() {
+        // Gap frames 100–200: tokens at the exact bounds and the one-frame
+        // margin at the tail must be excluded.
+        let result = splice(
+            tokens: [(5, 100), (5, 101), (5, 150), (5, 198), (5, 199), (5, 200)],
+            gap: (100, 200),
+            lead: token(10, 95),
+            tail: token(10, 205)
+        )
+        XCTAssertEqual(result.map { $0.timestamp }, [101, 150, 198])
+    }
+
+    func testGenuineSilenceRecoversNothing() {
+        // Probe re-decoded the window but every token lies outside the gap.
+        let result = splice(
+            tokens: [(5, 80), (7, 90), (5, 210)],
+            gap: (100, 200),
+            lead: token(10, 95),
+            tail: token(10, 205)
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: - Word-boundary hygiene (#683 rule)
+
+    func testLeadingContinuationPiecesAreTrimmed() {
+        // Candidate starts mid-word ("ing" continuation piece): trim to the
+        // first word-initial piece.
+        let result = splice(
+            tokens: [(6, 110), (5, 120), (7, 130)],
+            gap: (100, 200),
+            lead: token(10, 95),
+            tail: token(10, 205)
+        )
+        XCTAssertEqual(result.map { $0.token }, [5, 7])
+    }
+
+    // MARK: - Edge dedupe (observed artifacts)
+
+    func testCaseInsensitiveLeadDedupe() {
+        // Observed as "for For sharing": the probe re-hears the boundary
+        // word with different capitalisation (different token id).
+        let result = splice(
+            tokens: [(2, 104), (10, 120)],
+            gap: (100, 200),
+            lead: token(1, 100),
+            tail: token(10, 205)
+        )
+        XCTAssertEqual(result.map { $0.token }, [10])
+    }
+
+    func testTailDedupeSameTokenId() {
+        // Observed as "So So": probe re-hears the word that starts right
+        // after the gap.
+        let result = splice(
+            tokens: [(10, 120), (9, 196)],
+            gap: (100, 200),
+            lead: token(10, 95),
+            tail: token(9, 201)
+        )
+        XCTAssertEqual(result.map { $0.token }, [10])
+    }
+
+    func testPunctuationWalkResolvesWordNeighbor() {
+        // Observed as "else else.": the merged stream ends "…▁else ." — the
+        // dedupe must compare against ▁else, not the "." piece.
+        let stream = [token(5, 90), token(3, 98), token(4, 99)]
+        let lead = ChunkProcessor.wordNeighbor(in: stream, from: 2, step: -1, vocabulary: vocabulary)
+        XCTAssertEqual(lead.token, 3)
+
+        let result = splice(
+            tokens: [(3, 102), (10, 130)],
+            gap: (100, 200),
+            lead: lead,
+            tail: token(10, 205)
+        )
+        XCTAssertEqual(result.map { $0.token }, [10])
+    }
+
+    func testDedupeExposingOrphanPunctuationEmptiesCandidate() {
+        // If the only recovered word is a re-hearing of the boundary word,
+        // removing it must not leave its trailing punctuation behind.
+        let result = splice(
+            tokens: [(1, 104), (4, 106)],
+            gap: (100, 200),
+            lead: token(1, 100),
+            tail: token(10, 205)
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testGenuineStutterBeyondToleranceIsKept() {
+        // Observed as genuine "I I": separations beyond 6 frames are real
+        // re-spoken words, not probe echoes, and must survive.
+        let result = splice(
+            tokens: [(8, 108), (10, 130)],
+            gap: (100, 200),
+            lead: token(8, 100),
+            tail: token(10, 205)
+        )
+        XCTAssertEqual(result.map { $0.token }, [8, 10])
+    }
+
+    func testEmptyVocabularyStillAppliesIdEqualDedupe() {
+        // Without a vocabulary there are no safe ids and no piece text, but
+        // identical token ids at the edge still dedupe.
+        let result = splice(
+            tokens: [(1, 104), (10, 130)],
+            gap: (100, 200),
+            lead: token(1, 100),
+            tail: token(10, 205),
+            vocabulary: [:]
+        )
+        XCTAssertEqual(result.map { $0.token }, [10])
+    }
+
+    // MARK: - Speech-energy gate
+
+    func testSpeechLikeSecondsOnSilenceIsZero() throws {
+        let silence = [Float](repeating: 0.0, count: 16000 * 4)
+        let processor = ChunkProcessor(audioSamples: silence)
+        let seconds = try processor.speechLikeSecondsForTesting(from: 0, to: silence.count)
+        XCTAssertEqual(seconds, 0.0)
+    }
+
+    func testSpeechLikeSecondsCountsLoudRegion() throws {
+        // 4s of silence with 1s of speech-level tone in the middle.
+        var samples = [Float](repeating: 0.0, count: 16000 * 4)
+        for i in 16000..<32000 {
+            samples[i] = 0.1 * sin(Float(i) * 0.1)
+        }
+        let processor = ChunkProcessor(audioSamples: samples)
+        let seconds = try processor.speechLikeSecondsForTesting(from: 0, to: samples.count)
+        XCTAssertEqual(seconds, 1.0, accuracy: 0.1)
+    }
+
+    func testSpeechLikeSecondsIgnoresRoomTone() throws {
+        // Amplitude just above digital silence but below the speech
+        // threshold must not count.
+        var samples = [Float](repeating: 0.0, count: 16000 * 2)
+        for i in 0..<samples.count {
+            samples[i] = 0.004 * sin(Float(i) * 0.1)
+        }
+        let processor = ChunkProcessor(audioSamples: samples)
+        let seconds = try processor.speechLikeSecondsForTesting(from: 0, to: samples.count)
+        XCTAssertEqual(seconds, 0.0)
+    }
+}


### PR DESCRIPTION
Fixes #758.

## Problem

The long-form batch chunk merger can deterministically drop multi-second spans of clearly audible speech at a chunk seam when the overlap region is low-SNR (crosstalk, applause, soft speech). Which seams fail depends on decoder state and shifts with model recompilation — the same file drops different spans after an e5rt/ANE recompile — so no chunk-layout or config change fixes the class (see the A/B/C experiment in #758: `melChunkContext` relocates the failures rather than eliminating them).

## Approach

After merging, detect inter-token gaps longer than a configurable threshold (default 1.5 s) whose audio contains speech-level energy, and re-decode each with a single fresh window:

- **Placement matters.** A window centred on the gap can blank the same way the original chunk did, because it replays the same pre-gap noise history. The window starts **at the gap** — the decoder cold-starts directly on the dropped speech — with a gap-centred placement as fallback. On our test corpus the fallback recovers spans the first placement misses and vice versa.
- Only tokens strictly inside the gap are spliced in, starting at a word-initial piece (same rule as the seam merge, #683), with punctuation-aware, case-insensitive edge dedupe against the words bordering the gap.
- The scan iterates (max 3 rounds) so a partial recovery's residual gap gets its own probe; a probed-gap memo prevents re-probing silent pauses and a 32-probe budget bounds pathological inputs.
- Genuine silence yields no in-gap tokens by construction and is left untouched.

Opt out via `ASRConfig.seamGapRepair = false`; the CLI gets `--no-seam-gap-repair` for A/B measurement.

## Validation

- **Recall** (30-min English conference recording, the #758 source): every observed dropped span recovered — including a dropped audience question and a Q&A handover — across two different model-compilation states that dropped *different* spans.
- **Precision** (4 held-out talks, 2.3 h, repair on/off A/B): 349 insertions, 91% word-exact against an independent reference transcription (same model family, different runtime); the rest are filler/stutter-density disagreements on the same real speech between the two references. Zero insertions into genuine silence. All 12 genuine multi-second pauses left untouched.
- **Cost**: ~19 probed gaps ≈ 25–30 extra window decodes on a 30-min applause-heavy file (~20% over baseline); near zero on clean audio.
- **Tests**: full `swift test` suite passes — 1,938 XCTest + 45 swift-testing tests executed, 0 failures (38 environment-gated skips). Includes 14 new unit tests for the splice logic (`SeamGapRepairTests`), with cases modelled on artifacts observed during validation, and the existing 123 ChunkProcessor tests unaffected by the refactor.

## Known limitations (documented, out of scope)

- Seam **garbles** ("language in" → "languag ines") leave no token gap and are invisible to this pass — they need a fix in the merger itself.
- Edge re-hearings with different tokenization can occasionally duplicate a boundary word (~1 per 15–20 min of dense conference speech) — the same artifact class and rate the merger already produces. Deliberately not deduped harder: on held-out audio, genuine stutters sit at the same time separations, so a wider net would delete real speech.
- Very quiet off-mic speech (audience questions) can fall below the energy gate and stay unprobed — behaviour then matches current stock output.
- Validated on English conference audio; multilingual and music-heavy content untested.

Happy to adjust the default (opt-in vs opt-out), thresholds, or approach per your preferences.
