### PR TITLE
fix(asr): fetch parakeet_vocab.json in AsrModels.download (#748)

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -541,8 +541,50 @@ extension AsrModels {
             )
         }
 
+        // The compiled-model download above doesn't cover the vocab JSON that
+        // `load()` needs; guarantee it here (#748).
+        try await ensureVocabularyDownloaded(
+            version: version, encoderPrecision: encoderPrecision, targetDir: targetDir)
+
         logger.info("Successfully downloaded ASR models")
         return targetDir
+    }
+
+    /// On-disk location of the version's vocabulary JSON in a cache rooted at `targetDir`.
+    static func vocabularyFileURL(
+        version: AsrModelVersion,
+        encoderPrecision: ParakeetEncoderPrecision,
+        targetDir: URL
+    ) -> URL {
+        let vocabularyFileName = getModelFileNames(
+            version: version, encoderPrecision: encoderPrecision
+        ).vocabulary
+        return repoPath(from: targetDir, version: version)
+            .appendingPathComponent(vocabularyFileName)
+    }
+
+    /// Fetch the vocabulary JSON from HuggingFace if missing; no-op when already on disk (#748).
+    static func ensureVocabularyDownloaded(
+        version: AsrModelVersion,
+        encoderPrecision: ParakeetEncoderPrecision,
+        targetDir: URL
+    ) async throws {
+        let vocabURL = vocabularyFileURL(
+            version: version, encoderPrecision: encoderPrecision, targetDir: targetDir)
+        let vocabularyFileName = vocabURL.lastPathComponent
+
+        if FileManager.default.fileExists(atPath: vocabURL.path) {
+            return
+        }
+
+        logger.info("Vocabulary \(vocabularyFileName) missing after model download; fetching directly")
+        let remoteURL = try ModelRegistry.resolveModel(version.repo.remotePath, vocabularyFileName)
+        let data = try await DownloadUtils.fetchHuggingFaceFile(
+            from: remoteURL, description: vocabularyFileName)
+        try FileManager.default.createDirectory(
+            at: vocabURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try data.write(to: vocabURL, options: [.atomic])
+        logger.info("Downloaded vocabulary \(vocabularyFileName) (\(data.count / 1024) KB)")
     }
 
     public static func downloadAndLoad(

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
@@ -440,4 +440,66 @@ final class AsrModelsTests: XCTestCase {
             "Cache check must treat caller-requested model names as required."
         )
     }
+
+    // MARK: - Issue #748: vocabulary must ship with a downloaded ASR cache
+
+    /// A v3 cache with every bundle but no vocab must report incomplete (#748).
+    func testModelsExistTreatsMissingVocabularyAsIncomplete() throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory
+            .appendingPathComponent("AsrModelsTests-#748-\(UUID().uuidString)")
+            .appendingPathComponent(Repo.parakeetV3.folderName)
+        defer { try? fm.removeItem(at: tempDir.deletingLastPathComponent()) }
+
+        let repoDir = tempDir.deletingLastPathComponent()
+            .appendingPathComponent(Repo.parakeetV3.folderName)
+        for name in ModelNames.ASR.requiredModelsV3(precision: .int8) {
+            let modelDir = repoDir.appendingPathComponent(name)
+            try fm.createDirectory(at: modelDir, withIntermediateDirectories: true)
+            try Data().write(to: modelDir.appendingPathComponent("coremldata.bin"))
+        }
+
+        // All bundles present but vocab absent -> cache is incomplete.
+        XCTAssertFalse(
+            AsrModels.modelsExist(at: tempDir, version: .v3, encoderPrecision: .int8),
+            "Cache with bundles but no vocab must be treated as incomplete (#748)."
+        )
+
+        // Adding the vocab alongside the bundles completes the cache.
+        let vocabURL = AsrModels.vocabularyFileURL(
+            version: .v3, encoderPrecision: .int8, targetDir: tempDir)
+        XCTAssertEqual(vocabURL.deletingLastPathComponent().path, repoDir.path)
+        XCTAssertEqual(vocabURL.lastPathComponent, ModelNames.ASR.vocabularyFile)
+        try Data("{}".utf8).write(to: vocabURL)
+
+        XCTAssertTrue(
+            AsrModels.modelsExist(at: tempDir, version: .v3, encoderPrecision: .int8),
+            "Cache with bundles and vocab must be treated as complete."
+        )
+    }
+
+    /// `ensureVocabularyDownloaded` no-ops without overwriting an existing vocab (#748).
+    func testEnsureVocabularyDownloadedNoopsWhenPresent() async throws {
+        let fm = FileManager.default
+        let tempDir = fm.temporaryDirectory
+            .appendingPathComponent("AsrModelsTests-#748-present-\(UUID().uuidString)")
+            .appendingPathComponent(Repo.parakeetV3.folderName)
+        defer { try? fm.removeItem(at: tempDir.deletingLastPathComponent()) }
+
+        let vocabURL = AsrModels.vocabularyFileURL(
+            version: .v3, encoderPrecision: .int8, targetDir: tempDir)
+        try fm.createDirectory(
+            at: vocabURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let sentinel = Data(#"{"already":"here"}"#.utf8)
+        try sentinel.write(to: vocabURL)
+
+        // Present vocab -> returns without attempting any network fetch.
+        try await AsrModels.ensureVocabularyDownloaded(
+            version: .v3, encoderPrecision: .int8, targetDir: tempDir)
+
+        XCTAssertEqual(
+            try Data(contentsOf: vocabURL), sentinel,
+            "Existing vocab must not be overwritten by the guarantee step."
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #748. `AsrModels.download(version:)` could leave a clean/partial Parakeet cache **without** `parakeet_vocab.json`, then fail later in `AsrModels.load` → `loadVocabulary` with a `modelNotFound` error. This surfaced downstream in TypeWhisper installing Parakeet v3 from a clean cache.

**Root cause:** `download()` built `DownloadSpec`s only for the compiled `.mlmodelc` bundles, and `DownloadUtils.loadModels` re-fetches a repo only when a *model bundle* is missing. A cache that already has the bundles but lacks the vocab JSON (older install predating the required vocab, or an interrupted download) was therefore never repaired.

## Fix

- Add `ensureVocabularyDownloaded(version:encoderPrecision:targetDir:)`, called at the end of `download()`. It fetches the vocabulary JSON directly from HuggingFace (`ModelRegistry.resolveModel` → `DownloadUtils.fetchHuggingFaceFile`) when absent, and is a **no-op (no network)** when the file already exists. This also repairs pre-existing bundles-without-vocab caches, not just fresh downloads.
- Add `vocabularyFileURL(...)` to resolve the expected on-disk vocab path (also used by tests).

This is issue #748's suggested option B ("ensure `AsrModels.download` fetches the vocabulary JSON before returning"), chosen over adding it to `requiredModels` because it also self-heals existing partial caches. `modelsExist(...)` already checks the vocab path, so a bundles-without-vocab cache correctly reports incomplete and doesn't short-circuit `download()`.

## Tests

- `testModelsExistTreatsMissingVocabularyAsIncomplete` — a v3 cache with every required bundle but no vocab is reported incomplete; adding the vocab (at the path `vocabularyFileURL` resolves) completes it.
- `testEnsureVocabularyDownloadedNoopsWhenPresent` — the guarantee step no-ops without network and leaves an existing vocab byte-intact.

Both are CI-safe (no model download).

## Verification

- `swift build` clean; `swift format lint` clean.
- End-to-end repro of the exact bug against a real v3 cache: deleted `parakeet_vocab.json` (bundles left in place → the #748 partial-cache state), ran `asr-benchmark --max-files 1` (→ `downloadAndLoad` → `download` → `ensureVocabularyDownloaded`). The vocab was **re-fetched and restored byte-identical** (151,122 bytes) and transcription succeeded (0.0% WER) with no `modelNotFound`. Without the fix this path throws at `loadVocabulary`.

Once merged, the downstream local repair path (TypeWhisper/typewhisper-mac#820, Parakeet plugin 1.3.0) can be removed.