### PR TITLE
test(download): characterization tests for retry + cancellation classifiers (#765)

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -855,7 +855,10 @@ public class DownloadUtils {
     /// permanent. Transient: URLSession timeout / TLS / connectivity failures and
     /// HTTP 429/503/5xx. Everything else (404/other 4xx, invalid response,
     /// non-network errors) is permanent.
-    private static func isRetryableDownloadError(_ error: Error) -> Bool {
+    ///
+    /// Internal (not private) so retry-policy characterization tests can pin this
+    /// classification ahead of the #765 refactor.
+    static func isRetryableDownloadError(_ error: Error) -> Bool {
         if let urlError = error as? URLError {
             switch urlError.code {
             case .timedOut, .cannotConnectToHost, .cannotFindHost,

--- a/Tests/FluidAudioTests/Shared/DownloadClassifierTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadClassifierTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Characterization tests pinning the two classifiers the #765 refactor will
+/// consolidate: the transient/permanent retry policy (`isRetryableDownloadError`)
+/// and cancellation-vs-corruption detection (`isCancellationError`). Unifying the
+/// three divergent download paths onto one retry policy must not change these
+/// verdicts, so they are locked in against the current behavior first.
+final class DownloadClassifierTests: XCTestCase {
+
+    typealias HFError = DownloadUtils.HuggingFaceDownloadError
+
+    // MARK: - isRetryableDownloadError: transient (retry)
+
+    func testTransientURLErrorsAreRetryable() {
+        let transient: [URLError.Code] = [
+            .timedOut, .cannotConnectToHost, .cannotFindHost, .networkConnectionLost,
+            .notConnectedToInternet, .dnsLookupFailed, .secureConnectionFailed, .resourceUnavailable,
+        ]
+        for code in transient {
+            XCTAssertTrue(
+                DownloadUtils.isRetryableDownloadError(URLError(code)),
+                "URLError.\(code) should be retryable")
+        }
+    }
+
+    func testRateLimitedIsRetryable() {
+        XCTAssertTrue(
+            DownloadUtils.isRetryableDownloadError(HFError.rateLimited(statusCode: 429, message: "x")))
+        XCTAssertTrue(
+            DownloadUtils.isRetryableDownloadError(HFError.rateLimited(statusCode: 503, message: "x")))
+    }
+
+    func testInvalidArtifactIsRetryable() {
+        // An HTML error page / truncated body is usually a transient bad network path.
+        XCTAssertTrue(
+            DownloadUtils.isRetryableDownloadError(HFError.invalidArtifact(path: "p", reason: "html")))
+    }
+
+    func testDownloadFailedWith5xxIsRetryable() {
+        for code in [500, 502, 503, 599] {
+            let err = HFError.downloadFailed(path: "p", underlying: NSError(domain: "HTTP", code: code))
+            XCTAssertTrue(DownloadUtils.isRetryableDownloadError(err), "HTTP \(code) should be retryable")
+        }
+    }
+
+    // MARK: - isRetryableDownloadError: permanent (fail fast)
+
+    func testPermanentURLErrorsAreNotRetryable() {
+        for code in [URLError.Code.badURL, .unsupportedURL, .badServerResponse, .cancelled, .fileDoesNotExist] {
+            XCTAssertFalse(
+                DownloadUtils.isRetryableDownloadError(URLError(code)),
+                "URLError.\(code) should not be retryable")
+        }
+    }
+
+    func testDownloadFailedWith4xxIsNotRetryable() {
+        for code in [400, 401, 403, 404, 410] {
+            let err = HFError.downloadFailed(path: "p", underlying: NSError(domain: "HTTP", code: code))
+            XCTAssertFalse(DownloadUtils.isRetryableDownloadError(err), "HTTP \(code) should not retry")
+        }
+    }
+
+    func testDownloadFailedWithNonHTTPDomainIsNotRetryable() {
+        // Only the synthetic "HTTP" domain drives the 5xx rule; a 5xx code in some
+        // other domain must not be mistaken for a retryable status.
+        let err = HFError.downloadFailed(path: "p", underlying: NSError(domain: "Other", code: 500))
+        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(err))
+    }
+
+    func testOtherErrorsAreNotRetryable() {
+        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(HFError.invalidResponse))
+        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(HFError.modelNotFound(path: "p")))
+        XCTAssertFalse(
+            DownloadUtils.isRetryableDownloadError(HFError.htmlErrorResponse(path: "p", snippet: "s")))
+        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(CancellationError()))
+        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(NSError(domain: "x", code: 1)))
+    }
+
+    // MARK: - isCancellationError
+
+    func testRecognizesCancellation() {
+        XCTAssertTrue(DownloadUtils.isCancellationError(CancellationError()))
+        XCTAssertTrue(DownloadUtils.isCancellationError(URLError(.cancelled)))
+        XCTAssertTrue(
+            DownloadUtils.isCancellationError(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)))
+        XCTAssertTrue(
+            DownloadUtils.isCancellationError(NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)))
+    }
+
+    func testRecognizesCancellationNestedInUnderlyingError() {
+        let wrapped = NSError(
+            domain: "Wrapper", code: 1,
+            userInfo: [NSUnderlyingErrorKey: URLError(.cancelled) as NSError])
+        XCTAssertTrue(DownloadUtils.isCancellationError(wrapped))
+    }
+
+    func testNonCancellationErrorsAreNotCancellation() {
+        XCTAssertFalse(DownloadUtils.isCancellationError(URLError(.timedOut)))
+        XCTAssertFalse(DownloadUtils.isCancellationError(NSError(domain: "x", code: 1)))
+        XCTAssertFalse(
+            DownloadUtils.isCancellationError(HFError.downloadFailed(path: "p", underlying: URLError(.timedOut))))
+    }
+
+    // MARK: - Cross-check: a cancelled download is neither retryable nor treated as corruption
+
+    func testCancellationIsNotRetryableButIsCancellation() {
+        let cancelled = URLError(.cancelled)
+        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(cancelled))
+        XCTAssertTrue(DownloadUtils.isCancellationError(cancelled))
+    }
+}


