### PR TITLE
feat(download): byte-weighted progress for downloadSubdirectory

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -985,6 +985,20 @@ public class DownloadUtils {
         }
     }
 
+    static func subdirectoryProgressFraction(
+        completedBytes: Int64,
+        totalBytes: Int64,
+        completedFiles: Int,
+        totalFiles: Int
+    ) -> Double {
+        guard totalFiles > 0 else { return 1.0 }
+        guard totalBytes > 0 else {
+            return min(Double(completedFiles) / Double(totalFiles), 1.0)
+        }
+
+        return min(Double(completedBytes) / Double(totalBytes), 1.0)
+    }
+
     /// Download a specific subdirectory from a HuggingFace repository.
     ///
     /// Use this for optional model components that aren't part of the required model set
@@ -1049,18 +1063,35 @@ public class DownloadUtils {
         try await listFiles(at: subdirectory)
         let totalFiles = filesToDownload.count
         logger.info("Found \(totalFiles) files in \(subdirectory)")
+
+        // Compute total known bytes for byte-weighted progress.
+        // Files with unknown sizes (size == -1) are treated as 0 for weighting.
+        let totalBytes: Int64 = filesToDownload.reduce(0) { $0 + Int64(max(0, $1.size)) }
+        var completedBytes: Int64 = 0
+
         progressHandler?(
             DownloadProgress(
-                fractionCompleted: totalFiles == 0 ? 1.0 : 0.0,
+                fractionCompleted: subdirectoryProgressFraction(
+                    completedBytes: completedBytes,
+                    totalBytes: totalBytes,
+                    completedFiles: 0,
+                    totalFiles: totalFiles
+                ),
                 phase: .downloading(completedFiles: 0, totalFiles: totalFiles)))
 
         for (index, file) in filesToDownload.enumerated() {
             let destPath = repoDirectory.appendingPathComponent(file.path)
 
             if FileManager.default.fileExists(atPath: destPath.path) {
+                completedBytes += Int64(max(0, file.size))
                 progressHandler?(
                     DownloadProgress(
-                        fractionCompleted: Double(index + 1) / Double(totalFiles),
+                        fractionCompleted: subdirectoryProgressFraction(
+                            completedBytes: completedBytes,
+                            totalBytes: totalBytes,
+                            completedFiles: index + 1,
+                            totalFiles: totalFiles
+                        ),
                         phase: .downloading(
                             completedFiles: index + 1, totalFiles: totalFiles)))
                 continue
@@ -1073,9 +1104,15 @@ public class DownloadUtils {
 
             if file.size == 0 {
                 FileManager.default.createFile(atPath: destPath.path, contents: Data())
+                completedBytes += Int64(max(0, file.size))
                 progressHandler?(
                     DownloadProgress(
-                        fractionCompleted: Double(index + 1) / Double(totalFiles),
+                        fractionCompleted: subdirectoryProgressFraction(
+                            completedBytes: completedBytes,
+                            totalBytes: totalBytes,
+                            completedFiles: index + 1,
+                            totalFiles: totalFiles
+                        ),
                         phase: .downloading(
                             completedFiles: index + 1, totalFiles: totalFiles)))
                 if (index + 1) % 5 == 0 || index == totalFiles - 1 {
@@ -1089,36 +1126,61 @@ public class DownloadUtils {
             let fileURL = try ModelRegistry.resolveModel(repo.remotePath, encodedPath)
             let request = authorizedRequest(url: fileURL)
 
-            let (tempURL, response) = try await sharedSession.download(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else {
-                throw HuggingFaceDownloadError.invalidResponse
+            let onProgress: (@Sendable (Int64, Int64) -> Void)?
+            // Only stream live byte progress for files with a known size: an
+            // unknown-size file (-1) carries zero weight in totalBytes, so its
+            // real bytesWritten would inflate the fraction mid-file and snap
+            // back at the boundary. Boundary emits keep progress monotonic.
+            if let handler = progressHandler, file.size > 0 {
+                let baseBytes = completedBytes
+                let totalBytesSnapshot = totalBytes
+                let fileIndex = index
+                let fileCount = totalFiles
+                onProgress = { bytesWritten, _ in
+                    guard totalBytesSnapshot > 0 else { return }
+                    let currentBytes = baseBytes + bytesWritten
+                    let fraction = subdirectoryProgressFraction(
+                        completedBytes: currentBytes,
+                        totalBytes: totalBytesSnapshot,
+                        completedFiles: fileIndex,
+                        totalFiles: fileCount
+                    )
+                    handler(
+                        DownloadProgress(
+                            fractionCompleted: fraction,
+                            phase: .downloading(completedFiles: fileIndex, totalFiles: fileCount)
+                        ))
+                }
+            } else {
+                onProgress = nil
             }
 
-            if httpResponse.statusCode == 429 || httpResponse.statusCode == 503 {
-                throw HuggingFaceDownloadError.rateLimited(
-                    statusCode: httpResponse.statusCode,
-                    message: "Rate limited while downloading \(file.path)")
-            }
-
-            guard (200..<300).contains(httpResponse.statusCode) else {
-                throw HuggingFaceDownloadError.downloadFailed(
-                    path: file.path,
-                    underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
-                )
-            }
-
-            // Reject HTML error pages / truncated bodies before caching.
-            try validateDownloadedArtifact(
-                at: tempURL, response: httpResponse, path: file.path, expectedSize: file.size)
+            // downloadFileWithRetry validates the artifact (HTML error pages,
+            // truncated bodies) internally, and the persistent `.partial` file
+            // gives retries and re-runs byte-range resume, same as downloadRepo.
+            let tempURL = try await downloadFileWithRetry(
+                request: request,
+                path: file.path,
+                expectedSize: file.size,
+                partialFileURL: destPath.appendingPathExtension("partial"),
+                onProgress: onProgress
+            )
 
             if FileManager.default.fileExists(atPath: destPath.path) {
                 try? FileManager.default.removeItem(at: destPath)
             }
             try FileManager.default.moveItem(at: tempURL, to: destPath)
 
+            completedBytes += Int64(max(0, file.size))
+
             progressHandler?(
                 DownloadProgress(
-                    fractionCompleted: Double(index + 1) / Double(totalFiles),
+                    fractionCompleted: subdirectoryProgressFraction(
+                        completedBytes: completedBytes,
+                        totalBytes: totalBytes,
+                        completedFiles: index + 1,
+                        totalFiles: totalFiles
+                    ),
                     phase: .downloading(
                         completedFiles: index + 1, totalFiles: totalFiles)))
 

--- a/Tests/FluidAudioTests/Shared/DownloadUtilsProgressTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadUtilsProgressTests.swift
@@ -1,0 +1,94 @@
+import XCTest
+
+@testable import FluidAudio
+
+final class DownloadUtilsProgressTests: XCTestCase {
+
+    func testSubdirectoryProgressUsesByteWeightingDuringLargeFile() {
+        let fraction = DownloadUtils.subdirectoryProgressFraction(
+            completedBytes: 399,
+            totalBytes: 665,
+            completedFiles: 9,
+            totalFiles: 22
+        )
+
+        XCTAssertEqual(fraction, 399.0 / 665.0, accuracy: 0.0001)
+        XCTAssertGreaterThan(fraction, Double(9) / Double(22))
+    }
+
+    func testSubdirectoryProgressIsMonotonicForRealisticSequence() {
+        let progress = [
+            DownloadUtils.subdirectoryProgressFraction(
+                completedBytes: 0,
+                totalBytes: 665,
+                completedFiles: 0,
+                totalFiles: 22
+            ),
+            DownloadUtils.subdirectoryProgressFraction(
+                completedBytes: 40,
+                totalBytes: 665,
+                completedFiles: 4,
+                totalFiles: 22
+            ),
+            DownloadUtils.subdirectoryProgressFraction(
+                completedBytes: 120,
+                totalBytes: 665,
+                completedFiles: 9,
+                totalFiles: 22
+            ),
+            DownloadUtils.subdirectoryProgressFraction(
+                completedBytes: 399,
+                totalBytes: 665,
+                completedFiles: 9,
+                totalFiles: 22
+            ),
+            DownloadUtils.subdirectoryProgressFraction(
+                completedBytes: 565,
+                totalBytes: 665,
+                completedFiles: 10,
+                totalFiles: 22
+            ),
+            DownloadUtils.subdirectoryProgressFraction(
+                completedBytes: 665,
+                totalBytes: 665,
+                completedFiles: 22,
+                totalFiles: 22
+            ),
+        ]
+
+        XCTAssertEqual(progress, progress.sorted())
+    }
+
+    func testSubdirectoryProgressClampsToOne() {
+        let fraction = DownloadUtils.subdirectoryProgressFraction(
+            completedBytes: 700,
+            totalBytes: 665,
+            completedFiles: 22,
+            totalFiles: 22
+        )
+
+        XCTAssertEqual(fraction, 1.0)
+    }
+
+    func testSubdirectoryProgressFallsBackToFileCountWhenTotalBytesUnknown() {
+        let fraction = DownloadUtils.subdirectoryProgressFraction(
+            completedBytes: 0,
+            totalBytes: 0,
+            completedFiles: 9,
+            totalFiles: 22
+        )
+
+        XCTAssertEqual(fraction, Double(9) / Double(22), accuracy: 0.0001)
+    }
+
+    func testSubdirectoryProgressIsCompleteWhenThereAreNoFiles() {
+        let fraction = DownloadUtils.subdirectoryProgressFraction(
+            completedBytes: 0,
+            totalBytes: 0,
+            completedFiles: 0,
+            totalFiles: 0
+        )
+
+        XCTAssertEqual(fraction, 1.0)
+    }
+}


### PR DESCRIPTION
## Summary

`downloadSubdirectory` reports progress as completed-file count only, emitted after each whole file finishes. For repos dominated by a single large file, the fraction freezes for minutes mid-download. Concrete case: the Nemotron multilingual 1120ms variant is 22 files totaling ~665 MB, and `encoder.mlmodelc/weights/weight.bin` is ~565 MB of that (~85%), so a progress bar driven by this handler sits at 9/22 (~41%) for the entire encoder transfer and looks like a hang.

## Changes

- Progress is now byte-weighted, mirroring `downloadRepo`: `totalBytes` comes from the listed file sizes, per-file byte progress streams as data arrives, and emits go through a new internal pure helper `subdirectoryProgressFraction`. Unlike `downloadRepo` there is no in-call compile phase, so the fraction uses the full 0-1 range.
- The per-file transfer goes through `downloadFileWithRetry`, so subdirectory downloads get the bounded transient-error retry and the persistent `.partial` byte-range resume (#768) that `downloadRepo` already has. The inline status checks and the external `validateDownloadedArtifact` call are gone because the helper does the same validation internally.
- Unknown file sizes (-1) carry zero weight. Live byte emits are skipped for those files so progress stays monotonic, and a listing where every size is unknown falls back to the old file-count behavior.
- Five deterministic unit tests cover the helper: byte weighting mid-file, monotonicity across a realistic sequence, clamping, and both fallback cases.

## Validation

- `swift build` and `swift test --filter DownloadUtilsProgressTests`: 5/5 pass
- `swift format lint` clean on both changed files
- Field-tested in Hedy (our app): the multilingual Nemotron download used to freeze at 32.7% for minutes; with this change the bar climbs smoothly through the encoder file.