### PR TITLE
chore(diarizer): drop context comment on inferenceComputeUnits

### DIFF
--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerModels.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerModels.swift
@@ -85,11 +85,6 @@ public struct OfflineDiarizerModels: Sendable {
         logger.info("Loading offline diarization models from \(modelsDirectory.path)")
 
         let loadStart = Date()
-        // Honor a caller-supplied compute-units choice (the `configuration:`
-        // parameter was previously accepted but ignored here). Defaults to `.all`,
-        // so existing callers are unaffected; callers that need CPU/GPU-only
-        // inference (e.g. to avoid cross-device ANE numeric variance in the
-        // embeddings) can now pass `MLModelConfiguration(computeUnits:)`.
         let inferenceComputeUnits: MLComputeUnits = configuration?.computeUnits ?? .all
 
         let segmentationAndEmbeddingNames: [String] = [


### PR DESCRIPTION
Follow-up to #743 addressing the review nit (https://github.com/FluidInference/FluidAudio/pull/743#discussion_r3488513611): removes the inline context comment above `inferenceComputeUnits`. Commit history is sufficient reference; the behavior is unchanged.

Code before/after:
```swift
let loadStart = Date()
let inferenceComputeUnits: MLComputeUnits = configuration?.computeUnits ?? .all
```