### PR TITLE
fix(download): deliver byte-level progress during download (#756)

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -1,5 +1,6 @@
 import CoreML
 import Foundation
+import os
 
 /// HuggingFace model downloader using URLSession
 public class DownloadUtils {
@@ -747,7 +748,8 @@ public class DownloadUtils {
     ///   - request: The URLRequest to download.
     ///   - onProgress: Called with `(totalBytesWritten, totalBytesExpected)` as data arrives.
     /// - Returns: The temporary file URL and HTTP response.
-    private static func downloadWithProgress(
+    /// Internal (not private) so a network-gated test can assert progress fires.
+    static func downloadWithProgress(
         request: URLRequest,
         onProgress: @escaping @Sendable (Int64, Int64) -> Void
     ) async throws -> (URL, HTTPURLResponse) {
@@ -760,13 +762,16 @@ public class DownloadUtils {
         )
         defer { session.finishTasksAndInvalidate() }
 
-        let (tempURL, response) = try await session.download(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw HuggingFaceDownloadError.invalidResponse
+        // Explicit download task (not `download(for:)`) so the delegate reports byte progress (#756).
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = session.downloadTask(with: request)
+                delegate.attach(continuation: continuation, task: task)
+                task.resume()
+            }
+        } onCancel: {
+            delegate.cancel()
         }
-
-        return (tempURL, httpResponse)
     }
 
     // MARK: - Per-file download with bounded retry
@@ -1077,12 +1082,38 @@ public class DownloadUtils {
 
 // MARK: - URLSession download delegate for byte-level progress
 
-/// Lightweight delegate that forwards `didWriteData` callbacks to a closure.
+/// `URLSessionDownloadTask` → async/await bridge that forwards byte progress (#756).
 private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate, Sendable {
+    private struct State {
+        var continuation: CheckedContinuation<(URL, HTTPURLResponse), Error>?
+        var task: URLSessionDownloadTask?
+        var movedURL: URL?
+        var moveError: Error?
+        var finished = false
+    }
+
     private let onProgress: @Sendable (Int64, Int64) -> Void
+    // Holds the non-Sendable continuation; the lock (not `@unchecked`) makes the
+    // delegate Sendable as URLSession requires.
+    private let state = OSAllocatedUnfairLock<State>(uncheckedState: State())
 
     init(onProgress: @escaping @Sendable (Int64, Int64) -> Void) {
         self.onProgress = onProgress
+    }
+
+    /// Register the continuation and task before the task starts.
+    func attach(
+        continuation: CheckedContinuation<(URL, HTTPURLResponse), Error>,
+        task: URLSessionDownloadTask
+    ) {
+        state.withLockUnchecked {
+            $0.continuation = continuation
+            $0.task = task
+        }
+    }
+
+    func cancel() {
+        state.withLockUnchecked { $0.task }?.cancel()
     }
 
     func urlSession(
@@ -1100,6 +1131,44 @@ private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelega
         downloadTask: URLSessionDownloadTask,
         didFinishDownloadingTo location: URL
     ) {
-        // Required by protocol — the async download(for:) API handles the file.
+        // URLSession deletes `location` once this returns; move it somewhere
+        // durable now and hand the moved URL back at completion.
+        let durable = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+        do {
+            try FileManager.default.moveItem(at: location, to: durable)
+            state.withLockUnchecked { $0.movedURL = durable }
+        } catch {
+            state.withLockUnchecked { $0.moveError = error }
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        let response = task.response as? HTTPURLResponse
+        // Extract the resume action under the lock, run it after releasing.
+        let resume = state.withLockUnchecked { st -> (() -> Void)? in
+            guard !st.finished, let continuation = st.continuation else { return nil }
+            st.finished = true
+            st.continuation = nil
+            st.task = nil
+            let movedURL = st.movedURL
+            let moveError = st.moveError
+            return {
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let moveError {
+                    continuation.resume(throwing: moveError)
+                } else if let movedURL, let response {
+                    continuation.resume(returning: (movedURL, response))
+                } else {
+                    continuation.resume(throwing: DownloadUtils.HuggingFaceDownloadError.invalidResponse)
+                }
+            }
+        }
+        resume?()
     }
 }


### PR DESCRIPTION
## Summary

Fixes #756. `DownloadUtils.downloadWithProgress` used the async `URLSession.download(for:)` convenience, which **never invokes the session delegate's `didWriteData`**. The progress callback therefore fired only after the file had fully downloaded — callers saw 0% until a jump to 100%.

## Root cause (verified empirically)

A standalone probe downloading a 23 MB HF file:

| Pattern | `didWriteData` callbacks |
|---|---|
| session-level delegate + `await session.download(for:)` (current code) | **0** |
| per-task delegate via `await session.download(for:delegate:)` | **0** |
| explicit `downloadTask` + delegate + continuation | **~70** (incremental from the first chunk) |

The async convenience methods just don't route byte-progress to the delegate. Only an explicit download task does.

## Fix

Drive an explicit `URLSessionDownloadTask` through the delegate and bridge to async with a continuation:
- `didWriteData` forwards `(totalBytesWritten, totalBytesExpectedToWrite)` to `onProgress`.
- `didFinishDownloadingTo` moves the temp file to a durable location (URLSession deletes the original once the callback returns) and stores the moved URL.
- `didCompleteWithError` resumes the continuation exactly once with `(movedURL, response)` or the error.
- Task cancellation is forwarded to the download task via `withTaskCancellationHandler`.

Delegate state (continuation, task, moved URL) is guarded by `OSAllocatedUnfairLock`, so the delegate stays `Sendable` **without** `@unchecked Sendable` (per repo rules). `downloadWithProgress` is now `internal` so a test can exercise it.

## Test

`DownloadProgressTests` — network-gated integration test asserting **≥1** progress callback arrives before completion (the broken path yields **0**, so this cleanly distinguishes fixed vs. regressed regardless of file size) and that reported bytes are monotonic. Skips via `XCTSkip` when HuggingFace is unreachable or rate-limits, so it never hard-fails CI on transient connectivity.

## Verification

- `swift build` clean; `swift format lint` clean.
- Ran the exact new implementation end-to-end against a real HF file: HTTP 200, durable moved file (23.6 MB, survives after the delegate returns), **74** incremental progress callbacks, correct response returned.

## Scope

This PR fixes the `downloadWithProgress` delegate bug from #756 only. The same broken convenience appears in `downloadSubdirectory` (no byte progress + no retry) and the download system has other divergent retry/progress paths — those are captured in the refactor issue #765 and left for a follow-up.