### PR DESCRIPTION
## Summary

First step toward #765 (unifying the three divergent `DownloadUtils` download/retry/progress paths): a **fidelity net** that pins the current behavior the refactor must preserve, so consolidation can't silently change semantics.

This PR characterizes the two classifiers the retry-unification hinges on:
- **`isRetryableDownloadError`** — the transient/permanent retry policy. The refactor will collapse three inconsistent retry behaviors (`downloadFileWithRetry` classifies, `fetchHuggingFaceFile` retries everything, `downloadSubdirectory` retries nothing) onto this one. These tests lock in exactly which errors retry.
- **`isCancellationError`** — cancellation-vs-corruption detection, which protects a fully-downloaded cache from being wiped on a cancelled load.

## What's covered

`isRetryableDownloadError`:
- Retryable: transient `URLError`s (timeout/TLS/DNS/connectivity), `rateLimited`, `invalidArtifact`, `downloadFailed` with HTTP 5xx.
- Not retryable: HTTP 4xx, non-HTTP-domain 5xx, `badURL`/`cancelled`/other `URLError`s, `invalidResponse`, `modelNotFound`, `htmlErrorResponse`, `CancellationError`, arbitrary `NSError`.

`isCancellationError`:
- Recognizes `CancellationError`, `URLError.cancelled`, `NSURLErrorCancelled`, `NSUserCancelledError`, and cancellation nested in `NSUnderlyingErrorKey`.
- Rejects non-cancellation errors.
- Cross-check: a cancelled download is **not** retryable **and** **is** treated as cancellation.

## Notes

- Pure, no network, CI-safe.
- `isRetryableDownloadError` widened `private` → `internal` so the test can reach it.
- Verdicts were validated against the current implementation before committing (all cases matched), so these assert real behavior, not aspirational.
- `validateDownloadedArtifact` / `looksLikeHTML` are already covered by `DownloadArtifactValidationTests`; together these form the pure-logic half of the #765 fidelity net. The seam-based tests for the tree lister and progress model land with the refactor itself (see #765).