### PR TITLE
feat(download): resume interrupted downloads with HTTP Range requests

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -108,13 +108,15 @@ public class DownloadUtils {
         return lowered.hasPrefix("<!doctype html") || lowered.hasPrefix("<html") || lowered.hasPrefix("<?xml")
     }
 
+    /// `response` is nil when re-validating a fully-downloaded partial file from
+    /// a previous run (no live response to check Content-Type against).
     static func validateDownloadedArtifact(
         at tempURL: URL,
-        response: HTTPURLResponse,
+        response: HTTPURLResponse?,
         path: String,
         expectedSize: Int
     ) throws {
-        if let contentType = response.value(forHTTPHeaderField: "Content-Type")?.lowercased(),
+        if let contentType = response?.value(forHTTPHeaderField: "Content-Type")?.lowercased(),
             contentType.contains("text/html")
         {
             throw HuggingFaceDownloadError.invalidArtifact(
@@ -634,7 +636,10 @@ public class DownloadUtils {
             // Download with bounded retry on transient failures. A single TLS or
             // timeout blip on one of many repo files must not abort the whole
             // download — the per-file retry absorbs intermittent CDN errors so
-            // the caller doesn't have to restart from zero. See
+            // the caller doesn't have to restart from zero. Bytes stream into a
+            // persistent `<dest>.partial` file, so a retry (or a whole new run)
+            // resumes a partially-downloaded file with an HTTP Range request
+            // instead of restarting it from byte 0 (#757). See
             // downloadFileWithRetry for the transient-vs-permanent classification.
             let onProgress: (@Sendable (Int64, Int64) -> Void)?
             if let handler = progressHandler {
@@ -661,6 +666,7 @@ public class DownloadUtils {
                 request: request,
                 path: file.path,
                 expectedSize: file.size,
+                partialFileURL: destPath.appendingPathExtension("partial"),
                 onProgress: onProgress
             )
 
@@ -737,35 +743,56 @@ public class DownloadUtils {
         }
     }
 
-    // MARK: - Delegate-based download with per-byte progress
+    // MARK: - Streaming download to a persistent file
 
-    /// Download a single file using a delegate to get byte-level progress.
+    /// Stream a download directly into `destination`, so bytes already received
+    /// survive a mid-transfer connection drop and a later attempt can resume
+    /// with an HTTP `Range` request instead of restarting from byte 0 (#757).
     ///
-    /// This is a pure transport helper — the caller is responsible for validating
-    /// the HTTP status and moving the temporary file to its final destination.
+    /// This is a pure transport helper — the caller is responsible for setting
+    /// resume headers, validating the HTTP status, and moving `destination` to
+    /// its final location. Body bytes are written only for 2xx responses:
+    /// appended after `resumeOffset` on 206, from byte 0 on any other 2xx.
     ///
     /// - Parameters:
     ///   - request: The URLRequest to download.
-    ///   - onProgress: Called with `(totalBytesWritten, totalBytesExpected)` as data arrives.
-    /// - Returns: The temporary file URL and HTTP response.
-    /// Internal (not private) so a network-gated test can assert progress fires.
-    static func downloadWithProgress(
+    ///   - destination: File the body is streamed into (created if missing).
+    ///   - resumeOffset: Local byte count a 206 response appends after; also the
+    ///     base added to progress callbacks so resumed progress never dips.
+    ///   - configuration: Session configuration override (tests inject a stub
+    ///     `URLProtocol` here); defaults to the shared session's configuration.
+    ///   - onProgress: Called with `(totalBytesWritten, totalBytesExpected)`
+    ///     as data arrives, including `resumeOffset` in both values.
+    ///   - onResponse: Called once with the HTTP response before any body byte
+    ///     is written — the resume path persists the response validator here so
+    ///     it survives a drop mid-body.
+    /// - Returns: The HTTP response (delegate reports byte progress, #756).
+    /// Internal (not private) so download-resume tests can drive it directly.
+    static func streamDownload(
         request: URLRequest,
-        onProgress: @escaping @Sendable (Int64, Int64) -> Void
-    ) async throws -> (URL, HTTPURLResponse) {
-        let delegate = DownloadProgressDelegate(onProgress: onProgress)
+        to destination: URL,
+        resumeOffset: Int64 = 0,
+        configuration: URLSessionConfiguration? = nil,
+        onProgress: (@Sendable (Int64, Int64) -> Void)? = nil,
+        onResponse: (@Sendable (HTTPURLResponse) -> Void)? = nil
+    ) async throws -> HTTPURLResponse {
+        let delegate = StreamingDownloadDelegate(
+            destination: destination,
+            resumeOffset: resumeOffset,
+            onProgress: onProgress,
+            onResponse: onResponse
+        )
         // Dedicated session with delegate — one per download to avoid cross-talk.
         let session = URLSession(
-            configuration: sharedSession.configuration,
+            configuration: configuration ?? sharedSession.configuration,
             delegate: delegate,
             delegateQueue: nil
         )
         defer { session.finishTasksAndInvalidate() }
 
-        // Explicit download task (not `download(for:)`) so the delegate reports byte progress (#756).
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                let task = session.downloadTask(with: request)
+                let task = session.dataTask(with: request)
                 delegate.attach(continuation: continuation, task: task)
                 task.resume()
             }
@@ -774,11 +801,40 @@ public class DownloadUtils {
         }
     }
 
-    // MARK: - Per-file download with bounded retry
+    // MARK: - Per-file download with bounded retry and byte-range resume
 
-    /// Download a single repo file to a temporary URL, retrying transient
-    /// network failures with exponential backoff before validating the HTTP
-    /// status and returning the temp file.
+    /// Sidecar path storing the HTTP validator (ETag or Last-Modified) of the
+    /// response a partial file came from. Written at response time so a drop
+    /// mid-body still leaves the validator on disk for the next attempt or run.
+    static func resumeValidatorURL(for partialFileURL: URL) -> URL {
+        partialFileURL.appendingPathExtension("etag")
+    }
+
+    private static func fileSize(at url: URL) -> Int64 {
+        ((try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? Int64) ?? 0
+    }
+
+    /// Remove a partial download and its validator sidecar.
+    private static func clearPartialDownload(_ partialFileURL: URL) {
+        try? FileManager.default.removeItem(at: partialFileURL)
+        try? FileManager.default.removeItem(at: resumeValidatorURL(for: partialFileURL))
+    }
+
+    /// Pick a resume validator from a fresh (200) response: a strong ETag, else
+    /// Last-Modified. Weak ETags (`W/...`) are unusable for `If-Range` (RFC
+    /// 9110 §13.1.5), and with no validator at all a resume could splice bytes
+    /// from two different versions of the file — so return nil and restart
+    /// from 0 in that case.
+    private static func resumeValidator(from response: HTTPURLResponse) -> String? {
+        if let etag = response.value(forHTTPHeaderField: "ETag"), !etag.hasPrefix("W/") {
+            return etag
+        }
+        return response.value(forHTTPHeaderField: "Last-Modified")
+    }
+
+    /// Download a single repo file, retrying transient network failures with
+    /// exponential backoff before validating the HTTP status and returning the
+    /// downloaded file.
     ///
     /// Transient (retried): URLSession timeout / TLS / connectivity errors and
     /// HTTP 429/503/5xx. These are the intermittent CDN failures that otherwise
@@ -788,44 +844,107 @@ public class DownloadUtils {
     /// and any non-network error — a genuinely missing or misnamed file should
     /// surface immediately rather than waste the backoff budget.
     ///
+    /// Resume (#757): bytes are streamed into `partialFileURL` as they arrive,
+    /// so a mid-transfer drop keeps them. A retry sends
+    /// `Range: bytes=<partialSize>-` guarded by `If-Range: <validator>`; the
+    /// server appends via 206 or, if it ignored the range or the remote file
+    /// changed, replies 200 and the file restarts from 0 — never splicing
+    /// mixed-version bytes. Because the partial file and its validator sidecar
+    /// persist on disk, resume also works across process restarts. Progress
+    /// callbacks include the resumed offset, so reported bytes never dip.
+    ///
     /// - Parameters:
     ///   - request: The file URLRequest to download.
     ///   - path: Remote path, used for log/error context.
-    ///   - onProgress: Optional byte-progress callback. When non-nil, a delegate
-    ///     session is used; otherwise the shared session. On a retry the byte
-    ///     counter restarts for that file, so reported progress may briefly dip.
-    /// - Returns: The temporary file URL of a validated (2xx) download.
-    private static func downloadFileWithRetry(
+    ///   - partialFileURL: Where in-flight bytes live (e.g. `<dest>.partial`).
+    ///     Pass nil for a unique temp location (in-run resume only).
+    ///   - onProgress: Optional byte-progress callback.
+    ///   - configuration: Session configuration override for tests.
+    /// - Returns: The URL of a validated (2xx) download — `partialFileURL`
+    ///   fully written; the caller moves it into the cache.
+    /// Internal (not private) so download-resume tests can drive it directly.
+    static func downloadFileWithRetry(
         request: URLRequest,
         path: String,
         expectedSize: Int,
+        partialFileURL: URL? = nil,
         onProgress: (@Sendable (Int64, Int64) -> Void)?,
         maxAttempts: Int = 4,
-        minBackoff: TimeInterval = 1.0
+        minBackoff: TimeInterval = 1.0,
+        configuration: URLSessionConfiguration? = nil
     ) async throws -> URL {
+        let defaultPartialURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("partial")
+        let partialURL = partialFileURL ?? defaultPartialURL
+        let validatorURL = resumeValidatorURL(for: partialURL)
         var lastError: Error?
 
         for attempt in 1...maxAttempts {
             do {
-                let tempURL: URL
-                let httpResponse: HTTPURLResponse
+                var attemptRequest = request
+                var resumeOffset: Int64 = 0
 
-                if let onProgress {
-                    (tempURL, httpResponse) = try await downloadWithProgress(
-                        request: request, onProgress: onProgress)
-                } else {
-                    let (url, response) = try await sharedSession.download(for: request)
-                    guard let resp = response as? HTTPURLResponse else {
-                        throw HuggingFaceDownloadError.invalidResponse
+                let partialSize = fileSize(at: partialURL)
+                let validator = (try? String(contentsOf: validatorURL, encoding: .utf8))?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+
+                if partialSize > 0, let validator, !validator.isEmpty {
+                    if expectedSize > 0 && partialSize >= Int64(expectedSize) {
+                        // A previous run finished the body but didn't get to move
+                        // the file. Validate and reuse it instead of re-fetching.
+                        if (try? validateDownloadedArtifact(
+                            at: partialURL, response: nil, path: path, expectedSize: expectedSize))
+                            != nil
+                        {
+                            try? FileManager.default.removeItem(at: validatorURL)
+                            return partialURL
+                        }
+                        clearPartialDownload(partialURL)
+                    } else {
+                        attemptRequest.setValue("bytes=\(partialSize)-", forHTTPHeaderField: "Range")
+                        attemptRequest.setValue(validator, forHTTPHeaderField: "If-Range")
+                        resumeOffset = partialSize
+                        logger.info(
+                            "Resuming \(path) from byte \(partialSize) (attempt \(attempt))")
                     }
-                    tempURL = url
-                    httpResponse = resp
+                } else if partialSize > 0 {
+                    // Partial bytes with no validator can't be safely resumed.
+                    clearPartialDownload(partialURL)
                 }
+
+                let httpResponse = try await streamDownload(
+                    request: attemptRequest,
+                    to: partialURL,
+                    resumeOffset: resumeOffset,
+                    configuration: configuration,
+                    onProgress: onProgress,
+                    onResponse: { response in
+                        // Persist the validator as soon as the fresh body starts, so
+                        // a drop mid-body still leaves it for the next attempt. A 206
+                        // keeps the validator of the response it is extending.
+                        guard response.statusCode != 206, (200..<300).contains(response.statusCode)
+                        else { return }
+                        if let validator = resumeValidator(from: response) {
+                            try? validator.write(to: validatorURL, atomically: true, encoding: .utf8)
+                        } else {
+                            try? FileManager.default.removeItem(at: validatorURL)
+                        }
+                    }
+                )
 
                 if httpResponse.statusCode == 429 || httpResponse.statusCode == 503 {
                     throw HuggingFaceDownloadError.rateLimited(
                         statusCode: httpResponse.statusCode,
                         message: "Rate limited while downloading \(path)")
+                }
+
+                if httpResponse.statusCode == 416 {
+                    // Range not satisfiable — the partial is bogus (or the remote
+                    // shrank). Restart from 0 on the next attempt.
+                    clearPartialDownload(partialURL)
+                    throw HuggingFaceDownloadError.invalidArtifact(
+                        path: path, reason: "server rejected resume range (416)")
                 }
 
                 guard (200..<300).contains(httpResponse.statusCode) else {
@@ -835,11 +954,19 @@ public class DownloadUtils {
                     )
                 }
 
-                // Validate before the caller moves the temp file into the cache.
-                try validateDownloadedArtifact(
-                    at: tempURL, response: httpResponse, path: path, expectedSize: expectedSize)
+                // Validate before the caller moves the file into the cache.
+                do {
+                    try validateDownloadedArtifact(
+                        at: partialURL, response: httpResponse, path: path,
+                        expectedSize: expectedSize)
+                } catch {
+                    // A completed-but-invalid body must not be resumed from.
+                    clearPartialDownload(partialURL)
+                    throw error
+                }
 
-                return tempURL
+                try? FileManager.default.removeItem(at: validatorURL)
+                return partialURL
             } catch {
                 lastError = error
                 guard attempt < maxAttempts, isRetryableDownloadError(error) else {
@@ -1086,28 +1213,44 @@ public class DownloadUtils {
 // MARK: - URLSession download delegate for byte-level progress
 
 /// `URLSessionDownloadTask` → async/await bridge that forwards byte progress (#756).
-private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelegate, Sendable {
+/// Streams response bytes straight into a destination file so partial content
+/// survives connection drops (#757). Appends after `resumeOffset` on HTTP 206;
+/// truncates and writes from 0 on any other 2xx; discards the body otherwise.
+private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate, Sendable {
     private struct State {
-        var continuation: CheckedContinuation<(URL, HTTPURLResponse), Error>?
-        var task: URLSessionDownloadTask?
-        var movedURL: URL?
-        var moveError: Error?
+        var continuation: CheckedContinuation<HTTPURLResponse, Error>?
+        var task: URLSessionDataTask?
+        var handle: FileHandle?
+        var bytesWritten: Int64 = 0
+        var expectedTotal: Int64 = -1
+        var writeError: Error?
         var finished = false
     }
 
-    private let onProgress: @Sendable (Int64, Int64) -> Void
-    // Holds the non-Sendable continuation; the lock (not `@unchecked`) makes the
-    // delegate Sendable as URLSession requires.
+    private let destination: URL
+    private let resumeOffset: Int64
+    private let onProgress: (@Sendable (Int64, Int64) -> Void)?
+    private let onResponse: (@Sendable (HTTPURLResponse) -> Void)?
+    // Holds the non-Sendable continuation and file handle; the lock (not
+    // `@unchecked`) makes the delegate Sendable as URLSession requires.
     private let state = OSAllocatedUnfairLock<State>(uncheckedState: State())
 
-    init(onProgress: @escaping @Sendable (Int64, Int64) -> Void) {
+    init(
+        destination: URL,
+        resumeOffset: Int64,
+        onProgress: (@Sendable (Int64, Int64) -> Void)?,
+        onResponse: (@Sendable (HTTPURLResponse) -> Void)?
+    ) {
+        self.destination = destination
+        self.resumeOffset = resumeOffset
         self.onProgress = onProgress
+        self.onResponse = onResponse
     }
 
     /// Register the continuation and task before the task starts.
     func attach(
-        continuation: CheckedContinuation<(URL, HTTPURLResponse), Error>,
-        task: URLSessionDownloadTask
+        continuation: CheckedContinuation<HTTPURLResponse, Error>,
+        task: URLSessionDataTask
     ) {
         state.withLockUnchecked {
             $0.continuation = continuation
@@ -1121,28 +1264,74 @@ private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelega
 
     func urlSession(
         _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didWriteData bytesWritten: Int64,
-        totalBytesWritten: Int64,
-        totalBytesExpectedToWrite: Int64
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
     ) {
-        onProgress(totalBytesWritten, totalBytesExpectedToWrite)
+        guard let http = response as? HTTPURLResponse else {
+            completionHandler(.cancel)
+            return
+        }
+        onResponse?(http)
+
+        // Only 2xx bodies are file content worth keeping; error bodies are
+        // discarded so a 503 page can never overwrite resumable bytes.
+        if (200..<300).contains(http.statusCode) {
+            let appending = http.statusCode == 206
+            do {
+                if !FileManager.default.fileExists(atPath: destination.path) {
+                    FileManager.default.createFile(atPath: destination.path, contents: nil)
+                }
+                let handle = try FileHandle(forWritingTo: destination)
+                if appending {
+                    try handle.seekToEnd()
+                } else {
+                    try handle.truncate(atOffset: 0)
+                }
+                let base = appending ? resumeOffset : 0
+                // Content-Range carries the full object size on a 206; a plain
+                // 200 reports the full size via expectedContentLength.
+                let expectedTotal: Int64
+                if let contentRange = http.value(forHTTPHeaderField: "Content-Range"),
+                    let totalPart = contentRange.split(separator: "/").last,
+                    let total = Int64(totalPart)
+                {
+                    expectedTotal = total
+                } else if http.expectedContentLength >= 0 {
+                    expectedTotal = base + http.expectedContentLength
+                } else {
+                    expectedTotal = -1
+                }
+                state.withLockUnchecked {
+                    $0.handle = handle
+                    $0.bytesWritten = base
+                    $0.expectedTotal = expectedTotal
+                }
+            } catch {
+                state.withLockUnchecked { $0.writeError = error }
+                completionHandler(.cancel)
+                return
+            }
+        }
+        completionHandler(.allow)
     }
 
-    func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didFinishDownloadingTo location: URL
-    ) {
-        // URLSession deletes `location` once this returns; move it somewhere
-        // durable now and hand the moved URL back at completion.
-        let durable = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-        do {
-            try FileManager.default.moveItem(at: location, to: durable)
-            state.withLockUnchecked { $0.movedURL = durable }
-        } catch {
-            state.withLockUnchecked { $0.moveError = error }
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        let progress: (written: Int64, expected: Int64)? = state.withLockUnchecked { st in
+            guard let handle = st.handle, st.writeError == nil else { return nil }
+            do {
+                try handle.write(contentsOf: data)
+                st.bytesWritten += Int64(data.count)
+                return (st.bytesWritten, st.expectedTotal)
+            } catch {
+                st.writeError = error
+                return nil
+            }
+        }
+        if let progress {
+            onProgress?(progress.written, progress.expected)
+        } else if state.withLockUnchecked({ $0.writeError }) != nil {
+            cancel()
         }
     }
 
@@ -1158,15 +1347,16 @@ private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelega
             st.finished = true
             st.continuation = nil
             st.task = nil
-            let movedURL = st.movedURL
-            let moveError = st.moveError
+            try? st.handle?.close()
+            st.handle = nil
+            let writeError = st.writeError
             return {
-                if let error {
+                if let writeError {
+                    continuation.resume(throwing: writeError)
+                } else if let error {
                     continuation.resume(throwing: error)
-                } else if let moveError {
-                    continuation.resume(throwing: moveError)
-                } else if let movedURL, let response {
-                    continuation.resume(returning: (movedURL, response))
+                } else if let response {
+                    continuation.resume(returning: response)
                 } else {
                     continuation.resume(throwing: DownloadUtils.HuggingFaceDownloadError.invalidResponse)
                 }

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -633,14 +633,9 @@ public class DownloadUtils {
             let fileURL = try ModelRegistry.resolveModel(repo.remotePath, encodedFilePath)
             let request = authorizedRequest(url: fileURL)
 
-            // Download with bounded retry on transient failures. A single TLS or
-            // timeout blip on one of many repo files must not abort the whole
-            // download — the per-file retry absorbs intermittent CDN errors so
-            // the caller doesn't have to restart from zero. Bytes stream into a
-            // persistent `<dest>.partial` file, so a retry (or a whole new run)
-            // resumes a partially-downloaded file with an HTTP Range request
-            // instead of restarting it from byte 0 (#757). See
-            // downloadFileWithRetry for the transient-vs-permanent classification.
+            // Bounded retry on transient failures, with byte-range resume via a
+            // persistent `<dest>.partial` file so retries and re-runs continue a
+            // partially-downloaded file instead of restarting it (#757).
             let onProgress: (@Sendable (Int64, Int64) -> Void)?
             if let handler = progressHandler {
                 let baseBytes = completedBytes
@@ -745,28 +740,19 @@ public class DownloadUtils {
 
     // MARK: - Streaming download to a persistent file
 
-    /// Stream a download directly into `destination`, so bytes already received
-    /// survive a mid-transfer connection drop and a later attempt can resume
-    /// with an HTTP `Range` request instead of restarting from byte 0 (#757).
-    ///
-    /// This is a pure transport helper — the caller is responsible for setting
-    /// resume headers, validating the HTTP status, and moving `destination` to
-    /// its final location. Body bytes are written only for 2xx responses:
-    /// appended after `resumeOffset` on 206, from byte 0 on any other 2xx.
+    /// Stream a download directly into `destination` so received bytes survive
+    /// a mid-transfer drop (#757). Pure transport: the caller sets resume
+    /// headers and validates the HTTP status. Body bytes are written only for
+    /// 2xx — appended after `resumeOffset` on 206, from byte 0 otherwise.
     ///
     /// - Parameters:
-    ///   - request: The URLRequest to download.
-    ///   - destination: File the body is streamed into (created if missing).
-    ///   - resumeOffset: Local byte count a 206 response appends after; also the
-    ///     base added to progress callbacks so resumed progress never dips.
-    ///   - configuration: Session configuration override (tests inject a stub
-    ///     `URLProtocol` here); defaults to the shared session's configuration.
-    ///   - onProgress: Called with `(totalBytesWritten, totalBytesExpected)`
-    ///     as data arrives, including `resumeOffset` in both values.
-    ///   - onResponse: Called once with the HTTP response before any body byte
-    ///     is written — the resume path persists the response validator here so
-    ///     it survives a drop mid-body.
-    /// - Returns: The HTTP response (delegate reports byte progress, #756).
+    ///   - resumeOffset: Byte count a 206 appends after; also the base for
+    ///     progress callbacks so resumed progress never dips.
+    ///   - configuration: Session configuration override for tests.
+    ///   - onProgress: `(totalBytesWritten, totalBytesExpected)`, both
+    ///     including `resumeOffset`. Delegate-driven byte progress (#756).
+    ///   - onResponse: Fires before any body byte is written — the resume path
+    ///     persists the validator here so it survives a drop mid-body.
     /// Internal (not private) so download-resume tests can drive it directly.
     static func streamDownload(
         request: URLRequest,
@@ -803,9 +789,8 @@ public class DownloadUtils {
 
     // MARK: - Per-file download with bounded retry and byte-range resume
 
-    /// Sidecar path storing the HTTP validator (ETag or Last-Modified) of the
-    /// response a partial file came from. Written at response time so a drop
-    /// mid-body still leaves the validator on disk for the next attempt or run.
+    /// Sidecar storing the HTTP validator (ETag/Last-Modified) a partial file
+    /// came from; written at response time so it survives a drop mid-body.
     static func resumeValidatorURL(for partialFileURL: URL) -> URL {
         partialFileURL.appendingPathExtension("etag")
     }
@@ -820,11 +805,9 @@ public class DownloadUtils {
         try? FileManager.default.removeItem(at: resumeValidatorURL(for: partialFileURL))
     }
 
-    /// Pick a resume validator from a fresh (200) response: a strong ETag, else
-    /// Last-Modified. Weak ETags (`W/...`) are unusable for `If-Range` (RFC
-    /// 9110 §13.1.5), and with no validator at all a resume could splice bytes
-    /// from two different versions of the file — so return nil and restart
-    /// from 0 in that case.
+    /// Resume validator for `If-Range`: a strong ETag, else Last-Modified.
+    /// Weak ETags are unusable for `If-Range` (RFC 9110 §13.1.5); nil means
+    /// resume is unsafe and the file restarts from 0.
     private static func resumeValidator(from response: HTTPURLResponse) -> String? {
         if let etag = response.value(forHTTPHeaderField: "ETag"), !etag.hasPrefix("W/") {
             return etag
@@ -832,36 +815,21 @@ public class DownloadUtils {
         return response.value(forHTTPHeaderField: "Last-Modified")
     }
 
-    /// Download a single repo file, retrying transient network failures with
-    /// exponential backoff before validating the HTTP status and returning the
-    /// downloaded file.
+    /// Download a single repo file with bounded exponential-backoff retry on
+    /// transient failures (timeout/TLS/connectivity, HTTP 429/503/5xx; 4xx and
+    /// non-network errors fail fast — see `isRetryableDownloadError`).
     ///
-    /// Transient (retried): URLSession timeout / TLS / connectivity errors and
-    /// HTTP 429/503/5xx. These are the intermittent CDN failures that otherwise
-    /// abort an entire multi-file repo download on the first blip.
-    ///
-    /// Permanent (fails fast, no backoff): 404 and other 4xx, invalid responses,
-    /// and any non-network error — a genuinely missing or misnamed file should
-    /// surface immediately rather than waste the backoff budget.
-    ///
-    /// Resume (#757): bytes are streamed into `partialFileURL` as they arrive,
-    /// so a mid-transfer drop keeps them. A retry sends
-    /// `Range: bytes=<partialSize>-` guarded by `If-Range: <validator>`; the
-    /// server appends via 206 or, if it ignored the range or the remote file
-    /// changed, replies 200 and the file restarts from 0 — never splicing
-    /// mixed-version bytes. Because the partial file and its validator sidecar
-    /// persist on disk, resume also works across process restarts. Progress
-    /// callbacks include the resumed offset, so reported bytes never dip.
+    /// Resume (#757): bytes stream into `partialFileURL`, so a retry — or a new
+    /// process — continues with `Range`/`If-Range` instead of restarting from
+    /// byte 0. A 200 (range ignored / remote changed) restarts the file rather
+    /// than splicing mixed-version bytes.
     ///
     /// - Parameters:
-    ///   - request: The file URLRequest to download.
-    ///   - path: Remote path, used for log/error context.
     ///   - partialFileURL: Where in-flight bytes live (e.g. `<dest>.partial`).
     ///     Pass nil for a unique temp location (in-run resume only).
-    ///   - onProgress: Optional byte-progress callback.
     ///   - configuration: Session configuration override for tests.
-    /// - Returns: The URL of a validated (2xx) download — `partialFileURL`
-    ///   fully written; the caller moves it into the cache.
+    /// - Returns: The URL of a validated (2xx) fully-written download; the
+    ///   caller moves it into the cache.
     /// Internal (not private) so download-resume tests can drive it directly.
     static func downloadFileWithRetry(
         request: URLRequest,

--- a/Tests/FluidAudioTests/Shared/DownloadResumeTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadResumeTests.swift
@@ -1,0 +1,340 @@
+import Foundation
+import XCTest
+import os
+
+@testable import FluidAudio
+
+/// Tests for HTTP Range resume in `downloadFileWithRetry` (#757): partial
+/// bytes survive mid-transfer drops, retries send `Range`/`If-Range`, a 200
+/// after a range request replaces (never splices) the partial file, and a
+/// fully-downloaded partial from a previous run is reused without network.
+final class DownloadResumeTests: XCTestCase {
+
+    private var workDir: URL!
+
+    override func setUpWithError() throws {
+        workDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DownloadResumeTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+        ResumeStubURLProtocol.reset()
+    }
+
+    override func tearDownWithError() throws {
+        ResumeStubURLProtocol.reset()
+        try? FileManager.default.removeItem(at: workDir)
+    }
+
+    // MARK: - Helpers
+
+    private var stubConfiguration: URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ResumeStubURLProtocol.self]
+        return config
+    }
+
+    private var request: URLRequest {
+        URLRequest(url: URL(string: "https://stub.test/repo/resolve/main/model.bin")!)
+    }
+
+    private func partialURL(_ name: String = "model.bin") -> URL {
+        workDir.appendingPathComponent(name).appendingPathExtension("partial")
+    }
+
+    /// Body content that passes artifact validation (not empty, not HTML).
+    private static let fullBody = Data("BINARYCONTENT-0123456789-ABCDEFGHIJ".utf8)
+
+    private func download(
+        expectedSize: Int = fullBody.count,
+        partial: URL? = nil,
+        maxAttempts: Int = 3
+    ) async throws -> Data {
+        let url = try await DownloadUtils.downloadFileWithRetry(
+            request: request,
+            path: "model.bin",
+            expectedSize: expectedSize,
+            partialFileURL: partial ?? partialURL(),
+            onProgress: nil,
+            maxAttempts: maxAttempts,
+            minBackoff: 0.01,
+            configuration: stubConfiguration
+        )
+        return try Data(contentsOf: url)
+    }
+
+    private func seedPartial(_ data: Data, validator: String?) throws {
+        try data.write(to: partialURL())
+        if let validator {
+            try validator.write(
+                to: DownloadUtils.resumeValidatorURL(for: partialURL()),
+                atomically: true, encoding: .utf8)
+        }
+    }
+
+    // MARK: - Tests
+
+    func testFreshDownloadWritesFullBody() async throws {
+        ResumeStubURLProtocol.enqueue(
+            .init(status: 200, headers: ["ETag": "\"v1\""], chunks: [Self.fullBody]))
+
+        let body = try await download()
+
+        XCTAssertEqual(body, Self.fullBody)
+        let requests = ResumeStubURLProtocol.recordedRequests()
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertNil(requests[0].value(forHTTPHeaderField: "Range"))
+        // Validator sidecar is cleaned up after a completed download.
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: DownloadUtils.resumeValidatorURL(for: partialURL()).path))
+    }
+
+    func testMidStreamDropResumesWithRangeAndAppends() async throws {
+        let splitAt = 10
+        let head = Self.fullBody.prefix(splitAt)
+        let tail = Self.fullBody.dropFirst(splitAt)
+
+        // Attempt 1: 200 with ETag, drops after `head` bytes.
+        ResumeStubURLProtocol.enqueue(
+            .init(
+                status: 200, headers: ["ETag": "\"v1\""],
+                chunks: [Data(head), Data(tail)], failAfterChunks: 1))
+        // Attempt 2: server honors the range with a 206 for the remainder.
+        ResumeStubURLProtocol.enqueue(
+            .init(
+                status: 206,
+                headers: [
+                    "ETag": "\"v1\"",
+                    "Content-Range": "bytes \(splitAt)-\(Self.fullBody.count - 1)/\(Self.fullBody.count)",
+                ],
+                chunks: [Data(tail)]))
+
+        let body = try await download()
+
+        XCTAssertEqual(body, Self.fullBody, "resumed file must equal head + tail with no gap")
+        let requests = ResumeStubURLProtocol.recordedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertNil(requests[0].value(forHTTPHeaderField: "Range"))
+        XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Range"), "bytes=\(splitAt)-")
+        XCTAssertEqual(requests[1].value(forHTTPHeaderField: "If-Range"), "\"v1\"")
+    }
+
+    func testServerIgnoringRangeReplacesPartialInsteadOfSplicing() async throws {
+        // Stale partial from a different file version.
+        try seedPartial(Data("STALEBYTES".utf8), validator: "\"v0\"")
+        // Server replies 200 (range ignored / file changed) with the new body.
+        ResumeStubURLProtocol.enqueue(
+            .init(status: 200, headers: ["ETag": "\"v1\""], chunks: [Self.fullBody]))
+
+        let body = try await download()
+
+        XCTAssertEqual(body, Self.fullBody, "a 200 must replace the partial, never splice")
+        let requests = ResumeStubURLProtocol.recordedRequests()
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "Range"), "bytes=10-")
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "If-Range"), "\"v0\"")
+    }
+
+    func testRangeNotSatisfiableClearsPartialAndRetriesFresh() async throws {
+        try seedPartial(Data("BOGUSPARTIALBYTES".utf8), validator: "\"v0\"")
+        ResumeStubURLProtocol.enqueue(.init(status: 416, headers: [:], chunks: []))
+        ResumeStubURLProtocol.enqueue(
+            .init(status: 200, headers: ["ETag": "\"v1\""], chunks: [Self.fullBody]))
+
+        let body = try await download()
+
+        XCTAssertEqual(body, Self.fullBody)
+        let requests = ResumeStubURLProtocol.recordedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertNotNil(requests[0].value(forHTTPHeaderField: "Range"))
+        XCTAssertNil(
+            requests[1].value(forHTTPHeaderField: "Range"),
+            "after a 416 the partial is cleared and the retry starts from byte 0")
+    }
+
+    func testNoValidatorMeansNoResume() async throws {
+        let splitAt = 10
+        // Attempt 1: 200 with only a weak ETag (unusable for If-Range), drops mid-body.
+        ResumeStubURLProtocol.enqueue(
+            .init(
+                status: 200, headers: ["ETag": "W/\"weak\""],
+                chunks: [Data(Self.fullBody.prefix(splitAt)), Data(Self.fullBody.dropFirst(splitAt))],
+                failAfterChunks: 1))
+        // Attempt 2 must be a fresh full download.
+        ResumeStubURLProtocol.enqueue(
+            .init(status: 200, headers: [:], chunks: [Self.fullBody]))
+
+        let body = try await download()
+
+        XCTAssertEqual(body, Self.fullBody)
+        let requests = ResumeStubURLProtocol.recordedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertNil(
+            requests[1].value(forHTTPHeaderField: "Range"),
+            "without a strong validator the partial must be discarded, not resumed")
+    }
+
+    func testErrorBodyDoesNotClobberPartialBytes() async throws {
+        let splitAt = 10
+        try seedPartial(Data(Self.fullBody.prefix(splitAt)), validator: "\"v1\"")
+        // Attempt 1: 503 with an HTML error page body — must not touch the partial.
+        ResumeStubURLProtocol.enqueue(
+            .init(status: 503, headers: [:], chunks: [Data("<html>err</html>".utf8)]))
+        // Attempt 2: resume succeeds.
+        ResumeStubURLProtocol.enqueue(
+            .init(
+                status: 206,
+                headers: [
+                    "Content-Range": "bytes \(splitAt)-\(Self.fullBody.count - 1)/\(Self.fullBody.count)"
+                ],
+                chunks: [Data(Self.fullBody.dropFirst(splitAt))]))
+
+        let body = try await download()
+
+        XCTAssertEqual(body, Self.fullBody)
+        let requests = ResumeStubURLProtocol.recordedRequests()
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Range"), "bytes=\(splitAt)-")
+    }
+
+    func testCompletedPartialFromPreviousRunIsReusedWithoutNetwork() async throws {
+        try seedPartial(Self.fullBody, validator: "\"v1\"")
+        // No scripts enqueued — any network request would fail the test.
+
+        let body = try await download()
+
+        XCTAssertEqual(body, Self.fullBody)
+        XCTAssertTrue(
+            ResumeStubURLProtocol.recordedRequests().isEmpty,
+            "a complete, valid partial must be reused without hitting the network")
+    }
+
+    func testProgressIncludesResumedOffsetSoItNeverDips() async throws {
+        let splitAt = 10
+        try seedPartial(Data(Self.fullBody.prefix(splitAt)), validator: "\"v1\"")
+        ResumeStubURLProtocol.enqueue(
+            .init(
+                status: 206,
+                headers: [
+                    "Content-Range": "bytes \(splitAt)-\(Self.fullBody.count - 1)/\(Self.fullBody.count)"
+                ],
+                chunks: [Data(Self.fullBody.dropFirst(splitAt))]))
+
+        let recorded = ProgressRecorder()
+        _ = try await DownloadUtils.downloadFileWithRetry(
+            request: request,
+            path: "model.bin",
+            expectedSize: Self.fullBody.count,
+            partialFileURL: partialURL(),
+            onProgress: { written, expected in recorded.append((written, expected)) },
+            maxAttempts: 1,
+            minBackoff: 0.01,
+            configuration: stubConfiguration
+        )
+
+        let events = recorded.snapshot()
+        XCTAssertFalse(events.isEmpty)
+        XCTAssertGreaterThan(
+            events[0].written, Int64(splitAt) - 1,
+            "first progress callback must already include the resumed offset")
+        XCTAssertEqual(events.last?.written, Int64(Self.fullBody.count))
+        XCTAssertEqual(events.last?.expected, Int64(Self.fullBody.count))
+    }
+}
+
+// MARK: - Scripted URLProtocol stub
+
+/// Serves a FIFO queue of scripted responses and records every request,
+/// including mid-body connection drops (`failAfterChunks`).
+final class ResumeStubURLProtocol: URLProtocol {
+
+    struct Script {
+        let status: Int
+        let headers: [String: String]
+        let chunks: [Data]
+        /// Deliver this many chunks, then fail with `.networkConnectionLost`.
+        var failAfterChunks: Int? = nil
+    }
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var scripts: [Script] = []
+    nonisolated(unsafe) private static var requests: [URLRequest] = []
+
+    static func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        scripts = []
+        requests = []
+    }
+
+    static func enqueue(_ script: Script) {
+        lock.lock()
+        defer { lock.unlock() }
+        scripts.append(script)
+    }
+
+    static func recordedRequests() -> [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+
+    private static func dequeue(recording request: URLRequest) -> Script? {
+        lock.lock()
+        defer { lock.unlock() }
+        requests.append(request)
+        return scripts.isEmpty ? nil : scripts.removeFirst()
+    }
+
+    override static func canInit(with request: URLRequest) -> Bool { true }
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let script = Self.dequeue(recording: request), let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
+            return
+        }
+
+        var headers = script.headers
+        let bodyBytes = script.chunks.reduce(0) { $0 + $1.count }
+        if headers["Content-Length"] == nil {
+            headers["Content-Length"] = String(bodyBytes)
+        }
+        guard
+            let response = HTTPURLResponse(
+                url: url, statusCode: script.status, httpVersion: "HTTP/1.1",
+                headerFields: headers)
+        else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+
+        for (index, chunk) in script.chunks.enumerated() {
+            if let failAfter = script.failAfterChunks, index >= failAfter {
+                client?.urlProtocol(self, didFailWithError: URLError(.networkConnectionLost))
+                return
+            }
+            client?.urlProtocol(self, didLoad: chunk)
+        }
+        if let failAfter = script.failAfterChunks, failAfter >= script.chunks.count {
+            client?.urlProtocol(self, didFailWithError: URLError(.networkConnectionLost))
+            return
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+/// Lock-guarded accumulator for progress events (tests only).
+private final class ProgressRecorder: Sendable {
+    private let values = OSAllocatedUnfairLock<[(written: Int64, expected: Int64)]>(initialState: [])
+
+    func append(_ value: (written: Int64, expected: Int64)) {
+        values.withLock { $0.append(value) }
+    }
+
+    func snapshot() -> [(written: Int64, expected: Int64)] {
+        values.withLock { $0 }
+    }
+}


### PR DESCRIPTION
Closes #757

## Problem

`downloadFileWithRetry` restarted every retry from byte 0 (the transport was a download task whose temp file URLSession discards on failure). For repos dominated by one large file — parakeet-tdt-0.6b-v3's ~425 MB encoder weights — a connection drop deep into the transfer cost the whole file, both across in-run retries and across user-initiated retries. On flaky connections the large file could be effectively unfinishable.

## Changes

- **Streaming transport**: `StreamingDownloadDelegate` (data task) writes bytes into a persistent partial file as they arrive, so received bytes survive a mid-transfer drop. Error-status bodies (e.g. a 503 page) are discarded — they can never clobber resumable bytes.
- **Range resume**: retries send `Range: bytes=<partialSize>-` guarded by `If-Range` with a strong ETag (else `Last-Modified`), captured at response time so it survives a drop mid-body. `206` appends; `200` (range ignored / remote changed) truncates and restarts from 0 — mixed-version bytes are never spliced; `416` clears the partial and retries fresh; weak/absent validators disable resume for that file.
- **Cross-restart persistence**: the partial (`<dest>.partial`) and validator sidecar (`<dest>.partial.etag`) live next to the destination, so resume works across process restarts and composes with the existing skip-completed-files logic — end-to-end resumability for multi-hundred-MB repos. A fully-downloaded partial from a previous run is validated and reused with no network at all.
- **Progress**: callbacks include the resumed offset, so reported bytes never dip across retries (updates the old "byte counter restarts" behavior).
- Retry/backoff policy and the transient-vs-permanent classifier are unchanged.

## Tests

`DownloadResumeTests` — 7 deterministic cases via a scripted `URLProtocol` (injectable `URLSessionConfiguration`):

1. fresh 200 writes full body, no `Range` sent, sidecar cleaned up
2. mid-stream drop → retry sends `Range`/`If-Range`, 206 appends, final bytes = head + tail
3. server ignores range (200) → partial replaced, never spliced
4. 416 → partial cleared, retry starts from byte 0
5. weak ETag only → no resume (fresh retry)
6. 503 with HTML body → partial bytes untouched, next attempt resumes
7. completed partial from a previous run → reused with zero network requests; progress includes resumed offset and never dips

## Verification against the real HF CDN

`Range: bytes=400000-` on `silero-vad-coreml/.../weights/weight.bin` returns **206 with exactly the remaining 482,304 bytes, byte-identical to the original file**. One observed caveat: the CDN replies 206 even when `If-Range` carries a stale validator (it ignores the header rather than replying 200 per RFC 9110). We still send `If-Range` (correct client behavior, and honored by spec-compliant servers); the residual mixed-version risk on the CDN is covered by the exact-size check in `validateDownloadedArtifact` and by HF LFS objects being content-addressed (in-place same-size changes are not a practical occurrence).

cc @hyperaudio — happy to have this tested against the glider first-run setup mentioned in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)