### PR TITLE
refactor(download): Wave 3 — one paginating HFTreeLister replaces both inline listers (#765)

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -426,101 +426,41 @@ public class DownloadUtils {
             }
         }
 
-        // Get all files recursively using HuggingFace API
-        var filesToDownload: [(path: String, size: Int)] = []
-
-        func listDirectory(path: String) async throws {
-            let apiPath = path.isEmpty ? "tree/main" : "tree/main/\(path)"
-            let dirURL = try ModelRegistry.apiModels(repo.remotePath, apiPath)
-            let request = authorizedRequest(url: dirURL)
-
-            let (dirData, response) = try await listingSession.data(for: request)
-
-            if let httpResponse = response as? HTTPURLResponse {
-                try HFClient.checkRateLimit(httpResponse, context: "listing files")
-            }
-
-            // Validate that response is JSON, not HTML error page
-            try HFClient.validateJSONResponse(dirData, path: path)
-
-            guard let items = try JSONSerialization.jsonObject(with: dirData) as? [[String: Any]] else {
-                throw HuggingFaceDownloadError.invalidResponse
-            }
-
-            for item in items {
-                guard let itemPath = item["path"] as? String,
-                    let itemType = item["type"] as? String
-                else { continue }
-
-                if itemType == "directory" {
-                    // For subPath repos, only process paths within the subPath
-                    let shouldProcess: Bool
-                    if let sub = subPath {
-                        shouldProcess =
-                            itemPath == sub || itemPath.hasPrefix("\(sub)/")
-                            || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
-                    } else {
-                        shouldProcess =
-                            patterns.isEmpty
-                            || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
-                    }
-                    if shouldProcess {
-                        try await listDirectory(path: itemPath)
-                    }
-                } else if itemType == "file" {
-                    // For subPath repos, only include files within the subPath
-                    let shouldInclude: Bool
-                    if let sub = subPath {
-                        let isInSubPath = itemPath.hasPrefix("\(sub)/")
-                        let matchesPattern =
-                            patterns.isEmpty || patterns.contains { itemPath.hasPrefix($0) }
-                        let isMetadata =
-                            itemPath.hasSuffix(".json") || itemPath.hasSuffix(".model") || itemPath.hasSuffix(".bin")
-                        shouldInclude = isInSubPath && (matchesPattern || isMetadata)
-                    } else {
-                        shouldInclude =
-                            patterns.isEmpty || patterns.contains { itemPath.hasPrefix($0) }
-                            || itemPath.hasSuffix(".json") || itemPath.hasSuffix(".txt")
-                    }
-                    if shouldInclude {
-                        let fileSize = item["size"] as? Int ?? -1
-                        filesToDownload.append((path: itemPath, size: fileSize))
-                    }
+        // File selection rules, moved verbatim from the pre-#765 inline listers;
+        // DownloadFilterCharacterizationTests pins them.
+        let include: (String, Bool) -> Bool = { itemPath, isDirectory in
+            if isDirectory {
+                // For subPath repos, only process paths within the subPath
+                if let sub = subPath {
+                    return itemPath == sub || itemPath.hasPrefix("\(sub)/")
+                        || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
                 }
+                return patterns.isEmpty
+                    || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
             }
-        }
-
-        // Pull root-level files whose basename is in `names`. Some subPath repos
-        // keep shared auxiliary files at the repo root rather than inside the
-        // precision subdirectory, so a subPath-only traversal misses them.
-        func listRootFiles(matching names: Set<String>) async throws {
-            let dirURL = try ModelRegistry.apiModels(repo.remotePath, "tree/main")
-            let request = authorizedRequest(url: dirURL)
-            let (dirData, response) = try await listingSession.data(for: request)
-
-            if let httpResponse = response as? HTTPURLResponse {
-                try HFClient.checkRateLimit(httpResponse, context: "listing root files")
+            // For subPath repos, only include files within the subPath
+            if let sub = subPath {
+                let isInSubPath = itemPath.hasPrefix("\(sub)/")
+                let matchesPattern =
+                    patterns.isEmpty || patterns.contains { itemPath.hasPrefix($0) }
+                let isMetadata =
+                    itemPath.hasSuffix(".json") || itemPath.hasSuffix(".model") || itemPath.hasSuffix(".bin")
+                return isInSubPath && (matchesPattern || isMetadata)
             }
-
-            try HFClient.validateJSONResponse(dirData, path: "")
-
-            guard let items = try JSONSerialization.jsonObject(with: dirData) as? [[String: Any]] else {
-                throw HuggingFaceDownloadError.invalidResponse
-            }
-
-            for item in items {
-                guard let itemPath = item["path"] as? String,
-                    item["type"] as? String == "file",
-                    names.contains((itemPath as NSString).lastPathComponent)
-                else { continue }
-                let fileSize = item["size"] as? Int ?? -1
-                filesToDownload.append((path: itemPath, size: fileSize))
-            }
+            return patterns.isEmpty || patterns.contains { itemPath.hasPrefix($0) }
+                || itemPath.hasSuffix(".json") || itemPath.hasSuffix(".txt")
         }
 
         // Start listing from subPath if specified, otherwise from root
         progressHandler?(DownloadProgress(fractionCompleted: 0.0, phase: .listing))
-        try await listDirectory(path: subPath ?? "")
+        let treeFetch = HFTreeLister.fetch(using: listingSession)
+        var filesToDownload: [(path: String, size: Int)] =
+            try await HFTreeLister.listTree(
+                repoRemotePath: repo.remotePath,
+                startingAt: subPath ?? "",
+                include: include,
+                fetch: treeFetch
+            ).map { (path: $0.path, size: $0.size) }
 
         // Some subPath repos keep shared auxiliary files (e.g. vocab.json) at the
         // repo *root* rather than inside the precision subdirectory — the bundled
@@ -537,7 +477,17 @@ public class DownloadUtils {
                     && !collected.contains((model as NSString).lastPathComponent)
             }
             if !missingAux.isEmpty {
-                try await listRootFiles(matching: Set(missingAux))
+                // Root-level pass only: directories are pruned, files match by
+                // basename (moved verbatim from the old listRootFiles).
+                let names = Set(missingAux.map { ($0 as NSString).lastPathComponent })
+                filesToDownload +=
+                    try await HFTreeLister.listTree(
+                        repoRemotePath: repo.remotePath,
+                        include: { itemPath, isDirectory in
+                            !isDirectory && names.contains((itemPath as NSString).lastPathComponent)
+                        },
+                        fetch: treeFetch
+                    ).map { (path: $0.path, size: $0.size) }
             }
         }
 
@@ -930,40 +880,13 @@ public class DownloadUtils {
     ) async throws {
         try ensureOnlineAllowed("downloadSubdirectory(\(repo.folderName)/\(subdirectory))")
         progressHandler?(DownloadProgress(fractionCompleted: 0.0, phase: .listing))
-        var filesToDownload: [(path: String, size: Int)] = []
-
-        func listFiles(at path: String) async throws {
-            let dirURL = try ModelRegistry.apiModels(repo.remotePath, "tree/main/\(path)")
-            let (dirData, response) = try await fetchWithAuth(from: dirURL)
-            if let httpResponse = response as? HTTPURLResponse {
-                try HFClient.checkRateLimit(httpResponse, context: "listing files in \(path)")
-            }
-
-            // Validate that response is JSON, not HTML error page
-            try HFClient.validateJSONResponse(dirData, path: path)
-
-            guard let items = try JSONSerialization.jsonObject(with: dirData) as? [[String: Any]] else {
-                throw HuggingFaceDownloadError.invalidResponse
-            }
-            for item in items {
-                guard let itemPath = item["path"] as? String,
-                    let itemType = item["type"] as? String
-                else { continue }
-
-                if shouldSkip?(itemPath) == true {
-                    continue
-                }
-
-                if itemType == "directory" {
-                    try await listFiles(at: itemPath)
-                } else if itemType == "file" {
-                    let fileSize = item["size"] as? Int ?? -1
-                    filesToDownload.append((path: itemPath, size: fileSize))
-                }
-            }
-        }
-
-        try await listFiles(at: subdirectory)
+        let filesToDownload: [(path: String, size: Int)] =
+            try await HFTreeLister.listTree(
+                repoRemotePath: repo.remotePath,
+                startingAt: subdirectory,
+                include: { itemPath, _ in shouldSkip?(itemPath) != true },
+                fetch: HFTreeLister.fetch(using: sharedSession)
+            ).map { (path: $0.path, size: $0.size) }
         let totalFiles = filesToDownload.count
         logger.info("Found \(totalFiles) files in \(subdirectory)")
 

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -426,7 +426,8 @@ public class DownloadUtils {
             }
         }
 
-        // File selection rules, moved verbatim from the pre-#765 inline listers;
+        // File selection rules for repo downloads (subPath scoping, required-
+        // model patterns, metadata-extension allowances);
         // DownloadFilterCharacterizationTests pins them.
         let include: (String, Bool) -> Bool = { itemPath, isDirectory in
             if isDirectory {
@@ -454,13 +455,12 @@ public class DownloadUtils {
         // Start listing from subPath if specified, otherwise from root
         progressHandler?(DownloadProgress(fractionCompleted: 0.0, phase: .listing))
         let treeFetch = HFTreeLister.fetch(using: listingSession)
-        var filesToDownload: [(path: String, size: Int)] =
-            try await HFTreeLister.listTree(
-                repoRemotePath: repo.remotePath,
-                startingAt: subPath ?? "",
-                include: include,
-                fetch: treeFetch
-            ).map { (path: $0.path, size: $0.size) }
+        var filesToDownload: [RemoteFile] = try await HFTreeLister.listTree(
+            repoRemotePath: repo.remotePath,
+            startingAt: subPath ?? "",
+            include: include,
+            fetch: treeFetch
+        )
 
         // Some subPath repos keep shared auxiliary files (e.g. vocab.json) at the
         // repo *root* rather than inside the precision subdirectory — the bundled
@@ -477,17 +477,20 @@ public class DownloadUtils {
                     && !collected.contains((model as NSString).lastPathComponent)
             }
             if !missingAux.isEmpty {
-                // Root-level pass only: directories are pruned, files match by
-                // basename (moved verbatim from the old listRootFiles).
-                let names = Set(missingAux.map { ($0 as NSString).lastPathComponent })
-                filesToDownload +=
-                    try await HFTreeLister.listTree(
-                        repoRemotePath: repo.remotePath,
-                        include: { itemPath, isDirectory in
-                            !isDirectory && names.contains((itemPath as NSString).lastPathComponent)
-                        },
-                        fetch: treeFetch
-                    ).map { (path: $0.path, size: $0.size) }
+                // Root-level pass only: directories are pruned; a root file is
+                // pulled when its name equals a missing required aux file's
+                // FULL name. Slash-containing required paths (e.g.
+                // voices/zf_001.bin) therefore never match a root file — a
+                // same-named root file would land at the wrong local path, so
+                // the loud modelNotFound from the verify pass is preferable.
+                let names = Set(missingAux)
+                filesToDownload += try await HFTreeLister.listTree(
+                    repoRemotePath: repo.remotePath,
+                    include: { itemPath, isDirectory in
+                        !isDirectory && names.contains((itemPath as NSString).lastPathComponent)
+                    },
+                    fetch: treeFetch
+                )
             }
         }
 
@@ -880,13 +883,12 @@ public class DownloadUtils {
     ) async throws {
         try ensureOnlineAllowed("downloadSubdirectory(\(repo.folderName)/\(subdirectory))")
         progressHandler?(DownloadProgress(fractionCompleted: 0.0, phase: .listing))
-        let filesToDownload: [(path: String, size: Int)] =
-            try await HFTreeLister.listTree(
-                repoRemotePath: repo.remotePath,
-                startingAt: subdirectory,
-                include: { itemPath, _ in shouldSkip?(itemPath) != true },
-                fetch: HFTreeLister.fetch(using: sharedSession)
-            ).map { (path: $0.path, size: $0.size) }
+        let filesToDownload: [RemoteFile] = try await HFTreeLister.listTree(
+            repoRemotePath: repo.remotePath,
+            startingAt: subdirectory,
+            include: { itemPath, _ in shouldSkip?(itemPath) != true },
+            fetch: HFTreeLister.fetch(using: sharedSession)
+        )
         let totalFiles = filesToDownload.count
         logger.info("Found \(totalFiles) files in \(subdirectory)")
 

--- a/Sources/FluidAudio/Shared/Download/HFClient.swift
+++ b/Sources/FluidAudio/Shared/Download/HFClient.swift
@@ -60,6 +60,46 @@ enum HFClient {
         return nil
     }
 
+    /// Parse a pagination cursor from a `Link` header's `rel="next"` entry
+    /// (the HF APIs paginate this way; verified live in #765 Wave 0).
+    ///
+    /// Tolerates the RFC 8288 shapes a naive split breaks on: target URLs
+    /// containing `,`/`;` (legal inside `<…>`), unquoted `rel=next`, and
+    /// multi-value `rel="next last"`. Returns nil when there is no next page.
+    static func nextPageURL(from response: HTTPURLResponse) -> URL? {
+        guard let link = response.value(forHTTPHeaderField: "Link") else { return nil }
+
+        var rest = Substring(link)
+        while let start = rest.firstIndex(of: "<") {
+            guard let end = rest[start...].firstIndex(of: ">") else { return nil }
+            let target = rest[rest.index(after: start)..<end]
+
+            // Parameters run from after the target to the next top-level comma
+            // (commas inside a later <…> can't be reached: we stop at the first).
+            let afterTarget = rest[rest.index(after: end)...]
+            let paramsEnd = afterTarget.firstIndex(of: ",") ?? afterTarget.endIndex
+            let params = afterTarget[..<paramsEnd].lowercased()
+
+            if let relRange = params.range(of: "rel=") {
+                var value = params[relRange.upperBound...]
+                if let paramBreak = value.firstIndex(of: ";") {
+                    value = value[..<paramBreak]
+                }
+                let relations =
+                    value
+                    .trimmingCharacters(in: .whitespaces)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                    .split(separator: " ")
+                if relations.contains("next") {
+                    return URL(string: String(target))
+                }
+            }
+
+            rest = afterTarget[paramsEnd...].dropFirst()
+        }
+        return nil
+    }
+
     /// `true` when `data` begins with HTML/XML markup — the single HTML
     /// sniffer for the download stack (error pages served with 200s).
     static func looksLikeHTML(_ data: Data) -> Bool {

--- a/Sources/FluidAudio/Shared/Download/HFTreeLister.swift
+++ b/Sources/FluidAudio/Shared/Download/HFTreeLister.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// A file discovered in a HuggingFace repository tree listing.
+struct RemoteFile: Equatable, Sendable {
+    let path: String
+    /// Size in bytes as reported by the tree API; `-1` when not reported.
+    let size: Int
+}
+
+/// The one tree-listing implementation for the download stack (#765 Wave 3),
+/// replacing the two divergent recursive walkers in `downloadRepo` and
+/// `downloadSubdirectory`. Follows the HF tree API's `Link` pagination cursor,
+/// so directories with more entries than one API page (1,000 by default) no
+/// longer silently drop files.
+enum HFTreeLister {
+
+    /// Executes one listing request; injectable so fixtures can serve canned
+    /// pages. Returns the final HTTP response (headers carry the cursor).
+    typealias Fetch = (URL) async throws -> (Data, HTTPURLResponse)
+
+    /// Production fetch: authorized request on `session`. Non-HTTP responses
+    /// are rejected as `invalidResponse` — an explicit decision; the old
+    /// listers silently skipped the rate-limit check on non-HTTP responses.
+    static func fetch(using session: URLSession) -> Fetch {
+        { url in
+            let request = HFClient.authorizedRequest(url: url)
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw HFDownload.DownloadError.invalidResponse
+            }
+            return (data, httpResponse)
+        }
+    }
+
+    /// Recursively list files under `startingAt` (empty = repo root),
+    /// depth-first in server order, following pagination cursors within each
+    /// directory.
+    ///
+    /// `include` is consulted for every item: for directories, returning
+    /// false prunes the whole subtree without recursing; for files, false
+    /// excludes the file.
+    static func listTree(
+        repoRemotePath: String,
+        startingAt path: String = "",
+        include: (_ itemPath: String, _ isDirectory: Bool) -> Bool = { _, _ in true },
+        fetch: Fetch
+    ) async throws -> [RemoteFile] {
+        var files: [RemoteFile] = []
+        let apiPath = path.isEmpty ? "tree/main" : "tree/main/\(path)"
+        var pageURL: URL? = try ModelRegistry.apiModels(repoRemotePath, apiPath)
+
+        while let url = pageURL {
+            let (data, response) = try await fetch(url)
+            try HFClient.checkRateLimit(
+                response,
+                context: path.isEmpty ? "listing files" : "listing files in \(path)")
+            try HFClient.validateJSONResponse(data, path: path)
+            guard let items = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+                throw HFDownload.DownloadError.invalidResponse
+            }
+
+            for item in items {
+                guard let itemPath = item["path"] as? String,
+                    let itemType = item["type"] as? String
+                else { continue }
+
+                if itemType == "directory" {
+                    guard include(itemPath, true) else { continue }
+                    files += try await listTree(
+                        repoRemotePath: repoRemotePath,
+                        startingAt: itemPath,
+                        include: include,
+                        fetch: fetch
+                    )
+                } else if itemType == "file" {
+                    guard include(itemPath, false) else { continue }
+                    files.append(RemoteFile(path: itemPath, size: item["size"] as? Int ?? -1))
+                }
+            }
+
+            pageURL = nextPageURL(from: response)
+        }
+        return files
+    }
+
+    /// Parse the HF tree API's pagination cursor from a
+    /// `Link: <url>; rel="next"` header (verified against the live API in
+    /// #765 Wave 0). Returns nil when there is no next page.
+    static func nextPageURL(from response: HTTPURLResponse) -> URL? {
+        guard let link = response.value(forHTTPHeaderField: "Link") else { return nil }
+        // A Link header may carry multiple comma-separated entries.
+        for entry in link.split(separator: ",") {
+            let parts = entry.split(separator: ";")
+            guard
+                parts.dropFirst().contains(where: {
+                    $0.trimmingCharacters(in: .whitespaces) == "rel=\"next\""
+                }),
+                let target = parts.first,
+                let start = target.firstIndex(of: "<"),
+                let end = target.firstIndex(of: ">"),
+                start < end
+            else { continue }
+            return URL(string: String(target[target.index(after: start)..<end]))
+        }
+        return nil
+    }
+}

--- a/Sources/FluidAudio/Shared/Download/HFTreeLister.swift
+++ b/Sources/FluidAudio/Shared/Download/HFTreeLister.swift
@@ -14,15 +14,22 @@ struct RemoteFile: Equatable, Sendable {
 /// longer silently drop files.
 enum HFTreeLister {
 
+    private static let logger = AppLogger(category: "HFTreeLister")
+
     /// Executes one listing request; injectable so fixtures can serve canned
     /// pages. Returns the final HTTP response (headers carry the cursor).
     typealias Fetch = (URL) async throws -> (Data, HTTPURLResponse)
 
-    /// Production fetch: authorized request on `session`. Non-HTTP responses
-    /// are rejected as `invalidResponse` — an explicit decision; the old
-    /// listers silently skipped the rate-limit check on non-HTTP responses.
+    /// Production fetch: authorized request on `session`, re-checking
+    /// `enforceOffline` per request so flipping the flag mid-listing stops the
+    /// walk at the next fetch. Non-HTTP responses are rejected as
+    /// `invalidResponse` — an explicit decision; the old listers silently
+    /// skipped the rate-limit check on non-HTTP responses.
     static func fetch(using session: URLSession) -> Fetch {
         { url in
+            guard !DownloadUtils.enforceOffline else {
+                throw DownloadUtils.OfflineError.networkDisabled(operation: "listTree(\(url.path))")
+            }
             let request = HFClient.authorizedRequest(url: url)
             let (data, response) = try await session.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
@@ -42,14 +49,24 @@ enum HFTreeLister {
     static func listTree(
         repoRemotePath: String,
         startingAt path: String = "",
-        include: (_ itemPath: String, _ isDirectory: Bool) -> Bool = { _, _ in true },
+        include: (_ itemPath: String, _ isDirectory: Bool) -> Bool,
         fetch: Fetch
     ) async throws -> [RemoteFile] {
         var files: [RemoteFile] = []
         let apiPath = path.isEmpty ? "tree/main" : "tree/main/\(path)"
         var pageURL: URL? = try ModelRegistry.apiModels(repoRemotePath, apiPath)
+        // Guards the walk against a server echoing a cursor it already served
+        // (the old one-request-per-directory walkers could not loop).
+        var visitedPages: Set<URL> = []
 
         while let url = pageURL {
+            guard visitedPages.insert(url).inserted else {
+                logger.warning(
+                    "Pagination cursor for \(path.isEmpty ? "repo root" : path) repeats \(url.absoluteString); stopping after \(visitedPages.count) page(s)."
+                )
+                break
+            }
+
             let (data, response) = try await fetch(url)
             try HFClient.checkRateLimit(
                 response,
@@ -78,30 +95,8 @@ enum HFTreeLister {
                 }
             }
 
-            pageURL = nextPageURL(from: response)
+            pageURL = HFClient.nextPageURL(from: response)
         }
         return files
-    }
-
-    /// Parse the HF tree API's pagination cursor from a
-    /// `Link: <url>; rel="next"` header (verified against the live API in
-    /// #765 Wave 0). Returns nil when there is no next page.
-    static func nextPageURL(from response: HTTPURLResponse) -> URL? {
-        guard let link = response.value(forHTTPHeaderField: "Link") else { return nil }
-        // A Link header may carry multiple comma-separated entries.
-        for entry in link.split(separator: ",") {
-            let parts = entry.split(separator: ";")
-            guard
-                parts.dropFirst().contains(where: {
-                    $0.trimmingCharacters(in: .whitespaces) == "rel=\"next\""
-                }),
-                let target = parts.first,
-                let start = target.firstIndex(of: "<"),
-                let end = target.firstIndex(of: ">"),
-                start < end
-            else { continue }
-            return URL(string: String(target[target.index(after: start)..<end]))
-        }
-        return nil
     }
 }

--- a/Tests/FluidAudioTests/Shared/DownloadFilterCharacterizationTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadFilterCharacterizationTests.swift
@@ -159,6 +159,61 @@ final class DownloadFilterCharacterizationTests: XCTestCase {
         )
     }
 
+    // MARK: - Root fallback matches full names only
+
+    /// The #649 root fallback pulls a root file only when its name equals a
+    /// missing required aux file's FULL name. A slash-containing required
+    /// path (KokoroAne-zh's `voices/zf_001.bin`) must never match a
+    /// same-basename root file — that would download wrong-variant content
+    /// to the wrong local path instead of failing loudly with modelNotFound.
+    func testRootFallbackNeverMatchesSlashContainingAuxByBasename() async throws {
+        let sub = "ANE-zh"
+        let voice = ModelNames.KokoroAne.defaultVoiceFileZh  // "voices/zf_001.bin"
+        XCTAssertTrue(voice.contains("/"), "fixture requires a slash-containing aux model")
+        let decoyName = (voice as NSString).lastPathComponent
+
+        // Serve every required model EXCEPT the voice; plant a same-basename
+        // decoy at the repo root.
+        var subItems: [[String: Any]] = [
+            ["path": "\(sub)/\(ModelNames.KokoroAne.vocab)", "type": "file", "size": 10],
+            ["path": "\(sub)/g2pw", "type": "directory"],
+        ]
+        var trees: [String: [[String: Any]]] = [:]
+        for model in ModelNames.KokoroAne.requiredCoreMLModels {
+            subItems.append(["path": "\(sub)/\(model)", "type": "directory"])
+            trees["\(sub)/\(model)"] = [
+                ["path": "\(sub)/\(model)/coremldata.bin", "type": "file", "size": 10]
+            ]
+        }
+        let g2pw = ModelNames.KokoroAne.g2pwModelZh  // "g2pw/g2pw.mlmodelc"
+        trees["\(sub)/g2pw"] = [["path": "\(sub)/\(g2pw)", "type": "directory"]]
+        trees["\(sub)/\(g2pw)"] = [
+            ["path": "\(sub)/\(g2pw)/coremldata.bin", "type": "file", "size": 10]
+        ]
+        trees[sub] = subItems
+        trees[""] = [
+            ["path": decoyName, "type": "file", "size": 10],
+            ["path": sub, "type": "directory"],
+        ]
+        TreeStubURLProtocol.trees = trees
+        TreeStubURLProtocol.fileBody = body(10)
+
+        do {
+            try await DownloadUtils.downloadRepo(
+                .kokoroAneZh, to: workDir, configuration: stubConfiguration)
+            XCTFail("expected modelNotFound for the missing voice")
+        } catch DownloadUtils.HuggingFaceDownloadError.modelNotFound(let path) {
+            XCTAssertEqual(path, voice)
+        }
+
+        // Pinned: the decoy must NOT have been downloaded to the repo root.
+        let repoPath = workDir.appendingPathComponent(Repo.kokoroAneZh.folderName)
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: repoPath.appendingPathComponent(decoyName).path),
+            "a same-basename root file must not satisfy a slash-containing required path")
+    }
+
     // MARK: - additionalModelNames (#524)
 
     func testAdditionalModelNamesAreUnionedIntoSelection() async throws {

--- a/Tests/FluidAudioTests/Shared/HFTreeListerTests.swift
+++ b/Tests/FluidAudioTests/Shared/HFTreeListerTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Unit tests for the unified tree lister (#765 Wave 3): recursive walking,
+/// include-based pruning, Link-header pagination (confirmed against the live
+/// HF API in Wave 0), and typed errors for rate-limit/HTML/malformed pages.
+/// The repo-specific filter *rules* are pinned separately by
+/// `DownloadFilterCharacterizationTests` through `downloadRepo`.
+final class HFTreeListerTests: XCTestCase {
+
+    private static let repo = "FluidInference/test-repo"
+
+    /// Canned fetch: pages keyed by absolute URL; records request order.
+    private final class PageServer {
+        private var pages: [String: (Data, HTTPURLResponse)] = [:]
+        private(set) var requested: [String] = []
+
+        func addPage(
+            url: String, items: [[String: Any]], status: Int = 200, nextPage: String? = nil
+        ) throws {
+            var headers: [String: String] = [:]
+            if let nextPage {
+                headers["Link"] = "<\(nextPage)>; rel=\"next\""
+            }
+            let response = HTTPURLResponse(
+                url: URL(string: url)!, statusCode: status, httpVersion: "HTTP/1.1",
+                headerFields: headers)!
+            pages[url] = (try JSONSerialization.data(withJSONObject: items), response)
+        }
+
+        func addRawPage(url: String, body: Data, status: Int = 200) {
+            let response = HTTPURLResponse(
+                url: URL(string: url)!, statusCode: status, httpVersion: "HTTP/1.1",
+                headerFields: [:])!
+            pages[url] = (body, response)
+        }
+
+        var fetch: HFTreeLister.Fetch {
+            { url in
+                self.requested.append(url.absoluteString)
+                guard let page = self.pages[url.absoluteString] else {
+                    throw HFDownload.DownloadError.invalidResponse
+                }
+                return page
+            }
+        }
+    }
+
+    private func treeURL(_ path: String = "") -> String {
+        let apiPath = path.isEmpty ? "tree/main" : "tree/main/\(path)"
+        // Mirrors ModelRegistry.apiModels(repo, apiPath)
+        return (try! ModelRegistry.apiModels(Self.repo, apiPath)).absoluteString
+    }
+
+    // MARK: - Walking + pruning
+
+    func testRecursiveWalkWithPruningAndFileExclusion() async throws {
+        let server = PageServer()
+        try server.addPage(
+            url: treeURL(),
+            items: [
+                ["path": "keep.mlmodelc", "type": "directory"],
+                ["path": "prune.mlmodelc", "type": "directory"],
+                ["path": "root.json", "type": "file", "size": 7],
+                ["path": "excluded.txt", "type": "file", "size": 9],
+            ])
+        try server.addPage(
+            url: treeURL("keep.mlmodelc"),
+            items: [
+                ["path": "keep.mlmodelc/coremldata.bin", "type": "file", "size": 42],
+                ["path": "keep.mlmodelc/weights", "type": "directory"],
+            ])
+        try server.addPage(
+            url: treeURL("keep.mlmodelc/weights"),
+            items: [["path": "keep.mlmodelc/weights/weight.bin", "type": "file"]])
+
+        let files = try await HFTreeLister.listTree(
+            repoRemotePath: Self.repo,
+            include: { path, isDirectory in
+                if isDirectory { return path != "prune.mlmodelc" }
+                return path != "excluded.txt"
+            },
+            fetch: server.fetch
+        )
+
+        XCTAssertEqual(
+            files,
+            [
+                RemoteFile(path: "keep.mlmodelc/coremldata.bin", size: 42),
+                // Size defaults to -1 when the API omits it.
+                RemoteFile(path: "keep.mlmodelc/weights/weight.bin", size: -1),
+                RemoteFile(path: "root.json", size: 7),
+            ])
+        XCTAssertFalse(
+            server.requested.contains(treeURL("prune.mlmodelc")),
+            "a pruned directory must not be fetched at all")
+    }
+
+    // MARK: - Pagination
+
+    func testFollowsLinkCursorAcrossPagesWithinADirectory() async throws {
+        let server = PageServer()
+        let cursorURL = treeURL() + "?cursor=abc123&limit=2"
+        try server.addPage(
+            url: treeURL(),
+            items: [
+                ["path": "a.bin", "type": "file", "size": 1],
+                ["path": "sub", "type": "directory"],
+            ],
+            nextPage: cursorURL)
+        try server.addPage(
+            url: cursorURL,
+            items: [["path": "z.bin", "type": "file", "size": 3]])
+        try server.addPage(
+            url: treeURL("sub"),
+            items: [["path": "sub/b.bin", "type": "file", "size": 2]])
+
+        let files = try await HFTreeLister.listTree(
+            repoRemotePath: Self.repo, fetch: server.fetch)
+
+        XCTAssertEqual(
+            files,
+            [
+                RemoteFile(path: "a.bin", size: 1),
+                RemoteFile(path: "sub/b.bin", size: 2),
+                RemoteFile(path: "z.bin", size: 3),
+            ],
+            "page-2 entries must be walked; pre-pagination listers silently dropped them")
+        XCTAssertEqual(server.requested.last, cursorURL)
+    }
+
+    func testNextPageURLParsesMultiEntryLinkHeaders() {
+        func response(link: String?) -> HTTPURLResponse {
+            var headers: [String: String] = [:]
+            if let link { headers["Link"] = link }
+            return HTTPURLResponse(
+                url: URL(string: "https://example.test")!, statusCode: 200,
+                httpVersion: "HTTP/1.1", headerFields: headers)!
+        }
+
+        XCTAssertNil(HFTreeLister.nextPageURL(from: response(link: nil)))
+        XCTAssertEqual(
+            HFTreeLister.nextPageURL(
+                from: response(link: "<https://hf.co/api/x?cursor=abc>; rel=\"next\""))?
+                .absoluteString,
+            "https://hf.co/api/x?cursor=abc")
+        XCTAssertEqual(
+            HFTreeLister.nextPageURL(
+                from: response(
+                    link: "<https://hf.co/first>; rel=\"first\", <https://hf.co/n>; rel=\"next\""))?
+                .absoluteString,
+            "https://hf.co/n")
+        XCTAssertNil(
+            HFTreeLister.nextPageURL(from: response(link: "<https://hf.co/p>; rel=\"prev\"")))
+    }
+
+    // MARK: - Typed errors
+
+    func testRateLimitedPageThrowsTypedError() async throws {
+        let server = PageServer()
+        try server.addPage(url: treeURL(), items: [], status: 429)
+
+        do {
+            _ = try await HFTreeLister.listTree(repoRemotePath: Self.repo, fetch: server.fetch)
+            XCTFail("expected rateLimited")
+        } catch HFDownload.DownloadError.rateLimited(let statusCode, _) {
+            XCTAssertEqual(statusCode, 429)
+        }
+    }
+
+    func testHTMLErrorPageThrowsTypedError() async throws {
+        let server = PageServer()
+        server.addRawPage(url: treeURL(), body: Data("<!DOCTYPE html><html>err</html>".utf8))
+
+        do {
+            _ = try await HFTreeLister.listTree(repoRemotePath: Self.repo, fetch: server.fetch)
+            XCTFail("expected htmlErrorResponse")
+        } catch HFDownload.DownloadError.htmlErrorResponse {
+            // expected
+        }
+    }
+
+    func testMalformedJSONThrowsInvalidResponse() async throws {
+        let server = PageServer()
+        server.addRawPage(url: treeURL(), body: Data("{\"not\": \"an array\"}".utf8))
+
+        do {
+            _ = try await HFTreeLister.listTree(repoRemotePath: Self.repo, fetch: server.fetch)
+            XCTFail("expected invalidResponse")
+        } catch HFDownload.DownloadError.invalidResponse {
+            // expected
+        }
+    }
+}

--- a/Tests/FluidAudioTests/Shared/HFTreeListerTests.swift
+++ b/Tests/FluidAudioTests/Shared/HFTreeListerTests.swift
@@ -118,7 +118,7 @@ final class HFTreeListerTests: XCTestCase {
             items: [["path": "sub/b.bin", "type": "file", "size": 2]])
 
         let files = try await HFTreeLister.listTree(
-            repoRemotePath: Self.repo, fetch: server.fetch)
+            repoRemotePath: Self.repo, include: { _, _ in true }, fetch: server.fetch)
 
         XCTAssertEqual(
             files,
@@ -131,29 +131,90 @@ final class HFTreeListerTests: XCTestCase {
         XCTAssertEqual(server.requested.last, cursorURL)
     }
 
-    func testNextPageURLParsesMultiEntryLinkHeaders() {
-        func response(link: String?) -> HTTPURLResponse {
+    func testNextPageURLParsesLinkHeaderShapes() {
+        func next(_ link: String?) -> String? {
             var headers: [String: String] = [:]
             if let link { headers["Link"] = link }
-            return HTTPURLResponse(
+            let response = HTTPURLResponse(
                 url: URL(string: "https://example.test")!, statusCode: 200,
                 httpVersion: "HTTP/1.1", headerFields: headers)!
+            return HFClient.nextPageURL(from: response)?.absoluteString
         }
 
-        XCTAssertNil(HFTreeLister.nextPageURL(from: response(link: nil)))
+        XCTAssertNil(next(nil))
+        XCTAssertEqual(next("<https://hf.co/api/x?cursor=abc>; rel=\"next\""), "https://hf.co/api/x?cursor=abc")
         XCTAssertEqual(
-            HFTreeLister.nextPageURL(
-                from: response(link: "<https://hf.co/api/x?cursor=abc>; rel=\"next\""))?
-                .absoluteString,
-            "https://hf.co/api/x?cursor=abc")
-        XCTAssertEqual(
-            HFTreeLister.nextPageURL(
-                from: response(
-                    link: "<https://hf.co/first>; rel=\"first\", <https://hf.co/n>; rel=\"next\""))?
-                .absoluteString,
+            next("<https://hf.co/first>; rel=\"first\", <https://hf.co/n>; rel=\"next\""),
             "https://hf.co/n")
-        XCTAssertNil(
-            HFTreeLister.nextPageURL(from: response(link: "<https://hf.co/p>; rel=\"prev\"")))
+        XCTAssertNil(next("<https://hf.co/p>; rel=\"prev\""))
+        // RFC 8288 shapes a naive split breaks on:
+        XCTAssertEqual(
+            next("<https://hf.co/x?cursor=a,b;c=d>; rel=\"next\""),
+            "https://hf.co/x?cursor=a,b;c=d",
+            "commas/semicolons are legal inside the <target>")
+        XCTAssertEqual(next("<https://hf.co/n>; rel=next"), "https://hf.co/n", "unquoted rel token")
+        XCTAssertEqual(
+            next("<https://hf.co/n>; rel=\"next last\""), "https://hf.co/n", "multi-value rel")
+        XCTAssertNil(next("<https://hf.co/n>; rel=\"nexterior\""), "no substring false-positives")
+    }
+
+    func testPaginationCursorCycleTerminates() async throws {
+        let server = PageServer()
+        // Server echoes the SAME page URL as its own next cursor.
+        try server.addPage(
+            url: treeURL(),
+            items: [["path": "a.bin", "type": "file", "size": 1]],
+            nextPage: treeURL())
+
+        let files = try await HFTreeLister.listTree(
+            repoRemotePath: Self.repo, include: { _, _ in true }, fetch: server.fetch)
+
+        XCTAssertEqual(files, [RemoteFile(path: "a.bin", size: 1)])
+        XCTAssertEqual(server.requested.count, 1, "a repeating cursor must not refetch forever")
+    }
+
+    // MARK: - Pagination through the real fetch path
+
+    /// End-to-end: downloadRepo → configuration seam → HFTreeLister.fetch →
+    /// URLSession → Link cursor. The unit tests above bypass the session via
+    /// an injected Fetch; this pins the production wiring.
+    func testDownloadRepoFollowsPaginationThroughRealFetchPath() async throws {
+        let workDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("lister-e2e-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workDir) }
+        LinkedTreeStubURLProtocol.reset()
+
+        let model = ModelNames.VAD.sileroVadFile
+        let root = try ModelRegistry.apiModels(Repo.vad.remotePath, "tree/main").absoluteString
+        let cursor = root + "?cursor=page2"
+        let modelDir = try ModelRegistry.apiModels(Repo.vad.remotePath, "tree/main/\(model)")
+            .absoluteString
+
+        LinkedTreeStubURLProtocol.addJSONPage(
+            url: root,
+            items: [["path": model, "type": "directory"]],
+            linkNext: cursor)
+        LinkedTreeStubURLProtocol.addJSONPage(
+            url: cursor,
+            items: [["path": "config.json", "type": "file", "size": 10]])
+        LinkedTreeStubURLProtocol.addJSONPage(
+            url: modelDir,
+            items: [["path": "\(model)/coremldata.bin", "type": "file", "size": 10]])
+        LinkedTreeStubURLProtocol.fileBody = Data(String(repeating: "x", count: 10).utf8)
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [LinkedTreeStubURLProtocol.self]
+        try await DownloadUtils.downloadRepo(.vad, to: workDir, configuration: config)
+
+        let repoPath = workDir.appendingPathComponent(Repo.vad.folderName)
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: repoPath.appendingPathComponent("config.json").path),
+            "the page-2 file must arrive through the real session-backed fetch")
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: repoPath.appendingPathComponent("\(model)/coremldata.bin").path))
     }
 
     // MARK: - Typed errors
@@ -163,7 +224,8 @@ final class HFTreeListerTests: XCTestCase {
         try server.addPage(url: treeURL(), items: [], status: 429)
 
         do {
-            _ = try await HFTreeLister.listTree(repoRemotePath: Self.repo, fetch: server.fetch)
+            _ = try await HFTreeLister.listTree(
+                repoRemotePath: Self.repo, include: { _, _ in true }, fetch: server.fetch)
             XCTFail("expected rateLimited")
         } catch HFDownload.DownloadError.rateLimited(let statusCode, _) {
             XCTAssertEqual(statusCode, 429)
@@ -175,7 +237,8 @@ final class HFTreeListerTests: XCTestCase {
         server.addRawPage(url: treeURL(), body: Data("<!DOCTYPE html><html>err</html>".utf8))
 
         do {
-            _ = try await HFTreeLister.listTree(repoRemotePath: Self.repo, fetch: server.fetch)
+            _ = try await HFTreeLister.listTree(
+                repoRemotePath: Self.repo, include: { _, _ in true }, fetch: server.fetch)
             XCTFail("expected htmlErrorResponse")
         } catch HFDownload.DownloadError.htmlErrorResponse {
             // expected
@@ -187,10 +250,90 @@ final class HFTreeListerTests: XCTestCase {
         server.addRawPage(url: treeURL(), body: Data("{\"not\": \"an array\"}".utf8))
 
         do {
-            _ = try await HFTreeLister.listTree(repoRemotePath: Self.repo, fetch: server.fetch)
+            _ = try await HFTreeLister.listTree(
+                repoRemotePath: Self.repo, include: { _, _ in true }, fetch: server.fetch)
             XCTFail("expected invalidResponse")
         } catch HFDownload.DownloadError.invalidResponse {
             // expected
         }
     }
+}
+
+// MARK: - Link-capable URLProtocol stub
+
+/// Like `TreeStubURLProtocol` but with per-URL responses that can carry a
+/// `Link` pagination header — the piece the Wave 1 stub can't express, needed
+/// to test pagination through the real session-backed fetch path.
+final class LinkedTreeStubURLProtocol: URLProtocol {
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var pages: [String: (data: Data, headers: [String: String])] = [:]
+    nonisolated(unsafe) private static var _fileBody = Data()
+
+    static var fileBody: Data {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _fileBody
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _fileBody = newValue
+        }
+    }
+
+    static func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        pages = [:]
+        _fileBody = Data()
+    }
+
+    static func addJSONPage(url: String, items: [[String: Any]], linkNext: String? = nil) {
+        guard let data = try? JSONSerialization.data(withJSONObject: items) else { return }
+        var headers: [String: String] = [:]
+        if let linkNext {
+            headers["Link"] = "<\(linkNext)>; rel=\"next\""
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        pages[url] = (data, headers)
+    }
+
+    private static func page(for url: String) -> (data: Data, headers: [String: String])? {
+        lock.lock()
+        defer { lock.unlock() }
+        return pages[url]
+    }
+
+    override static func canInit(with request: URLRequest) -> Bool { true }
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        let payload: Data
+        var headers: [String: String] = [:]
+        if let page = Self.page(for: url.absoluteString) {
+            payload = page.data
+            headers = page.headers
+        } else if url.path.contains("/resolve/main/") {
+            payload = Self.fileBody
+        } else {
+            payload = Data("[]".utf8)
+        }
+        headers["Content-Length"] = String(payload.count)
+
+        let response = HTTPURLResponse(
+            url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: headers)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
 }


### PR DESCRIPTION
Wave 3 of the #765 execution plan. **The Wave 1 filter fixtures (`DownloadFilterCharacterizationTests`) are the oracle for this PR and are untouched** — them passing unmodified proves the selection rules moved verbatim.

## What this does

**`Shared/Download/HFTreeLister.swift`** (new): one recursive, depth-first, server-order tree walker for both `downloadRepo` and `downloadSubdirectory`, replacing the two divergent inline implementations (flaw 7):

- `listTree(repoRemotePath:startingAt:include:fetch:)` — the `include` closure prunes directories (false = skip subtree, never fetched) and filters files
- `fetch` is injectable (unit fixtures) and defaults to `HFTreeLister.fetch(using:)`, honoring `downloadRepo`'s Wave 1 `configuration:` seam

**Pagination — the called-out correctness fix (flaw 9)**: Wave 0 confirmed live that the HF tree API paginates via a `Link: <…&cursor=…>; rel="next"` header (default page size 1,000). Neither old lister followed it, so any directory beyond one page silently dropped files. The walker now follows the cursor within each directory. Latent today (largest FluidInference repo directory ≈ 19 entries), but real for larger repos.

**Moved verbatim** (no cleanup, per the plan — even where the rules look quirky):
- `downloadRepo`'s subPath/pattern rules, the root-vs-subPath metadata-extension asymmetry, and the #649 root-aux fallback (now a root-level `listTree` with directories pruned and basename matching)
- `downloadSubdirectory`'s `shouldSkip` predicate (as an `include` closure)

`listDirectory`, `listRootFiles`, `listFiles` deleted — **−123 lines** from `DownloadUtils`.

## Deliberate deltas (2, both small)

1. Non-HTTP responses in the production fetch now throw `invalidResponse`; the old listers silently skipped the rate-limit check and attempted to parse anyway (flagged as an unexamined divergence in the Wave 2 review — resolved explicitly here).
2. Message drift: `listRootFiles`' rate-limit context `"listing root files"` folds into `"listing files"`.

## Tests

`HFTreeListerTests` (new): recursive walk + pruning (asserts pruned directories are **never fetched**), Link-cursor pagination across pages within a directory (the fixture the plan required), multi-entry `Link` header parsing, typed errors for 429/HTML/malformed pages, `size == -1` default.

## Verification gates on this PR

- Wave 1 oracle: zero edits (filter fixtures + progress sequences + offline suite)
- `download-smoke`: live cold download through the new lister
- Cold benchmarks (auto-triggered): baseline parity expected

Part of #765. Wave 4 (`FileDownloader`/`ModelCache`/`ProgressReporter`) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Self-review pass applied (`e4bd6e32`)

A 7-angle review surfaced 10 findings; all applied. The important one: **the review caught a real verbatim-rule violation** — the #649 root fallback had been silently widened from full-name matching to basename matching, which on kokoroAne-zh/ja repo shapes (`voices/zf_001.bin`) could download wrong-variant content to the wrong path instead of failing loudly. Reverted to exact pre-PR semantics and pinned with a new characterization fixture (kokoroAneZh + same-basename root decoy) — the Wave 1 fixtures missed this class because they only covered basename-only aux names.

Also applied:
- **Pagination cycle guard** — a repeated cursor stops the walk with a warning instead of looping forever (+ test)
- **Per-fetch offline enforcement** — `fetch(using:)` re-checks `enforceOffline` per request, restoring the invariant `downloadSubdirectory`'s old `fetchWithAuth`-based lister had (and extending it to `downloadRepo`'s walk)
- **Robust Link parsing, moved to `HFClient`** — tolerates `,`/`;` inside `<target>`, unquoted `rel=next`, multi-value `rel="next last"`; each silently disabled pagination under the naive split (+ parser cases)
- **Real-path pagination e2e** — `downloadRepo` → configuration seam → session-backed fetch → Link cursor, via a new Link-capable `URLProtocol` stub
- `[RemoteFile]` end-to-end (tuple-erasing maps gone; Wave 4's `FileDownloader` types on it); `include` no longer defaults to list-everything; comments no longer cite deleted symbols

Message-drift ledger for this PR (all message-only, no in-repo matchers): repo-walk non-root rate-limit contexts are now `"listing files in <path>"`, and the fallback's `"listing root files"` context folded into `"listing files"`.
