### PR TITLE
feat(download): Wave 5 — converge fetchHuggingFaceFile onto the shared policy; honor Retry-After (#765)

### DIFF
--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -600,45 +600,34 @@ public class DownloadUtils {
         logger.info("Downloaded \(subdirectory) from \(repo.folderName)")
     }
 
-    /// Fetch a single file from HuggingFace with retry
+    /// Fetch a single file from HuggingFace with the converged retry policy
+    /// (#765 Wave 5): permanent errors (404s) fail fast instead of consuming
+    /// the backoff budget, 5xx/rate-limits retry with Retry-After pacing, and
+    /// HTML/empty bodies are rejected instead of returned as content.
     public static func fetchHuggingFaceFile(
         from url: URL,
         description: String,
         maxAttempts: Int = 4,
         minBackoff: TimeInterval = 1.0
     ) async throws -> Data {
+        try await fetchHuggingFaceFile(
+            from: url, description: description,
+            maxAttempts: maxAttempts, minBackoff: minBackoff,
+            configuration: nil)
+    }
+
+    /// Internal seam: `configuration` lets tests stub the transport.
+    static func fetchHuggingFaceFile(
+        from url: URL,
+        description: String,
+        maxAttempts: Int = 4,
+        minBackoff: TimeInterval = 1.0,
+        configuration: URLSessionConfiguration?
+    ) async throws -> Data {
         try ensureOnlineAllowed("fetchHuggingFaceFile(\(description))")
-        var lastError: Error?
-        let request = authorizedRequest(url: url)
-
-        for attempt in 1...maxAttempts {
-            do {
-                let (data, response) = try await sharedSession.data(for: request)
-
-                guard let httpResponse = response as? HTTPURLResponse else {
-                    throw HuggingFaceDownloadError.invalidResponse
-                }
-
-                try HFClient.checkRateLimit(httpResponse, context: "fetching \(description)")
-
-                guard (200..<300).contains(httpResponse.statusCode) else {
-                    throw HuggingFaceDownloadError.invalidResponse
-                }
-
-                return data
-
-            } catch {
-                lastError = error
-                if attempt < maxAttempts {
-                    let backoffSeconds = pow(2.0, Double(attempt - 1)) * minBackoff
-                    logger.warning(
-                        "Download attempt \(attempt) for \(description) failed: \(error.localizedDescription). Retrying in \(String(format: "%.1f", backoffSeconds))s."
-                    )
-                    try await Task.sleep(nanoseconds: UInt64(backoffSeconds * 1_000_000_000))
-                }
-            }
-        }
-
-        throw lastError ?? HuggingFaceDownloadError.invalidResponse
+        return try await FileDownloader.fetchData(
+            from: url, description: description,
+            maxAttempts: maxAttempts, minBackoff: minBackoff,
+            configuration: configuration)
     }
 }

--- a/Sources/FluidAudio/Shared/Download/FileDownloader.swift
+++ b/Sources/FluidAudio/Shared/Download/FileDownloader.swift
@@ -133,6 +133,62 @@ enum FileDownloader {
     ///     including `resumeOffset`. Delegate-driven byte progress (#756).
     ///   - onResponse: Fires before any body byte is written — the resume path
     ///     persists the validator here so it survives a drop mid-body.
+    /// Fetch a small file into memory with the converged policy (#765 Wave 5):
+    /// classified retry (permanent 4xx fails fast, 5xx/rate-limits retry with
+    /// Retry-After pacing) and artifact validation (HTML error pages and empty
+    /// bodies are rejected, never returned as content). Replaces
+    /// `fetchHuggingFaceFile`'s historical retry-everything loop.
+    static func fetchData(
+        from url: URL,
+        description: String,
+        maxAttempts: Int = 4,
+        minBackoff: TimeInterval = 1.0,
+        configuration: URLSessionConfiguration? = nil
+    ) async throws -> Data {
+        let request = HFClient.authorizedRequest(url: url)
+        let session = configuration.map { URLSession(configuration: $0) } ?? DownloadUtils.sharedSession
+        defer {
+            if configuration != nil { session.finishTasksAndInvalidate() }
+        }
+
+        return try await RetryPolicy.withRetry(
+            label: description, maxAttempts: maxAttempts, minBackoff: minBackoff, logger: logger
+        ) { _ in
+            // Re-check per attempt, matching download(): flipping
+            // enforceOffline mid-operation stops at the next request.
+            guard !DownloadUtils.enforceOffline else {
+                throw DownloadUtils.OfflineError.networkDisabled(operation: "fetchData(\(description))")
+            }
+
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw HFDownload.DownloadError.invalidResponse
+            }
+
+            try HFClient.checkRateLimitForRetry(httpResponse, context: "fetching \(description)")
+
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                throw HFDownload.DownloadError.downloadFailed(
+                    path: description,
+                    underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
+                )
+            }
+
+            // Reject bodies that are error pages or truncated-to-nothing —
+            // a 200 carrying HTML must never be cached as content (#748).
+            if data.isEmpty {
+                throw HFDownload.DownloadError.invalidArtifact(
+                    path: description, reason: "empty file")
+            }
+            if HFClient.looksLikeHTML(data) {
+                throw HFDownload.DownloadError.invalidArtifact(
+                    path: description, reason: "response body begins with HTML markup")
+            }
+
+            return data
+        }
+    }
+
     /// Coverage flows through the `DownloadUtils.downloadFileWithRetry`
     /// forward (DownloadResumeTests); no test drives this directly.
     static func streamDownload(
@@ -290,7 +346,7 @@ enum FileDownloader {
                 }
             )
 
