### PR TITLE
refactor(download): Wave 2 — extract HFClient + RetryPolicy primitives (#765)

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -59,26 +59,12 @@ public class DownloadUtils {
         }
     }
 
-    /// Get HuggingFace token from environment if available.
-    /// Supports multiple env vars for compatibility with different HuggingFace tools:
-    /// - HF_TOKEN: Official HuggingFace CLI
-    /// - HUGGING_FACE_HUB_TOKEN: Python huggingface_hub library
-    /// - HUGGINGFACEHUB_API_TOKEN: LangChain and older integrations
-    private static var huggingFaceToken: String? {
-        ProcessInfo.processInfo.environment["HF_TOKEN"]
-            ?? ProcessInfo.processInfo.environment["HUGGING_FACE_HUB_TOKEN"]
-            ?? ProcessInfo.processInfo.environment["HUGGINGFACEHUB_API_TOKEN"]
-    }
-
-    /// Create a URLRequest with optional auth header and timeout
+    /// Create a URLRequest with optional auth header and timeout (HFClient owns
+    /// token resolution and header shape — #765 Wave 2).
     private static func authorizedRequest(
         url: URL, timeout: TimeInterval = DownloadConfig.default.timeout
     ) -> URLRequest {
-        var request = URLRequest(url: url, timeoutInterval: timeout)
-        if let token = huggingFaceToken {
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-        return request
+        HFClient.authorizedRequest(url: url, timeout: timeout)
     }
 
     /// Fetch data from a URL with HuggingFace authentication if available
@@ -87,18 +73,6 @@ public class DownloadUtils {
         try ensureOnlineAllowed("fetchWithAuth(\(url.absoluteString))")
         let request = authorizedRequest(url: url)
         return try await sharedSession.data(for: request)
-    }
-
-    /// Validate that response data is JSON, not HTML error page
-    /// HuggingFace sometimes returns 200 OK with HTML error pages during rate limiting/timeouts
-    private static func validateJSONResponse(_ data: Data, path: String) throws {
-        // Check if response starts with HTML markers
-        if let responseString = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) {
-            if responseString.hasPrefix("<") || responseString.lowercased().contains("<!doctype html") {
-                let snippet = String(responseString.prefix(100))
-                throw HuggingFaceDownloadError.htmlErrorResponse(path: path, snippet: snippet)
-            }
-        }
     }
 
     static func looksLikeHTML(_ data: Data) -> Bool {
@@ -278,20 +252,7 @@ public class DownloadUtils {
     /// are tracked by identity so a self-referential chain terminates without
     /// an arbitrary depth cap.
     static func isCancellationError(_ error: Error) -> Bool {
-        if error is CancellationError { return true }
-
-        var current: NSError? = error as NSError
-        var visited: Set<ObjectIdentifier> = []
-        while let nsError = current, visited.insert(ObjectIdentifier(nsError)).inserted {
-            if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
-                return true
-            }
-            if nsError.domain == NSCocoaErrorDomain, nsError.code == NSUserCancelledError {
-                return true
-            }
-            current = nsError.userInfo[NSUnderlyingErrorKey] as? NSError
-        }
-        return false
+        RetryPolicy.isCancellation(error)
     }
 
     public static func clearModelCache(forRepo repo: Repo, directory: URL) {
@@ -509,14 +470,11 @@ public class DownloadUtils {
             let (dirData, response) = try await listingSession.data(for: request)
 
             if let httpResponse = response as? HTTPURLResponse {
-                if httpResponse.statusCode == 429 || httpResponse.statusCode == 503 {
-                    throw HuggingFaceDownloadError.rateLimited(
-                        statusCode: httpResponse.statusCode, message: "Rate limited while listing files")
-                }
+                try HFClient.checkRateLimit(httpResponse, context: "listing files")
             }
 
             // Validate that response is JSON, not HTML error page
-            try validateJSONResponse(dirData, path: path)
+            try HFClient.validateJSONResponse(dirData, path: path)
 
             guard let items = try JSONSerialization.jsonObject(with: dirData) as? [[String: Any]] else {
                 throw HuggingFaceDownloadError.invalidResponse
@@ -573,14 +531,11 @@ public class DownloadUtils {
             let request = authorizedRequest(url: dirURL)
             let (dirData, response) = try await listingSession.data(for: request)
 
-            if let httpResponse = response as? HTTPURLResponse,
-                httpResponse.statusCode == 429 || httpResponse.statusCode == 503
-            {
-                throw HuggingFaceDownloadError.rateLimited(
-                    statusCode: httpResponse.statusCode, message: "Rate limited while listing root files")
+            if let httpResponse = response as? HTTPURLResponse {
+                try HFClient.checkRateLimit(httpResponse, context: "listing root files")
             }
 
-            try validateJSONResponse(dirData, path: "")
+            try HFClient.validateJSONResponse(dirData, path: "")
 
             guard let items = try JSONSerialization.jsonObject(with: dirData) as? [[String: Any]] else {
                 throw HuggingFaceDownloadError.invalidResponse
@@ -871,109 +826,92 @@ public class DownloadUtils {
             .appendingPathExtension("partial")
         let partialURL = partialFileURL ?? defaultPartialURL
         let validatorURL = resumeValidatorURL(for: partialURL)
-        var lastError: Error?
 
-        for attempt in 1...maxAttempts {
-            do {
-                var attemptRequest = request
-                var resumeOffset: Int64 = 0
+        return try await RetryPolicy.withRetry(
+            label: path, maxAttempts: maxAttempts, minBackoff: minBackoff
+        ) { attempt in
+            var attemptRequest = request
+            var resumeOffset: Int64 = 0
 
-                let partialSize = fileSize(at: partialURL)
-                let validator = (try? String(contentsOf: validatorURL, encoding: .utf8))?
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            let partialSize = fileSize(at: partialURL)
+            let validator = (try? String(contentsOf: validatorURL, encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
 
-                if partialSize > 0, let validator, !validator.isEmpty {
-                    if expectedSize > 0 && partialSize >= Int64(expectedSize) {
-                        // A previous run finished the body but didn't get to move
-                        // the file. Validate and reuse it instead of re-fetching.
-                        if (try? validateDownloadedArtifact(
-                            at: partialURL, response: nil, path: path, expectedSize: expectedSize))
-                            != nil
-                        {
-                            try? FileManager.default.removeItem(at: validatorURL)
-                            return partialURL
-                        }
-                        clearPartialDownload(partialURL)
-                    } else {
-                        attemptRequest.setValue("bytes=\(partialSize)-", forHTTPHeaderField: "Range")
-                        attemptRequest.setValue(validator, forHTTPHeaderField: "If-Range")
-                        resumeOffset = partialSize
-                        logger.info(
-                            "Resuming \(path) from byte \(partialSize) (attempt \(attempt))")
+            if partialSize > 0, let validator, !validator.isEmpty {
+                if expectedSize > 0 && partialSize >= Int64(expectedSize) {
+                    // A previous run finished the body but didn't get to move
+                    // the file. Validate and reuse it instead of re-fetching.
+                    if (try? validateDownloadedArtifact(
+                        at: partialURL, response: nil, path: path, expectedSize: expectedSize))
+                        != nil
+                    {
+                        try? FileManager.default.removeItem(at: validatorURL)
+                        return partialURL
                     }
-                } else if partialSize > 0 {
-                    // Partial bytes with no validator can't be safely resumed.
                     clearPartialDownload(partialURL)
+                } else {
+                    attemptRequest.setValue("bytes=\(partialSize)-", forHTTPHeaderField: "Range")
+                    attemptRequest.setValue(validator, forHTTPHeaderField: "If-Range")
+                    resumeOffset = partialSize
+                    logger.info(
+                        "Resuming \(path) from byte \(partialSize) (attempt \(attempt))")
                 }
-
-                let httpResponse = try await streamDownload(
-                    request: attemptRequest,
-                    to: partialURL,
-                    resumeOffset: resumeOffset,
-                    configuration: configuration,
-                    onProgress: onProgress,
-                    onResponse: { response in
-                        // Persist the validator as soon as the fresh body starts, so
-                        // a drop mid-body still leaves it for the next attempt. A 206
-                        // keeps the validator of the response it is extending.
-                        guard response.statusCode != 206, (200..<300).contains(response.statusCode)
-                        else { return }
-                        if let validator = resumeValidator(from: response) {
-                            try? validator.write(to: validatorURL, atomically: true, encoding: .utf8)
-                        } else {
-                            try? FileManager.default.removeItem(at: validatorURL)
-                        }
-                    }
-                )
-
-                if httpResponse.statusCode == 429 || httpResponse.statusCode == 503 {
-                    throw HuggingFaceDownloadError.rateLimited(
-                        statusCode: httpResponse.statusCode,
-                        message: "Rate limited while downloading \(path)")
-                }
-
-                if httpResponse.statusCode == 416 {
-                    // Range not satisfiable — the partial is bogus (or the remote
-                    // shrank). Restart from 0 on the next attempt.
-                    clearPartialDownload(partialURL)
-                    throw HuggingFaceDownloadError.invalidArtifact(
-                        path: path, reason: "server rejected resume range (416)")
-                }
-
-                guard (200..<300).contains(httpResponse.statusCode) else {
-                    throw HuggingFaceDownloadError.downloadFailed(
-                        path: path,
-                        underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
-                    )
-                }
-
-                // Validate before the caller moves the file into the cache.
-                do {
-                    try validateDownloadedArtifact(
-                        at: partialURL, response: httpResponse, path: path,
-                        expectedSize: expectedSize)
-                } catch {
-                    // A completed-but-invalid body must not be resumed from.
-                    clearPartialDownload(partialURL)
-                    throw error
-                }
-
-                try? FileManager.default.removeItem(at: validatorURL)
-                return partialURL
-            } catch {
-                lastError = error
-                guard attempt < maxAttempts, isRetryableDownloadError(error) else {
-                    throw error
-                }
-                let backoffSeconds = pow(2.0, Double(attempt - 1)) * minBackoff
-                logger.warning(
-                    "Download attempt \(attempt) for \(path) failed: \(error.localizedDescription). Retrying in \(String(format: "%.1f", backoffSeconds))s."
-                )
-                try await Task.sleep(nanoseconds: UInt64(backoffSeconds * 1_000_000_000))
+            } else if partialSize > 0 {
+                // Partial bytes with no validator can't be safely resumed.
+                clearPartialDownload(partialURL)
             }
-        }
 
-        throw lastError ?? HuggingFaceDownloadError.invalidResponse
+            let httpResponse = try await streamDownload(
+                request: attemptRequest,
+                to: partialURL,
+                resumeOffset: resumeOffset,
+                configuration: configuration,
+                onProgress: onProgress,
+                onResponse: { response in
+                    // Persist the validator as soon as the fresh body starts, so
+                    // a drop mid-body still leaves it for the next attempt. A 206
+                    // keeps the validator of the response it is extending.
+                    guard response.statusCode != 206, (200..<300).contains(response.statusCode)
+                    else { return }
+                    if let validator = resumeValidator(from: response) {
+                        try? validator.write(to: validatorURL, atomically: true, encoding: .utf8)
+                    } else {
+                        try? FileManager.default.removeItem(at: validatorURL)
+                    }
+                }
+            )
+
+            try HFClient.checkRateLimit(httpResponse, context: "downloading \(path)")
+
+            if httpResponse.statusCode == 416 {
+                // Range not satisfiable — the partial is bogus (or the remote
+                // shrank). Restart from 0 on the next attempt.
+                clearPartialDownload(partialURL)
+                throw HuggingFaceDownloadError.invalidArtifact(
+                    path: path, reason: "server rejected resume range (416)")
+            }
+
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                throw HuggingFaceDownloadError.downloadFailed(
+                    path: path,
+                    underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
+                )
+            }
+
+            // Validate before the caller moves the file into the cache.
+            do {
+                try validateDownloadedArtifact(
+                    at: partialURL, response: httpResponse, path: path,
+                    expectedSize: expectedSize)
+            } catch {
+                // A completed-but-invalid body must not be resumed from.
+                clearPartialDownload(partialURL)
+                throw error
+            }
+
+            try? FileManager.default.removeItem(at: validatorURL)
+            return partialURL
+        }
     }
 
     /// Classify a per-file download error as transient (worth retrying) or
@@ -984,30 +922,7 @@ public class DownloadUtils {
     /// Internal (not private) so retry-policy characterization tests can pin this
     /// classification ahead of the #765 refactor.
     static func isRetryableDownloadError(_ error: Error) -> Bool {
-        if let urlError = error as? URLError {
-            switch urlError.code {
-            case .timedOut, .cannotConnectToHost, .cannotFindHost,
-                .networkConnectionLost, .notConnectedToInternet,
-                .dnsLookupFailed, .secureConnectionFailed,
-                .resourceUnavailable:
-                return true
-            default:
-                return false
-            }
-        }
-
-        switch error {
-        case HuggingFaceDownloadError.rateLimited:
-            return true
-        case HuggingFaceDownloadError.invalidArtifact:
-            // Usually a transient unhealthy network path (proxy, mirror 5xx) — retry.
-            return true
-        case HuggingFaceDownloadError.downloadFailed(_, let underlying):
-            let nsError = underlying as NSError
-            return nsError.domain == "HTTP" && (500...599).contains(nsError.code)
-        default:
-            return false
-        }
+        RetryPolicy.isRetryable(error)
     }
 
     static func subdirectoryProgressFraction(
@@ -1053,16 +968,12 @@ public class DownloadUtils {
         func listFiles(at path: String) async throws {
             let dirURL = try ModelRegistry.apiModels(repo.remotePath, "tree/main/\(path)")
             let (dirData, response) = try await fetchWithAuth(from: dirURL)
-            if let httpResponse = response as? HTTPURLResponse,
-                httpResponse.statusCode == 429 || httpResponse.statusCode == 503
-            {
-                throw HuggingFaceDownloadError.rateLimited(
-                    statusCode: httpResponse.statusCode,
-                    message: "Rate limited while listing files in \(path)")
+            if let httpResponse = response as? HTTPURLResponse {
+                try HFClient.checkRateLimit(httpResponse, context: "listing files in \(path)")
             }
 
             // Validate that response is JSON, not HTML error page
-            try validateJSONResponse(dirData, path: path)
+            try HFClient.validateJSONResponse(dirData, path: path)
 
             guard let items = try JSONSerialization.jsonObject(with: dirData) as? [[String: Any]] else {
                 throw HuggingFaceDownloadError.invalidResponse
@@ -1236,12 +1147,7 @@ public class DownloadUtils {
                     throw HuggingFaceDownloadError.invalidResponse
                 }
 
-                if httpResponse.statusCode == 429 || httpResponse.statusCode == 503 {
-                    throw HuggingFaceDownloadError.rateLimited(
-                        statusCode: httpResponse.statusCode,
-                        message: "HTTP \(httpResponse.statusCode)"
-                    )
-                }
+                try HFClient.checkRateLimit(httpResponse, context: "fetching \(description)")
 
                 guard (200..<300).contains(httpResponse.statusCode) else {
                     throw HuggingFaceDownloadError.invalidResponse

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -75,11 +75,10 @@ public class DownloadUtils {
         return try await sharedSession.data(for: request)
     }
 
+    /// Forward — the single HTML sniffer lives in HFClient (#765 Wave 2);
+    /// kept here because DownloadArtifactValidationTests pins this symbol.
     static func looksLikeHTML(_ data: Data) -> Bool {
-        let prefix = data.prefix(512)
-        let text = String(data: prefix, encoding: .utf8) ?? String(decoding: prefix, as: UTF8.self)
-        let lowered = text.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-        return lowered.hasPrefix("<!doctype html") || lowered.hasPrefix("<html") || lowered.hasPrefix("<?xml")
+        HFClient.looksLikeHTML(data)
     }
 
     /// `response` is nil when re-validating a fully-downloaded partial file from
@@ -119,31 +118,10 @@ public class DownloadUtils {
         }
     }
 
-    public enum HuggingFaceDownloadError: LocalizedError {
-        case invalidResponse
-        case rateLimited(statusCode: Int, message: String)
-        case downloadFailed(path: String, underlying: Error)
-        case modelNotFound(path: String)
-        case htmlErrorResponse(path: String, snippet: String)
-        case invalidArtifact(path: String, reason: String)
-
-        public var errorDescription: String? {
-            switch self {
-            case .invalidResponse:
-                return "Received an invalid response from Hugging Face."
-            case .rateLimited(_, let message):
-                return "Hugging Face rate limit encountered: \(message)"
-            case .downloadFailed(let path, let underlying):
-                return "Failed to download \(path): \(underlying.localizedDescription)"
-            case .htmlErrorResponse(let path, let snippet):
-                return "HuggingFace returned HTML instead of JSON for \(path) (rate limit or server issue): \(snippet)"
-            case .modelNotFound(let path):
-                return "Model file not found: \(path)"
-            case .invalidArtifact(let path, let reason):
-                return "Downloaded artifact for \(path) is invalid (\(reason)); refusing to cache it."
-            }
-        }
-    }
+    /// Moved to `FluidAudio.HuggingFaceDownloadError` (Shared/Download/DownloadTypes.swift)
+    /// so the extracted download primitives don't depend back on this class
+    /// (#765 Wave 2). The nested spelling stays source-compatible.
+    public typealias HuggingFaceDownloadError = HFDownload.DownloadError
 
     /// Phase of a model download operation.
     public enum DownloadPhase: Sendable {
@@ -174,15 +152,9 @@ public class DownloadUtils {
     /// the main actor inside your handler.
     public typealias ProgressHandler = @Sendable (DownloadProgress) -> Void
 
-    public struct DownloadConfig: Sendable {
-        public let timeout: TimeInterval
-
-        public init(timeout: TimeInterval = 1800) {  // 30 minutes for large models
-            self.timeout = timeout
-        }
-
-        public static let `default` = DownloadConfig()
-    }
+    /// Moved to `FluidAudio.DownloadConfig` (Shared/Download/DownloadTypes.swift);
+    /// nested spelling stays source-compatible.
+    public typealias DownloadConfig = HFDownload.Config
 
     public static func loadModels(
         _ repo: Repo,
@@ -244,13 +216,8 @@ public class DownloadUtils {
         }
     }
 
-    /// `true` when `error` represents cancellation (Swift `CancellationError`,
-    /// `NSURLErrorCancelled`, or `NSUserCancelledError`, at any depth of the
-    /// underlying-error chain) rather than a corrupted cache.
-    ///
-    /// The `NSUnderlyingErrorKey` chain is walked to its end. Visited errors
-    /// are tracked by identity so a self-referential chain terminates without
-    /// an arbitrary depth cap.
+    /// Forward to `RetryPolicy.isCancellation` (see there for the chain-walk
+    /// semantics); kept because DownloadUtilsCancellationTests pins this symbol.
     static func isCancellationError(_ error: Error) -> Bool {
         RetryPolicy.isCancellation(error)
     }
@@ -828,7 +795,7 @@ public class DownloadUtils {
         let validatorURL = resumeValidatorURL(for: partialURL)
 
         return try await RetryPolicy.withRetry(
-            label: path, maxAttempts: maxAttempts, minBackoff: minBackoff
+            label: path, maxAttempts: maxAttempts, minBackoff: minBackoff, logger: logger
         ) { attempt in
             var attemptRequest = request
             var resumeOffset: Int64 = 0

--- a/Sources/FluidAudio/Shared/Download/DownloadTypes.swift
+++ b/Sources/FluidAudio/Shared/Download/DownloadTypes.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Namespace for the canonical download-stack types (#765 Wave 2).
+///
+/// These live outside `DownloadUtils` so the Shared/Download primitives
+/// (HFClient, RetryPolicy, and later extractions) don't depend back on the
+/// class they were extracted from. The long-standing nested spellings
+/// (`DownloadUtils.HuggingFaceDownloadError`, `DownloadUtils.DownloadConfig`)
+/// remain source-compatible via typealiases.
+public enum HFDownload {
+
+    /// Errors thrown by the HuggingFace download stack.
+    public enum DownloadError: LocalizedError {
+        case invalidResponse
+        case rateLimited(statusCode: Int, message: String)
+        case downloadFailed(path: String, underlying: Error)
+        case modelNotFound(path: String)
+        case htmlErrorResponse(path: String, snippet: String)
+        case invalidArtifact(path: String, reason: String)
+
+        public var errorDescription: String? {
+            switch self {
+            case .invalidResponse:
+                return "Received an invalid response from Hugging Face."
+            case .rateLimited(_, let message):
+                return "Hugging Face rate limit encountered: \(message)"
+            case .downloadFailed(let path, let underlying):
+                return "Failed to download \(path): \(underlying.localizedDescription)"
+            case .htmlErrorResponse(let path, let snippet):
+                return "HuggingFace returned HTML instead of JSON for \(path) (rate limit or server issue): \(snippet)"
+            case .modelNotFound(let path):
+                return "Model file not found: \(path)"
+            case .invalidArtifact(let path, let reason):
+                return "Downloaded artifact for \(path) is invalid (\(reason)); refusing to cache it."
+            }
+        }
+    }
+
+    /// Download configuration shared by the download stack.
+    public struct Config: Sendable {
+        public let timeout: TimeInterval
+
+        public init(timeout: TimeInterval = 1800) {  // 30 minutes for large models
+            self.timeout = timeout
+        }
+
+        public static let `default` = Config()
+    }
+}

--- a/Sources/FluidAudio/Shared/Download/HFClient.swift
+++ b/Sources/FluidAudio/Shared/Download/HFClient.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// HuggingFace HTTP plumbing shared by every download path (#765 Wave 2):
+/// token resolution, authorized request building, and the single place where
+/// rate-limit (429/503) responses become typed errors.
+enum HFClient {
+
+    /// HuggingFace token from the environment, if available. Supports the env
+    /// vars used by the official CLI (`HF_TOKEN`), the Python `huggingface_hub`
+    /// library (`HUGGING_FACE_HUB_TOKEN`), and LangChain/older integrations
+    /// (`HUGGINGFACEHUB_API_TOKEN`).
+    static var huggingFaceToken: String? {
+        ProcessInfo.processInfo.environment["HF_TOKEN"]
+            ?? ProcessInfo.processInfo.environment["HUGGING_FACE_HUB_TOKEN"]
+            ?? ProcessInfo.processInfo.environment["HUGGINGFACEHUB_API_TOKEN"]
+    }
+
+    /// Create a URLRequest with optional auth header and timeout.
+    static func authorizedRequest(
+        url: URL, timeout: TimeInterval = DownloadUtils.DownloadConfig.default.timeout
+    ) -> URLRequest {
+        var request = URLRequest(url: url, timeoutInterval: timeout)
+        if let token = huggingFaceToken {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        return request
+    }
+
+    /// The one place 429/503 responses are turned into
+    /// `HuggingFaceDownloadError.rateLimited`. A `Retry-After` header, when
+    /// present, is included in the message for diagnostics.
+    static func checkRateLimit(_ response: HTTPURLResponse, context: String) throws {
+        guard response.statusCode == 429 || response.statusCode == 503 else { return }
+        var message = "Rate limited while \(context)"
+        if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
+            message += " (Retry-After: \(retryAfter))"
+        }
+        throw DownloadUtils.HuggingFaceDownloadError.rateLimited(
+            statusCode: response.statusCode, message: message)
+    }
+
+    /// Reject 200-OK responses whose body is an HTML error page instead of the
+    /// JSON the HF API was asked for (seen during rate limiting/timeouts).
+    static func validateJSONResponse(_ data: Data, path: String) throws {
+        if let responseString = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        {
+            if responseString.hasPrefix("<") || responseString.lowercased().contains("<!doctype html") {
+                let snippet = String(responseString.prefix(100))
+                throw DownloadUtils.HuggingFaceDownloadError.htmlErrorResponse(
+                    path: path, snippet: snippet)
+            }
+        }
+    }
+}

--- a/Sources/FluidAudio/Shared/Download/HFClient.swift
+++ b/Sources/FluidAudio/Shared/Download/HFClient.swift
@@ -1,8 +1,11 @@
 import Foundation
 
-/// HuggingFace HTTP plumbing shared by every download path (#765 Wave 2):
-/// token resolution, authorized request building, and the single place where
-/// rate-limit (429/503) responses become typed errors.
+/// HuggingFace HTTP plumbing for the DownloadUtils download paths, converging
+/// here across the #765 waves: token resolution, authorized request building,
+/// and the single place where rate-limit (429/503) responses become typed
+/// errors. (`fetchHuggingFaceFile` keeps its divergent retry loop until
+/// Wave 5; `AssetDownloader` and the CLI's `DatasetDownloader` are not yet in
+/// scope.)
 enum HFClient {
 
     /// HuggingFace token from the environment, if available. Supports the env
@@ -17,7 +20,7 @@ enum HFClient {
 
     /// Create a URLRequest with optional auth header and timeout.
     static func authorizedRequest(
-        url: URL, timeout: TimeInterval = DownloadUtils.DownloadConfig.default.timeout
+        url: URL, timeout: TimeInterval = HFDownload.Config.default.timeout
     ) -> URLRequest {
         var request = URLRequest(url: url, timeoutInterval: timeout)
         if let token = huggingFaceToken {
@@ -27,29 +30,55 @@ enum HFClient {
     }
 
     /// The one place 429/503 responses are turned into
-    /// `HuggingFaceDownloadError.rateLimited`. A `Retry-After` header, when
-    /// present, is included in the message for diagnostics.
-    static func checkRateLimit(_ response: HTTPURLResponse, context: String) throws {
+    /// `HFDownload.DownloadError.rateLimited`. The message is deterministic
+    /// ("Rate limited while <context> (HTTP <code>)"); the machine-readable
+    /// `Retry-After` hint stays available via `retryAfter(from:)` for the
+    /// retry layer to honor (Wave 5) rather than being flattened into text.
+    static func checkRateLimit(
+        _ response: HTTPURLResponse, context: @autoclosure () -> String
+    ) throws {
         guard response.statusCode == 429 || response.statusCode == 503 else { return }
-        var message = "Rate limited while \(context)"
-        if let retryAfter = response.value(forHTTPHeaderField: "Retry-After") {
-            message += " (Retry-After: \(retryAfter))"
+        throw HFDownload.DownloadError.rateLimited(
+            statusCode: response.statusCode,
+            message: "Rate limited while \(context()) (HTTP \(response.statusCode))")
+    }
+
+    /// Typed `Retry-After` from a response: delay-seconds, or an HTTP-date
+    /// converted to seconds-from-now. Nil when absent or unparsable.
+    static func retryAfter(from response: HTTPURLResponse) -> TimeInterval? {
+        guard let value = response.value(forHTTPHeaderField: "Retry-After") else { return nil }
+        if let seconds = TimeInterval(value) {
+            return max(0, seconds)
         }
-        throw DownloadUtils.HuggingFaceDownloadError.rateLimited(
-            statusCode: response.statusCode, message: message)
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "GMT")
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        if let date = formatter.date(from: value) {
+            return max(0, date.timeIntervalSinceNow)
+        }
+        return nil
+    }
+
+    /// `true` when `data` begins with HTML/XML markup — the single HTML
+    /// sniffer for the download stack (error pages served with 200s).
+    static func looksLikeHTML(_ data: Data) -> Bool {
+        let prefix = data.prefix(512)
+        let text = String(data: prefix, encoding: .utf8) ?? String(decoding: prefix, as: UTF8.self)
+        let lowered = text.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        return lowered.hasPrefix("<!doctype html") || lowered.hasPrefix("<html") || lowered.hasPrefix("<?xml")
     }
 
     /// Reject 200-OK responses whose body is an HTML error page instead of the
     /// JSON the HF API was asked for (seen during rate limiting/timeouts).
+    /// Delegates markup detection to `looksLikeHTML`, plus the JSON-specific
+    /// check that a JSON document can never open with `<`.
     static func validateJSONResponse(_ data: Data, path: String) throws {
-        if let responseString = String(data: data, encoding: .utf8)?
+        let trimmed = String(data: data.prefix(512), encoding: .utf8)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        {
-            if responseString.hasPrefix("<") || responseString.lowercased().contains("<!doctype html") {
-                let snippet = String(responseString.prefix(100))
-                throw DownloadUtils.HuggingFaceDownloadError.htmlErrorResponse(
-                    path: path, snippet: snippet)
-            }
+        if trimmed?.hasPrefix("<") == true || looksLikeHTML(data) {
+            let snippet = String((trimmed ?? "").prefix(100))
+            throw HFDownload.DownloadError.htmlErrorResponse(path: path, snippet: snippet)
         }
     }
 }

--- a/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
+++ b/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
@@ -1,27 +1,36 @@
 import Foundation
 
-/// The single retry policy for download paths (#765 Wave 2): bounded
-/// exponential backoff on transient failures, fail-fast on permanent ones.
+/// The retry policy the DownloadUtils download paths converge on across the
+/// #765 waves (#765 Wave 2): bounded exponential backoff on transient
+/// failures, fail-fast on permanent ones. `fetchHuggingFaceFile` still runs
+/// its historical retry-everything loop and converges in Wave 5.
 enum RetryPolicy {
 
-    private static let logger = AppLogger(category: "RetryPolicy")
+    private static let defaultLogger = AppLogger(category: "RetryPolicy")
 
     /// Run `operation`, retrying transient failures (per `isRetryable`) with
     /// exponential backoff. Permanent errors and the final attempt's error are
     /// rethrown unchanged. The closure receives the 1-based attempt number
     /// (for logging/resume diagnostics).
+    ///
+    /// - Parameters:
+    ///   - maxAttempts: Total attempts including the first; must be >= 1.
+    ///   - logger: Where per-attempt retry warnings go. Pass the calling
+    ///     component's logger so one operation's log trail stays in one
+    ///     category.
     static func withRetry<T>(
         label: String,
         maxAttempts: Int = 4,
         minBackoff: TimeInterval = 1.0,
+        logger: AppLogger = defaultLogger,
         operation: (_ attempt: Int) async throws -> T
     ) async throws -> T {
-        var lastError: Error?
+        precondition(maxAttempts >= 1, "maxAttempts must be >= 1 (got \(maxAttempts))")
+
         for attempt in 1...maxAttempts {
             do {
                 return try await operation(attempt)
             } catch {
-                lastError = error
                 guard attempt < maxAttempts, isRetryable(error) else {
                     throw error
                 }
@@ -32,7 +41,10 @@ enum RetryPolicy {
                 try await Task.sleep(nanoseconds: UInt64(backoffSeconds * 1_000_000_000))
             }
         }
-        throw lastError ?? DownloadUtils.HuggingFaceDownloadError.invalidResponse
+
+        // The final attempt's catch always rethrows (attempt < maxAttempts
+        // fails), so the loop cannot complete normally.
+        preconditionFailure("unreachable: the final attempt rethrows in the catch guard")
     }
 
     /// Classify an error as transient (worth retrying) or permanent.
@@ -53,12 +65,12 @@ enum RetryPolicy {
         }
 
         switch error {
-        case DownloadUtils.HuggingFaceDownloadError.rateLimited:
+        case HFDownload.DownloadError.rateLimited:
             return true
-        case DownloadUtils.HuggingFaceDownloadError.invalidArtifact:
+        case HFDownload.DownloadError.invalidArtifact:
             // Usually a transient unhealthy network path (proxy, mirror 5xx) — retry.
             return true
-        case DownloadUtils.HuggingFaceDownloadError.downloadFailed(_, let underlying):
+        case HFDownload.DownloadError.downloadFailed(_, let underlying):
             let nsError = underlying as NSError
             return nsError.domain == "HTTP" && (500...599).contains(nsError.code)
         default:

--- a/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
+++ b/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// The single retry policy for download paths (#765 Wave 2): bounded
+/// exponential backoff on transient failures, fail-fast on permanent ones.
+enum RetryPolicy {
+
+    private static let logger = AppLogger(category: "RetryPolicy")
+
+    /// Run `operation`, retrying transient failures (per `isRetryable`) with
+    /// exponential backoff. Permanent errors and the final attempt's error are
+    /// rethrown unchanged. The closure receives the 1-based attempt number
+    /// (for logging/resume diagnostics).
+    static func withRetry<T>(
+        label: String,
+        maxAttempts: Int = 4,
+        minBackoff: TimeInterval = 1.0,
+        operation: (_ attempt: Int) async throws -> T
+    ) async throws -> T {
+        var lastError: Error?
+        for attempt in 1...maxAttempts {
+            do {
+                return try await operation(attempt)
+            } catch {
+                lastError = error
+                guard attempt < maxAttempts, isRetryable(error) else {
+                    throw error
+                }
+                let backoffSeconds = pow(2.0, Double(attempt - 1)) * minBackoff
+                logger.warning(
+                    "Download attempt \(attempt) for \(label) failed: \(error.localizedDescription). Retrying in \(String(format: "%.1f", backoffSeconds))s."
+                )
+                try await Task.sleep(nanoseconds: UInt64(backoffSeconds * 1_000_000_000))
+            }
+        }
+        throw lastError ?? DownloadUtils.HuggingFaceDownloadError.invalidResponse
+    }
+
+    /// Classify an error as transient (worth retrying) or permanent.
+    /// Transient: URLSession timeout / TLS / connectivity failures and HTTP
+    /// 429/503/5xx. Everything else (404/other 4xx, invalid response,
+    /// non-network errors) is permanent.
+    static func isRetryable(_ error: Error) -> Bool {
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut, .cannotConnectToHost, .cannotFindHost,
+                .networkConnectionLost, .notConnectedToInternet,
+                .dnsLookupFailed, .secureConnectionFailed,
+                .resourceUnavailable:
+                return true
+            default:
+                return false
+            }
+        }
+
+        switch error {
+        case DownloadUtils.HuggingFaceDownloadError.rateLimited:
+            return true
+        case DownloadUtils.HuggingFaceDownloadError.invalidArtifact:
+            // Usually a transient unhealthy network path (proxy, mirror 5xx) — retry.
+            return true
+        case DownloadUtils.HuggingFaceDownloadError.downloadFailed(_, let underlying):
+            let nsError = underlying as NSError
+            return nsError.domain == "HTTP" && (500...599).contains(nsError.code)
+        default:
+            return false
+        }
+    }
+
+    /// `true` when `error` represents cancellation (Swift `CancellationError`,
+    /// `NSURLErrorCancelled`, or `NSUserCancelledError`, at any depth of the
+    /// underlying-error chain) rather than a real failure.
+    ///
+    /// The `NSUnderlyingErrorKey` chain is walked to its end. Visited errors
+    /// are tracked by identity so a self-referential chain terminates without
+    /// an arbitrary depth cap.
+    static func isCancellation(_ error: Error) -> Bool {
+        if error is CancellationError { return true }
+
+        var current: NSError? = error as NSError
+        var visited: Set<ObjectIdentifier> = []
+        while let nsError = current, visited.insert(ObjectIdentifier(nsError)).inserted {
+            if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+                return true
+            }
+            if nsError.domain == NSCocoaErrorDomain, nsError.code == NSUserCancelledError {
+                return true
+            }
+            current = nsError.userInfo[NSUnderlyingErrorKey] as? NSError
+        }
+        return false
+    }
+}

--- a/Tests/FluidAudioTests/Shared/RetryPolicyTests.swift
+++ b/Tests/FluidAudioTests/Shared/RetryPolicyTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import XCTest
+import os
+
+@testable import FluidAudio
+
+/// Unit tests for the extracted retry primitive (#765 Wave 2). Classification
+/// itself is characterized by `DownloadClassifierTests` (which now runs
+/// through the `DownloadUtils.isRetryableDownloadError` forward); these tests
+/// pin the loop mechanics: attempt counting, fail-fast on permanent errors,
+/// and error propagation.
+final class RetryPolicyTests: XCTestCase {
+
+    private final class Counter: Sendable {
+        private let value = OSAllocatedUnfairLock<Int>(initialState: 0)
+        func increment() -> Int {
+            value.withLock { (v: inout Int) -> Int in
+                v += 1
+                return v
+            }
+        }
+        var count: Int { value.withLock { $0 } }
+    }
+
+    func testTransientFailuresConsumeAllAttemptsThenThrowLastError() async {
+        let counter = Counter()
+        do {
+            let _: Never = try await RetryPolicy.withRetry(
+                label: "transient", maxAttempts: 3, minBackoff: 0.01
+            ) { _ in
+                _ = counter.increment()
+                throw URLError(.timedOut)
+            }
+            XCTFail("expected error")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .timedOut)
+        } catch {
+            XCTFail("expected URLError.timedOut, got \(error)")
+        }
+        XCTAssertEqual(counter.count, 3, "transient errors must use the whole attempt budget")
+    }
+
+    func testPermanentFailureFailsFastOnFirstAttempt() async {
+        let counter = Counter()
+        do {
+            let _: Never = try await RetryPolicy.withRetry(
+                label: "permanent", maxAttempts: 4, minBackoff: 0.01
+            ) { _ in
+                _ = counter.increment()
+                throw DownloadUtils.HuggingFaceDownloadError.downloadFailed(
+                    path: "missing.bin", underlying: NSError(domain: "HTTP", code: 404))
+            }
+            XCTFail("expected error")
+        } catch {
+            // expected
+        }
+        XCTAssertEqual(counter.count, 1, "a permanent 404 must not consume the backoff budget")
+    }
+
+    func testSucceedsAfterTransientFailuresAndReportsAttemptNumber() async throws {
+        let counter = Counter()
+        let result = try await RetryPolicy.withRetry(
+            label: "flaky", maxAttempts: 3, minBackoff: 0.01
+        ) { attempt -> Int in
+            XCTAssertEqual(attempt, counter.increment(), "closure must receive the 1-based attempt")
+            if attempt < 3 {
+                throw DownloadUtils.HuggingFaceDownloadError.rateLimited(
+                    statusCode: 503, message: "busy")
+            }
+            return attempt
+        }
+        XCTAssertEqual(result, 3)
+        XCTAssertEqual(counter.count, 3)
+    }
+
+    func testCancellationPropagatesWithoutRetry() async {
+        let counter = Counter()
+        do {
+            let _: Never = try await RetryPolicy.withRetry(
+                label: "cancelled", maxAttempts: 4, minBackoff: 0.01
+            ) { _ in
+                _ = counter.increment()
+                throw URLError(.cancelled)
+            }
+            XCTFail("expected error")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .cancelled)
+        } catch {
+            XCTFail("expected URLError.cancelled, got \(error)")
+        }
+        XCTAssertEqual(counter.count, 1, "cancellation is not transient; it must not retry")
+    }
+}


### PR DESCRIPTION
Wave 2 of the #765 execution plan. **Behavior-preserving extraction — the Wave 1 oracle suite (#770) is untouched**; it passing unmodified is this PR's correctness proof, alongside the auto-triggered cold-download benchmarks and smoke test.

## What moved where

**`Shared/Download/HFClient.swift`** (new)
- HF token resolution (`HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` / `HUGGINGFACEHUB_API_TOKEN`)
- `authorizedRequest(url:timeout:)`
- `checkRateLimit(_:context:)` — the **one** place 429/503 becomes `rateLimited`, replacing 5 copy-pasted blocks (flaw 6). `Retry-After`, when present, now surfaces in the error message; honoring it in backoff is a later, deliberate change.
- JSON-vs-HTML response validation (`validateJSONResponse`)

**`Shared/Download/RetryPolicy.swift`** (new)
- `withRetry(label:maxAttempts:minBackoff:operation:)` — the bounded exponential-backoff loop; the closure receives the 1-based attempt number (used by the resume path's diagnostics)
- the transient/permanent classifier and the cancellation-chain walker, moved **verbatim**

**`DownloadUtils`** (−94 net lines)
- `downloadFileWithRetry`'s manual retry loop → `RetryPolicy.withRetry`
- test-pinned symbols kept as one-line forwards (`isRetryableDownloadError`, `isCancellationError`) so `DownloadClassifierTests` / `DownloadUtilsCancellationTests` characterize the moved logic **unchanged**

## Deliberately not in this wave

`fetchHuggingFaceFile` keeps its own divergent loop (it retries everything, including permanent 404s — flaw 2). Converging it onto `RetryPolicy` changes behavior and belongs to Wave 5, per the plan's extraction-vs-behavior separation.

## Tests

`RetryPolicyTests` (new): transient errors consume the whole attempt budget; a permanent 404 fails on attempt 1; cancellation never retries; success after transient failures; the closure receives correct attempt numbers.

## Verification gates on this PR

- Wave 1 oracle: filter fixtures, progress sequences, offline suite — **zero edits**
- `download-smoke`: live cold 2 MB download + CoreML load through the extracted primitives
- Cold benchmarks (auto-triggered by the download-source-keyed cache keys): baseline parity expected (diarizer 15.1% DER)

Part of #765. Wave 3 (`HFTreeLister`, incl. the now-confirmed Link-header pagination fix) and Wave 4 (`FileDownloader`/`ModelCache`/`ProgressReporter`) are unblocked once this lands and can proceed in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Self-review pass applied (`5a7201cd`)

A 7-angle review of this diff surfaced 10 findings; all applied:

- **Layering inversion fixed**: canonical types moved to `HFDownload.DownloadError`/`HFDownload.Config` (`Shared/Download/DownloadTypes.swift`); nested `DownloadUtils.*` spellings stay source-compatible via typealiases (same types — pattern matching and all tests unaffected). The primitives no longer depend back on `DownloadUtils`, so Waves 3–5 reference the final home once instead of a wide mechanical rename at Wave 6.
- **Retry-After is now a typed seam**: `HFClient.retryAfter(from:)` (delta-seconds or HTTP-date) instead of flattening the hint into the error message; `checkRateLimit` messages are deterministic — `"Rate limited while <context> (HTTP <code>)"` — restoring the status code the old `fetchHuggingFaceFile` string carried. Honoring the delay in backoff lands with Wave 5.
- **Primitive hygiene**: `withRetry` gets `precondition(maxAttempts >= 1)`; the dead `lastError`/unreachable fallback is now an explicit `preconditionFailure`; a `logger` param keeps one download's retry trail in one log category (`DownloadUtils`); `checkRateLimit`'s context is `@autoclosure` (no happy-path string allocations).
- **One HTML sniffer**: `looksLikeHTML` moved to `HFClient`, `validateJSONResponse` delegates to it (bounded 512-byte prefix instead of the old whole-body scan); `DownloadUtils.looksLikeHTML` kept as the test-pinned forward.
- **Doc accuracy**: headers no longer claim "single policy for every path" while `fetchHuggingFaceFile` (Wave 5) and `AssetDownloader`/CLI `DatasetDownloader` (unscoped — flagged for #765) still diverge.

Behavior deltas vs main are now exactly two, both deliberate and uniform: rate-limit messages gained `"(HTTP <code>)"`, and JSON-response HTML detection uses the bounded-prefix sniffer (kills a whole-body scan and a mid-body false-positive class).
