### PR TITLE
refactor(download): Wave 4 — FileDownloader, ModelCache, ProgressReporter; DownloadUtils becomes a façade (#765)

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -81,43 +81,6 @@ public class DownloadUtils {
         HFClient.looksLikeHTML(data)
     }
 
-    /// `response` is nil when re-validating a fully-downloaded partial file from
-    /// a previous run (no live response to check Content-Type against).
-    static func validateDownloadedArtifact(
-        at tempURL: URL,
-        response: HTTPURLResponse?,
-        path: String,
-        expectedSize: Int
-    ) throws {
-        if let contentType = response?.value(forHTTPHeaderField: "Content-Type")?.lowercased(),
-            contentType.contains("text/html")
-        {
-            throw HuggingFaceDownloadError.invalidArtifact(
-                path: path, reason: "server returned Content-Type: \(contentType)")
-        }
-
-        let actualSize =
-            ((try? FileManager.default.attributesOfItem(atPath: tempURL.path))?[.size] as? Int) ?? 0
-        if actualSize == 0 {
-            throw HuggingFaceDownloadError.invalidArtifact(path: path, reason: "empty file")
-        }
-
-        if let handle = try? FileHandle(forReadingFrom: tempURL) {
-            defer { try? handle.close() }
-            if looksLikeHTML(handle.readData(ofLength: 512)) {
-                throw HuggingFaceDownloadError.invalidArtifact(
-                    path: path, reason: "response body begins with HTML markup")
-            }
-        }
-
-        // HuggingFace reports the exact (LFS-resolved) object size; a short body is truncation.
-        if expectedSize > 0 && actualSize != expectedSize {
-            throw HuggingFaceDownloadError.invalidArtifact(
-                path: path,
-                reason: "size mismatch (expected \(expectedSize) bytes, got \(actualSize))")
-        }
-    }
-
     /// Moved to `FluidAudio.HuggingFaceDownloadError` (Shared/Download/DownloadTypes.swift)
     /// so the extracted download primitives don't depend back on this class
     /// (#765 Wave 2). The nested spelling stays source-compatible.
@@ -193,21 +156,7 @@ public class DownloadUtils {
             logger.info("Deleting cache and re-downloading…")
             let repoPath = directory.appendingPathComponent(repo.folderName)
 
-            // Try to delete the corrupted cache
-            do {
-                try FileManager.default.removeItem(at: repoPath)
-                logger.info("Successfully deleted corrupted cache at \(repoPath.path)")
-            } catch {
-                // If deletion fails (excluding "file not found"), log the error but continue
-                // Robust directory creation will handle any remaining files
-                let nsError = error as NSError
-                if nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileNoSuchFileError {
-                    // File already doesn't exist - this is fine
-                } else {
-                    logger.warning("Failed to delete cache: \(error.localizedDescription)")
-                    logger.info("Will attempt to overwrite during re-download")
-                }
-            }
+            ModelCache.purgeCorruptedCache(at: repoPath)
 
             return try await loadModelsOnce(
                 repo, modelNames: modelNames,
@@ -279,18 +228,13 @@ public class DownloadUtils {
         // every model the caller actually needs.
         let extraModelNames = Set(modelNames).subtracting(requiredModels)
         let effectiveModels = requiredModels.union(extraModelNames)
-        let allModelsExist = effectiveModels.allSatisfy { model in
-            let modelPath = repoPath.appendingPathComponent(model)
-            return FileManager.default.fileExists(atPath: modelPath.path)
-        }
+        let reporter = ProgressReporter(handler: progressHandler, downloadPhaseWeight: 0.5)
 
-        if !allModelsExist {
+        if !ModelCache.allModelsExist(at: repoPath, models: effectiveModels) {
             // In offline mode surface a typed error listing the
             // missing files instead of attempting a HuggingFace fetch.
             if enforceOffline {
-                let missing = effectiveModels.filter { name in
-                    !FileManager.default.fileExists(atPath: repoPath.appendingPathComponent(name).path)
-                }.sorted()
+                let missing = ModelCache.missingModels(at: repoPath, models: effectiveModels)
                 logger.error(
                     "Offline mode: required models missing at \(repoPath.path): \(missing)"
                 )
@@ -303,8 +247,7 @@ public class DownloadUtils {
                 progressHandler: progressHandler)
         } else {
             logger.info("Found \(repo.folderName) locally, no download needed")
-            progressHandler?(
-                DownloadProgress(fractionCompleted: 0.5, phase: .downloading(completedFiles: 0, totalFiles: 0)))
+            reporter.cachedModelsAvailable()
         }
 
         let config = MLModelConfiguration()
@@ -314,44 +257,9 @@ public class DownloadUtils {
         var models: [String: MLModel] = [:]
         for (index, name) in modelNames.enumerated() {
             let modelPath = repoPath.appendingPathComponent(name)
-            guard FileManager.default.fileExists(atPath: modelPath.path) else {
-                throw CocoaError(
-                    .fileNoSuchFile,
-                    userInfo: [
-                        NSFilePathErrorKey: modelPath.path,
-                        NSLocalizedDescriptionKey: "Model file not found: \(name)",
-                    ])
-            }
+            try ModelCache.validateCompiledModelLayout(at: modelPath, name: name)
 
-            var isDirectory: ObjCBool = false
-            guard
-                FileManager.default.fileExists(atPath: modelPath.path, isDirectory: &isDirectory),
-                isDirectory.boolValue
-            else {
-                throw CocoaError(
-                    .fileReadCorruptFile,
-                    userInfo: [
-                        NSFilePathErrorKey: modelPath.path,
-                        NSLocalizedDescriptionKey: "Model path is not a directory: \(name)",
-                    ])
-            }
-
-            let coremlDataPath = modelPath.appendingPathComponent("coremldata.bin")
-            guard FileManager.default.fileExists(atPath: coremlDataPath.path) else {
-                logger.error("Missing coremldata.bin in \(name)")
-                throw CocoaError(
-                    .fileReadCorruptFile,
-                    userInfo: [
-                        NSFilePathErrorKey: coremlDataPath.path,
-                        NSLocalizedDescriptionKey: "Missing coremldata.bin in model: \(name)",
-                    ])
-            }
-
-            progressHandler?(
-                DownloadProgress(
-                    fractionCompleted: 0.5 + 0.5 * Double(index) / Double(modelNames.count),
-                    phase: .compiling(modelName: name)
-                ))
+            reporter.compiling(name: name, index: index, count: modelNames.count)
 
             let start = Date()
             let model = try MLModel(contentsOf: modelPath, configuration: config)
@@ -364,7 +272,7 @@ public class DownloadUtils {
             logger.info("Compiled model \(name) in \(formatted) ms :: \(SystemInfo.summary())")
         }
 
-        progressHandler?(DownloadProgress(fractionCompleted: 1.0, phase: .compiling(modelName: "")))
+        reporter.finished()
         return models
     }
 
@@ -452,8 +360,11 @@ public class DownloadUtils {
                 || itemPath.hasSuffix(".json") || itemPath.hasSuffix(".txt")
         }
 
+        // Repo loads: download occupies 0-0.5, CoreML compile 0.5-1.0.
+        let reporter = ProgressReporter(handler: progressHandler, downloadPhaseWeight: 0.5)
+
         // Start listing from subPath if specified, otherwise from root
-        progressHandler?(DownloadProgress(fractionCompleted: 0.0, phase: .listing))
+        reporter.listing()
         let treeFetch = HFTreeLister.fetch(using: listingSession)
         var filesToDownload: [RemoteFile] = try await HFTreeLister.listTree(
             repoRemotePath: repo.remotePath,
@@ -510,227 +421,74 @@ public class DownloadUtils {
             }
             let destPath = repoPath.appendingPathComponent(localPath)
 
-            // Skip if already exists
-            if FileManager.default.fileExists(atPath: destPath.path) {
-                completedBytes += Int64(max(0, file.size))
-                continue
-            }
-
-            // Create parent directory, removing any conflicting files in the path
-            let parentDir = destPath.deletingLastPathComponent()
-            try createDirectoryRobustly(at: parentDir)
-
-            // HuggingFace returns 500 for 0-byte files — create empty file locally
-            if file.size == 0 {
-                FileManager.default.createFile(atPath: destPath.path, contents: Data())
-                continue
-            }
-
-            // Download file (use original path for HuggingFace URL)
-            let encodedFilePath =
-                file.path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? file.path
-            let fileURL = try ModelRegistry.resolveModel(repo.remotePath, encodedFilePath)
-            let request = authorizedRequest(url: fileURL)
-
-            // Bounded retry on transient failures, with byte-range resume via a
-            // persistent `<dest>.partial` file so retries and re-runs continue a
-            // partially-downloaded file instead of restarting it (#757).
-            let onProgress: (@Sendable (Int64, Int64) -> Void)?
-            if let handler = progressHandler {
+            let onBytes: (@Sendable (Int64, Int64) -> Void)?
+            if progressHandler != nil {
                 let baseBytes = completedBytes
                 let fileCount = filesToDownload.count
                 let totalBytesSnapshot = totalBytes
                 let fileIndex = index
-                onProgress = { bytesWritten, _ in
-                    guard totalBytesSnapshot > 0 else { return }
-                    let current = baseBytes + bytesWritten
-                    // Download phase occupies 0.0–0.5 of the overall range.
-                    let fraction = 0.5 * Double(current) / Double(totalBytesSnapshot)
-                    handler(
-                        DownloadProgress(
-                            fractionCompleted: min(fraction, 0.5),
-                            phase: .downloading(completedFiles: fileIndex, totalFiles: fileCount)
-                        ))
+                onBytes = { bytesWritten, _ in
+                    reporter.liveBytes(
+                        completedBytes: baseBytes + bytesWritten,
+                        totalBytes: totalBytesSnapshot,
+                        fileIndex: fileIndex,
+                        totalFiles: fileCount)
                 }
             } else {
-                onProgress = nil
+                onBytes = nil
             }
 
-            let tempFileURL = try await downloadFileWithRetry(
-                request: request,
-                path: file.path,
-                expectedSize: file.size,
-                partialFileURL: destPath.appendingPathExtension("partial"),
-                onProgress: onProgress,
-                configuration: configuration
+            let outcome = try await FileDownloader.ensure(
+                file: file,
+                from: repo.remotePath,
+                at: destPath,
+                configuration: configuration,
+                onBytes: onBytes
             )
-
-            // Move downloaded file to destination
-            if FileManager.default.fileExists(atPath: destPath.path) {
-                try? FileManager.default.removeItem(at: destPath)
-            }
-            try FileManager.default.moveItem(at: tempFileURL, to: destPath)
-
             completedBytes += Int64(max(0, file.size))
+
+            guard outcome == .downloaded else { continue }
 
             if (index + 1) % 10 == 0 || index == filesToDownload.count - 1 {
                 logger.info("Downloaded \(index + 1)/\(filesToDownload.count) files")
             }
 
-            progressHandler?(
-                DownloadProgress(
-                    fractionCompleted: totalBytes > 0
-                        ? 0.5 * Double(completedBytes) / Double(totalBytes)
-                        : 0.5 * Double(index + 1) / Double(filesToDownload.count),
-                    phase: .downloading(completedFiles: index + 1, totalFiles: filesToDownload.count)
-                ))
+            reporter.fileBoundary(
+                completedBytes: completedBytes,
+                totalBytes: totalBytes,
+                completedFiles: index + 1,
+                totalFiles: filesToDownload.count)
         }
 
         // Verify required models are present
-        for model in requiredModels {
-            let modelPath = repoPath.appendingPathComponent(model)
-            guard FileManager.default.fileExists(atPath: modelPath.path) else {
-                throw HuggingFaceDownloadError.modelNotFound(path: model)
-            }
-        }
+        try ModelCache.verifyModelsPresent(at: repoPath, models: requiredModels)
 
         logger.info("Downloaded all required models for \(repo.folderName)")
     }
 
     // MARK: - Helper Functions
 
-    /// Robustly create a directory, removing any conflicting files in the path.
-    ///
-    /// This handles cases where a file exists where a directory should be, which can happen
-    /// during corrupted cache recovery when partial deletion leaves files in place of directories.
-    ///
-    /// - Parameter url: The directory path to create
-    /// - Throws: Errors from FileManager if directory creation fails after cleanup
-    private static func createDirectoryRobustly(at url: URL) throws {
-        let fm = FileManager.default
-        var pathComponents = url.pathComponents
-
-        // Remove leading "/" if present
-        if pathComponents.first == "/" {
-            pathComponents.removeFirst()
-        }
-
-        // Build path incrementally, checking each component
-        var currentPath = "/"
-        for component in pathComponents {
-            currentPath = (currentPath as NSString).appendingPathComponent(component)
-            let componentURL = URL(fileURLWithPath: currentPath)
-
-            var isDirectory: ObjCBool = false
-            if fm.fileExists(atPath: currentPath, isDirectory: &isDirectory) {
-                if !isDirectory.boolValue {
-                    // A file exists where a directory should be - remove it
-                    logger.warning("Removing file blocking directory creation: \(currentPath)")
-                    try fm.removeItem(at: componentURL)
-                    try fm.createDirectory(at: componentURL, withIntermediateDirectories: false)
-                }
-                // If it's already a directory, continue
-            } else {
-                // Path doesn't exist, create remaining path with intermediate directories
-                try fm.createDirectory(at: url, withIntermediateDirectories: true)
-                return
-            }
-        }
+    /// Forwards to the Wave 4 primitives — kept because the download-resume,
+    /// artifact-validation, and retry characterization suites pin these
+    /// symbols on DownloadUtils.
+    static func isRetryableDownloadError(_ error: Error) -> Bool {
+        RetryPolicy.isRetryable(error)
     }
 
-    // MARK: - Streaming download to a persistent file
-
-    /// Stream a download directly into `destination` so received bytes survive
-    /// a mid-transfer drop (#757). Pure transport: the caller sets resume
-    /// headers and validates the HTTP status. Body bytes are written only for
-    /// 2xx — appended after `resumeOffset` on 206, from byte 0 otherwise.
-    ///
-    /// - Parameters:
-    ///   - resumeOffset: Byte count a 206 appends after; also the base for
-    ///     progress callbacks so resumed progress never dips.
-    ///   - configuration: Session configuration override for tests.
-    ///   - onProgress: `(totalBytesWritten, totalBytesExpected)`, both
-    ///     including `resumeOffset`. Delegate-driven byte progress (#756).
-    ///   - onResponse: Fires before any body byte is written — the resume path
-    ///     persists the validator here so it survives a drop mid-body.
-    /// Internal (not private) so download-resume tests can drive it directly.
-    static func streamDownload(
-        request: URLRequest,
-        to destination: URL,
-        resumeOffset: Int64 = 0,
-        configuration: URLSessionConfiguration? = nil,
-        onProgress: (@Sendable (Int64, Int64) -> Void)? = nil,
-        onResponse: (@Sendable (HTTPURLResponse) -> Void)? = nil
-    ) async throws -> HTTPURLResponse {
-        let delegate = StreamingDownloadDelegate(
-            destination: destination,
-            resumeOffset: resumeOffset,
-            onProgress: onProgress,
-            onResponse: onResponse
-        )
-        // Dedicated session with delegate — one per download to avoid cross-talk.
-        let session = URLSession(
-            configuration: configuration ?? sharedSession.configuration,
-            delegate: delegate,
-            delegateQueue: nil
-        )
-        defer { session.finishTasksAndInvalidate() }
-
-        return try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                let task = session.dataTask(with: request)
-                delegate.attach(continuation: continuation, task: task)
-                task.resume()
-            }
-        } onCancel: {
-            delegate.cancel()
-        }
+    static func validateDownloadedArtifact(
+        at tempURL: URL,
+        response: HTTPURLResponse?,
+        path: String,
+        expectedSize: Int
+    ) throws {
+        try FileDownloader.validateDownloadedArtifact(
+            at: tempURL, response: response, path: path, expectedSize: expectedSize)
     }
 
-    // MARK: - Per-file download with bounded retry and byte-range resume
-
-    /// Sidecar storing the HTTP validator (ETag/Last-Modified) a partial file
-    /// came from; written at response time so it survives a drop mid-body.
     static func resumeValidatorURL(for partialFileURL: URL) -> URL {
-        partialFileURL.appendingPathExtension("etag")
+        FileDownloader.resumeValidatorURL(for: partialFileURL)
     }
 
-    private static func fileSize(at url: URL) -> Int64 {
-        ((try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? Int64) ?? 0
-    }
-
-    /// Remove a partial download and its validator sidecar.
-    private static func clearPartialDownload(_ partialFileURL: URL) {
-        try? FileManager.default.removeItem(at: partialFileURL)
-        try? FileManager.default.removeItem(at: resumeValidatorURL(for: partialFileURL))
-    }
-
-    /// Resume validator for `If-Range`: a strong ETag, else Last-Modified.
-    /// Weak ETags are unusable for `If-Range` (RFC 9110 §13.1.5); nil means
-    /// resume is unsafe and the file restarts from 0.
-    private static func resumeValidator(from response: HTTPURLResponse) -> String? {
-        if let etag = response.value(forHTTPHeaderField: "ETag"), !etag.hasPrefix("W/") {
-            return etag
-        }
-        return response.value(forHTTPHeaderField: "Last-Modified")
-    }
-
-    /// Download a single repo file with bounded exponential-backoff retry on
-    /// transient failures (timeout/TLS/connectivity, HTTP 429/503/5xx; 4xx and
-    /// non-network errors fail fast — see `isRetryableDownloadError`).
-    ///
-    /// Resume (#757): bytes stream into `partialFileURL`, so a retry — or a new
-    /// process — continues with `Range`/`If-Range` instead of restarting from
-    /// byte 0. A 200 (range ignored / remote changed) restarts the file rather
-    /// than splicing mixed-version bytes.
-    ///
-    /// - Parameters:
-    ///   - partialFileURL: Where in-flight bytes live (e.g. `<dest>.partial`).
-    ///     Pass nil for a unique temp location (in-run resume only).
-    ///   - configuration: Session configuration override for tests.
-    /// - Returns: The URL of a validated (2xx) fully-written download; the
-    ///   caller moves it into the cache.
-    /// Internal (not private) so download-resume tests can drive it directly.
     static func downloadFileWithRetry(
         request: URLRequest,
         path: String,
@@ -741,122 +499,23 @@ public class DownloadUtils {
         minBackoff: TimeInterval = 1.0,
         configuration: URLSessionConfiguration? = nil
     ) async throws -> URL {
-        let defaultPartialURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString)
-            .appendingPathExtension("partial")
-        let partialURL = partialFileURL ?? defaultPartialURL
-        let validatorURL = resumeValidatorURL(for: partialURL)
-
-        return try await RetryPolicy.withRetry(
-            label: path, maxAttempts: maxAttempts, minBackoff: minBackoff, logger: logger
-        ) { attempt in
-            var attemptRequest = request
-            var resumeOffset: Int64 = 0
-
-            let partialSize = fileSize(at: partialURL)
-            let validator = (try? String(contentsOf: validatorURL, encoding: .utf8))?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-
-            if partialSize > 0, let validator, !validator.isEmpty {
-                if expectedSize > 0 && partialSize >= Int64(expectedSize) {
-                    // A previous run finished the body but didn't get to move
-                    // the file. Validate and reuse it instead of re-fetching.
-                    if (try? validateDownloadedArtifact(
-                        at: partialURL, response: nil, path: path, expectedSize: expectedSize))
-                        != nil
-                    {
-                        try? FileManager.default.removeItem(at: validatorURL)
-                        return partialURL
-                    }
-                    clearPartialDownload(partialURL)
-                } else {
-                    attemptRequest.setValue("bytes=\(partialSize)-", forHTTPHeaderField: "Range")
-                    attemptRequest.setValue(validator, forHTTPHeaderField: "If-Range")
-                    resumeOffset = partialSize
-                    logger.info(
-                        "Resuming \(path) from byte \(partialSize) (attempt \(attempt))")
-                }
-            } else if partialSize > 0 {
-                // Partial bytes with no validator can't be safely resumed.
-                clearPartialDownload(partialURL)
-            }
-
-            let httpResponse = try await streamDownload(
-                request: attemptRequest,
-                to: partialURL,
-                resumeOffset: resumeOffset,
-                configuration: configuration,
-                onProgress: onProgress,
-                onResponse: { response in
-                    // Persist the validator as soon as the fresh body starts, so
-                    // a drop mid-body still leaves it for the next attempt. A 206
-                    // keeps the validator of the response it is extending.
-                    guard response.statusCode != 206, (200..<300).contains(response.statusCode)
-                    else { return }
-                    if let validator = resumeValidator(from: response) {
-                        try? validator.write(to: validatorURL, atomically: true, encoding: .utf8)
-                    } else {
-                        try? FileManager.default.removeItem(at: validatorURL)
-                    }
-                }
-            )
-
-            try HFClient.checkRateLimit(httpResponse, context: "downloading \(path)")
-
-            if httpResponse.statusCode == 416 {
-                // Range not satisfiable — the partial is bogus (or the remote
-                // shrank). Restart from 0 on the next attempt.
-                clearPartialDownload(partialURL)
-                throw HuggingFaceDownloadError.invalidArtifact(
-                    path: path, reason: "server rejected resume range (416)")
-            }
-
-            guard (200..<300).contains(httpResponse.statusCode) else {
-                throw HuggingFaceDownloadError.downloadFailed(
-                    path: path,
-                    underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
-                )
-            }
-
-            // Validate before the caller moves the file into the cache.
-            do {
-                try validateDownloadedArtifact(
-                    at: partialURL, response: httpResponse, path: path,
-                    expectedSize: expectedSize)
-            } catch {
-                // A completed-but-invalid body must not be resumed from.
-                clearPartialDownload(partialURL)
-                throw error
-            }
-
-            try? FileManager.default.removeItem(at: validatorURL)
-            return partialURL
-        }
+        try await FileDownloader.download(
+            request: request, path: path, expectedSize: expectedSize,
+            partialFileURL: partialFileURL, onProgress: onProgress,
+            maxAttempts: maxAttempts, minBackoff: minBackoff,
+            configuration: configuration)
     }
 
-    /// Classify a per-file download error as transient (worth retrying) or
-    /// permanent. Transient: URLSession timeout / TLS / connectivity failures and
-    /// HTTP 429/503/5xx. Everything else (404/other 4xx, invalid response,
-    /// non-network errors) is permanent.
-    ///
-    /// Internal (not private) so retry-policy characterization tests can pin this
-    /// classification ahead of the #765 refactor.
-    static func isRetryableDownloadError(_ error: Error) -> Bool {
-        RetryPolicy.isRetryable(error)
-    }
-
+    /// Forward to ProgressReporter (kept: DownloadUtilsProgressTests pins it).
     static func subdirectoryProgressFraction(
         completedBytes: Int64,
         totalBytes: Int64,
         completedFiles: Int,
         totalFiles: Int
     ) -> Double {
-        guard totalFiles > 0 else { return 1.0 }
-        guard totalBytes > 0 else {
-            return min(Double(completedFiles) / Double(totalFiles), 1.0)
-        }
-
-        return min(Double(completedBytes) / Double(totalBytes), 1.0)
+        ProgressReporter.downloadFraction(
+            completedBytes: completedBytes, totalBytes: totalBytes,
+            completedFiles: completedFiles, totalFiles: totalFiles)
     }
 
     /// Download a specific subdirectory from a HuggingFace repository.
@@ -882,7 +541,9 @@ public class DownloadUtils {
         shouldSkip: (@Sendable (String) -> Bool)? = nil
     ) async throws {
         try ensureOnlineAllowed("downloadSubdirectory(\(repo.folderName)/\(subdirectory))")
-        progressHandler?(DownloadProgress(fractionCompleted: 0.0, phase: .listing))
+        // Subdirectory downloads have no compile phase: download spans 0-1.
+        let reporter = ProgressReporter(handler: progressHandler, downloadPhaseWeight: 1.0)
+        reporter.listing()
         let filesToDownload: [RemoteFile] = try await HFTreeLister.listTree(
             repoRemotePath: repo.remotePath,
             startingAt: subdirectory,
@@ -897,122 +558,51 @@ public class DownloadUtils {
         let totalBytes: Int64 = filesToDownload.reduce(0) { $0 + Int64(max(0, $1.size)) }
         var completedBytes: Int64 = 0
 
-        progressHandler?(
-            DownloadProgress(
-                fractionCompleted: subdirectoryProgressFraction(
-                    completedBytes: completedBytes,
-                    totalBytes: totalBytes,
-                    completedFiles: 0,
-                    totalFiles: totalFiles
-                ),
-                phase: .downloading(completedFiles: 0, totalFiles: totalFiles)))
+        reporter.fileBoundary(
+            completedBytes: completedBytes,
+            totalBytes: totalBytes,
+            completedFiles: 0,
+            totalFiles: totalFiles)
 
         for (index, file) in filesToDownload.enumerated() {
             let destPath = repoDirectory.appendingPathComponent(file.path)
 
-            if FileManager.default.fileExists(atPath: destPath.path) {
-                completedBytes += Int64(max(0, file.size))
-                progressHandler?(
-                    DownloadProgress(
-                        fractionCompleted: subdirectoryProgressFraction(
-                            completedBytes: completedBytes,
-                            totalBytes: totalBytes,
-                            completedFiles: index + 1,
-                            totalFiles: totalFiles
-                        ),
-                        phase: .downloading(
-                            completedFiles: index + 1, totalFiles: totalFiles)))
-                continue
-            }
-
-            try FileManager.default.createDirectory(
-                at: destPath.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-
-            if file.size == 0 {
-                FileManager.default.createFile(atPath: destPath.path, contents: Data())
-                completedBytes += Int64(max(0, file.size))
-                progressHandler?(
-                    DownloadProgress(
-                        fractionCompleted: subdirectoryProgressFraction(
-                            completedBytes: completedBytes,
-                            totalBytes: totalBytes,
-                            completedFiles: index + 1,
-                            totalFiles: totalFiles
-                        ),
-                        phase: .downloading(
-                            completedFiles: index + 1, totalFiles: totalFiles)))
-                if (index + 1) % 5 == 0 || index == totalFiles - 1 {
-                    logger.info("Downloaded \(index + 1)/\(totalFiles) \(subdirectory) files")
-                }
-                continue
-            }
-
-            let encodedPath =
-                file.path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? file.path
-            let fileURL = try ModelRegistry.resolveModel(repo.remotePath, encodedPath)
-            let request = authorizedRequest(url: fileURL)
-
-            let onProgress: (@Sendable (Int64, Int64) -> Void)?
+            let onBytes: (@Sendable (Int64, Int64) -> Void)?
             // Only stream live byte progress for files with a known size: an
             // unknown-size file (-1) carries zero weight in totalBytes, so its
             // real bytesWritten would inflate the fraction mid-file and snap
             // back at the boundary. Boundary emits keep progress monotonic.
-            if let handler = progressHandler, file.size > 0 {
+            if progressHandler != nil, file.size > 0 {
                 let baseBytes = completedBytes
                 let totalBytesSnapshot = totalBytes
                 let fileIndex = index
                 let fileCount = totalFiles
-                onProgress = { bytesWritten, _ in
-                    guard totalBytesSnapshot > 0 else { return }
-                    let currentBytes = baseBytes + bytesWritten
-                    let fraction = subdirectoryProgressFraction(
-                        completedBytes: currentBytes,
+                onBytes = { bytesWritten, _ in
+                    reporter.liveBytes(
+                        completedBytes: baseBytes + bytesWritten,
                         totalBytes: totalBytesSnapshot,
-                        completedFiles: fileIndex,
-                        totalFiles: fileCount
-                    )
-                    handler(
-                        DownloadProgress(
-                            fractionCompleted: fraction,
-                            phase: .downloading(completedFiles: fileIndex, totalFiles: fileCount)
-                        ))
+                        fileIndex: fileIndex,
+                        totalFiles: fileCount)
                 }
             } else {
-                onProgress = nil
+                onBytes = nil
             }
 
-            // downloadFileWithRetry validates the artifact (HTML error pages,
-            // truncated bodies) internally, and the persistent `.partial` file
-            // gives retries and re-runs byte-range resume, same as downloadRepo.
-            let tempURL = try await downloadFileWithRetry(
-                request: request,
-                path: file.path,
-                expectedSize: file.size,
-                partialFileURL: destPath.appendingPathExtension("partial"),
-                onProgress: onProgress
+            let outcome = try await FileDownloader.ensure(
+                file: file,
+                from: repo.remotePath,
+                at: destPath,
+                onBytes: onBytes
             )
-
-            if FileManager.default.fileExists(atPath: destPath.path) {
-                try? FileManager.default.removeItem(at: destPath)
-            }
-            try FileManager.default.moveItem(at: tempURL, to: destPath)
-
             completedBytes += Int64(max(0, file.size))
 
-            progressHandler?(
-                DownloadProgress(
-                    fractionCompleted: subdirectoryProgressFraction(
-                        completedBytes: completedBytes,
-                        totalBytes: totalBytes,
-                        completedFiles: index + 1,
-                        totalFiles: totalFiles
-                    ),
-                    phase: .downloading(
-                        completedFiles: index + 1, totalFiles: totalFiles)))
+            reporter.fileBoundary(
+                completedBytes: completedBytes,
+                totalBytes: totalBytes,
+                completedFiles: index + 1,
+                totalFiles: totalFiles)
 
-            if (index + 1) % 5 == 0 || index == totalFiles - 1 {
+            if outcome != .alreadyPresent, (index + 1) % 5 == 0 || index == totalFiles - 1 {
                 logger.info("Downloaded \(index + 1)/\(totalFiles) \(subdirectory) files")
             }
         }
@@ -1060,161 +650,5 @@ public class DownloadUtils {
         }
 
         throw lastError ?? HuggingFaceDownloadError.invalidResponse
-    }
-}
-
-// MARK: - URLSession download delegate for byte-level progress
-
-/// `URLSessionDownloadTask` → async/await bridge that forwards byte progress (#756).
-/// Streams response bytes straight into a destination file so partial content
-/// survives connection drops (#757). Appends after `resumeOffset` on HTTP 206;
-/// truncates and writes from 0 on any other 2xx; discards the body otherwise.
-private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate, Sendable {
-    private struct State {
-        var continuation: CheckedContinuation<HTTPURLResponse, Error>?
-        var task: URLSessionDataTask?
-        var handle: FileHandle?
-        var bytesWritten: Int64 = 0
-        var expectedTotal: Int64 = -1
-        var writeError: Error?
-        var finished = false
-    }
-
-    private let destination: URL
-    private let resumeOffset: Int64
-    private let onProgress: (@Sendable (Int64, Int64) -> Void)?
-    private let onResponse: (@Sendable (HTTPURLResponse) -> Void)?
-    // Holds the non-Sendable continuation and file handle; the lock (not
-    // `@unchecked`) makes the delegate Sendable as URLSession requires.
-    private let state = OSAllocatedUnfairLock<State>(uncheckedState: State())
-
-    init(
-        destination: URL,
-        resumeOffset: Int64,
-        onProgress: (@Sendable (Int64, Int64) -> Void)?,
-        onResponse: (@Sendable (HTTPURLResponse) -> Void)?
-    ) {
-        self.destination = destination
-        self.resumeOffset = resumeOffset
-        self.onProgress = onProgress
-        self.onResponse = onResponse
-    }
-
-    /// Register the continuation and task before the task starts.
-    func attach(
-        continuation: CheckedContinuation<HTTPURLResponse, Error>,
-        task: URLSessionDataTask
-    ) {
-        state.withLockUnchecked {
-            $0.continuation = continuation
-            $0.task = task
-        }
-    }
-
-    func cancel() {
-        state.withLockUnchecked { $0.task }?.cancel()
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        dataTask: URLSessionDataTask,
-        didReceive response: URLResponse,
-        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
-    ) {
-        guard let http = response as? HTTPURLResponse else {
-            completionHandler(.cancel)
-            return
-        }
-        onResponse?(http)
-
-        // Only 2xx bodies are file content worth keeping; error bodies are
-        // discarded so a 503 page can never overwrite resumable bytes.
-        if (200..<300).contains(http.statusCode) {
-            let appending = http.statusCode == 206
-            do {
-                if !FileManager.default.fileExists(atPath: destination.path) {
-                    FileManager.default.createFile(atPath: destination.path, contents: nil)
-                }
-                let handle = try FileHandle(forWritingTo: destination)
-                if appending {
-                    try handle.seekToEnd()
-                } else {
-                    try handle.truncate(atOffset: 0)
-                }
-                let base = appending ? resumeOffset : 0
-                // Content-Range carries the full object size on a 206; a plain
-                // 200 reports the full size via expectedContentLength.
-                let expectedTotal: Int64
-                if let contentRange = http.value(forHTTPHeaderField: "Content-Range"),
-                    let totalPart = contentRange.split(separator: "/").last,
-                    let total = Int64(totalPart)
-                {
-                    expectedTotal = total
-                } else if http.expectedContentLength >= 0 {
-                    expectedTotal = base + http.expectedContentLength
-                } else {
-                    expectedTotal = -1
-                }
-                state.withLockUnchecked {
-                    $0.handle = handle
-                    $0.bytesWritten = base
-                    $0.expectedTotal = expectedTotal
-                }
-            } catch {
-                state.withLockUnchecked { $0.writeError = error }
-                completionHandler(.cancel)
-                return
-            }
-        }
-        completionHandler(.allow)
-    }
-
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        let progress: (written: Int64, expected: Int64)? = state.withLockUnchecked { st in
-            guard let handle = st.handle, st.writeError == nil else { return nil }
-            do {
-                try handle.write(contentsOf: data)
-                st.bytesWritten += Int64(data.count)
-                return (st.bytesWritten, st.expectedTotal)
-            } catch {
-                st.writeError = error
-                return nil
-            }
-        }
-        if let progress {
-            onProgress?(progress.written, progress.expected)
-        } else if state.withLockUnchecked({ $0.writeError }) != nil {
-            cancel()
-        }
-    }
-
-    func urlSession(
-        _ session: URLSession,
-        task: URLSessionTask,
-        didCompleteWithError error: Error?
-    ) {
-        let response = task.response as? HTTPURLResponse
-        // Extract the resume action under the lock, run it after releasing.
-        let resume = state.withLockUnchecked { st -> (() -> Void)? in
-            guard !st.finished, let continuation = st.continuation else { return nil }
-            st.finished = true
-            st.continuation = nil
-            st.task = nil
-            try? st.handle?.close()
-            st.handle = nil
-            let writeError = st.writeError
-            return {
-                if let writeError {
-                    continuation.resume(throwing: writeError)
-                } else if let error {
-                    continuation.resume(throwing: error)
-                } else if let response {
-                    continuation.resume(returning: response)
-                } else {
-                    continuation.resume(throwing: DownloadUtils.HuggingFaceDownloadError.invalidResponse)
-                }
-            }
-        }
-        resume?()
     }
 }

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -1,6 +1,5 @@
 import CoreML
 import Foundation
-import os
 
 /// HuggingFace model downloader using URLSession
 public class DownloadUtils {
@@ -421,32 +420,27 @@ public class DownloadUtils {
             }
             let destPath = repoPath.appendingPathComponent(localPath)
 
-            let onBytes: (@Sendable (Int64, Int64) -> Void)?
-            if progressHandler != nil {
-                let baseBytes = completedBytes
-                let fileCount = filesToDownload.count
-                let totalBytesSnapshot = totalBytes
-                let fileIndex = index
-                onBytes = { bytesWritten, _ in
-                    reporter.liveBytes(
-                        completedBytes: baseBytes + bytesWritten,
-                        totalBytes: totalBytesSnapshot,
-                        fileIndex: fileIndex,
-                        totalFiles: fileCount)
-                }
-            } else {
-                onBytes = nil
-            }
+            let onBytes = reporter.liveBytesCallback(
+                baseBytes: completedBytes,
+                totalBytes: totalBytes,
+                fileIndex: index,
+                totalFiles: filesToDownload.count)
 
+            // Repo caches keep the historical corrupt-recovery behavior:
+            // a regular file blocking a path component is replaced.
             let outcome = try await FileDownloader.ensure(
                 file: file,
                 from: repo.remotePath,
                 at: destPath,
+                recoveringBlockedPaths: true,
                 configuration: configuration,
                 onBytes: onBytes
             )
             completedBytes += Int64(max(0, file.size))
 
+            // Pinned asymmetry vs downloadSubdirectory: cached/empty files
+            // emit no boundary here (the pre-#765 behavior ProgressSequence
+            // relies on); the subdirectory loop emits for every outcome.
             guard outcome == .downloaded else { continue }
 
             if (index + 1) % 10 == 0 || index == filesToDownload.count - 1 {
@@ -466,7 +460,7 @@ public class DownloadUtils {
         logger.info("Downloaded all required models for \(repo.folderName)")
     }
 
-    // MARK: - Helper Functions
+    // MARK: - Test-pinned forwards (#765)
 
     /// Forwards to the Wave 4 primitives — kept because the download-resume,
     /// artifact-validation, and retry characterization suites pin these
@@ -567,31 +561,27 @@ public class DownloadUtils {
         for (index, file) in filesToDownload.enumerated() {
             let destPath = repoDirectory.appendingPathComponent(file.path)
 
-            let onBytes: (@Sendable (Int64, Int64) -> Void)?
             // Only stream live byte progress for files with a known size: an
             // unknown-size file (-1) carries zero weight in totalBytes, so its
             // real bytesWritten would inflate the fraction mid-file and snap
             // back at the boundary. Boundary emits keep progress monotonic.
-            if progressHandler != nil, file.size > 0 {
-                let baseBytes = completedBytes
-                let totalBytesSnapshot = totalBytes
-                let fileIndex = index
-                let fileCount = totalFiles
-                onBytes = { bytesWritten, _ in
-                    reporter.liveBytes(
-                        completedBytes: baseBytes + bytesWritten,
-                        totalBytes: totalBytesSnapshot,
-                        fileIndex: fileIndex,
-                        totalFiles: fileCount)
-                }
-            } else {
-                onBytes = nil
-            }
+            let onBytes =
+                file.size > 0
+                ? reporter.liveBytesCallback(
+                    baseBytes: completedBytes,
+                    totalBytes: totalBytes,
+                    fileIndex: index,
+                    totalFiles: totalFiles)
+                : nil
 
+            // Fail loudly on blocked paths: subdirectory downloads land in
+            // caller-provided directories, so a regular file where a directory
+            // belongs is surfaced, never silently deleted.
             let outcome = try await FileDownloader.ensure(
                 file: file,
                 from: repo.remotePath,
                 at: destPath,
+                recoveringBlockedPaths: false,
                 onBytes: onBytes
             )
             completedBytes += Int64(max(0, file.size))

--- a/Sources/FluidAudio/Shared/Download/FileDownloader.swift
+++ b/Sources/FluidAudio/Shared/Download/FileDownloader.swift
@@ -7,7 +7,10 @@ import os
 /// cache. Used by both `downloadRepo` and `downloadSubdirectory`.
 enum FileDownloader {
 
-    private static let logger = AppLogger(category: "FileDownloader")
+    /// Historical category kept so existing log predicates keep capturing the
+    /// whole download trail across the #765 refactor; Wave 6 renames it
+    /// deliberately alongside the API cutover.
+    private static let logger = AppLogger(category: "DownloadUtils")
 
     /// What `ensure(file:from:at:)` did for a file.
     enum Outcome {
@@ -23,11 +26,18 @@ enum FileDownloader {
     /// present, create empties locally, otherwise download with retry +
     /// byte-range resume (via `<destination>.partial`), validate, and move
     /// atomically into place.
+    ///
+    /// - Parameter recoveringBlockedPaths: When true, a regular file blocking
+    ///   a parent-directory component is DELETED and replaced (the repo-cache
+    ///   corrupt-recovery behavior). When false, a blocked path fails loudly
+    ///   with the thrown filesystem error — callers outside the managed model
+    ///   cache must not silently destroy user files.
     @discardableResult
     static func ensure(
         file: RemoteFile,
         from repoRemotePath: String,
         at destination: URL,
+        recoveringBlockedPaths: Bool,
         configuration: URLSessionConfiguration? = nil,
         onBytes: (@Sendable (Int64, Int64) -> Void)? = nil
     ) async throws -> Outcome {
@@ -35,8 +45,14 @@ enum FileDownloader {
             return .alreadyPresent
         }
 
-        // Create parent directory, removing any conflicting files in the path.
-        try ModelCache.createDirectoryRobustly(at: destination.deletingLastPathComponent())
+        let parentDir = destination.deletingLastPathComponent()
+        if recoveringBlockedPaths {
+            // Create parent directory, removing any conflicting files in the path.
+            try ModelCache.createDirectoryRobustly(at: parentDir)
+        } else {
+            try FileManager.default.createDirectory(
+                at: parentDir, withIntermediateDirectories: true)
+        }
 
         // HuggingFace returns 500 for 0-byte files — create empty file locally.
         if file.size == 0 {
@@ -117,7 +133,8 @@ enum FileDownloader {
     ///     including `resumeOffset`. Delegate-driven byte progress (#756).
     ///   - onResponse: Fires before any body byte is written — the resume path
     ///     persists the validator here so it survives a drop mid-body.
-    /// Internal (not private) so download-resume tests can drive it directly.
+    /// Coverage flows through the `DownloadUtils.downloadFileWithRetry`
+    /// forward (DownloadResumeTests); no test drives this directly.
     static func streamDownload(
         request: URLRequest,
         to destination: URL,
@@ -133,6 +150,8 @@ enum FileDownloader {
             onResponse: onResponse
         )
         // Dedicated session with delegate — one per download to avoid cross-talk.
+        // DownloadUtils still owns the shared session (public API); ownership
+        // moves to the new surface in the Wave 6 cutover.
         let session = URLSession(
             configuration: configuration ?? DownloadUtils.sharedSession.configuration,
             delegate: delegate,
@@ -194,7 +213,8 @@ enum FileDownloader {
     ///   - configuration: Session configuration override for tests.
     /// - Returns: The URL of a validated (2xx) fully-written download; the
     ///   caller moves it into the cache.
-    /// Internal (not private) so download-resume tests can drive it directly.
+    /// Pinned via the `DownloadUtils.downloadFileWithRetry` forward
+    /// (DownloadResumeTests drives resume/splice/416 behavior through it).
     static func download(
         request: URLRequest,
         path: String,
@@ -214,6 +234,11 @@ enum FileDownloader {
         return try await RetryPolicy.withRetry(
             label: path, maxAttempts: maxAttempts, minBackoff: minBackoff, logger: logger
         ) { attempt in
+            // Re-check per attempt, matching HFTreeLister.fetch: flipping
+            // enforceOffline mid-operation stops the walk at the next request.
+            guard !DownloadUtils.enforceOffline else {
+                throw DownloadUtils.OfflineError.networkDisabled(operation: "download(\(path))")
+            }
             var attemptRequest = request
             var resumeOffset: Int64 = 0
 
@@ -447,7 +472,7 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
                 } else if let response {
                     continuation.resume(returning: response)
                 } else {
-                    continuation.resume(throwing: DownloadUtils.HuggingFaceDownloadError.invalidResponse)
+                    continuation.resume(throwing: HFDownload.DownloadError.invalidResponse)
                 }
             }
         }

--- a/Sources/FluidAudio/Shared/Download/FileDownloader.swift
+++ b/Sources/FluidAudio/Shared/Download/FileDownloader.swift
@@ -1,0 +1,456 @@
+import Foundation
+import os
+
+/// The one per-file download unit for the download stack (#765 Wave 4):
+/// bounded retry (RetryPolicy) around the streaming byte-range-resume
+/// transport (#757), artifact validation, and atomic placement into the
+/// cache. Used by both `downloadRepo` and `downloadSubdirectory`.
+enum FileDownloader {
+
+    private static let logger = AppLogger(category: "FileDownloader")
+
+    /// What `ensure(file:from:at:)` did for a file.
+    enum Outcome {
+        /// Destination already existed; nothing fetched.
+        case alreadyPresent
+        /// Zero-byte file created locally (HF serves 500s for empty files).
+        case createdEmpty
+        /// Fetched from the network, validated, and moved into place.
+        case downloaded
+    }
+
+    /// Ensure `file` from `repoRemotePath` exists at `destination`: skip when
+    /// present, create empties locally, otherwise download with retry +
+    /// byte-range resume (via `<destination>.partial`), validate, and move
+    /// atomically into place.
+    @discardableResult
+    static func ensure(
+        file: RemoteFile,
+        from repoRemotePath: String,
+        at destination: URL,
+        configuration: URLSessionConfiguration? = nil,
+        onBytes: (@Sendable (Int64, Int64) -> Void)? = nil
+    ) async throws -> Outcome {
+        if FileManager.default.fileExists(atPath: destination.path) {
+            return .alreadyPresent
+        }
+
+        // Create parent directory, removing any conflicting files in the path.
+        try ModelCache.createDirectoryRobustly(at: destination.deletingLastPathComponent())
+
+        // HuggingFace returns 500 for 0-byte files — create empty file locally.
+        if file.size == 0 {
+            FileManager.default.createFile(atPath: destination.path, contents: Data())
+            return .createdEmpty
+        }
+
+        let encodedPath =
+            file.path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? file.path
+        let fileURL = try ModelRegistry.resolveModel(repoRemotePath, encodedPath)
+        let request = HFClient.authorizedRequest(url: fileURL)
+
+        let tempURL = try await download(
+            request: request,
+            path: file.path,
+            expectedSize: file.size,
+            partialFileURL: destination.appendingPathExtension("partial"),
+            onProgress: onBytes,
+            configuration: configuration
+        )
+
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try? FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.moveItem(at: tempURL, to: destination)
+        return .downloaded
+    }
+
+    /// `response` is nil when re-validating a fully-downloaded partial file from
+    /// a previous run (no live response to check Content-Type against).
+    static func validateDownloadedArtifact(
+        at tempURL: URL,
+        response: HTTPURLResponse?,
+        path: String,
+        expectedSize: Int
+    ) throws {
+        if let contentType = response?.value(forHTTPHeaderField: "Content-Type")?.lowercased(),
+            contentType.contains("text/html")
+        {
+            throw HFDownload.DownloadError.invalidArtifact(
+                path: path, reason: "server returned Content-Type: \(contentType)")
+        }
+
+        let actualSize =
+            ((try? FileManager.default.attributesOfItem(atPath: tempURL.path))?[.size] as? Int) ?? 0
+        if actualSize == 0 {
+            throw HFDownload.DownloadError.invalidArtifact(path: path, reason: "empty file")
+        }
+
+        if let handle = try? FileHandle(forReadingFrom: tempURL) {
+            defer { try? handle.close() }
+            if HFClient.looksLikeHTML(handle.readData(ofLength: 512)) {
+                throw HFDownload.DownloadError.invalidArtifact(
+                    path: path, reason: "response body begins with HTML markup")
+            }
+        }
+
+        // HuggingFace reports the exact (LFS-resolved) object size; a short body is truncation.
+        if expectedSize > 0 && actualSize != expectedSize {
+            throw HFDownload.DownloadError.invalidArtifact(
+                path: path,
+                reason: "size mismatch (expected \(expectedSize) bytes, got \(actualSize))")
+        }
+    }
+
+    // MARK: - Streaming download to a persistent file
+
+    /// Stream a download directly into `destination` so received bytes survive
+    /// a mid-transfer drop (#757). Pure transport: the caller sets resume
+    /// headers and validates the HTTP status. Body bytes are written only for
+    /// 2xx — appended after `resumeOffset` on 206, from byte 0 otherwise.
+    ///
+    /// - Parameters:
+    ///   - resumeOffset: Byte count a 206 appends after; also the base for
+    ///     progress callbacks so resumed progress never dips.
+    ///   - configuration: Session configuration override for tests.
+    ///   - onProgress: `(totalBytesWritten, totalBytesExpected)`, both
+    ///     including `resumeOffset`. Delegate-driven byte progress (#756).
+    ///   - onResponse: Fires before any body byte is written — the resume path
+    ///     persists the validator here so it survives a drop mid-body.
+    /// Internal (not private) so download-resume tests can drive it directly.
+    static func streamDownload(
+        request: URLRequest,
+        to destination: URL,
+        resumeOffset: Int64 = 0,
+        configuration: URLSessionConfiguration? = nil,
+        onProgress: (@Sendable (Int64, Int64) -> Void)? = nil,
+        onResponse: (@Sendable (HTTPURLResponse) -> Void)? = nil
+    ) async throws -> HTTPURLResponse {
+        let delegate = StreamingDownloadDelegate(
+            destination: destination,
+            resumeOffset: resumeOffset,
+            onProgress: onProgress,
+            onResponse: onResponse
+        )
+        // Dedicated session with delegate — one per download to avoid cross-talk.
+        let session = URLSession(
+            configuration: configuration ?? DownloadUtils.sharedSession.configuration,
+            delegate: delegate,
+            delegateQueue: nil
+        )
+        defer { session.finishTasksAndInvalidate() }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = session.dataTask(with: request)
+                delegate.attach(continuation: continuation, task: task)
+                task.resume()
+            }
+        } onCancel: {
+            delegate.cancel()
+        }
+    }
+
+    // MARK: - Per-file download with bounded retry and byte-range resume
+
+    /// Sidecar storing the HTTP validator (ETag/Last-Modified) a partial file
+    /// came from; written at response time so it survives a drop mid-body.
+    static func resumeValidatorURL(for partialFileURL: URL) -> URL {
+        partialFileURL.appendingPathExtension("etag")
+    }
+
+    private static func fileSize(at url: URL) -> Int64 {
+        ((try? FileManager.default.attributesOfItem(atPath: url.path))?[.size] as? Int64) ?? 0
+    }
+
+    /// Remove a partial download and its validator sidecar.
+    private static func clearPartialDownload(_ partialFileURL: URL) {
+        try? FileManager.default.removeItem(at: partialFileURL)
+        try? FileManager.default.removeItem(at: resumeValidatorURL(for: partialFileURL))
+    }
+
+    /// Resume validator for `If-Range`: a strong ETag, else Last-Modified.
+    /// Weak ETags are unusable for `If-Range` (RFC 9110 §13.1.5); nil means
+    /// resume is unsafe and the file restarts from 0.
+    private static func resumeValidator(from response: HTTPURLResponse) -> String? {
+        if let etag = response.value(forHTTPHeaderField: "ETag"), !etag.hasPrefix("W/") {
+            return etag
+        }
+        return response.value(forHTTPHeaderField: "Last-Modified")
+    }
+
+    /// Download a single repo file with bounded exponential-backoff retry on
+    /// transient failures (timeout/TLS/connectivity, HTTP 429/503/5xx; 4xx and
+    /// non-network errors fail fast — see `RetryPolicy.isRetryable`).
+    ///
+    /// Resume (#757): bytes stream into `partialFileURL`, so a retry — or a new
+    /// process — continues with `Range`/`If-Range` instead of restarting from
+    /// byte 0. A 200 (range ignored / remote changed) restarts the file rather
+    /// than splicing mixed-version bytes.
+    ///
+    /// - Parameters:
+    ///   - partialFileURL: Where in-flight bytes live (e.g. `<dest>.partial`).
+    ///     Pass nil for a unique temp location (in-run resume only).
+    ///   - configuration: Session configuration override for tests.
+    /// - Returns: The URL of a validated (2xx) fully-written download; the
+    ///   caller moves it into the cache.
+    /// Internal (not private) so download-resume tests can drive it directly.
+    static func download(
+        request: URLRequest,
+        path: String,
+        expectedSize: Int,
+        partialFileURL: URL? = nil,
+        onProgress: (@Sendable (Int64, Int64) -> Void)?,
+        maxAttempts: Int = 4,
+        minBackoff: TimeInterval = 1.0,
+        configuration: URLSessionConfiguration? = nil
+    ) async throws -> URL {
+        let defaultPartialURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("partial")
+        let partialURL = partialFileURL ?? defaultPartialURL
+        let validatorURL = resumeValidatorURL(for: partialURL)
+
+        return try await RetryPolicy.withRetry(
+            label: path, maxAttempts: maxAttempts, minBackoff: minBackoff, logger: logger
+        ) { attempt in
+            var attemptRequest = request
+            var resumeOffset: Int64 = 0
+
+            let partialSize = fileSize(at: partialURL)
+            let validator = (try? String(contentsOf: validatorURL, encoding: .utf8))?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if partialSize > 0, let validator, !validator.isEmpty {
+                if expectedSize > 0 && partialSize >= Int64(expectedSize) {
+                    // A previous run finished the body but didn't get to move
+                    // the file. Validate and reuse it instead of re-fetching.
+                    if (try? validateDownloadedArtifact(
+                        at: partialURL, response: nil, path: path, expectedSize: expectedSize))
+                        != nil
+                    {
+                        try? FileManager.default.removeItem(at: validatorURL)
+                        return partialURL
+                    }
+                    clearPartialDownload(partialURL)
+                } else {
+                    attemptRequest.setValue("bytes=\(partialSize)-", forHTTPHeaderField: "Range")
+                    attemptRequest.setValue(validator, forHTTPHeaderField: "If-Range")
+                    resumeOffset = partialSize
+                    logger.info(
+                        "Resuming \(path) from byte \(partialSize) (attempt \(attempt))")
+                }
+            } else if partialSize > 0 {
+                // Partial bytes with no validator can't be safely resumed.
+                clearPartialDownload(partialURL)
+            }
+
+            let httpResponse = try await streamDownload(
+                request: attemptRequest,
+                to: partialURL,
+                resumeOffset: resumeOffset,
+                configuration: configuration,
+                onProgress: onProgress,
+                onResponse: { response in
+                    // Persist the validator as soon as the fresh body starts, so
+                    // a drop mid-body still leaves it for the next attempt. A 206
+                    // keeps the validator of the response it is extending.
+                    guard response.statusCode != 206, (200..<300).contains(response.statusCode)
+                    else { return }
+                    if let validator = resumeValidator(from: response) {
+                        try? validator.write(to: validatorURL, atomically: true, encoding: .utf8)
+                    } else {
+                        try? FileManager.default.removeItem(at: validatorURL)
+                    }
+                }
+            )
+
+            try HFClient.checkRateLimit(httpResponse, context: "downloading \(path)")
+
+            if httpResponse.statusCode == 416 {
+                // Range not satisfiable — the partial is bogus (or the remote
+                // shrank). Restart from 0 on the next attempt.
+                clearPartialDownload(partialURL)
+                throw HFDownload.DownloadError.invalidArtifact(
+                    path: path, reason: "server rejected resume range (416)")
+            }
+
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                throw HFDownload.DownloadError.downloadFailed(
+                    path: path,
+                    underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
+                )
+            }
+
+            // Validate before the caller moves the file into the cache.
+            do {
+                try validateDownloadedArtifact(
+                    at: partialURL, response: httpResponse, path: path,
+                    expectedSize: expectedSize)
+            } catch {
+                // A completed-but-invalid body must not be resumed from.
+                clearPartialDownload(partialURL)
+                throw error
+            }
+
+            try? FileManager.default.removeItem(at: validatorURL)
+            return partialURL
+        }
+    }
+}
+
+// MARK: - URLSession download delegate for byte-level progress
+
+/// `URLSessionDownloadTask` → async/await bridge that forwards byte progress (#756).
+/// Streams response bytes straight into a destination file so partial content
+/// survives connection drops (#757). Appends after `resumeOffset` on HTTP 206;
+/// truncates and writes from 0 on any other 2xx; discards the body otherwise.
+private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate, Sendable {
+    private struct State {
+        var continuation: CheckedContinuation<HTTPURLResponse, Error>?
+        var task: URLSessionDataTask?
+        var handle: FileHandle?
+        var bytesWritten: Int64 = 0
+        var expectedTotal: Int64 = -1
+        var writeError: Error?
+        var finished = false
+    }
+
+    private let destination: URL
+    private let resumeOffset: Int64
+    private let onProgress: (@Sendable (Int64, Int64) -> Void)?
+    private let onResponse: (@Sendable (HTTPURLResponse) -> Void)?
+    // Holds the non-Sendable continuation and file handle; the lock (not
+    // `@unchecked`) makes the delegate Sendable as URLSession requires.
+    private let state = OSAllocatedUnfairLock<State>(uncheckedState: State())
+
+    init(
+        destination: URL,
+        resumeOffset: Int64,
+        onProgress: (@Sendable (Int64, Int64) -> Void)?,
+        onResponse: (@Sendable (HTTPURLResponse) -> Void)?
+    ) {
+        self.destination = destination
+        self.resumeOffset = resumeOffset
+        self.onProgress = onProgress
+        self.onResponse = onResponse
+    }
+
+    /// Register the continuation and task before the task starts.
+    func attach(
+        continuation: CheckedContinuation<HTTPURLResponse, Error>,
+        task: URLSessionDataTask
+    ) {
+        state.withLockUnchecked {
+            $0.continuation = continuation
+            $0.task = task
+        }
+    }
+
+    func cancel() {
+        state.withLockUnchecked { $0.task }?.cancel()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let http = response as? HTTPURLResponse else {
+            completionHandler(.cancel)
+            return
+        }
+        onResponse?(http)
+
+        // Only 2xx bodies are file content worth keeping; error bodies are
+        // discarded so a 503 page can never overwrite resumable bytes.
+        if (200..<300).contains(http.statusCode) {
+            let appending = http.statusCode == 206
+            do {
+                if !FileManager.default.fileExists(atPath: destination.path) {
+                    FileManager.default.createFile(atPath: destination.path, contents: nil)
+                }
+                let handle = try FileHandle(forWritingTo: destination)
+                if appending {
+                    try handle.seekToEnd()
+                } else {
+                    try handle.truncate(atOffset: 0)
+                }
+                let base = appending ? resumeOffset : 0
+                // Content-Range carries the full object size on a 206; a plain
+                // 200 reports the full size via expectedContentLength.
+                let expectedTotal: Int64
+                if let contentRange = http.value(forHTTPHeaderField: "Content-Range"),
+                    let totalPart = contentRange.split(separator: "/").last,
+                    let total = Int64(totalPart)
+                {
+                    expectedTotal = total
+                } else if http.expectedContentLength >= 0 {
+                    expectedTotal = base + http.expectedContentLength
+                } else {
+                    expectedTotal = -1
+                }
+                state.withLockUnchecked {
+                    $0.handle = handle
+                    $0.bytesWritten = base
+                    $0.expectedTotal = expectedTotal
+                }
+            } catch {
+                state.withLockUnchecked { $0.writeError = error }
+                completionHandler(.cancel)
+                return
+            }
+        }
+        completionHandler(.allow)
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        let progress: (written: Int64, expected: Int64)? = state.withLockUnchecked { st in
+            guard let handle = st.handle, st.writeError == nil else { return nil }
+            do {
+                try handle.write(contentsOf: data)
+                st.bytesWritten += Int64(data.count)
+                return (st.bytesWritten, st.expectedTotal)
+            } catch {
+                st.writeError = error
+                return nil
+            }
+        }
+        if let progress {
+            onProgress?(progress.written, progress.expected)
+        } else if state.withLockUnchecked({ $0.writeError }) != nil {
+            cancel()
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        let response = task.response as? HTTPURLResponse
+        // Extract the resume action under the lock, run it after releasing.
+        let resume = state.withLockUnchecked { st -> (() -> Void)? in
+            guard !st.finished, let continuation = st.continuation else { return nil }
+            st.finished = true
+            st.continuation = nil
+            st.task = nil
+            try? st.handle?.close()
+            st.handle = nil
+            let writeError = st.writeError
+            return {
+                if let writeError {
+                    continuation.resume(throwing: writeError)
+                } else if let error {
+                    continuation.resume(throwing: error)
+                } else if let response {
+                    continuation.resume(returning: response)
+                } else {
+                    continuation.resume(throwing: DownloadUtils.HuggingFaceDownloadError.invalidResponse)
+                }
+            }
+        }
+        resume?()
+    }
+}

--- a/Sources/FluidAudio/Shared/Download/ModelCache.swift
+++ b/Sources/FluidAudio/Shared/Download/ModelCache.swift
@@ -6,7 +6,10 @@ import Foundation
 /// public API.
 enum ModelCache {
 
-    private static let logger = AppLogger(category: "ModelCache")
+    /// Historical category kept so existing log predicates keep capturing the
+    /// whole download trail across the #765 refactor; Wave 6 renames it
+    /// deliberately alongside the API cutover.
+    private static let logger = AppLogger(category: "DownloadUtils")
 
     /// Robustly create a directory, removing any conflicting files in the path.
     ///
@@ -17,6 +20,14 @@ enum ModelCache {
     /// - Throws: Errors from FileManager if directory creation fails after cleanup
     static func createDirectoryRobustly(at url: URL) throws {
         let fm = FileManager.default
+
+        // Hot path: the directory usually already exists (one stat instead of
+        // one per ancestor component on every per-file call).
+        var isDirectory: ObjCBool = false
+        if fm.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue {
+            return
+        }
+
         var pathComponents = url.pathComponents
 
         // Remove leading "/" if present
@@ -49,9 +60,7 @@ enum ModelCache {
 
     /// `true` when every model in `models` exists under `repoPath`.
     static func allModelsExist(at repoPath: URL, models: Set<String>) -> Bool {
-        models.allSatisfy { model in
-            FileManager.default.fileExists(atPath: repoPath.appendingPathComponent(model).path)
-        }
+        missingModels(at: repoPath, models: models).isEmpty
     }
 
     /// The subset of `models` missing under `repoPath`, sorted for stable
@@ -62,14 +71,11 @@ enum ModelCache {
         }.sorted()
     }
 
-    /// Throw `modelNotFound` for the first required model absent under
-    /// `repoPath` (the post-download verify pass).
+    /// Throw `modelNotFound` for the (deterministically first, sorted)
+    /// required model absent under `repoPath` — the post-download verify pass.
     static func verifyModelsPresent(at repoPath: URL, models: Set<String>) throws {
-        for model in models {
-            let modelPath = repoPath.appendingPathComponent(model)
-            guard FileManager.default.fileExists(atPath: modelPath.path) else {
-                throw HFDownload.DownloadError.modelNotFound(path: model)
-            }
+        if let missing = missingModels(at: repoPath, models: models).first {
+            throw HFDownload.DownloadError.modelNotFound(path: missing)
         }
     }
 
@@ -112,6 +118,10 @@ enum ModelCache {
 
     /// Delete a corrupted repo cache, tolerating an already-missing path
     /// (robust directory creation handles any remnants on re-download).
+    ///
+    /// Callers MUST check `RetryPolicy.isCancellation` first: cancellation is
+    /// not corruption, and purging on a cancelled load threw away valid
+    /// multi-hundred-MB caches before the guard existed (see loadModels).
     static func purgeCorruptedCache(at repoPath: URL) {
         do {
             try FileManager.default.removeItem(at: repoPath)

--- a/Sources/FluidAudio/Shared/Download/ModelCache.swift
+++ b/Sources/FluidAudio/Shared/Download/ModelCache.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// On-disk model-cache knowledge for the download stack (#765 Wave 4):
+/// existence/completeness checks, corrupt-cache purging, robust directory
+/// creation, and the cache-clearing operations behind the DownloadUtils
+/// public API.
+enum ModelCache {
+
+    private static let logger = AppLogger(category: "ModelCache")
+
+    /// Robustly create a directory, removing any conflicting files in the path.
+    ///
+    /// This handles cases where a file exists where a directory should be, which can happen
+    /// during corrupted cache recovery when partial deletion leaves files in place of directories.
+    ///
+    /// - Parameter url: The directory path to create
+    /// - Throws: Errors from FileManager if directory creation fails after cleanup
+    static func createDirectoryRobustly(at url: URL) throws {
+        let fm = FileManager.default
+        var pathComponents = url.pathComponents
+
+        // Remove leading "/" if present
+        if pathComponents.first == "/" {
+            pathComponents.removeFirst()
+        }
+
+        // Build path incrementally, checking each component
+        var currentPath = "/"
+        for component in pathComponents {
+            currentPath = (currentPath as NSString).appendingPathComponent(component)
+            let componentURL = URL(fileURLWithPath: currentPath)
+
+            var isDirectory: ObjCBool = false
+            if fm.fileExists(atPath: currentPath, isDirectory: &isDirectory) {
+                if !isDirectory.boolValue {
+                    // A file exists where a directory should be - remove it
+                    logger.warning("Removing file blocking directory creation: \(currentPath)")
+                    try fm.removeItem(at: componentURL)
+                    try fm.createDirectory(at: componentURL, withIntermediateDirectories: false)
+                }
+                // If it's already a directory, continue
+            } else {
+                // Path doesn't exist, create remaining path with intermediate directories
+                try fm.createDirectory(at: url, withIntermediateDirectories: true)
+                return
+            }
+        }
+    }
+
+    /// `true` when every model in `models` exists under `repoPath`.
+    static func allModelsExist(at repoPath: URL, models: Set<String>) -> Bool {
+        models.allSatisfy { model in
+            FileManager.default.fileExists(atPath: repoPath.appendingPathComponent(model).path)
+        }
+    }
+
+    /// The subset of `models` missing under `repoPath`, sorted for stable
+    /// error reporting.
+    static func missingModels(at repoPath: URL, models: Set<String>) -> [String] {
+        models.filter { model in
+            !FileManager.default.fileExists(atPath: repoPath.appendingPathComponent(model).path)
+        }.sorted()
+    }
+
+    /// Throw `modelNotFound` for the first required model absent under
+    /// `repoPath` (the post-download verify pass).
+    static func verifyModelsPresent(at repoPath: URL, models: Set<String>) throws {
+        for model in models {
+            let modelPath = repoPath.appendingPathComponent(model)
+            guard FileManager.default.fileExists(atPath: modelPath.path) else {
+                throw HFDownload.DownloadError.modelNotFound(path: model)
+            }
+        }
+    }
+
+    /// Validate the on-disk shape of a compiled CoreML model before loading:
+    /// it must be a directory containing `coremldata.bin`.
+    static func validateCompiledModelLayout(at modelPath: URL, name: String) throws {
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw CocoaError(
+                .fileNoSuchFile,
+                userInfo: [
+                    NSFilePathErrorKey: modelPath.path,
+                    NSLocalizedDescriptionKey: "Model file not found: \(name)",
+                ])
+        }
+
+        var isDirectory: ObjCBool = false
+        guard
+            FileManager.default.fileExists(atPath: modelPath.path, isDirectory: &isDirectory),
+            isDirectory.boolValue
+        else {
+            throw CocoaError(
+                .fileReadCorruptFile,
+                userInfo: [
+                    NSFilePathErrorKey: modelPath.path,
+                    NSLocalizedDescriptionKey: "Model path is not a directory: \(name)",
+                ])
+        }
+
+        let coremlDataPath = modelPath.appendingPathComponent("coremldata.bin")
+        guard FileManager.default.fileExists(atPath: coremlDataPath.path) else {
+            logger.error("Missing coremldata.bin in \(name)")
+            throw CocoaError(
+                .fileReadCorruptFile,
+                userInfo: [
+                    NSFilePathErrorKey: coremlDataPath.path,
+                    NSLocalizedDescriptionKey: "Missing coremldata.bin in model: \(name)",
+                ])
+        }
+    }
+
+    /// Delete a corrupted repo cache, tolerating an already-missing path
+    /// (robust directory creation handles any remnants on re-download).
+    static func purgeCorruptedCache(at repoPath: URL) {
+        do {
+            try FileManager.default.removeItem(at: repoPath)
+            logger.info("Successfully deleted corrupted cache at \(repoPath.path)")
+        } catch {
+            let nsError = error as NSError
+            if nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileNoSuchFileError {
+                // Already gone — fine.
+            } else {
+                logger.warning("Failed to delete cache: \(error.localizedDescription)")
+                logger.info("Will attempt to overwrite during re-download")
+            }
+        }
+    }
+}

--- a/Sources/FluidAudio/Shared/Download/ProgressReporter.swift
+++ b/Sources/FluidAudio/Shared/Download/ProgressReporter.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Models download-operation progress as weighted phases (#765 Wave 4),
+/// replacing the fraction math previously copy-pasted at call sites.
+///
+/// The documented invariant: `fractionCompleted` is a monotonic fraction of
+/// THIS operation in [0, 1]; inspect `phase` for what is happening. Repo
+/// loads declare `downloadPhaseWeight: 0.5` (compile occupies the rest);
+/// subdirectory downloads declare `1.0`.
+struct ProgressReporter: Sendable {
+    let handler: DownloadUtils.ProgressHandler?
+    /// Fraction of the overall operation the download phase occupies.
+    let downloadPhaseWeight: Double
+
+    private func emit(_ fraction: Double, _ phase: DownloadUtils.DownloadPhase) {
+        handler?(DownloadUtils.DownloadProgress(fractionCompleted: fraction, phase: phase))
+    }
+
+    /// Byte-weighted fraction of the download phase: bytes when total bytes
+    /// are known, file counts otherwise; complete when there are no files.
+    static func downloadFraction(
+        completedBytes: Int64,
+        totalBytes: Int64,
+        completedFiles: Int,
+        totalFiles: Int
+    ) -> Double {
+        guard totalFiles > 0 else { return 1.0 }
+        guard totalBytes > 0 else {
+            return min(Double(completedFiles) / Double(totalFiles), 1.0)
+        }
+        return min(Double(completedBytes) / Double(totalBytes), 1.0)
+    }
+
+    /// The listing phase opens every operation at fraction 0.
+    func listing() {
+        emit(0.0, .listing)
+    }
+
+    /// Live byte progress within a file. No emission when total bytes are
+    /// unknown — mid-file bytes of unweighted files would inflate then snap
+    /// back, breaking monotonicity.
+    func liveBytes(
+        completedBytes: Int64, totalBytes: Int64, fileIndex: Int, totalFiles: Int
+    ) {
+        guard totalBytes > 0 else { return }
+        let fraction = downloadPhaseWeight * Double(completedBytes) / Double(totalBytes)
+        emit(
+            min(fraction, downloadPhaseWeight),
+            .downloading(completedFiles: fileIndex, totalFiles: totalFiles))
+    }
+
+    /// A file boundary (downloaded, skipped, or created empty).
+    func fileBoundary(
+        completedBytes: Int64, totalBytes: Int64, completedFiles: Int, totalFiles: Int
+    ) {
+        let fraction =
+            downloadPhaseWeight
+            * Self.downloadFraction(
+                completedBytes: completedBytes, totalBytes: totalBytes,
+                completedFiles: completedFiles, totalFiles: totalFiles)
+        emit(fraction, .downloading(completedFiles: completedFiles, totalFiles: totalFiles))
+    }
+
+    /// The cached fast path: download phase complete without network.
+    func cachedModelsAvailable() {
+        emit(downloadPhaseWeight, .downloading(completedFiles: 0, totalFiles: 0))
+    }
+
+    /// Compiling model `index` of `count`.
+    func compiling(name: String, index: Int, count: Int) {
+        let compileWeight = 1.0 - downloadPhaseWeight
+        emit(
+            downloadPhaseWeight + compileWeight * Double(index) / Double(count),
+            .compiling(modelName: name))
+    }
+
+    /// The operation is complete.
+    func finished() {
+        emit(1.0, .compiling(modelName: ""))
+    }
+}

--- a/Sources/FluidAudio/Shared/Download/ProgressReporter.swift
+++ b/Sources/FluidAudio/Shared/Download/ProgressReporter.swift
@@ -43,10 +43,28 @@ struct ProgressReporter: Sendable {
         completedBytes: Int64, totalBytes: Int64, fileIndex: Int, totalFiles: Int
     ) {
         guard totalBytes > 0 else { return }
-        let fraction = downloadPhaseWeight * Double(completedBytes) / Double(totalBytes)
-        emit(
-            min(fraction, downloadPhaseWeight),
-            .downloading(completedFiles: fileIndex, totalFiles: totalFiles))
+        let fraction =
+            downloadPhaseWeight
+            * Self.downloadFraction(
+                completedBytes: completedBytes, totalBytes: totalBytes,
+                completedFiles: fileIndex, totalFiles: totalFiles)
+        emit(fraction, .downloading(completedFiles: fileIndex, totalFiles: totalFiles))
+    }
+
+    /// Factory for the per-file live-bytes callback both download loops hand
+    /// to FileDownloader; nil when there is no handler (skip the closure
+    /// allocation and delegate churn entirely).
+    func liveBytesCallback(
+        baseBytes: Int64, totalBytes: Int64, fileIndex: Int, totalFiles: Int
+    ) -> (@Sendable (Int64, Int64) -> Void)? {
+        guard handler != nil else { return nil }
+        return { bytesWritten, _ in
+            self.liveBytes(
+                completedBytes: baseBytes + bytesWritten,
+                totalBytes: totalBytes,
+                fileIndex: fileIndex,
+                totalFiles: totalFiles)
+        }
     }
 
     /// A file boundary (downloaded, skipped, or created empty).
@@ -66,8 +84,10 @@ struct ProgressReporter: Sendable {
         emit(downloadPhaseWeight, .downloading(completedFiles: 0, totalFiles: 0))
     }
 
-    /// Compiling model `index` of `count`.
+    /// Compiling model `index` of `count`. No emission for an empty set —
+    /// dividing by zero would hand the handler a NaN fraction.
     func compiling(name: String, index: Int, count: Int) {
+        guard count > 0 else { return }
         let compileWeight = 1.0 - downloadPhaseWeight
         emit(
             downloadPhaseWeight + compileWeight * Double(index) / Double(count),


### PR DESCRIPTION
Wave 4 of the #765 execution plan — the last extraction wave. **All characterization suites (Wave 1 oracle + resume/artifact/cancellation) ride along untouched**; them passing unmodified is the behavior-preservation proof.

## What this does

`DownloadUtils` shrinks **1220 → ~650 lines** and becomes what the plan calls the thin façade: public API + orchestration, with every mechanism in a named, unit-tested primitive.

**`FileDownloader`** (new) — the per-file unit both entry points now share:
- `ensure(file:from:at:configuration:onBytes:)` → `.alreadyPresent` / `.createdEmpty` / `.downloaded`
- skip-if-present, robust parent-dir creation, local zero-byte creation (HF 500s on empty files), authorized download through `RetryPolicy` + the #757 byte-range-resume transport (`streamDownload`, delegate, resume helpers, `validateDownloadedArtifact` — all moved **verbatim**), atomic move into place

**`ModelCache`** (new) — the on-disk knowledge: `allModelsExist`/`missingModels` (typed offline errors), `verifyModelsPresent` (post-download pass), `validateCompiledModelLayout` (pre-compile checks), `purgeCorruptedCache` (the `loadModels` recovery; the cancellation-is-not-corruption guard stays at its call site), `createDirectoryRobustly`

**`ProgressReporter`** (new) — weighted phases with one documented invariant: *monotonic fraction of THIS operation; inspect `phase` for what's happening.* Repo loads declare `download 0.5 / compile 0.5` (byte-weighted; emissions bit-identical to before — `ProgressSequenceTests` pins them), subdirectory declares `1.0` (the #769 math absorbed as `ProgressReporter.downloadFraction`)

**Test-pinned forwards kept**: `downloadFileWithRetry`, `resumeValidatorURL`, `validateDownloadedArtifact`, `subdirectoryProgressFraction`, `isRetryableDownloadError`, `isCancellationError` — the characterization suites verify the moved logic unchanged.

## Deliberate micro-deltas (ledger)

1. `downloadSubdirectory`'s parent-directory creation now uses `createDirectoryRobustly` (was plain `createDirectory`) — strictly more capable (recovers from files blocking directory paths), unifying the two loops' one remaining filesystem divergence.
2. Per-file transport logs (`Resuming <path>…`, retry warnings) move to the `FileDownloader` log category; orchestration logs (`Downloaded N/M files`) stay under `DownloadUtils`.

## Verification

- **Cache-layout snapshot (the Wave 4 acceptance artifact)**: fresh cold silero download on a *clean main build* vs this branch — **byte-identical paths + sizes**, both loads succeed. No existing user's cache invalidates.
- Local: clean full build 0 errors, swift-format clean, live cold download + VAD load through the new primitives (exit 0).
- This PR's CI: oracle + all pinned suites unmodified, `download-smoke` live round-trip, cold benchmarks at baseline. If #773 (all-repo cache keying) merges first, this PR's sync becomes the first full nine-repo cold sweep.

Part of #765. Wave 5 (converge `fetchHuggingFaceFile` + honor typed Retry-After — the behavior-change wave) is next and last before the API cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Self-review pass applied (`dcdfb096`)

A 7-angle review surfaced 10 findings; all applied. Two mattered:

1. **The ledger under-sold a destructive change**: routing `downloadSubdirectory` through `createDirectoryRobustly` extended silent delete-blocking-file recovery to caller-provided directories that previously failed loudly. Fixed with an explicit `recoveringBlockedPaths` parameter on `FileDownloader.ensure` — repo caches keep the historical recovery, subdirectory downloads surface the error and never delete user files.
2. **Log-category sprawl reversed**: the review found a third, unledgered category move (ModelCache purge/layout lines). Resolution: `FileDownloader` and `ModelCache` log under the historical `DownloadUtils` category (Wave 6 renames deliberately), so one download's full trail — listing, transport, retries, resume, purge — stays under the one predicate existing diagnostics use. Both previous ledger deltas about categories are now void.

Also: per-attempt `enforceOffline` re-check in `download()` (matching `HFTreeLister.fetch`); `createDirectoryRobustly` early-exit (a 500-file subdirectory paid ~5,000 redundant stats); deterministic sorted `modelNotFound` via one existence predicate; `compiling()` NaN guard; one byte-fraction formula (`liveBytes` → `downloadFraction`); `liveBytesCallback` factory deduplicating the loops' identical closure blocks; canonical error spelling in the delegate + Wave 6 marker on the façade session default; corrected stale coverage comments; cancellation invariant documented on `purgeCorruptedCache`; dead import/MARK cleanup; the repo-loop cached-no-boundary asymmetry pinned with a comment.

**Remaining ledgered deltas are now exactly two**: subdirectory parent-dir creation fails loudly on blocked paths *by design* (documented above), and `enforceOffline` flips now stop per-file downloads at the next attempt.

Rebased onto main with #773 merged — **this push is the first full nine-repo cold-download sweep** through the Wave 4 stack.