-            try HFClient.checkRateLimit(httpResponse, context: "downloading \(path)")
+            try HFClient.checkRateLimitForRetry(httpResponse, context: "downloading \(path)")
 
             if httpResponse.statusCode == 416 {
                 // Range not satisfiable — the partial is bogus (or the remote

--- a/Sources/FluidAudio/Shared/Download/FileDownloader.swift
+++ b/Sources/FluidAudio/Shared/Download/FileDownloader.swift
@@ -118,21 +118,8 @@ enum FileDownloader {
         }
     }
 
-    // MARK: - Streaming download to a persistent file
+    // MARK: - Small-file fetch with converged policy (#765 Wave 5)
 
-    /// Stream a download directly into `destination` so received bytes survive
-    /// a mid-transfer drop (#757). Pure transport: the caller sets resume
-    /// headers and validates the HTTP status. Body bytes are written only for
-    /// 2xx — appended after `resumeOffset` on 206, from byte 0 otherwise.
-    ///
-    /// - Parameters:
-    ///   - resumeOffset: Byte count a 206 appends after; also the base for
-    ///     progress callbacks so resumed progress never dips.
-    ///   - configuration: Session configuration override for tests.
-    ///   - onProgress: `(totalBytesWritten, totalBytesExpected)`, both
-    ///     including `resumeOffset`. Delegate-driven byte progress (#756).
-    ///   - onResponse: Fires before any body byte is written — the resume path
-    ///     persists the validator here so it survives a drop mid-body.
     /// Fetch a small file into memory with the converged policy (#765 Wave 5):
     /// classified retry (permanent 4xx fails fast, 5xx/rate-limits retry with
     /// Retry-After pacing) and artifact validation (HTML error pages and empty
