### PR TITLE
ci(download): source-key every model cache — all repos cold-download on download-stack PRs (#765)

### DIFF
--- a/.github/workflows/japanese-asr-benchmark.yml
+++ b/.github/workflows/japanese-asr-benchmark.yml
@@ -44,7 +44,7 @@ jobs:
             ~/Library/Caches/Homebrew
             /usr/local/Cellar/ffmpeg
             /opt/homebrew/Cellar/ffmpeg
-          key: ${{ runner.os }}-ja-asr-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/TdtJa*.swift', 'Sources/FluidAudio/ModelNames.swift') }}
+          key: ${{ runner.os }}-ja-asr-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/TdtJa*.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Install ffmpeg
         run: |

--- a/.github/workflows/nemotron-multilingual-benchmark.yml
+++ b/.github/workflows/nemotron-multilingual-benchmark.yml
@@ -54,7 +54,7 @@ jobs:
           path: |
             .build
             ~/Library/Application Support/FluidAudio
-          key: ${{ runner.os }}-nemotron-multi-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/**', 'Sources/FluidAudio/ModelNames.swift') }}
+          key: ${{ runner.os }}-nemotron-multi-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/**', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Build
         run: swift build -c release

--- a/.github/workflows/parakeet-eou-benchmark.yml
+++ b/.github/workflows/parakeet-eou-benchmark.yml
@@ -30,7 +30,7 @@ jobs:
             ~/Library/Caches/Homebrew
             /usr/local/Cellar/ffmpeg
             /opt/homebrew/Cellar/ffmpeg
-          key: ${{ runner.os }}-parakeet-eou-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/Frameworks/**', 'Sources/FluidAudio/ModelRegistry.swift', 'Sources/FluidAudio/ModelNames.swift') }}
+          key: ${{ runner.os }}-parakeet-eou-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/Frameworks/**', 'Sources/FluidAudio/ModelRegistry.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Install ffmpeg
         run: |

--- a/.github/workflows/pocket-tts-test.yml
+++ b/.github/workflows/pocket-tts-test.yml
@@ -28,7 +28,7 @@ jobs:
           path: |
             .build
             ~/.cache/fluidaudio/Models/pocket-tts
-          key: ${{ runner.os }}-pocket-tts-v2.1-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/TTS/PocketTTS/**', 'Sources/FluidAudio/ModelNames.swift') }}
+          key: ${{ runner.os }}-pocket-tts-v2.1-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/TTS/PocketTTS/**', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Build
         run: swift build -c release

--- a/.github/workflows/sortformer-benchmark.yml
+++ b/.github/workflows/sortformer-benchmark.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/Library/Application Support/FluidAudio/Models/diar-streaming-sortformer-coreml
-          key: ${{ runner.os }}-sortformer-models-high-latency
+          key: ${{ runner.os }}-sortformer-models-high-latency-${{ hashFiles('Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Cache AMI dataset
         uses: actions/cache@v4

--- a/.github/workflows/supertonic3-tts-test.yml
+++ b/.github/workflows/supertonic3-tts-test.yml
@@ -28,7 +28,7 @@ jobs:
           path: |
             .build
             ~/Library/Application Support/FluidAudio/Models/supertonic-3
-          key: ${{ runner.os }}-supertonic3-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/TTS/Supertonic3/**', 'Sources/FluidAudio/ModelNames.swift') }}
+          key: ${{ runner.os }}-supertonic3-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/TTS/Supertonic3/**', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Build
         run: swift build -c release


### PR DESCRIPTION
Extends #765 Wave 1's cache-key mechanism to **every** model cache, so the remaining refactor waves (4–6) get maximal live-download coverage.

## Before / after

Wave 1 source-keyed three model caches (ASR, diarizer, VAD) — on the wave PRs so far, those repos cold-downloaded through each wave's stack with the bots' baseline numbers (diarizer 15.1% DER on all three PRs, ~11–12s download stage proving real cache misses) as the bit-correctness record. The other six model caches stayed warm, meaning:

- the **subPath repo shape** (parakeet-eou `160ms/`) never cold-downloaded live on a wave PR — only through stubs/fixtures
- `sortformer-benchmark`'s key was fully static (never rotated at all)
- the `downloadSubdirectory` consumer (nemotron-multilingual, dynamic `<lang>/<tier>` paths) and the TTS paths never exercised cold

## Change

One-line key change in six workflows — append `hashFiles('Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**')` to the model-cache keys of: `parakeet-eou-benchmark`, `sortformer-benchmark`, `pocket-tts-test`, `supertonic3-tts-test`, `nemotron-multilingual-benchmark`, `japanese-asr-benchmark`.

Result: any PR touching the download stack cold-downloads **all** CI-exercised repo shapes from the live CDN; unrelated PRs keep warm caches.

## Cost

Download-stack PRs re-fetch every repo once per push (nemotron/parakeet-ja are multi-hundred-MB) — deliberately accepted for waves 4–6, where `FileDownloader` and the divergent-path rewiring are exactly the changes that should face every repo shape live. This PR itself doesn't trigger the cold sweep (it touches only workflow files); the first wave-4 push will.

Part of #765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)