@@ -157,7 +144,8 @@ enum FileDownloader {
             // Re-check per attempt, matching download(): flipping
             // enforceOffline mid-operation stops at the next request.
             guard !DownloadUtils.enforceOffline else {
-                throw DownloadUtils.OfflineError.networkDisabled(operation: "fetchData(\(description))")
+                throw DownloadUtils.OfflineError.networkDisabled(
+                    operation: "fetchHuggingFaceFile(\(description))")
             }
 
             let (data, response) = try await session.data(for: request)
@@ -176,6 +164,14 @@ enum FileDownloader {
 
             // Reject bodies that are error pages or truncated-to-nothing —
             // a 200 carrying HTML must never be cached as content (#748).
+            // Content-Type check mirrors validateDownloadedArtifact's, so a
+            // text/html page without a sniffable prefix is caught here too.
+            if let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")?.lowercased(),
+                contentType.contains("text/html")
+            {
+                throw HFDownload.DownloadError.invalidArtifact(
+                    path: description, reason: "server returned Content-Type: \(contentType)")
+            }
             if data.isEmpty {
                 throw HFDownload.DownloadError.invalidArtifact(
                     path: description, reason: "empty file")
@@ -189,6 +185,21 @@ enum FileDownloader {
         }
     }
 
+    // MARK: - Streaming download to a persistent file
+
+    /// Stream a download directly into `destination` so received bytes survive
+    /// a mid-transfer drop (#757). Pure transport: the caller sets resume
+    /// headers and validates the HTTP status. Body bytes are written only for
+    /// 2xx — appended after `resumeOffset` on 206, from byte 0 otherwise.
+    ///
+    /// - Parameters:
+    ///   - resumeOffset: Byte count a 206 appends after; also the base for
+    ///     progress callbacks so resumed progress never dips.
+    ///   - configuration: Session configuration override for tests.
+    ///   - onProgress: `(totalBytesWritten, totalBytesExpected)`, both
+    ///     including `resumeOffset`. Delegate-driven byte progress (#756).
+    ///   - onResponse: Fires before any body byte is written — the resume path
+    ///     persists the validator here so it survives a drop mid-body.
     /// Coverage flows through the `DownloadUtils.downloadFileWithRetry`
     /// forward (DownloadResumeTests); no test drives this directly.
     static func streamDownload(

--- a/Sources/FluidAudio/Shared/Download/HFClient.swift
+++ b/Sources/FluidAudio/Shared/Download/HFClient.swift
@@ -43,6 +43,25 @@ enum HFClient {
             message: "Rate limited while \(context()) (HTTP \(response.statusCode))")
     }
 
+    /// `checkRateLimit` for call sites inside `RetryPolicy.withRetry`: when
+    /// the response carries `Retry-After`, the thrown `rateLimited` error is
+    /// wrapped in `RetryPolicy.RetryAfterHint` so backoff honors the server's
+    /// pacing (#765 Wave 5). Never use outside a retry operation — the
+    /// envelope must not escape to callers (unpaced sites like the tree
+    /// lister keep plain `checkRateLimit`).
+    static func checkRateLimitForRetry(
+        _ response: HTTPURLResponse, context: @autoclosure () -> String
+    ) throws {
+        do {
+            try checkRateLimit(response, context: context())
+        } catch {
+            if let delay = retryAfter(from: response) {
+                throw RetryPolicy.RetryAfterHint(underlying: error, retryAfter: delay)
+            }
+            throw error
+        }
+    }
+
     /// Typed `Retry-After` from a response: delay-seconds, or an HTTP-date
     /// converted to seconds-from-now. Nil when absent or unparsable.
     static func retryAfter(from response: HTTPURLResponse) -> TimeInterval? {

--- a/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
+++ b/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
@@ -8,6 +8,21 @@ enum RetryPolicy {
 
     private static let defaultLogger = AppLogger(category: "RetryPolicy")
 
+    /// Longest server-requested pause `withRetry` will honor. Rate-limited
+    /// endpoints occasionally send hour-scale `Retry-After` values; waiting
+    /// that long inside a download call would look like a hang.
+    static let maxHonoredRetryAfter: TimeInterval = 30
+
+    /// Internal envelope carrying a typed `Retry-After` hint alongside the
+    /// real error (#765 Wave 5). Thrown ONLY inside `withRetry` operations
+    /// (see `HFClient.checkRateLimitForRetry`); `withRetry` unwraps it for
+    /// pacing and always rethrows the underlying error, so the envelope never
+    /// escapes to callers or tests.
+    struct RetryAfterHint: Error {
+        let underlying: Error
+        let retryAfter: TimeInterval
+    }
+
     /// Run `operation`, retrying transient failures (per `isRetryable`) with
     /// exponential backoff. Permanent errors and the final attempt's error are
     /// rethrown unchanged. The closure receives the 1-based attempt number

--- a/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
+++ b/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
@@ -46,14 +46,23 @@ enum RetryPolicy {
             do {
                 return try await operation(attempt)
             } catch {
-                guard attempt < maxAttempts, isRetryable(error) else {
-                    throw error
+                // Unwrap a Retry-After envelope: the hint paces the sleep, the
+                // underlying error drives classification and is what callers
+                // see — the envelope never escapes this function.
+                let hint = error as? RetryAfterHint
+                let underlying = hint?.underlying ?? error
+
+                guard attempt < maxAttempts, isRetryable(underlying) else {
+                    throw underlying
                 }
                 let backoffSeconds = pow(2.0, Double(attempt - 1)) * minBackoff
+                let serverPause = min(hint?.retryAfter ?? 0, maxHonoredRetryAfter)
+                let pauseSeconds = max(backoffSeconds, serverPause)
+                let pacedNote = serverPause > backoffSeconds ? " (server Retry-After)" : ""
                 logger.warning(
-                    "Download attempt \(attempt) for \(label) failed: \(error.localizedDescription). Retrying in \(String(format: "%.1f", backoffSeconds))s."
+                    "Download attempt \(attempt) for \(label) failed: \(underlying.localizedDescription). Retrying in \(String(format: "%.1f", pauseSeconds))s\(pacedNote)."
                 )
-                try await Task.sleep(nanoseconds: UInt64(backoffSeconds * 1_000_000_000))
+                try await Task.sleep(nanoseconds: UInt64(pauseSeconds * 1_000_000_000))
             }
         }
 

--- a/Tests/FluidAudioTests/Shared/FetchHuggingFaceFileTests.swift
+++ b/Tests/FluidAudioTests/Shared/FetchHuggingFaceFileTests.swift
@@ -1,0 +1,198 @@
+import Foundation
+import XCTest
+import os
+
+@testable import FluidAudio
+
+/// Wave 5 behavior tests (#765): `fetchHuggingFaceFile` converges onto the
+/// shared retry policy and artifact validation. These pin the DELIBERATE
+/// behavior changes this wave introduces:
+///   - permanent errors (404) fail fast instead of consuming the backoff budget
+///   - 5xx retries, then succeeds
+///   - HTML and empty 200 bodies throw instead of being returned as content
+///   - `Retry-After` paces the backoff, and the envelope never escapes
+final class FetchHuggingFaceFileTests: XCTestCase {
+
+    private var stubConfiguration: URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [FetchStubURLProtocol.self]
+        return config
+    }
+
+    private let url = URL(string: "https://stub.test/repo/resolve/main/vocab.json")!
+
+    override func setUp() {
+        super.setUp()
+        FetchStubURLProtocol.reset()
+    }
+
+    override func tearDown() {
+        FetchStubURLProtocol.reset()
+        super.tearDown()
+    }
+
+    private func fetch(maxAttempts: Int = 4) async throws -> Data {
+        try await DownloadUtils.fetchHuggingFaceFile(
+            from: url, description: "vocab.json",
+            maxAttempts: maxAttempts, minBackoff: 0.01,
+            configuration: stubConfiguration)
+    }
+
+    func testSuccessReturnsBody() async throws {
+        FetchStubURLProtocol.enqueue(status: 200, body: Data("{\"vocab\": 1}".utf8))
+        let data = try await fetch()
+        XCTAssertEqual(data, Data("{\"vocab\": 1}".utf8))
+        XCTAssertEqual(FetchStubURLProtocol.requestCount, 1)
+    }
+
+    func testPermanent404FailsFastOnFirstAttempt() async {
+        FetchStubURLProtocol.enqueue(status: 404, body: Data())
+        do {
+            _ = try await fetch()
+            XCTFail("expected downloadFailed")
+        } catch HFDownload.DownloadError.downloadFailed(let path, let underlying) {
+            XCTAssertEqual(path, "vocab.json")
+            XCTAssertEqual((underlying as NSError).code, 404)
+        } catch {
+            XCTFail("expected downloadFailed, got \(error)")
+        }
+        XCTAssertEqual(
+            FetchStubURLProtocol.requestCount, 1,
+            "Wave 5 delta: a hard 404 must not consume the backoff budget")
+    }
+
+    func testTransient5xxRetriesThenSucceeds() async throws {
+        FetchStubURLProtocol.enqueue(status: 502, body: Data())
+        FetchStubURLProtocol.enqueue(status: 200, body: Data("payload".utf8))
+        let data = try await fetch()
+        XCTAssertEqual(data, Data("payload".utf8))
+        XCTAssertEqual(FetchStubURLProtocol.requestCount, 2)
+    }
+
+    func testHTMLBodyIsRejectedNotReturned() async {
+        // Wave 5 delta: previously a 200 HTML error page was returned as-is
+        // and could be cached as vocab.json (#748). invalidArtifact is
+        // classified retryable, so with the queue exhausted the fetch fails.
+        FetchStubURLProtocol.enqueue(
+            status: 200, body: Data("<!DOCTYPE html><html>rate limited</html>".utf8))
+        do {
+            _ = try await fetch(maxAttempts: 1)
+            XCTFail("expected invalidArtifact")
+        } catch HFDownload.DownloadError.invalidArtifact(_, let reason) {
+            XCTAssertTrue(reason.contains("HTML"), "got: \(reason)")
+        } catch {
+            XCTFail("expected invalidArtifact, got \(error)")
+        }
+    }
+
+    func testEmptyBodyIsRejected() async {
+        // Wave 5 delta: previously an empty 200 body was returned as Data().
+        FetchStubURLProtocol.enqueue(status: 200, body: Data())
+        do {
+            _ = try await fetch(maxAttempts: 1)
+            XCTFail("expected invalidArtifact")
+        } catch HFDownload.DownloadError.invalidArtifact(_, let reason) {
+            XCTAssertEqual(reason, "empty file")
+        } catch {
+            XCTFail("expected invalidArtifact, got \(error)")
+        }
+    }
+
+    func testRetryAfterPacesBackoffAndEnvelopeNeverEscapes() async {
+        // 429 with a 0.3s Retry-After (>> the 0.01s minBackoff), then success.
+        FetchStubURLProtocol.enqueue(
+            status: 429, body: Data(), headers: ["Retry-After": "0.3"])
+        FetchStubURLProtocol.enqueue(status: 200, body: Data("ok".utf8))
+
+        let start = Date()
+        do {
+            let data = try await fetch()
+            XCTAssertEqual(data, Data("ok".utf8))
+        } catch {
+            XCTFail("expected success after paced retry, got \(error)")
+        }
+        XCTAssertGreaterThanOrEqual(
+            Date().timeIntervalSince(start), 0.3,
+            "backoff must honor the server's Retry-After over the 0.01s exponential floor")
+    }
+
+    func testExhaustedRateLimitSurfacesPlainRateLimitedError() async {
+        // Every attempt 429s; the surfaced error must be the plain typed
+        // rateLimited — never the internal RetryAfterHint envelope.
+        for _ in 0..<2 {
+            FetchStubURLProtocol.enqueue(
+                status: 429, body: Data(), headers: ["Retry-After": "0.05"])
+        }
+        do {
+            _ = try await fetch(maxAttempts: 2)
+            XCTFail("expected rateLimited")
+        } catch HFDownload.DownloadError.rateLimited(let statusCode, let message) {
+            XCTAssertEqual(statusCode, 429)
+            XCTAssertTrue(message.contains("fetching vocab.json"), "got: \(message)")
+        } catch {
+            XCTFail("the RetryAfterHint envelope escaped: \(error)")
+        }
+        XCTAssertEqual(FetchStubURLProtocol.requestCount, 2)
+    }
+}
+
+// MARK: - Simple FIFO data-response stub
+
+final class FetchStubURLProtocol: URLProtocol {
+
+    private struct Response {
+        let status: Int
+        let body: Data
+        let headers: [String: String]
+    }
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var queue: [Response] = []
+    nonisolated(unsafe) private static var _requestCount = 0
+
+    static var requestCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _requestCount
+    }
+
+    static func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        queue = []
+        _requestCount = 0
+    }
+
+    static func enqueue(status: Int, body: Data, headers: [String: String] = [:]) {
+        lock.lock()
+        defer { lock.unlock() }
+        queue.append(Response(status: status, body: body, headers: headers))
+    }
+
+    private static func dequeue() -> Response? {
+        lock.lock()
+        defer { lock.unlock() }
+        _requestCount += 1
+        return queue.isEmpty ? nil : queue.removeFirst()
+    }
+
+    override static func canInit(with request: URLRequest) -> Bool { true }
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let url = request.url, let next = Self.dequeue() else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unsupportedURL))
+            return
+        }
+        var headers = next.headers
+        headers["Content-Length"] = String(next.body.count)
+        let response = HTTPURLResponse(
+            url: url, statusCode: next.status, httpVersion: "HTTP/1.1",
+            headerFields: headers)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: next.body)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/FluidAudioTests/Shared/FetchHuggingFaceFileTests.swift
+++ b/Tests/FluidAudioTests/Shared/FetchHuggingFaceFileTests.swift
@@ -98,6 +98,35 @@ final class FetchHuggingFaceFileTests: XCTestCase {
         }
     }
 
+    func testHTMLPageIsRetryableAndRecovers() async throws {
+        // Pinned: invalidArtifact classifies as transient — an HTML body is
+        // usually a passing rate-limit/proxy page, so the next attempt can
+        // succeed. (A persistent page still burns the budget; accepted.)
+        FetchStubURLProtocol.enqueue(
+            status: 200, body: Data("<!DOCTYPE html><html>moment</html>".utf8))
+        FetchStubURLProtocol.enqueue(status: 200, body: Data("real content".utf8))
+
+        let data = try await fetch(maxAttempts: 2)
+        XCTAssertEqual(data, Data("real content".utf8))
+        XCTAssertEqual(FetchStubURLProtocol.requestCount, 2)
+    }
+
+    func testTextHTMLContentTypeIsRejectedWithoutSniffablePrefix() async {
+        // A 200 error page whose body lacks a doctype/html prefix is still
+        // caught via the Content-Type header (mirrors the file path's check).
+        FetchStubURLProtocol.enqueue(
+            status: 200, body: Data("<h1>502 Bad Gateway</h1>".utf8),
+            headers: ["Content-Type": "text/html; charset=utf-8"])
+        do {
+            _ = try await fetch(maxAttempts: 1)
+            XCTFail("expected invalidArtifact")
+        } catch HFDownload.DownloadError.invalidArtifact(_, let reason) {
+            XCTAssertTrue(reason.contains("text/html"), "got: \(reason)")
+        } catch {
+            XCTFail("expected invalidArtifact, got \(error)")
+        }
+    }
+
     func testRetryAfterPacesBackoffAndEnvelopeNeverEscapes() async {
         // 429 with a 0.3s Retry-After (>> the 0.01s minBackoff), then success.
         FetchStubURLProtocol.enqueue(

--- a/Tests/FluidAudioTests/Shared/RetryPolicyTests.swift
+++ b/Tests/FluidAudioTests/Shared/RetryPolicyTests.swift
@@ -73,6 +73,29 @@ final class RetryPolicyTests: XCTestCase {
         XCTAssertEqual(counter.count, 3)
     }
 
+    func testRetryAfterHintUnwrapsToUnderlyingAndRespectsClassification() async {
+        // A permanent error inside the envelope must fail fast AND surface as
+        // the underlying error — the envelope never escapes withRetry.
+        let counter = Counter()
+        do {
+            let _: Never = try await RetryPolicy.withRetry(
+                label: "hinted-permanent", maxAttempts: 4, minBackoff: 0.01
+            ) { _ in
+                _ = counter.increment()
+                throw RetryPolicy.RetryAfterHint(
+                    underlying: DownloadUtils.HuggingFaceDownloadError.downloadFailed(
+                        path: "missing.bin", underlying: NSError(domain: "HTTP", code: 404)),
+                    retryAfter: 60)
+            }
+            XCTFail("expected error")
+        } catch DownloadUtils.HuggingFaceDownloadError.downloadFailed(let path, _) {
+            XCTAssertEqual(path, "missing.bin")
+        } catch {
+            XCTFail("envelope escaped or wrong error: \(error)")
+        }
+        XCTAssertEqual(counter.count, 1, "hint must not make a permanent error retryable")
+    }
+
     func testCancellationPropagatesWithoutRetry() async {
         let counter = Counter()
         do {


### PR DESCRIPTION
Wave 5 of the #765 execution plan — **the behavior-change wave**, the only one in the series (waves 1–4 were behavior-preserving extraction; this is what they existed to enable). Every delta below is deliberate, ledgered, and pinned by a new test.

## `fetchHuggingFaceFile` converges (flaws 2 & 4 closed)

Now a thin public wrapper over `FileDownloader.fetchData`:

| Behavior | Before | After |
|---|---|---|
| Hard 404 | retried 4× with 1s+2s+4s backoff (~7s wasted per missing file) | **fails fast on attempt 1** |
| 5xx | thrown as bare `invalidResponse` → never classified transient | `downloadFailed(HTTP code)` → **retries** |
| 200 with an HTML error page | returned as content — cacheable as vocab.json (#748's poisoning class) | **throws `invalidArtifact`** |
| 200 with empty body | returned as `Data()` | **throws `invalidArtifact("empty file")`** |
| `enforceOffline` flip mid-operation | unchecked after entry | **re-checked per attempt** (matches `download()`/`fetch(using:)`) |

Public signature unchanged; internal `configuration:` seam added (same pattern as every other entry point).

## `Retry-After` honored (completes the Wave 2 typed seam)

- `RetryPolicy.RetryAfterHint` — an internal envelope attached via `HFClient.checkRateLimitForRetry`, **thrown only inside `withRetry` operations**. `withRetry` paces the sleep as `max(exponential backoff, min(Retry-After, 30s cap))` and **always rethrows the underlying error** — the envelope cannot escape to callers or tests (pinned by the exhaustion test and a direct unwrap+classification unit).
- Applied to both paced paths: `FileDownloader.download` (model files) and `fetchData`. Unpaced sites (the tree lister, which has no retry loop) keep plain `checkRateLimit` and are untouched.
- A 429/503 with `Retry-After: 60` now waits what the server asked (capped) instead of hammering at 1s/2s/4s — the behavior the Wave 2 review flagged as half-built.

## Tests

`FetchHuggingFaceFileTests` (new, 7 cases): success passthrough; 404 fail-fast (request-count asserted); 5xx retry-then-success; HTML rejection; empty-body rejection; Retry-After pacing (elapsed-time asserted over a 0.01s backoff floor); envelope-never-escapes on exhaustion (surfaced error is plain `rateLimited`). `RetryPolicyTests` gains the direct envelope-unwrap case (permanent error inside a hint fails fast as the underlying error).

## Oracle policy

Per the plan, this is the one wave allowed to edit oracle tests in-diff — **zero oracle edits turned out to be needed**: Wave 1 deliberately pinned `fetchHuggingFaceFile` loosely because this change was planned. All characterization suites ride along untouched.

## Verification gates

This PR touches download sources → full nine-repo cold-download sweep (post-#773) + `download-smoke` + the untouched oracle.

Part of #765. Wave 6 (the `ModelHub` API cutover, 0.16.0) is last, and can ship these fixes to 0.15.x users first via a tag on this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Self-review pass applied (`fb6d2c89`) — including a caught ship-blocker

The review's headline finding was real and severe: **the Retry-After pacing half of this PR was a silent no-op as originally pushed.** The `withRetry` edit had been written against stale text and never applied — `RetryAfterHint` was thrown but never unwrapped, so a 429/503 *with* `Retry-After` classified as permanent, failed on attempt 1, and leaked the internal envelope to callers, on **both** the fetch and model-download paths (strictly worse than before the PR). Three of this PR's own tests would have gone red in CI; three independent review angles converged on it from the code alone. Now implemented for real: unwrap → classify/rethrow the **underlying** → pace `sleep = max(backoff, min(Retry-After, 30s cap))`.

Also applied:
- **Content-Type gap closed**: `fetchData` now mirrors the file path's `text/html` header check — a 200 error page without a sniffable doctype prefix (`<h1>502 Bad Gateway</h1>`) is rejected on the data path too (+ test)
- **Retryable-HTML behavior pinned**: a `maxAttempts:2` HTML→200 recovery test asserts the deliberate classification (transient proxy/rate-limit pages recover on retry); tradeoff documented — a *persistent* HTML page (e.g. gated-repo auth wall) burns the ~7s budget before surfacing
- **Offline tag**: per-attempt guard uses the public `fetchHuggingFaceFile(<desc>)` operation tag — no internal names in public error messages
- **Doc layout**: `fetchData` had been inserted between `streamDownload`'s doc comment and its function (Quick Help attributed `resumeOffset`/`onResponse` params to `fetchData`); relocated under its own MARK

**Ledger addition** (from the review's caller audit): legitimately-empty 200 bodies now throw where `MinimaxCorpusCommand`/`FleursBenchmark` previously received `Data()` — accepted because HF serves 500s (not empty 200s) for truly-empty files, making an empty 200 anomalous by construction.
