### PR TITLE
refactor(download)!: Wave 6 — ModelHub replaces DownloadUtils (#765)

### DIFF
--- a/.github/workflows/asr-benchmark.yml
+++ b/.github/workflows/asr-benchmark.yml
@@ -31,7 +31,7 @@ jobs:
             ~/Library/Caches/Homebrew
             /usr/local/Cellar/ffmpeg
             /opt/homebrew/Cellar/ffmpeg
-          key: ${{ runner.os }}-asr-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/Frameworks/**', 'Sources/FluidAudio/ModelRegistry.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
+          key: ${{ runner.os }}-asr-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/Frameworks/**', 'Sources/FluidAudio/ModelRegistry.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Install ffmpeg
         run: |

--- a/.github/workflows/diarizer-benchmark.yml
+++ b/.github/workflows/diarizer-benchmark.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/Library/Application Support/FluidAudio/Models/speaker-diarization-coreml
-          key: ${{ runner.os }}-diarizer-models-${{ hashFiles('Sources/FluidAudio/ModelRegistry.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
+          key: ${{ runner.os }}-diarizer-models-${{ hashFiles('Sources/FluidAudio/ModelRegistry.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Cache AMI dataset
         uses: actions/cache@v4

--- a/.github/workflows/download-smoke.yml
+++ b/.github/workflows/download-smoke.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "Sources/FluidAudio/DownloadUtils.swift"
       - "Sources/FluidAudio/Shared/Download/**"
       - "Sources/FluidAudio/ModelRegistry.swift"
       - ".github/workflows/download-smoke.yml"

--- a/.github/workflows/japanese-asr-benchmark.yml
+++ b/.github/workflows/japanese-asr-benchmark.yml
@@ -44,7 +44,7 @@ jobs:
             ~/Library/Caches/Homebrew
             /usr/local/Cellar/ffmpeg
             /opt/homebrew/Cellar/ffmpeg
-          key: ${{ runner.os }}-ja-asr-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/TdtJa*.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
+          key: ${{ runner.os }}-ja-asr-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/TdtJa*.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Install ffmpeg
         run: |

--- a/.github/workflows/nemotron-multilingual-benchmark.yml
+++ b/.github/workflows/nemotron-multilingual-benchmark.yml
@@ -54,7 +54,7 @@ jobs:
           path: |
             .build
             ~/Library/Application Support/FluidAudio
-          key: ${{ runner.os }}-nemotron-multi-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/**', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
+          key: ${{ runner.os }}-nemotron-multi-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/**', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Build
         run: swift build -c release

--- a/.github/workflows/parakeet-eou-benchmark.yml
+++ b/.github/workflows/parakeet-eou-benchmark.yml
@@ -30,7 +30,7 @@ jobs:
             ~/Library/Caches/Homebrew
             /usr/local/Cellar/ffmpeg
             /opt/homebrew/Cellar/ffmpeg
-          key: ${{ runner.os }}-parakeet-eou-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/Frameworks/**', 'Sources/FluidAudio/ModelRegistry.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
+          key: ${{ runner.os }}-parakeet-eou-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/Frameworks/**', 'Sources/FluidAudio/ModelRegistry.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Install ffmpeg
         run: |

--- a/.github/workflows/pocket-tts-test.yml
+++ b/.github/workflows/pocket-tts-test.yml
@@ -28,7 +28,7 @@ jobs:
           path: |
             .build
             ~/.cache/fluidaudio/Models/pocket-tts
-          key: ${{ runner.os }}-pocket-tts-v2.1-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/TTS/PocketTTS/**', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
+          key: ${{ runner.os }}-pocket-tts-v2.1-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/TTS/PocketTTS/**', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Build
         run: swift build -c release

--- a/.github/workflows/sortformer-benchmark.yml
+++ b/.github/workflows/sortformer-benchmark.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/Library/Application Support/FluidAudio/Models/diar-streaming-sortformer-coreml
-          key: ${{ runner.os }}-sortformer-models-high-latency-${{ hashFiles('Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
+          key: ${{ runner.os }}-sortformer-models-high-latency-${{ hashFiles('Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Cache AMI dataset
         uses: actions/cache@v4

--- a/.github/workflows/supertonic3-tts-test.yml
+++ b/.github/workflows/supertonic3-tts-test.yml
@@ -28,7 +28,7 @@ jobs:
           path: |
             .build
             ~/Library/Application Support/FluidAudio/Models/supertonic-3
-          key: ${{ runner.os }}-supertonic3-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/TTS/Supertonic3/**', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
+          key: ${{ runner.os }}-supertonic3-${{ hashFiles('Package.resolved', 'Sources/FluidAudio/TTS/Supertonic3/**', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Build
         run: swift build -c release

--- a/.github/workflows/vad-benchmark.yml
+++ b/.github/workflows/vad-benchmark.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/Library/Application Support/FluidAudio/Models/silero-vad-coreml
-          key: ${{ runner.os }}-vad-models-${{ hashFiles('Sources/FluidAudio/ModelRegistry.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/DownloadUtils.swift', 'Sources/FluidAudio/Shared/Download/**') }}
+          key: ${{ runner.os }}-vad-models-${{ hashFiles('Sources/FluidAudio/ModelRegistry.swift', 'Sources/FluidAudio/ModelNames.swift', 'Sources/FluidAudio/Shared/Download/**') }}
 
       - name: Cache VOiCES dataset
         uses: actions/cache@v4

--- a/Documentation/ASR/Nemotron.md
+++ b/Documentation/ASR/Nemotron.md
@@ -70,7 +70,7 @@ let chunkSize: NemotronChunkSize = .ms560  // Recommended balance
 let repo = chunkSize.repo  // .nemotronStreaming560
 
 // Download models
-try await DownloadUtils.downloadRepo(repo, to: modelsBaseDir)
+try await ModelHub.download(repo, to: modelsBaseDir)
 
 // Models will be at: modelsBaseDir/nemotron-streaming/560ms/
 ```
@@ -85,7 +85,7 @@ let modelsBaseDir = FileManager.default.homeDirectoryForCurrentUser
     .appendingPathComponent(".cache/fluidaudio/models")
 
 // Download if not cached
-try await DownloadUtils.downloadRepo(chunkSize.repo, to: modelsBaseDir)
+try await ModelHub.download(chunkSize.repo, to: modelsBaseDir)
 
 // Load from cache
 let modelDir = modelsBaseDir.appendingPathComponent(chunkSize.repo.folderName)

--- a/Documentation/Architecture.md
+++ b/Documentation/Architecture.md
@@ -429,7 +429,7 @@ characteristics in ways the diarizer's clustering wasn't tuned for.
   component.
 - `MLModelConfigurationUtils` — default `MLComputeUnits` selection,
   CI overrides.
-- `DownloadUtils` — HuggingFace fetch + caching + token resolution.
+- `ModelHub` (+ `Shared/Download/` primitives: HFClient, RetryPolicy, HFTreeLister, FileDownloader, ModelCache, ProgressReporter) — HuggingFace fetch + caching + token resolution.
 
 ### Per-Module
 

--- a/Documentation/Diarization/LS-EEND.md
+++ b/Documentation/Diarization/LS-EEND.md
@@ -520,7 +520,7 @@ public static func loadFromHuggingFace(
     stepSize: LSEENDStepSize = .step100ms,
     cacheDirectory: URL? = nil,
     computeUnits: MLComputeUnits = .cpuOnly,
-    progressHandler: DownloadUtils.ProgressHandler? = nil
+    progressHandler: ProgressHandler? = nil
 ) async throws -> LSEENDModel
 ```
 

--- a/Documentation/ModelConversion.md
+++ b/Documentation/ModelConversion.md
@@ -159,7 +159,7 @@ Also update `getRequiredModelNames(for:variant:)` to return the new model's requ
 
 The manager:
 - Is an `actor` (thread safety, no `@unchecked Sendable`)
-- Downloads models via `DownloadUtils.loadModels()`
+- Downloads models via `ModelHub.loadModels()`
 - Exposes a public inference API
 
 ```swift
@@ -168,7 +168,7 @@ public actor MyModelManager {
     private var decoder: MLModel?
 
     public init(config: MyModelConfig = .default) async throws {
-        let models = try await DownloadUtils.loadModels(
+        let models = try await ModelHub.loadModels(
             .myModel,
             modelNames: Array(ModelNames.MyModel.requiredModels),
             directory: cacheDir,

--- a/README.md
+++ b/README.md
@@ -234,22 +234,22 @@ swift run fluidaudiocli transcribe audio.wav
 <details>
 <summary><b>Offline-only mode</b> - Refuse every network fetch, bundle your own models</summary>
 
-If your application ships pre-downloaded model assets and never wants FluidAudio to reach HuggingFace at runtime (privacy-sensitive desktop apps, air-gapped deployments, kiosk builds), set the static `DownloadUtils.enforceOffline` flag at startup:
+If your application ships pre-downloaded model assets and never wants FluidAudio to reach HuggingFace at runtime (privacy-sensitive desktop apps, air-gapped deployments, kiosk builds), set the static `ModelHub.offlineMode` flag at startup:
 
 ```swift
 import FluidAudio
 
 // Set once before any FluidAudio loader runs.
-DownloadUtils.enforceOffline = true
+ModelHub.offlineMode = true
 
 // Load via manual APIs that read from your bundled directory:
 let asr = try await AsrModels.load(from: bundledModelURL, configuration: config)
 ```
 
 When the flag is on:
-- `fetchWithAuth`, `downloadRepo`, `downloadSubdirectory`, and `fetchHuggingFaceFile` throw `DownloadUtils.OfflineError.networkDisabled(operation:)` instead of touching the network.
+- `fetchWithAuth`, `download`, and `fetchFile` throw `DownloadError.networkDisabled(operation:)` instead of touching the network.
 - `loadModels` short-circuits its retry-with-redownload fallback so a corrupt-detected `.mlmodelc` surfaces the original load error instead of silently re-fetching.
-- If `loadModels` is invoked but required files are missing from the local directory, `DownloadUtils.OfflineError.modelMissing(repo:missing:)` is thrown with the missing file list so the caller can ship a fix.
+- If `loadModels` is invoked but required files are missing from the local directory, `DownloadError.modelMissing(repo:missing:)` is thrown with the missing file list so the caller can ship a fix.
 
 The default is `false` — no behaviour change for existing callers. Combine with a custom `ModelRegistry.baseURL` only if you want offline-mode + a typed offline error rather than relying on a mirror URL.
 

--- a/Sources/FluidAudio/ASR/Paraformer/ParaformerManager.swift
+++ b/Sources/FluidAudio/ASR/Paraformer/ParaformerManager.swift
@@ -17,7 +17,7 @@ public actor ParaformerManager {
     }
 
     public static func load(
-        precision: ParaformerPrecision = .fp16, progressHandler: DownloadUtils.ProgressHandler? = nil
+        precision: ParaformerPrecision = .fp16, progressHandler: ProgressHandler? = nil
     ) async throws -> ParaformerManager {
         ParaformerManager(
             models: try await ParaformerModels.downloadAndLoad(precision: precision, progressHandler: progressHandler))

--- a/Sources/FluidAudio/ASR/Paraformer/ParaformerModels.swift
+++ b/Sources/FluidAudio/ASR/Paraformer/ParaformerModels.swift
@@ -45,7 +45,7 @@ public struct ParaformerModels: Sendable {
 
     public static func downloadAndLoad(
         precision: ParaformerPrecision = .fp16,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> ParaformerModels {
         let directory = try await download(precision: precision, progressHandler: progressHandler)
         return try load(from: directory, precision: precision)
@@ -53,7 +53,7 @@ public struct ParaformerModels: Sendable {
 
     public static func download(
         precision: ParaformerPrecision = .fp16,
-        force: Bool = false, progressHandler: DownloadUtils.ProgressHandler? = nil
+        force: Bool = false, progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
         let modelsRoot = modelsRootDirectory()
         let targetDir = modelsRoot.appendingPathComponent(Repo.paraformerLargeZh.folderName, isDirectory: true)
@@ -63,7 +63,7 @@ public struct ParaformerModels: Sendable {
         }
         if force { try? FileManager.default.removeItem(at: targetDir) }
         logger.info("Downloading Paraformer models from HuggingFace...")
-        try await DownloadUtils.downloadRepo(.paraformerLargeZh, to: modelsRoot, progressHandler: progressHandler)
+        try await ModelHub.download(.paraformerLargeZh, to: modelsRoot, progressHandler: progressHandler)
         logger.info("Successfully downloaded Paraformer models")
         return targetDir
     }

--- a/Sources/FluidAudio/ASR/Parakeet/ParakeetLanguageModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/ParakeetLanguageModels.swift
@@ -79,7 +79,7 @@ extension ParakeetLanguageModels {
         from directory: URL,
         useInt8Encoder: Bool = true,
         configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> ParakeetLanguageModels<Config> {
         logger.info("Loading \(Config.languageLabel) models from: \(directory.path)")
 
@@ -105,7 +105,7 @@ extension ParakeetLanguageModels {
             modelNames.append(jointFile)
         }
 
-        let models = try await DownloadUtils.loadModels(
+        let models = try await ModelHub.loadModels(
             Config.repository,
             modelNames: modelNames,
             directory: parentDirectory,
@@ -174,7 +174,7 @@ extension ParakeetLanguageModels {
         useInt8Encoder: Bool = true,
         downloadBothEncoders: Bool = false,
         force: Bool = false,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
         let targetDir = directory ?? defaultCacheDirectory()
         logger.info("Preparing \(Config.languageLabel) models at: \(targetDir.path)")
@@ -213,7 +213,7 @@ extension ParakeetLanguageModels {
             modelNames.append(jointFile)
         }
 
-        _ = try await DownloadUtils.loadModels(
+        _ = try await ModelHub.loadModels(
             Config.repository,
             modelNames: modelNames,
             directory: parentDir,
@@ -236,7 +236,7 @@ extension ParakeetLanguageModels {
         to directory: URL? = nil,
         useInt8Encoder: Bool = true,
         configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> ParakeetLanguageModels<Config> {
         let targetDir = try await download(
             to: directory,

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/WordSpotting/CtcModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/WordSpotting/CtcModels.swift
@@ -158,7 +158,7 @@ extension CtcModels {
             ModelNames.CTC.audioEncoderPath,
         ]
 
-        let models = try await DownloadUtils.loadModels(
+        let models = try await ModelHub.loadModels(
             variant.repo,
             modelNames: modelNames,
             directory: parentDirectory,
@@ -221,7 +221,7 @@ extension CtcModels {
         ]
 
         for name in modelNames {
-            _ = try await DownloadUtils.loadModels(
+            _ = try await ModelHub.loadModels(
                 variant.repo,
                 modelNames: [name],
                 directory: parentDir

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/WordSpotting/CtcModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/WordSpotting/CtcModels.swift
@@ -61,7 +61,7 @@ extension CtcModels {
 
     /// Load CTC models directly from a custom directory (e.g., canary-1b-v2).
     ///
-    /// This method loads models directly without going through DownloadUtils,
+    /// This method loads models directly without going through ModelHub,
     /// allowing support for custom CTC models like canary-1b-v2.
     ///
     /// Expected directory structure:
@@ -151,7 +151,7 @@ extension CtcModels {
         let parentDirectory = directory.deletingLastPathComponent()
         let config = defaultConfiguration()
 
-        // DownloadUtils expects the base directory (without the repo folder) and
+        // ModelHub expects the base directory (without the repo folder) and
         // resolves the repo's folderName internally.
         let modelNames = [
             ModelNames.CTC.melSpectrogramPath,

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -130,7 +130,7 @@ public actor SlidingWindowAsrManager {
     ///   - progressHandler: Optional download progress callback
     public func loadModels(
         to directory: URL? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         logger.info("Loading ASR models...")
         let models = try await AsrModels.downloadAndLoad(

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -623,7 +623,7 @@ extension AsrModels {
         let fileManager = FileManager.default
         let requiredFiles = getRequiredModels(version: version, encoderPrecision: encoderPrecision)
 
-        // Check in the DownloadUtils repo structure
+        // Check in the ModelHub repo structure
         let repoPath = repoPath(from: directory, version: version)
 
         let modelsPresent = requiredFiles.allSatisfy { fileName in

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -232,7 +232,7 @@ extension AsrModels {
         version: AsrModelVersion = .v3,
         encoderPrecision: ParakeetEncoderPrecision = .int8,
         encoderComputeUnits: MLComputeUnits? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> AsrModels {
         logger.info("Loading ASR models from: \(directory.path)")
 
@@ -247,7 +247,7 @@ extension AsrModels {
         var loadedModels: [String: MLModel] = [:]
 
         for spec in specs {
-            let models = try await DownloadUtils.loadModels(
+            let models = try await ModelHub.loadModels(
                 version.repo,
                 modelNames: [spec.fileName],
                 directory: parentDirectory,
@@ -275,7 +275,7 @@ extension AsrModels {
         }
 
         // Load decoder first
-        let decoderModels = try await DownloadUtils.loadModels(
+        let decoderModels = try await ModelHub.loadModels(
             version.repo,
             modelNames: [fileNames.decoder],
             directory: parentDirectory,
@@ -291,7 +291,7 @@ extension AsrModels {
         // Load the joint model. For v3 this is JointDecisionv3.mlmodelc (with
         // top-K outputs); for v2 / 110m / tdtJa it is the version-specific
         // JointDecision.mlmodelc.
-        let jointModels = try await DownloadUtils.loadModels(
+        let jointModels = try await ModelHub.loadModels(
             version.repo,
             modelNames: [fileNames.joint],
             directory: parentDirectory,
@@ -332,7 +332,7 @@ extension AsrModels {
             // v2: Fall back to downloading from parakeet-ctc-110m HF repo
             if ctcHeadModel == nil {
                 do {
-                    let ctcModels = try await DownloadUtils.loadModels(
+                    let ctcModels = try await ModelHub.loadModels(
                         .parakeetCtc110m,
                         modelNames: [Names.ctcHeadFile],
                         directory: parentDirectory,
@@ -412,7 +412,7 @@ extension AsrModels {
         configuration: MLModelConfiguration? = nil,
         version: AsrModelVersion = .v3,
         encoderComputeUnits: MLComputeUnits? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> AsrModels {
         let cacheDir = defaultCacheDirectory(for: version)
         return try await load(
@@ -426,7 +426,7 @@ extension AsrModels {
         from directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
         encoderComputeUnits: MLComputeUnits? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> AsrModels {
         let targetDir = directory ?? defaultCacheDirectory()
         return try await load(
@@ -485,7 +485,7 @@ extension AsrModels {
         force: Bool = false,
         version: AsrModelVersion = .v3,
         encoderPrecision: ParakeetEncoderPrecision = .int8,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
         let targetDir = directory ?? defaultCacheDirectory(for: version)
         logger.info("Downloading ASR models to: \(targetDir.path)")
@@ -531,7 +531,7 @@ extension AsrModels {
         }
 
         for spec in specs {
-            _ = try await DownloadUtils.loadModels(
+            _ = try await ModelHub.loadModels(
                 version.repo,
                 modelNames: [spec.fileName],
                 directory: parentDir,
@@ -579,7 +579,7 @@ extension AsrModels {
 
         logger.info("Vocabulary \(vocabularyFileName) missing after model download; fetching directly")
         let remoteURL = try ModelRegistry.resolveModel(version.repo.remotePath, vocabularyFileName)
-        let data = try await DownloadUtils.fetchHuggingFaceFile(
+        let data = try await ModelHub.fetchFile(
             from: remoteURL, description: vocabularyFileName)
         try FileManager.default.createDirectory(
             at: vocabURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -593,7 +593,7 @@ extension AsrModels {
         version: AsrModelVersion = .v3,
         encoderPrecision: ParakeetEncoderPrecision = .int8,
         encoderComputeUnits: MLComputeUnits? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> AsrModels {
         let targetDir = try await download(
             to: directory,

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/EOU/StreamingEouAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/EOU/StreamingEouAsrManager.swift
@@ -333,7 +333,7 @@ public actor StreamingEouAsrManager {
     public func loadModels(
         to directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         if let configuration {
             self.configuration = configuration
@@ -358,7 +358,7 @@ public actor StreamingEouAsrManager {
 
         if !modelsExist {
             logger.info("Downloading Parakeet EOU models to \(modelsRoot.path)...")
-            try await DownloadUtils.downloadRepo(repo, to: modelsRoot, progressHandler: progressHandler)
+            try await ModelHub.download(repo, to: modelsRoot, progressHandler: progressHandler)
         } else {
             logger.info("Using cached Parakeet EOU models at \(modelDir.path)")
         }

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronAsrManager.swift
@@ -169,7 +169,7 @@ public actor StreamingNemotronAsrManager {
     public func loadModels(
         to directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         if let configuration {
             self.mlConfiguration = configuration
@@ -191,7 +191,7 @@ public actor StreamingNemotronAsrManager {
 
         if !FileManager.default.fileExists(atPath: encoderInt8Path.path) {
             logger.info("Downloading Nemotron models to \(modelsBaseDir.path)...")
-            try await DownloadUtils.downloadRepo(repo, to: modelsBaseDir, progressHandler: progressHandler)
+            try await ModelHub.download(repo, to: modelsBaseDir, progressHandler: progressHandler)
         } else {
             logger.info("Using cached Nemotron models at \(cacheDir.path)")
         }

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Shared.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Shared.swift
@@ -393,7 +393,7 @@ extension StreamingNemotronMultilingualAsrManager {
                 logger.warning(
                     "Cached tokenizer.json at \(tokenizerPath.path) has a corrupt duplicate '<blank>' entry — re-downloading the fixed file"
                 )
-                // Move the corrupt file aside so downloadSubdirectory re-fetches
+                // Move the corrupt file aside so download(subdirectory:) re-fetches
                 // it; restore on failure so offline users keep a working variant.
                 let backupPath = tokenizerPath.appendingPathExtension("corrupt")
                 try? FileManager.default.removeItem(at: backupPath)

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Shared.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+Shared.swift
@@ -345,7 +345,7 @@ extension StreamingNemotronMultilingualAsrManager {
         chunkMs: Int = 2240,
         to directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> SharedNemotronMultilingualModels {
         let variantDir = try await downloadVariant(
             languageCode: languageCode, chunkMs: chunkMs,
@@ -360,7 +360,7 @@ extension StreamingNemotronMultilingualAsrManager {
         languageCode: String = "auto",
         chunkMs: Int = 2240,
         to directory: URL? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
         let logger = AppLogger(category: "NemotronMultilingualStreaming")
         let langDir = languageDirectory(for: languageCode)
@@ -399,7 +399,7 @@ extension StreamingNemotronMultilingualAsrManager {
                 try? FileManager.default.removeItem(at: backupPath)
                 try FileManager.default.moveItem(at: tokenizerPath, to: backupPath)
                 do {
-                    try await DownloadUtils.downloadSubdirectory(
+                    try await ModelHub.download(
                         .nemotronMultilingual,
                         subdirectory: subdirectory,
                         to: repoCacheDir,
@@ -419,7 +419,7 @@ extension StreamingNemotronMultilingualAsrManager {
             }
         } else {
             logger.info("Downloading multilingual variant \(subdirectory) (.mlmodelc only)...")
-            try await DownloadUtils.downloadSubdirectory(
+            try await ModelHub.download(
                 .nemotronMultilingual,
                 subdirectory: subdirectory,
                 to: repoCacheDir,

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
@@ -125,7 +125,7 @@ public actor StreamingUnifiedAsrManager {
     public func loadModels(
         to directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         if let configuration {
             self.mlConfiguration = configuration
@@ -150,7 +150,7 @@ public actor StreamingUnifiedAsrManager {
 
         if !FileManager.default.fileExists(atPath: encoderPath.path) {
             logger.info("Downloading Parakeet Unified models to \(modelsBaseDir.path)...")
-            try await DownloadUtils.downloadRepo(
+            try await ModelHub.download(
                 repo, to: modelsBaseDir,
                 variant: encoderPrecision == .fp16 ? "fp16" : nil,
                 additionalModelNames: [encoderFile],

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
@@ -133,7 +133,7 @@ public actor UnifiedAsrManager {
     public func loadModels(
         to directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         if let configuration {
             self.mlConfiguration = configuration
@@ -154,7 +154,7 @@ public actor UnifiedAsrManager {
 
         if !FileManager.default.fileExists(atPath: encoderPath.path) {
             logger.info("Downloading Parakeet Unified offline models to \(modelsBaseDir.path)...")
-            try await DownloadUtils.downloadRepo(
+            try await ModelHub.download(
                 repo, to: modelsBaseDir,
                 variant: encoderPrecision == .fp16 ? "offline-fp16" : "offline",
                 progressHandler: progressHandler)

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceManager.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceManager.swift
@@ -27,7 +27,7 @@ public actor SenseVoiceManager {
     /// Load models from the default cache (downloading if needed), then build a manager.
     public static func load(
         precision: SenseVoiceEncoderPrecision = .fp16,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> SenseVoiceManager {
         let models = try await SenseVoiceModels.downloadAndLoad(
             precision: precision, progressHandler: progressHandler)

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceModels.swift
@@ -47,7 +47,7 @@ public struct SenseVoiceModels: Sendable {
     ///   `.int8` ~half size on ANE, `.fp32` fallback for non-ANE hardware).
     public static func downloadAndLoad(
         precision: SenseVoiceEncoderPrecision = .fp16,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> SenseVoiceModels {
         let directory = try await download(precision: precision, progressHandler: progressHandler)
         return try load(from: directory, precision: precision)
@@ -57,11 +57,11 @@ public struct SenseVoiceModels: Sendable {
     ///
     /// `precision` ensures the requested encoder variant is present — a cache that
     /// predates a variant (e.g. fp16-only) re-fetches just the missing file
-    /// (`DownloadUtils.downloadRepo` skips files already on disk).
+    /// (`ModelHub.download` skips files already on disk).
     public static func download(
         precision: SenseVoiceEncoderPrecision = .fp16,
         force: Bool = false,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
         let modelsRoot = modelsRootDirectory()
         let targetDir = modelsRoot.appendingPathComponent(Repo.senseVoiceSmall.folderName, isDirectory: true)
@@ -73,7 +73,7 @@ public struct SenseVoiceModels: Sendable {
         if force { try? FileManager.default.removeItem(at: targetDir) }
 
         logger.info("Downloading SenseVoice models from HuggingFace...")
-        try await DownloadUtils.downloadRepo(
+        try await ModelHub.download(
             .senseVoiceSmall,
             to: modelsRoot,
             variant: precision.rawValue,

--- a/Sources/FluidAudio/Diarizer/Core/DiarizerModels.swift
+++ b/Sources/FluidAudio/Diarizer/Core/DiarizerModels.swift
@@ -40,7 +40,7 @@ extension DiarizerModels {
     public static func download(
         to directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> DiarizerModels {
         let logger = AppLogger(category: "DiarizerModels")
         logger.info("Checking for diarizer models...")
@@ -53,7 +53,7 @@ extension DiarizerModels {
         let segmentationModelName = ModelNames.Diarizer.segmentationFile
         let embeddingModelName = ModelNames.Diarizer.embeddingFile
 
-        let models = try await DownloadUtils.loadModels(
+        let models = try await ModelHub.loadModels(
             .diarizer,
             modelNames: Array(requiredModelNames),
             directory: directory.deletingLastPathComponent(),
@@ -83,7 +83,7 @@ extension DiarizerModels {
     public static func load(
         from directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> DiarizerModels {
         let directory = directory ?? defaultModelsDirectory()
         return try await download(to: directory, configuration: configuration, progressHandler: progressHandler)
@@ -92,7 +92,7 @@ extension DiarizerModels {
     public static func downloadIfNeeded(
         to directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> DiarizerModels {
         return try await download(to: directory, configuration: configuration, progressHandler: progressHandler)
     }

--- a/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDDiarizer.swift
+++ b/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDDiarizer.swift
@@ -101,7 +101,7 @@ public final class LSEENDDiarizer: Diarizer {
         stepSize: LSEENDStepSize = .step100ms,
         cacheDirectory: URL? = nil,
         computeUnits: MLComputeUnits = .cpuOnly,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         let model = try await LSEENDModel.loadFromHuggingFace(
             variant: variant,

--- a/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDInference.swift
+++ b/Sources/FluidAudio/Diarizer/LS-EEND/LSEENDInference.swift
@@ -46,7 +46,7 @@ public class LSEENDModel {
         stepSize: LSEENDStepSize = .step100ms,
         cacheDirectory: URL? = nil,
         computeUnits: MLComputeUnits = .cpuOnly,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> LSEENDModel {
         let directory =
             cacheDirectory
@@ -67,7 +67,7 @@ public class LSEENDModel {
             // Narrow to just the one mlmodelc — listing the whole step dir
             // is fine here since each step dir contains only its own mlmodelc.
             logger.info("Models not found in cache at \(modelURL.path); downloading \(fullRelPath)…")
-            try await DownloadUtils.downloadSubdirectory(
+            try await ModelHub.download(
                 repo, subdirectory: fullRelPath, to: repoPath
             )
         }

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerModels.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerModels.swift
@@ -78,7 +78,7 @@ public struct OfflineDiarizerModels: Sendable {
     public static func load(
         from directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> OfflineDiarizerModels {
         let modelsDirectory = directory ?? defaultModelsDirectory()
         let logger = Self.logger
@@ -93,7 +93,7 @@ public struct OfflineDiarizerModels: Sendable {
             ModelNames.OfflineDiarizer.pldaRhoPath,
         ]
 
-        let segmentationEmbeddingModels = try await DownloadUtils.loadModels(
+        let segmentationEmbeddingModels = try await ModelHub.loadModels(
             .diarizer,
             modelNames: segmentationAndEmbeddingNames,
             directory: modelsDirectory,
@@ -113,7 +113,7 @@ public struct OfflineDiarizerModels: Sendable {
         }
 
         let fbankComputeUnits: MLComputeUnits = .cpuOnly
-        let fbankModels = try await DownloadUtils.loadModels(
+        let fbankModels = try await ModelHub.loadModels(
             .diarizer,
             modelNames: [ModelNames.OfflineDiarizer.fbankPath],
             directory: modelsDirectory,

--- a/Sources/FluidAudio/Diarizer/Sortformer/Offline/OfflineSortformerDiarizer.swift
+++ b/Sources/FluidAudio/Diarizer/Sortformer/Offline/OfflineSortformerDiarizer.swift
@@ -171,7 +171,7 @@ extension OfflineSortformerModels {
         config: OfflineSortformerConfig = .offlineV2_1,
         cacheDirectory: URL? = nil,
         computeUnits: MLComputeUnits = .all,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> OfflineSortformerModels {
         let start = Date()
 
@@ -186,7 +186,7 @@ extension OfflineSortformerModels {
         let bundle = ModelNames.Sortformer.offlineBundle(precision: config.precision)
         logger.info("Downloading offline Sortformer model: \(bundle)...")
 
-        let models = try await DownloadUtils.loadModels(
+        let models = try await ModelHub.loadModels(
             .sortformer,
             modelNames: [bundle],
             directory: directory,
@@ -258,7 +258,7 @@ public final class OfflineSortformerDiarizer {
     /// Initialize from HuggingFace.
     public func initializeFromHuggingFace(
         computeUnits: MLComputeUnits = .all,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         let models = try await OfflineSortformerModels.loadFromHuggingFace(
             config: config, computeUnits: computeUnits, progressHandler: progressHandler)

--- a/Sources/FluidAudio/Diarizer/Sortformer/SortformerModelInference.swift
+++ b/Sources/FluidAudio/Diarizer/Sortformer/SortformerModelInference.swift
@@ -139,7 +139,7 @@ extension SortformerModels {
         config: SortformerConfig,
         cacheDirectory: URL? = nil,
         computeUnits: MLComputeUnits? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> SortformerModels {
         logger.info("Loading Sortformer models from HuggingFace...")
 
@@ -165,7 +165,7 @@ extension SortformerModels {
 
         let resolvedComputeUnits = computeUnits ?? recommendedComputeUnits(for: config)
 
-        let models = try await DownloadUtils.loadModels(
+        let models = try await ModelHub.loadModels(
             .sortformer,
             modelNames: [bundle],
             directory: directory,

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -591,7 +591,7 @@ public enum ModelNames {
             var models: Set<String> = [decoderFile, jointDecisionFile, vocab, metadata]
             // The streaming encoder is context-specific — each [L,C,R] latency
             // tier bakes its attention mask into a distinct bundle — so the
-            // streaming manager passes its exact encoder via downloadRepo's
+            // streaming manager passes its exact encoder via ModelHub.download's
             // `additionalModelNames` instead of pulling a fixed default here
             // (which would over-fetch the 70_13_13 encoder for every tier). The
             // offline encoder is fixed, so it stays in the base set.
@@ -1273,7 +1273,7 @@ public enum ModelNames {
         switch repo {
         case .nemotronMultilingual:
             // Compiled .mlmodelc component dirs. Download is normally driven by
-            // `downloadSubdirectory` (dynamic <lang>/<tier>ms path), which does
+            // `download(subdirectory:)` (dynamic <lang>/<tier>ms path), which does
             // not consult this set; provided for completeness / exhaustiveness.
             return [
                 NemotronMultilingualStreaming.preprocessorFile,

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -1237,7 +1237,7 @@ public enum ModelNames {
         /// trip. The two auxiliary text files (`vocab.txt`,
         /// `POLYPHONIC_CHARS.txt`) ship via the lazy
         /// `KokoroAneResourceDownloader.ensureMandarinG2pw` helper because
-        /// `DownloadUtils.downloadRepo` does not whitelist `.txt` for
+        /// `ModelHub.download` does not whitelist `.txt` for
         /// subPath repos and a manual fetch keeps the bulk-grab matcher
         /// idempotent.
         public static let g2pwModelZh = "g2pw/g2pw.mlmodelc"

--- a/Sources/FluidAudio/Shared/AssetDownloader.swift
+++ b/Sources/FluidAudio/Shared/AssetDownloader.swift
@@ -59,7 +59,7 @@ public enum AssetDownloader {
 
     public static func ensure(
         _ descriptor: Descriptor,
-        session: URLSession = DownloadUtils.sharedSession,
+        session: URLSession = ModelHub.session,
         logger: AppLogger = AppLogger(category: "AssetDownloader")
     ) async throws -> URL {
         if descriptor.skipIfExists,
@@ -99,7 +99,7 @@ public enum AssetDownloader {
     public static func fetchData(
         from remoteURL: URL,
         description: String,
-        session: URLSession = DownloadUtils.sharedSession,
+        session: URLSession = ModelHub.session,
         logger: AppLogger = AppLogger(category: "AssetDownloader")
     ) async throws -> Data {
         logger.debug("Fetching \(description) from \(remoteURL.absoluteString)")

--- a/Sources/FluidAudio/Shared/Download/DownloadTypes.swift
+++ b/Sources/FluidAudio/Shared/Download/DownloadTypes.swift
@@ -1,49 +1,85 @@
 import Foundation
 
-/// Namespace for the canonical download-stack types (#765 Wave 2).
-///
-/// These live outside `DownloadUtils` so the Shared/Download primitives
-/// (HFClient, RetryPolicy, and later extractions) don't depend back on the
-/// class they were extracted from. The long-standing nested spellings
-/// (`DownloadUtils.HuggingFaceDownloadError`, `DownloadUtils.DownloadConfig`)
-/// remain source-compatible via typealiases.
-public enum HFDownload {
+/// Errors thrown by the model-download stack (#765 Wave 6: one merged,
+/// top-level error domain — absorbs the pre-0.16 `DownloadUtils.
+/// DownloadError` and `DownloadError`).
+public enum DownloadError: LocalizedError {
+    case invalidResponse
+    case rateLimited(statusCode: Int, message: String)
+    case downloadFailed(path: String, underlying: Error)
+    case modelNotFound(path: String)
+    case htmlErrorResponse(path: String, snippet: String)
+    case invalidArtifact(path: String, reason: String)
 
-    /// Errors thrown by the HuggingFace download stack.
-    public enum DownloadError: LocalizedError {
-        case invalidResponse
-        case rateLimited(statusCode: Int, message: String)
-        case downloadFailed(path: String, underlying: Error)
-        case modelNotFound(path: String)
-        case htmlErrorResponse(path: String, snippet: String)
-        case invalidArtifact(path: String, reason: String)
+    /// A code path that would have hit the network was blocked by
+    /// `ModelHub.offlineMode`. `operation` is the short tag of the blocked
+    /// entry point (e.g. `"download(parakeet-tdt-0.6b-v3-coreml)"`).
+    case networkDisabled(operation: String)
 
-        public var errorDescription: String? {
-            switch self {
-            case .invalidResponse:
-                return "Received an invalid response from Hugging Face."
-            case .rateLimited(_, let message):
-                return "Hugging Face rate limit encountered: \(message)"
-            case .downloadFailed(let path, let underlying):
-                return "Failed to download \(path): \(underlying.localizedDescription)"
-            case .htmlErrorResponse(let path, let snippet):
-                return "HuggingFace returned HTML instead of JSON for \(path) (rate limit or server issue): \(snippet)"
-            case .modelNotFound(let path):
-                return "Model file not found: \(path)"
-            case .invalidArtifact(let path, let reason):
-                return "Downloaded artifact for \(path) is invalid (\(reason)); refusing to cache it."
-            }
+    /// `loadModels` was invoked in offline mode but one or more required
+    /// files are missing from the local cache; the missing list lets the
+    /// caller decide whether to ship a fix or fail loudly.
+    case modelMissing(repo: String, missing: [String])
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "Received an invalid response from Hugging Face."
+        case .rateLimited(_, let message):
+            return "Hugging Face rate limit encountered: \(message)"
+        case .downloadFailed(let path, let underlying):
+            return "Failed to download \(path): \(underlying.localizedDescription)"
+        case .htmlErrorResponse(let path, let snippet):
+            return "HuggingFace returned HTML instead of JSON for \(path) (rate limit or server issue): \(snippet)"
+        case .modelNotFound(let path):
+            return "Model file not found: \(path)"
+        case .invalidArtifact(let path, let reason):
+            return "Downloaded artifact for \(path) is invalid (\(reason)); refusing to cache it."
+        case .networkDisabled(let operation):
+            return "FluidAudio offline mode: \(operation) blocked"
+        case .modelMissing(let repo, let missing):
+            return
+                "FluidAudio offline mode: required models missing for \(repo): \(missing.joined(separator: ", "))"
         }
-    }
-
-    /// Download configuration shared by the download stack.
-    public struct Config: Sendable {
-        public let timeout: TimeInterval
-
-        public init(timeout: TimeInterval = 1800) {  // 30 minutes for large models
-            self.timeout = timeout
-        }
-
-        public static let `default` = Config()
     }
 }
+
+/// Download configuration shared by the download stack.
+public struct DownloadConfig: Sendable {
+    public let timeout: TimeInterval
+
+    public init(timeout: TimeInterval = 1800) {  // 30 minutes for large models
+        self.timeout = timeout
+    }
+
+    public static let `default` = DownloadConfig()
+}
+
+/// Phase of a model download operation.
+public enum DownloadPhase: Sendable {
+    /// Listing files from the remote repository.
+    case listing
+    /// Downloading model files. `completedFiles` / `totalFiles` track per-file progress.
+    case downloading(completedFiles: Int, totalFiles: Int)
+    /// Compiling CoreML models after download.
+    case compiling(modelName: String)
+}
+
+/// Progress snapshot passed to ``ProgressHandler`` closures.
+public struct DownloadProgress: Sendable {
+    /// Fraction complete in [0, 1].
+    public let fractionCompleted: Double
+    /// Current phase of the operation.
+    public let phase: DownloadPhase
+
+    public init(fractionCompleted: Double, phase: DownloadPhase) {
+        self.fractionCompleted = fractionCompleted
+        self.phase = phase
+    }
+}
+
+/// Callback type for download progress reporting.
+///
+/// Called on an unspecified queue. If you need to update UI, dispatch to
+/// the main actor inside your handler.
+public typealias ProgressHandler = @Sendable (DownloadProgress) -> Void

--- a/Sources/FluidAudio/Shared/Download/DownloadTypes.swift
+++ b/Sources/FluidAudio/Shared/Download/DownloadTypes.swift
@@ -1,8 +1,10 @@
 import Foundation
 
-/// Errors thrown by the model-download stack (#765 Wave 6: one merged,
-/// top-level error domain — absorbs the pre-0.16 `DownloadUtils.
-/// DownloadError` and `DownloadError`).
+/// Errors thrown by the model-download stack: one merged, top-level error
+/// domain. Absorbs the two pre-0.16 nested enums — `DownloadUtils
+/// .HuggingFaceDownloadError` (the six download cases) and `DownloadUtils
+/// .OfflineError` (`networkDisabled`/`modelMissing`) — with all case names
+/// preserved, so catch-pattern migration is a prefix swap.
 public enum DownloadError: LocalizedError {
     case invalidResponse
     case rateLimited(statusCode: Int, message: String)

--- a/Sources/FluidAudio/Shared/Download/FileDownloader.swift
+++ b/Sources/FluidAudio/Shared/Download/FileDownloader.swift
@@ -92,27 +92,27 @@ enum FileDownloader {
         if let contentType = response?.value(forHTTPHeaderField: "Content-Type")?.lowercased(),
             contentType.contains("text/html")
         {
-            throw HFDownload.DownloadError.invalidArtifact(
+            throw DownloadError.invalidArtifact(
                 path: path, reason: "server returned Content-Type: \(contentType)")
         }
 
         let actualSize =
             ((try? FileManager.default.attributesOfItem(atPath: tempURL.path))?[.size] as? Int) ?? 0
         if actualSize == 0 {
-            throw HFDownload.DownloadError.invalidArtifact(path: path, reason: "empty file")
+            throw DownloadError.invalidArtifact(path: path, reason: "empty file")
         }
 
         if let handle = try? FileHandle(forReadingFrom: tempURL) {
             defer { try? handle.close() }
             if HFClient.looksLikeHTML(handle.readData(ofLength: 512)) {
-                throw HFDownload.DownloadError.invalidArtifact(
+                throw DownloadError.invalidArtifact(
                     path: path, reason: "response body begins with HTML markup")
             }
         }
 
         // HuggingFace reports the exact (LFS-resolved) object size; a short body is truncation.
         if expectedSize > 0 && actualSize != expectedSize {
-            throw HFDownload.DownloadError.invalidArtifact(
+            throw DownloadError.invalidArtifact(
                 path: path,
                 reason: "size mismatch (expected \(expectedSize) bytes, got \(actualSize))")
         }
@@ -133,7 +133,7 @@ enum FileDownloader {
         configuration: URLSessionConfiguration? = nil
     ) async throws -> Data {
         let request = HFClient.authorizedRequest(url: url)
-        let session = configuration.map { URLSession(configuration: $0) } ?? DownloadUtils.sharedSession
+        let session = configuration.map { URLSession(configuration: $0) } ?? ModelHub.session
         defer {
             if configuration != nil { session.finishTasksAndInvalidate() }
         }
@@ -143,20 +143,20 @@ enum FileDownloader {
         ) { _ in
             // Re-check per attempt, matching download(): flipping
             // enforceOffline mid-operation stops at the next request.
-            guard !DownloadUtils.enforceOffline else {
-                throw DownloadUtils.OfflineError.networkDisabled(
-                    operation: "fetchHuggingFaceFile(\(description))")
+            guard !ModelHub.offlineMode else {
+                throw DownloadError.networkDisabled(
+                    operation: "fetchFile(\(description))")
             }
 
             let (data, response) = try await session.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
-                throw HFDownload.DownloadError.invalidResponse
+                throw DownloadError.invalidResponse
             }
 
             try HFClient.checkRateLimitForRetry(httpResponse, context: "fetching \(description)")
 
             guard (200..<300).contains(httpResponse.statusCode) else {
-                throw HFDownload.DownloadError.downloadFailed(
+                throw DownloadError.downloadFailed(
                     path: description,
                     underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
                 )
@@ -169,15 +169,15 @@ enum FileDownloader {
             if let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type")?.lowercased(),
                 contentType.contains("text/html")
             {
-                throw HFDownload.DownloadError.invalidArtifact(
+                throw DownloadError.invalidArtifact(
                     path: description, reason: "server returned Content-Type: \(contentType)")
             }
             if data.isEmpty {
-                throw HFDownload.DownloadError.invalidArtifact(
+                throw DownloadError.invalidArtifact(
                     path: description, reason: "empty file")
             }
             if HFClient.looksLikeHTML(data) {
-                throw HFDownload.DownloadError.invalidArtifact(
+                throw DownloadError.invalidArtifact(
                     path: description, reason: "response body begins with HTML markup")
             }
 
@@ -200,7 +200,7 @@ enum FileDownloader {
     ///     including `resumeOffset`. Delegate-driven byte progress (#756).
     ///   - onResponse: Fires before any body byte is written — the resume path
     ///     persists the validator here so it survives a drop mid-body.
-    /// Coverage flows through the `DownloadUtils.downloadFileWithRetry`
+    /// Coverage flows through the `FileDownloader.download`
     /// forward (DownloadResumeTests); no test drives this directly.
     static func streamDownload(
         request: URLRequest,
@@ -220,7 +220,7 @@ enum FileDownloader {
         // DownloadUtils still owns the shared session (public API); ownership
         // moves to the new surface in the Wave 6 cutover.
         let session = URLSession(
-            configuration: configuration ?? DownloadUtils.sharedSession.configuration,
+            configuration: configuration ?? ModelHub.session.configuration,
             delegate: delegate,
             delegateQueue: nil
         )
@@ -280,7 +280,7 @@ enum FileDownloader {
     ///   - configuration: Session configuration override for tests.
     /// - Returns: The URL of a validated (2xx) fully-written download; the
     ///   caller moves it into the cache.
-    /// Pinned via the `DownloadUtils.downloadFileWithRetry` forward
+    /// Pinned via the `FileDownloader.download` forward
     /// (DownloadResumeTests drives resume/splice/416 behavior through it).
     static func download(
         request: URLRequest,
@@ -303,8 +303,8 @@ enum FileDownloader {
         ) { attempt in
             // Re-check per attempt, matching HFTreeLister.fetch: flipping
             // enforceOffline mid-operation stops the walk at the next request.
-            guard !DownloadUtils.enforceOffline else {
-                throw DownloadUtils.OfflineError.networkDisabled(operation: "download(\(path))")
+            guard !ModelHub.offlineMode else {
+                throw DownloadError.networkDisabled(operation: "download(\(path))")
             }
             var attemptRequest = request
             var resumeOffset: Int64 = 0
@@ -363,12 +363,12 @@ enum FileDownloader {
                 // Range not satisfiable — the partial is bogus (or the remote
                 // shrank). Restart from 0 on the next attempt.
                 clearPartialDownload(partialURL)
-                throw HFDownload.DownloadError.invalidArtifact(
+                throw DownloadError.invalidArtifact(
                     path: path, reason: "server rejected resume range (416)")
             }
 
             guard (200..<300).contains(httpResponse.statusCode) else {
-                throw HFDownload.DownloadError.downloadFailed(
+                throw DownloadError.downloadFailed(
                     path: path,
                     underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
                 )
@@ -539,7 +539,7 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
                 } else if let response {
                     continuation.resume(returning: response)
                 } else {
-                    continuation.resume(throwing: HFDownload.DownloadError.invalidResponse)
+                    continuation.resume(throwing: DownloadError.invalidResponse)
                 }
             }
         }

--- a/Sources/FluidAudio/Shared/Download/FileDownloader.swift
+++ b/Sources/FluidAudio/Shared/Download/FileDownloader.swift
@@ -4,12 +4,12 @@ import os
 /// The one per-file download unit for the download stack (#765 Wave 4):
 /// bounded retry (RetryPolicy) around the streaming byte-range-resume
 /// transport (#757), artifact validation, and atomic placement into the
-/// cache. Used by both `downloadRepo` and `downloadSubdirectory`.
+/// cache. Used by both `ModelHub.download` and `download(subdirectory:)`.
 enum FileDownloader {
 
-    /// Historical category kept so existing log predicates keep capturing the
-    /// whole download trail across the #765 refactor; Wave 6 renames it
-    /// deliberately alongside the API cutover.
+    /// Historical log category retained deliberately across the 0.16 rename so
+    /// existing `category == "DownloadUtils"` predicates keep capturing the
+    /// whole download trail; renaming it is a separate, opt-in decision.
     private static let logger = AppLogger(category: "DownloadUtils")
 
     /// What `ensure(file:from:at:)` did for a file.
@@ -124,7 +124,7 @@ enum FileDownloader {
     /// classified retry (permanent 4xx fails fast, 5xx/rate-limits retry with
     /// Retry-After pacing) and artifact validation (HTML error pages and empty
     /// bodies are rejected, never returned as content). Replaces
-    /// `fetchHuggingFaceFile`'s historical retry-everything loop.
+    /// `fetchFile`'s historical retry-everything loop.
     static func fetchData(
         from url: URL,
         description: String,
@@ -133,7 +133,7 @@ enum FileDownloader {
         configuration: URLSessionConfiguration? = nil
     ) async throws -> Data {
         let request = HFClient.authorizedRequest(url: url)
-        let session = configuration.map { URLSession(configuration: $0) } ?? ModelHub.session
+        let session = configuration.map { URLSession(configuration: $0) } ?? HFClient.session
         defer {
             if configuration != nil { session.finishTasksAndInvalidate() }
         }
@@ -142,8 +142,8 @@ enum FileDownloader {
             label: description, maxAttempts: maxAttempts, minBackoff: minBackoff, logger: logger
         ) { _ in
             // Re-check per attempt, matching download(): flipping
-            // enforceOffline mid-operation stops at the next request.
-            guard !ModelHub.offlineMode else {
+            // offlineMode mid-operation stops at the next request.
+            guard !HFClient.offlineMode else {
                 throw DownloadError.networkDisabled(
                     operation: "fetchFile(\(description))")
             }
@@ -217,10 +217,10 @@ enum FileDownloader {
             onResponse: onResponse
         )
         // Dedicated session with delegate — one per download to avoid cross-talk.
-        // DownloadUtils still owns the shared session (public API); ownership
-        // moves to the new surface in the Wave 6 cutover.
+        // One session per download to avoid delegate cross-talk; the
+        // configuration comes from the shared HFClient session.
         let session = URLSession(
-            configuration: configuration ?? ModelHub.session.configuration,
+            configuration: configuration ?? HFClient.session.configuration,
             delegate: delegate,
             delegateQueue: nil
         )
@@ -302,8 +302,8 @@ enum FileDownloader {
             label: path, maxAttempts: maxAttempts, minBackoff: minBackoff, logger: logger
         ) { attempt in
             // Re-check per attempt, matching HFTreeLister.fetch: flipping
-            // enforceOffline mid-operation stops the walk at the next request.
-            guard !ModelHub.offlineMode else {
+            // offlineMode mid-operation stops the walk at the next request.
+            guard !HFClient.offlineMode else {
                 throw DownloadError.networkDisabled(operation: "download(\(path))")
             }
             var attemptRequest = request

--- a/Sources/FluidAudio/Shared/Download/HFClient.swift
+++ b/Sources/FluidAudio/Shared/Download/HFClient.swift
@@ -20,7 +20,7 @@ enum HFClient {
 
     /// Create a URLRequest with optional auth header and timeout.
     static func authorizedRequest(
-        url: URL, timeout: TimeInterval = HFDownload.Config.default.timeout
+        url: URL, timeout: TimeInterval = DownloadConfig.default.timeout
     ) -> URLRequest {
         var request = URLRequest(url: url, timeoutInterval: timeout)
         if let token = huggingFaceToken {
@@ -30,7 +30,7 @@ enum HFClient {
     }
 
     /// The one place 429/503 responses are turned into
-    /// `HFDownload.DownloadError.rateLimited`. The message is deterministic
+    /// `DownloadError.rateLimited`. The message is deterministic
     /// ("Rate limited while <context> (HTTP <code>)"); the machine-readable
     /// `Retry-After` hint stays available via `retryAfter(from:)` for the
     /// retry layer to honor (Wave 5) rather than being flattened into text.
@@ -38,7 +38,7 @@ enum HFClient {
         _ response: HTTPURLResponse, context: @autoclosure () -> String
     ) throws {
         guard response.statusCode == 429 || response.statusCode == 503 else { return }
-        throw HFDownload.DownloadError.rateLimited(
+        throw DownloadError.rateLimited(
             statusCode: response.statusCode,
             message: "Rate limited while \(context()) (HTTP \(response.statusCode))")
     }
@@ -137,7 +137,7 @@ enum HFClient {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed?.hasPrefix("<") == true || looksLikeHTML(data) {
             let snippet = String((trimmed ?? "").prefix(100))
-            throw HFDownload.DownloadError.htmlErrorResponse(path: path, snippet: snippet)
+            throw DownloadError.htmlErrorResponse(path: path, snippet: snippet)
         }
     }
 }

--- a/Sources/FluidAudio/Shared/Download/HFClient.swift
+++ b/Sources/FluidAudio/Shared/Download/HFClient.swift
@@ -1,12 +1,26 @@
 import Foundation
 
-/// HuggingFace HTTP plumbing for the DownloadUtils download paths, converging
-/// here across the #765 waves: token resolution, authorized request building,
-/// and the single place where rate-limit (429/503) responses become typed
-/// errors. (`fetchHuggingFaceFile` keeps its divergent retry loop until
-/// Wave 5; `AssetDownloader` and the CLI's `DatasetDownloader` are not yet in
-/// scope.)
+/// HuggingFace HTTP plumbing for the download stack: the shared configured
+/// session, offline-mode storage, token resolution, authorized request
+/// building, and the single place where rate-limit (429/503) responses
+/// become typed errors. `ModelHub` is the public surface over this.
 enum HFClient {
+
+    /// Shared URLSession with registry and proxy configuration; created
+    /// lazily on first use. `ModelHub.session` is the public spelling.
+    static let session: URLSession = ModelRegistry.configuredSession()
+
+    /// Offline-mode storage; `ModelHub.offlineMode` is the public spelling.
+    /// Set once at startup before any loaders are touched
+    /// (`nonisolated(unsafe)` is acceptable under that contract).
+    nonisolated(unsafe) static var offlineMode: Bool = false
+
+    /// Authenticated data fetch (`ModelHub.fetchWithAuth` is the public
+    /// spelling): authorized request on the shared session.
+    static func fetchWithAuth(from url: URL) async throws -> (Data, URLResponse) {
+        let request = authorizedRequest(url: url)
+        return try await session.data(for: request)
+    }
 
     /// HuggingFace token from the environment, if available. Supports the env
     /// vars used by the official CLI (`HF_TOKEN`), the Python `huggingface_hub`

--- a/Sources/FluidAudio/Shared/Download/HFTreeLister.swift
+++ b/Sources/FluidAudio/Shared/Download/HFTreeLister.swift
@@ -8,8 +8,8 @@ struct RemoteFile: Equatable, Sendable {
 }
 
 /// The one tree-listing implementation for the download stack (#765 Wave 3),
-/// replacing the two divergent recursive walkers in `downloadRepo` and
-/// `downloadSubdirectory`. Follows the HF tree API's `Link` pagination cursor,
+/// replacing the two divergent recursive walkers in `ModelHub.download` and
+/// `download(subdirectory:)`. Follows the HF tree API's `Link` pagination cursor,
 /// so directories with more entries than one API page (1,000 by default) no
 /// longer silently drop files.
 enum HFTreeLister {
@@ -21,13 +21,13 @@ enum HFTreeLister {
     typealias Fetch = (URL) async throws -> (Data, HTTPURLResponse)
 
     /// Production fetch: authorized request on `session`, re-checking
-    /// `enforceOffline` per request so flipping the flag mid-listing stops the
+    /// `offlineMode` per request so flipping the flag mid-listing stops the
     /// walk at the next fetch. Non-HTTP responses are rejected as
     /// `invalidResponse` — an explicit decision; the old listers silently
     /// skipped the rate-limit check on non-HTTP responses.
     static func fetch(using session: URLSession) -> Fetch {
         { url in
-            guard !ModelHub.offlineMode else {
+            guard !HFClient.offlineMode else {
                 throw DownloadError.networkDisabled(operation: "listTree(\(url.path))")
             }
             let request = HFClient.authorizedRequest(url: url)

--- a/Sources/FluidAudio/Shared/Download/HFTreeLister.swift
+++ b/Sources/FluidAudio/Shared/Download/HFTreeLister.swift
@@ -27,13 +27,13 @@ enum HFTreeLister {
     /// skipped the rate-limit check on non-HTTP responses.
     static func fetch(using session: URLSession) -> Fetch {
         { url in
-            guard !DownloadUtils.enforceOffline else {
-                throw DownloadUtils.OfflineError.networkDisabled(operation: "listTree(\(url.path))")
+            guard !ModelHub.offlineMode else {
+                throw DownloadError.networkDisabled(operation: "listTree(\(url.path))")
             }
             let request = HFClient.authorizedRequest(url: url)
             let (data, response) = try await session.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else {
-                throw HFDownload.DownloadError.invalidResponse
+                throw DownloadError.invalidResponse
             }
             return (data, httpResponse)
         }
@@ -73,7 +73,7 @@ enum HFTreeLister {
                 context: path.isEmpty ? "listing files" : "listing files in \(path)")
             try HFClient.validateJSONResponse(data, path: path)
             guard let items = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
-                throw HFDownload.DownloadError.invalidResponse
+                throw DownloadError.invalidResponse
             }
 
             for item in items {

--- a/Sources/FluidAudio/Shared/Download/ModelCache.swift
+++ b/Sources/FluidAudio/Shared/Download/ModelCache.swift
@@ -75,7 +75,7 @@ enum ModelCache {
     /// required model absent under `repoPath` — the post-download verify pass.
     static func verifyModelsPresent(at repoPath: URL, models: Set<String>) throws {
         if let missing = missingModels(at: repoPath, models: models).first {
-            throw HFDownload.DownloadError.modelNotFound(path: missing)
+            throw DownloadError.modelNotFound(path: missing)
         }
     }
 

--- a/Sources/FluidAudio/Shared/Download/ModelCache.swift
+++ b/Sources/FluidAudio/Shared/Download/ModelCache.swift
@@ -2,13 +2,13 @@ import Foundation
 
 /// On-disk model-cache knowledge for the download stack (#765 Wave 4):
 /// existence/completeness checks, corrupt-cache purging, robust directory
-/// creation, and the cache-clearing operations behind the DownloadUtils
+/// creation, and the cache-clearing operations behind the ModelHub
 /// public API.
 enum ModelCache {
 
-    /// Historical category kept so existing log predicates keep capturing the
-    /// whole download trail across the #765 refactor; Wave 6 renames it
-    /// deliberately alongside the API cutover.
+    /// Historical log category retained deliberately across the 0.16 rename so
+    /// existing `category == "DownloadUtils"` predicates keep capturing the
+    /// whole download trail; renaming it is a separate, opt-in decision.
     private static let logger = AppLogger(category: "DownloadUtils")
 
     /// Robustly create a directory, removing any conflicting files in the path.

--- a/Sources/FluidAudio/Shared/Download/ModelHub.swift
+++ b/Sources/FluidAudio/Shared/Download/ModelHub.swift
@@ -1,122 +1,75 @@
 import CoreML
 import Foundation
 
-/// HuggingFace model downloader using URLSession
-public class DownloadUtils {
+/// The model-download surface for FluidAudio (#765 Wave 6): loading CoreML
+/// model repos from HuggingFace into the local cache, targeted subdirectory
+/// and single-file fetches, offline enforcement, and cache management.
+///
+/// Replaces the pre-0.16 `DownloadUtils` class — see the 0.16.0 migration
+/// table for the mechanical old→new spellings.
+public enum ModelHub {
 
     private static let logger = AppLogger(category: "DownloadUtils")
 
-    /// Shared URLSession with registry and proxy configuration
-    public static let sharedSession: URLSession = ModelRegistry.configuredSession()
+    /// Shared URLSession with registry and proxy configuration. Advanced
+    /// plumbing — exposed for tooling (the FluidAudio CLI's dataset
+    /// downloads); apps normally never touch it.
+    public static let session: URLSession = ModelRegistry.configuredSession()
 
-    /// Offline-only mode. When true, every public download surface
-    /// (`fetchWithAuth`, `downloadRepo`, `downloadSubdirectory`,
-    /// `fetchHuggingFaceFile`) and the `loadModels` retry-with-redownload
-    /// fallback throws `DownloadUtils.OfflineError` instead of touching
-    /// the network. Applications that bundle their own model assets
-    /// should set this once at startup and route loading through manual
-    /// APIs (e.g. `MLModel(contentsOf:)`, `VadManager(config:vadModel:)`)
-    /// so a corrupt-detected `.mlmodelc` never silently re-downloads at
-    /// runtime.
-    ///
-    /// Defaults to `false`. `nonisolated(unsafe)` is acceptable because
-    /// the flag is set once at startup before any FluidAudio loaders
-    /// are touched and is read-only thereafter.
-    nonisolated(unsafe) public static var enforceOffline: Bool = false
+    /// Offline-only mode. When true, every download surface and the
+    /// `loadModels` retry-with-redownload fallback throws
+    /// `DownloadError.networkDisabled` / `.modelMissing` instead of touching
+    /// the network. Set once at startup before any FluidAudio loaders are
+    /// touched (`nonisolated(unsafe)` is acceptable under that contract).
+    nonisolated(unsafe) public static var offlineMode: Bool = false
 
-    /// Errors thrown when `enforceOffline` is on and FluidAudio would
-    /// otherwise attempt a network fetch or a cache rebuild that
-    /// requires network. Sibling to `HuggingFaceDownloadError`.
-    public enum OfflineError: LocalizedError {
-        /// A code path that would have hit the network was blocked.
-        /// `operation` is the short tag of the blocked entry point
-        /// (e.g. `"downloadRepo(parakeet-tdt-0.6b-v3-coreml)"`).
-        case networkDisabled(operation: String)
-
-        /// `loadModels` was invoked but one or more required files are
-        /// missing from the local cache. Caller bundled assets but the
-        /// bundle was incomplete; surfacing the missing list lets the
-        /// caller decide whether to ship a fix or fail loudly.
-        case modelMissing(repo: String, missing: [String])
-
-        public var errorDescription: String? {
-            switch self {
-            case .networkDisabled(let operation):
-                return "FluidAudio offline mode: \(operation) blocked"
-            case .modelMissing(let repo, let missing):
-                return
-                    "FluidAudio offline mode: required models missing for \(repo): \(missing.joined(separator: ", "))"
-            }
-        }
-    }
-
-    /// Throws `OfflineError.networkDisabled` if `enforceOffline` is on.
+    /// Throws `DownloadError.networkDisabled` if `offlineMode` is on.
     /// Call this at the top of any path that would touch the network.
-    private static func ensureOnlineAllowed(_ operation: String) throws {
-        if enforceOffline {
-            throw OfflineError.networkDisabled(operation: operation)
+    static func ensureOnlineAllowed(_ operation: String) throws {
+        if offlineMode {
+            throw DownloadError.networkDisabled(operation: operation)
         }
     }
 
-    /// Create a URLRequest with optional auth header and timeout (HFClient owns
-    /// token resolution and header shape — #765 Wave 2).
-    private static func authorizedRequest(
-        url: URL, timeout: TimeInterval = DownloadConfig.default.timeout
-    ) -> URLRequest {
-        HFClient.authorizedRequest(url: url, timeout: timeout)
-    }
-
-    /// Fetch data from a URL with HuggingFace authentication if available
-    /// Use this for API calls that need auth tokens for private repos or higher rate limits
+    /// Fetch data from a URL with HuggingFace authentication if available.
+    /// Advanced plumbing for API calls needing auth tokens (private repos,
+    /// higher rate limits); prefer `fetchFile` for content.
     public static func fetchWithAuth(from url: URL) async throws -> (Data, URLResponse) {
         try ensureOnlineAllowed("fetchWithAuth(\(url.absoluteString))")
-        let request = authorizedRequest(url: url)
-        return try await sharedSession.data(for: request)
+        let request = HFClient.authorizedRequest(url: url)
+        return try await session.data(for: request)
     }
 
-    /// Forward — the single HTML sniffer lives in HFClient (#765 Wave 2);
-    /// kept here because DownloadArtifactValidationTests pins this symbol.
-    static func looksLikeHTML(_ data: Data) -> Bool {
-        HFClient.looksLikeHTML(data)
+    public static func clearCache(for repo: Repo, directory: URL) {
+        let repoPath = directory.appendingPathComponent(repo.folderName)
+        try? FileManager.default.removeItem(at: repoPath)
     }
 
-    /// Moved to `FluidAudio.HuggingFaceDownloadError` (Shared/Download/DownloadTypes.swift)
-    /// so the extracted download primitives don't depend back on this class
-    /// (#765 Wave 2). The nested spelling stays source-compatible.
-    public typealias HuggingFaceDownloadError = HFDownload.DownloadError
+    /// Remove all downloaded models and caches (ASR/VAD/diarization models
+    /// under Application Support, and the shared TTS cache root).
+    public static func clearAllCaches() {
+        let fm = FileManager.default
 
-    /// Phase of a model download operation.
-    public enum DownloadPhase: Sendable {
-        /// Listing files from the remote repository.
-        case listing
-        /// Downloading model files. `completedFiles` / `totalFiles` track per-file progress.
-        case downloading(completedFiles: Int, totalFiles: Int)
-        /// Compiling CoreML models after download.
-        case compiling(modelName: String)
-    }
-
-    /// Progress snapshot passed to ``ProgressHandler`` closures.
-    public struct DownloadProgress: Sendable {
-        /// Fraction complete in [0, 1].
-        public let fractionCompleted: Double
-        /// Current phase of the operation.
-        public let phase: DownloadPhase
-
-        public init(fractionCompleted: Double, phase: DownloadPhase) {
-            self.fractionCompleted = fractionCompleted
-            self.phase = phase
+        // ASR, VAD, Diarization models
+        if let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            let modelsDir = appSupport.appendingPathComponent("FluidAudio/Models")
+            try? fm.removeItem(at: modelsDir)
         }
+
+        // TTS models (Kokoro, PocketTTS, Supertonic3, StyleTTS2).
+        #if os(macOS)
+        let home = fm.homeDirectoryForCurrentUser
+        let ttsCache = home.appendingPathComponent(".cache/fluidaudio")
+        try? fm.removeItem(at: ttsCache)
+        #else
+        if let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            let ttsCache = appSupport.appendingPathComponent("fluidaudio")
+            try? fm.removeItem(at: ttsCache)
+        }
+        #endif
+
+        logger.info("All model caches cleared")
     }
-
-    /// Callback type for download progress reporting.
-    ///
-    /// Called on an unspecified queue. If you need to update UI, dispatch to
-    /// the main actor inside your handler.
-    public typealias ProgressHandler = @Sendable (DownloadProgress) -> Void
-
-    /// Moved to `FluidAudio.DownloadConfig` (Shared/Download/DownloadTypes.swift);
-    /// nested spelling stays source-compatible.
-    public typealias DownloadConfig = HFDownload.Config
 
     public static func loadModels(
         _ repo: Repo,
@@ -135,7 +88,7 @@ public class DownloadUtils {
         } catch {
             // In offline mode never delete cache + re-download. Surface
             // the original load failure so the caller can decide.
-            if enforceOffline {
+            if offlineMode {
                 logger.warning(
                     "Offline mode: load failed and re-download blocked. \(error.localizedDescription)"
                 )
@@ -145,7 +98,7 @@ public class DownloadUtils {
             // Cancellation is not corruption. A cancelled first load (app
             // teardown, user abort) must never wipe a valid cache — deleting
             // here threw away fully-downloaded multi-hundred-MB repos.
-            if isCancellationError(error) {
+            if RetryPolicy.isCancellation(error) {
                 logger.info(
                     "Load cancelled; preserving model cache. \(error.localizedDescription)")
                 throw error
@@ -163,50 +116,6 @@ public class DownloadUtils {
                 progressHandler: progressHandler)
         }
     }
-
-    /// Forward to `RetryPolicy.isCancellation` (see there for the chain-walk
-    /// semantics); kept because DownloadUtilsCancellationTests pins this symbol.
-    static func isCancellationError(_ error: Error) -> Bool {
-        RetryPolicy.isCancellation(error)
-    }
-
-    public static func clearModelCache(forRepo repo: Repo, directory: URL) {
-        let repoPath = directory.appendingPathComponent(repo.folderName)
-        try? FileManager.default.removeItem(at: repoPath)
-    }
-
-    /// Remove all downloaded models and caches.
-    ///
-    /// Clears both cache locations:
-    /// - `~/Library/Application Support/FluidAudio/Models/` (ASR, VAD, Diarization)
-    /// - the shared TTS root: `~/.cache/fluidaudio/` on macOS,
-    ///   `Application Support/fluidaudio/` on iOS (matches `TtsCacheDirectory`).
-    public static func clearAllModelCaches() {
-        let fm = FileManager.default
-
-        // ASR, VAD, Diarization models
-        if let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
-            let modelsDir = appSupport.appendingPathComponent("FluidAudio/Models")
-            try? fm.removeItem(at: modelsDir)
-        }
-
-        // TTS models (Kokoro, PocketTTS, Supertonic3, StyleTTS2).
-        // Remove the whole `fluidaudio/` root so every backend subdirectory
-        // (Models/, voice packs, etc.) is cleared, not just `Models/`.
-        #if os(macOS)
-        let home = fm.homeDirectoryForCurrentUser
-        let ttsCache = home.appendingPathComponent(".cache/fluidaudio")
-        try? fm.removeItem(at: ttsCache)
-        #else
-        if let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
-            let ttsCache = appSupport.appendingPathComponent("fluidaudio")
-            try? fm.removeItem(at: ttsCache)
-        }
-        #endif
-
-        logger.info("All model caches cleared")
-    }
-
     private static func loadModelsOnce(
         _ repo: Repo,
         modelNames: [String],
@@ -232,15 +141,15 @@ public class DownloadUtils {
         if !ModelCache.allModelsExist(at: repoPath, models: effectiveModels) {
             // In offline mode surface a typed error listing the
             // missing files instead of attempting a HuggingFace fetch.
-            if enforceOffline {
+            if offlineMode {
                 let missing = ModelCache.missingModels(at: repoPath, models: effectiveModels)
                 logger.error(
                     "Offline mode: required models missing at \(repoPath.path): \(missing)"
                 )
-                throw OfflineError.modelMissing(repo: repo.folderName, missing: missing)
+                throw DownloadError.modelMissing(repo: repo.folderName, missing: missing)
             }
             logger.info("Models not found in cache at \(repoPath.path)")
-            try await downloadRepo(
+            try await download(
                 repo, to: directory, variant: variant,
                 additionalModelNames: extraModelNames,
                 progressHandler: progressHandler)
@@ -282,14 +191,14 @@ public class DownloadUtils {
     ///   `ModelNames.getRequiredModelNames(...)` set. Used by `loadModels` to
     ///   forward caller-requested files that are not part of the repo's
     ///   baseline required set.
-    public static func downloadRepo(
+    public static func download(
         _ repo: Repo,
         to directory: URL,
         variant: String? = nil,
         additionalModelNames: Set<String> = [],
         progressHandler: ProgressHandler? = nil
     ) async throws {
-        try await downloadRepo(
+        try await download(
             repo, to: directory, variant: variant,
             additionalModelNames: additionalModelNames,
             progressHandler: progressHandler,
@@ -300,7 +209,7 @@ public class DownloadUtils {
     /// listing and per-file downloads so characterization tests can drive the
     /// full listing/filtering/download pipeline with a stub `URLProtocol`
     /// (#765 Wave 1). `nil` (the public path) uses the shared session.
-    static func downloadRepo(
+    static func download(
         _ repo: Repo,
         to directory: URL,
         variant: String? = nil,
@@ -308,10 +217,10 @@ public class DownloadUtils {
         progressHandler: ProgressHandler? = nil,
         configuration: URLSessionConfiguration?
     ) async throws {
-        try ensureOnlineAllowed("downloadRepo(\(repo.folderName))")
+        try ensureOnlineAllowed("download(\(repo.folderName))")
         logger.info("Downloading \(repo.folderName) from HuggingFace...")
 
-        let listingSession = configuration.map { URLSession(configuration: $0) } ?? sharedSession
+        let listingSession = configuration.map { URLSession(configuration: $0) } ?? session
         defer {
             if configuration != nil { listingSession.finishTasksAndInvalidate() }
         }
@@ -460,58 +369,6 @@ public class DownloadUtils {
         logger.info("Downloaded all required models for \(repo.folderName)")
     }
 
-    // MARK: - Test-pinned forwards (#765)
-
-    /// Forwards to the Wave 4 primitives — kept because the download-resume,
-    /// artifact-validation, and retry characterization suites pin these
-    /// symbols on DownloadUtils.
-    static func isRetryableDownloadError(_ error: Error) -> Bool {
-        RetryPolicy.isRetryable(error)
-    }
-
-    static func validateDownloadedArtifact(
-        at tempURL: URL,
-        response: HTTPURLResponse?,
-        path: String,
-        expectedSize: Int
-    ) throws {
-        try FileDownloader.validateDownloadedArtifact(
-            at: tempURL, response: response, path: path, expectedSize: expectedSize)
-    }
-
-    static func resumeValidatorURL(for partialFileURL: URL) -> URL {
-        FileDownloader.resumeValidatorURL(for: partialFileURL)
-    }
-
-    static func downloadFileWithRetry(
-        request: URLRequest,
-        path: String,
-        expectedSize: Int,
-        partialFileURL: URL? = nil,
-        onProgress: (@Sendable (Int64, Int64) -> Void)?,
-        maxAttempts: Int = 4,
-        minBackoff: TimeInterval = 1.0,
-        configuration: URLSessionConfiguration? = nil
-    ) async throws -> URL {
-        try await FileDownloader.download(
-            request: request, path: path, expectedSize: expectedSize,
-            partialFileURL: partialFileURL, onProgress: onProgress,
-            maxAttempts: maxAttempts, minBackoff: minBackoff,
-            configuration: configuration)
-    }
-
-    /// Forward to ProgressReporter (kept: DownloadUtilsProgressTests pins it).
-    static func subdirectoryProgressFraction(
-        completedBytes: Int64,
-        totalBytes: Int64,
-        completedFiles: Int,
-        totalFiles: Int
-    ) -> Double {
-        ProgressReporter.downloadFraction(
-            completedBytes: completedBytes, totalBytes: totalBytes,
-            completedFiles: completedFiles, totalFiles: totalFiles)
-    }
-
     /// Download a specific subdirectory from a HuggingFace repository.
     ///
     /// Use this for optional model components that aren't part of the required model set
@@ -527,14 +384,14 @@ public class DownloadUtils {
     ///     or, for directories, skips the whole subtree without recursing.
     ///     Used to avoid pulling redundant artifacts (e.g. `.mlpackage`
     ///     sources next to compiled `.mlmodelc`).
-    public static func downloadSubdirectory(
+    public static func download(
         _ repo: Repo,
         subdirectory: String,
         to repoDirectory: URL,
         progressHandler: ProgressHandler? = nil,
         shouldSkip: (@Sendable (String) -> Bool)? = nil
     ) async throws {
-        try ensureOnlineAllowed("downloadSubdirectory(\(repo.folderName)/\(subdirectory))")
+        try ensureOnlineAllowed("download(\(repo.folderName)/\(subdirectory))")
         // Subdirectory downloads have no compile phase: download spans 0-1.
         let reporter = ProgressReporter(handler: progressHandler, downloadPhaseWeight: 1.0)
         reporter.listing()
@@ -542,7 +399,7 @@ public class DownloadUtils {
             repoRemotePath: repo.remotePath,
             startingAt: subdirectory,
             include: { itemPath, _ in shouldSkip?(itemPath) != true },
-            fetch: HFTreeLister.fetch(using: sharedSession)
+            fetch: HFTreeLister.fetch(using: session)
         )
         let totalFiles = filesToDownload.count
         logger.info("Found \(totalFiles) files in \(subdirectory)")
@@ -604,27 +461,27 @@ public class DownloadUtils {
     /// (#765 Wave 5): permanent errors (404s) fail fast instead of consuming
     /// the backoff budget, 5xx/rate-limits retry with Retry-After pacing, and
     /// HTML/empty bodies are rejected instead of returned as content.
-    public static func fetchHuggingFaceFile(
+    public static func fetchFile(
         from url: URL,
         description: String,
         maxAttempts: Int = 4,
         minBackoff: TimeInterval = 1.0
     ) async throws -> Data {
-        try await fetchHuggingFaceFile(
+        try await fetchFile(
             from: url, description: description,
             maxAttempts: maxAttempts, minBackoff: minBackoff,
             configuration: nil)
     }
 
     /// Internal seam: `configuration` lets tests stub the transport.
-    static func fetchHuggingFaceFile(
+    static func fetchFile(
         from url: URL,
         description: String,
         maxAttempts: Int = 4,
         minBackoff: TimeInterval = 1.0,
         configuration: URLSessionConfiguration?
     ) async throws -> Data {
-        try ensureOnlineAllowed("fetchHuggingFaceFile(\(description))")
+        try ensureOnlineAllowed("fetchFile(\(description))")
         return try await FileDownloader.fetchData(
             from: url, description: description,
             maxAttempts: maxAttempts, minBackoff: minBackoff,

--- a/Sources/FluidAudio/Shared/Download/ModelHub.swift
+++ b/Sources/FluidAudio/Shared/Download/ModelHub.swift
@@ -5,27 +5,37 @@ import Foundation
 /// model repos from HuggingFace into the local cache, targeted subdirectory
 /// and single-file fetches, offline enforcement, and cache management.
 ///
-/// Replaces the pre-0.16 `DownloadUtils` class — see the 0.16.0 migration
+/// Replaces the pre-0.16 `ModelHub` class — see the 0.16.0 migration
 /// table for the mechanical old→new spellings.
 public enum ModelHub {
 
+    /// Historical log category retained deliberately across the 0.16 rename:
+    /// existing `log stream --predicate 'category == "ModelHub"'`
+    /// diagnostics keep capturing the whole download trail. Renaming the
+    /// category is a separate, opt-in decision.
     private static let logger = AppLogger(category: "DownloadUtils")
 
     /// Shared URLSession with registry and proxy configuration. Advanced
     /// plumbing — exposed for tooling (the FluidAudio CLI's dataset
     /// downloads); apps normally never touch it.
-    public static let session: URLSession = ModelRegistry.configuredSession()
+    public static var session: URLSession { HFClient.session }
 
-    /// Offline-only mode. When true, every download surface and the
-    /// `loadModels` retry-with-redownload fallback throws
-    /// `DownloadError.networkDisabled` / `.modelMissing` instead of touching
-    /// the network. Set once at startup before any FluidAudio loaders are
-    /// touched (`nonisolated(unsafe)` is acceptable under that contract).
-    nonisolated(unsafe) public static var offlineMode: Bool = false
+    /// Offline-only mode. When true, every download surface (`fetchWithAuth`,
+    /// `download`, `fetchFile`) and the `loadModels` retry-with-redownload
+    /// fallback throws `DownloadError.networkDisabled` / `.modelMissing`
+    /// instead of touching the network. Applications that bundle their own
+    /// model assets should set this once at startup and route loading through
+    /// manual APIs (e.g. `MLModel(contentsOf:)`, `VadManager(config:vadModel:)`)
+    /// so a corrupt-detected `.mlmodelc` never silently re-downloads at
+    /// runtime. Set before any FluidAudio loaders are touched.
+    public static var offlineMode: Bool {
+        get { HFClient.offlineMode }
+        set { HFClient.offlineMode = newValue }
+    }
 
     /// Throws `DownloadError.networkDisabled` if `offlineMode` is on.
     /// Call this at the top of any path that would touch the network.
-    static func ensureOnlineAllowed(_ operation: String) throws {
+    private static func ensureOnlineAllowed(_ operation: String) throws {
         if offlineMode {
             throw DownloadError.networkDisabled(operation: operation)
         }
@@ -36,8 +46,7 @@ public enum ModelHub {
     /// higher rate limits); prefer `fetchFile` for content.
     public static func fetchWithAuth(from url: URL) async throws -> (Data, URLResponse) {
         try ensureOnlineAllowed("fetchWithAuth(\(url.absoluteString))")
-        let request = HFClient.authorizedRequest(url: url)
-        return try await session.data(for: request)
+        return try await HFClient.fetchWithAuth(from: url)
     }
 
     public static func clearCache(for repo: Repo, directory: URL) {
@@ -45,8 +54,10 @@ public enum ModelHub {
         try? FileManager.default.removeItem(at: repoPath)
     }
 
-    /// Remove all downloaded models and caches (ASR/VAD/diarization models
-    /// under Application Support, and the shared TTS cache root).
+    /// Remove all downloaded models and caches. Clears both cache locations:
+    /// `~/Library/Application Support/FluidAudio/Models/` (ASR, VAD,
+    /// Diarization) and the shared TTS root — `~/.cache/fluidaudio/` on
+    /// macOS, `Application Support/fluidaudio/` on iOS.
     public static func clearAllCaches() {
         let fm = FileManager.default
 
@@ -347,7 +358,7 @@ public enum ModelHub {
             )
             completedBytes += Int64(max(0, file.size))
 
-            // Pinned asymmetry vs downloadSubdirectory: cached/empty files
+            // Pinned asymmetry vs download(subdirectory:): cached/empty files
             // emit no boundary here (the pre-#765 behavior ProgressSequence
             // relies on); the subdirectory loop emits for every outcome.
             guard outcome == .downloaded else { continue }

--- a/Sources/FluidAudio/Shared/Download/ProgressReporter.swift
+++ b/Sources/FluidAudio/Shared/Download/ProgressReporter.swift
@@ -8,12 +8,12 @@ import Foundation
 /// loads declare `downloadPhaseWeight: 0.5` (compile occupies the rest);
 /// subdirectory downloads declare `1.0`.
 struct ProgressReporter: Sendable {
-    let handler: DownloadUtils.ProgressHandler?
+    let handler: ProgressHandler?
     /// Fraction of the overall operation the download phase occupies.
     let downloadPhaseWeight: Double
 
-    private func emit(_ fraction: Double, _ phase: DownloadUtils.DownloadPhase) {
-        handler?(DownloadUtils.DownloadProgress(fractionCompleted: fraction, phase: phase))
+    private func emit(_ fraction: Double, _ phase: DownloadPhase) {
+        handler?(DownloadProgress(fractionCompleted: fraction, phase: phase))
     }
 
     /// Byte-weighted fraction of the download phase: bytes when total bytes

--- a/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
+++ b/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-/// The retry policy the DownloadUtils download paths converge on across the
-/// #765 waves (#765 Wave 2): bounded exponential backoff on transient
-/// failures, fail-fast on permanent ones. `fetchHuggingFaceFile` still runs
-/// its historical retry-everything loop and converges in Wave 5.
+/// The single retry policy for the download stack: bounded exponential
+/// backoff on transient failures (paced by a server `Retry-After` when one
+/// is provided), fail-fast on permanent ones. Every network path —
+/// `ModelHub.loadModels`/`download`/`fetchFile` — retries through here.
 enum RetryPolicy {
 
     private static let defaultLogger = AppLogger(category: "RetryPolicy")

--- a/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
+++ b/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
@@ -89,12 +89,12 @@ enum RetryPolicy {
         }
 
         switch error {
-        case HFDownload.DownloadError.rateLimited:
+        case DownloadError.rateLimited:
             return true
-        case HFDownload.DownloadError.invalidArtifact:
+        case DownloadError.invalidArtifact:
             // Usually a transient unhealthy network path (proxy, mirror 5xx) — retry.
             return true
-        case HFDownload.DownloadError.downloadFailed(_, let underlying):
+        case DownloadError.downloadFailed(_, let underlying):
             let nsError = underlying as NSError
             return nsError.domain == "HTTP" && (500...599).contains(nsError.code)
         default:

--- a/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
@@ -17,7 +17,7 @@ public enum KokoroAneResourceDownloader {
     public static func ensureModels(
         variant: KokoroAneVariant = .english,
         directory: URL? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
         let modelsDirectory = try directory ?? defaultModelsDirectory()
         let repo = variant.repo
@@ -38,7 +38,7 @@ public enum KokoroAneResourceDownloader {
 
         if !allPresent {
             logger.info("Downloading laishere Kokoro models (\(variant.rawValue)) from HuggingFace...")
-            try await DownloadUtils.downloadRepo(
+            try await ModelHub.download(
                 repo,
                 to: modelsDirectory,
                 progressHandler: progressHandler
@@ -61,7 +61,7 @@ public enum KokoroAneResourceDownloader {
     @discardableResult
     public static func ensureMandarinG2P(
         repoDirectory: URL,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
         let g2pDir = repoDirectory.appendingPathComponent(KokoroAneConstants.g2pSubdir)
         if !FileManager.default.fileExists(atPath: g2pDir.path) {
@@ -256,7 +256,7 @@ public enum KokoroAneResourceDownloader {
     /// `G2PModelError.vocabLoadFailed`.
     public static func ensureG2PAssets(
         directory: URL? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         let modelsDirectory = try directory ?? defaultModelsDirectory()
         let kokoroDir = modelsDirectory.appendingPathComponent(Repo.kokoro.folderName)
@@ -267,7 +267,7 @@ public enum KokoroAneResourceDownloader {
             return
         }
         logger.info("Downloading shared kokoro G2P assets from HuggingFace...")
-        try await DownloadUtils.downloadRepo(
+        try await ModelHub.download(
             .kokoro,
             to: modelsDirectory,
             variant: "g2p-only",

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -39,7 +39,7 @@ public enum PocketTtsResourceDownloader {
         directory: URL? = nil,
         precision: PocketTtsPrecision = .fp16,
         placement: PocketTtsModelPlacement = .gpu,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
         let targetDir = try directory ?? cacheDirectory()
         let modelsDirectory = targetDir.appendingPathComponent(
@@ -83,7 +83,7 @@ public enum PocketTtsResourceDownloader {
         logger.info(
             "Downloading PocketTTS \(language.rawValue) (\(precision)) language pack from HuggingFace (\(subdir))..."
         )
-        try await DownloadUtils.downloadSubdirectory(
+        try await ModelHub.download(
             .pocketTts,
             subdirectory: subdir,
             to: repoDir,
@@ -226,7 +226,7 @@ public enum PocketTtsResourceDownloader {
             at: repoDir, withIntermediateDirectories: true)
 
         logger.info("Downloading Mimi encoder for voice cloning...")
-        try await DownloadUtils.downloadSubdirectory(
+        try await ModelHub.download(
             .pocketTts,
             subdirectory: ModelNames.PocketTTS.mimiEncoderFile,
             to: repoDir

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -142,7 +142,7 @@ public enum PocketTtsResourceDownloader {
 
     /// Backfill `constants_bin/bos_before_voice.bin` for cached language packs
     /// that were downloaded before the FluidAudio #592 fix. New downloads pick
-    /// it up via `downloadSubdirectory` — this helper exists only to upgrade
+    /// it up via `download(subdirectory:)` — this helper exists only to upgrade
     /// older caches without a full re-download.
     private static func ensureBosBeforeVoice(
         language: PocketTtsLanguage,

--- a/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2ResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2ResourceDownloader.swift
@@ -26,7 +26,7 @@ public enum StyleTTS2ResourceDownloader {
     @discardableResult
     public static func ensureDefaultModels(
         directory: URL? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
         let modelsRoot = try directory ?? defaultCacheRoot()
         let repoDir = modelsRoot.appendingPathComponent(Repo.styletts2.folderName)
@@ -38,7 +38,7 @@ public enum StyleTTS2ResourceDownloader {
         if !allDefaultsPresent {
             logger.info("Downloading StyleTTS2 LibriTTS models (iteration_3) from HuggingFace…")
             do {
-                try await DownloadUtils.downloadRepo(
+                try await ModelHub.download(
                     .styletts2, to: modelsRoot, progressHandler: progressHandler)
             } catch {
                 throw StyleTTS2Error.downloadFailed("\(error)")
@@ -90,7 +90,7 @@ public enum StyleTTS2ResourceDownloader {
     /// `G2PModelError.vocabLoadFailed` the first time the OOV path is hit.
     public static func ensureG2PAssets(
         directory: URL? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         let modelsRoot = try directory ?? defaultCacheRoot()
         let kokoroDir = modelsRoot.appendingPathComponent(Repo.kokoro.folderName)
@@ -102,7 +102,7 @@ public enum StyleTTS2ResourceDownloader {
         }
         logger.info("Downloading kokoro G2P CoreML assets (g2p-only variant) from HuggingFace…")
         do {
-            try await DownloadUtils.downloadRepo(
+            try await ModelHub.download(
                 .kokoro,
                 to: modelsRoot,
                 variant: "g2p-only",
@@ -132,7 +132,7 @@ public enum StyleTTS2ResourceDownloader {
         logger.info("Fetching StyleTTS2 bucket T=\(t) (\(missing.count) bundles)")
         for fileName in missing {
             do {
-                try await DownloadUtils.downloadSubdirectory(
+                try await ModelHub.download(
                     .styletts2,
                     subdirectory: fileName,
                     to: repoDir

--- a/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Assets/Supertonic3ResourceDownloader.swift
@@ -17,7 +17,7 @@ public enum Supertonic3ResourceDownloader {
     public static func ensureModels(
         directory: URL? = nil,
         veVariant: String? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
         let modelsRoot = try directory ?? defaultCacheRoot()
         let repoDir = modelsRoot.appendingPathComponent(Repo.supertonic3.folderName)
@@ -30,7 +30,7 @@ public enum Supertonic3ResourceDownloader {
         if !allPresent {
             logger.info("Downloading Supertonic-3 CoreML assets from HuggingFace…")
             do {
-                try await DownloadUtils.downloadRepo(
+                try await ModelHub.download(
                     .supertonic3, to: modelsRoot, variant: veVariant,
                     progressHandler: progressHandler)
             } catch {
@@ -51,7 +51,7 @@ public enum Supertonic3ResourceDownloader {
     public static func downloadVoiceStyle(
         _ voice: Supertonic3Voice,
         directory: URL? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
         let modelsRoot = try directory ?? defaultCacheRoot()
         let repoDir = modelsRoot.appendingPathComponent(Repo.supertonic3.folderName)
@@ -66,7 +66,7 @@ public enum Supertonic3ResourceDownloader {
         do {
             // The HF tree API only lists directories, so pull the single file
             // out of voice_styles/ by skipping every other entry.
-            try await DownloadUtils.downloadSubdirectory(
+            try await ModelHub.download(
                 .supertonic3,
                 subdirectory: "voice_styles",
                 to: repoDir,
@@ -88,7 +88,7 @@ public enum Supertonic3ResourceDownloader {
     public static func loadVoiceStyle(
         _ voice: Supertonic3Voice,
         directory: URL? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws -> Supertonic3VoiceStyle {
         let url = try await downloadVoiceStyle(
             voice, directory: directory, progressHandler: progressHandler)

--- a/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
+++ b/Sources/FluidAudio/TTS/Supertonic3/Supertonic3Types.swift
@@ -107,7 +107,7 @@ public enum Supertonic3VectorEstimator: Sendable, Equatable {
         return false
     }
 
-    /// Variant token passed to `DownloadUtils.downloadRepo` / `getRequiredModelNames`
+    /// Variant token passed to `ModelHub.download` / `getRequiredModelNames`
     /// so only the selected VectorEstimator file(s) are fetched.
     var downloadVariant: String? {
         switch self {

--- a/Sources/FluidAudio/VAD/VadManager.swift
+++ b/Sources/FluidAudio/VAD/VadManager.swift
@@ -78,7 +78,7 @@ public actor VadManager {
     /// Initialize with configuration
     public init(
         config: VadConfig = .default,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         self.config = config
 
@@ -110,7 +110,7 @@ public actor VadManager {
     public init(
         config: VadConfig = .default,
         modelDirectory: URL,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         self.config = config
 
@@ -123,12 +123,12 @@ public actor VadManager {
 
     private func loadUnifiedModel(
         from directory: URL? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        progressHandler: ProgressHandler? = nil
     ) async throws {
         let baseDirectory = directory ?? getDefaultBaseDirectory()
 
         // Use DownloadUtils to load the model (handles downloading if needed)
-        let models = try await DownloadUtils.loadModels(
+        let models = try await ModelHub.loadModels(
             .vad,
             modelNames: Array(ModelNames.VAD.requiredModels),
             directory: baseDirectory.appendingPathComponent("Models"),

--- a/Sources/FluidAudio/VAD/VadManager.swift
+++ b/Sources/FluidAudio/VAD/VadManager.swift
@@ -127,7 +127,7 @@ public actor VadManager {
     ) async throws {
         let baseDirectory = directory ?? getDefaultBaseDirectory()
 
-        // Use DownloadUtils to load the model (handles downloading if needed)
+        // Use ModelHub to load the model (handles downloading if needed)
         let models = try await ModelHub.loadModels(
             .vad,
             modelNames: Array(ModelNames.VAD.requiredModels),

--- a/Sources/FluidAudioCLI/Commands/ASR/JapaneseAsrBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/JapaneseAsrBenchmark.swift
@@ -478,7 +478,7 @@ enum JapaneseAsrBenchmark {
         try jsonData.write(to: URL(fileURLWithPath: outputFile))
     }
 
-    private static func createProgressHandler() -> DownloadUtils.ProgressHandler {
+    private static func createProgressHandler() -> ProgressHandler {
         return { progress in
             let percentage = progress.fractionCompleted * 100.0
             switch progress.phase {

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/AsrBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/AsrBenchmark.swift
@@ -446,7 +446,7 @@ public class ASRBenchmark {
         let downloadURL = URL(string: url)!
 
         logger.info("Downloading \(url)...")
-        let (tempFile, _) = try await DownloadUtils.sharedSession.download(from: downloadURL)
+        let (tempFile, _) = try await ModelHub.session.download(from: downloadURL)
 
         try FileManager.default.createDirectory(at: extractTo, withIntermediateDirectories: true)
 

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/FleursBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/FleursBenchmark.swift
@@ -260,7 +260,7 @@ public class FLEURSBenchmark {
         do {
             // List files in the language directory using HuggingFace API (registry-aware with auth)
             let apiURL = try ModelRegistry.apiDatasets(datasetRepo, "tree/main/\(language)")
-            let (listData, _) = try await DownloadUtils.fetchWithAuth(from: apiURL)
+            let (listData, _) = try await ModelHub.fetchWithAuth(from: apiURL)
 
             guard let items = try JSONSerialization.jsonObject(with: listData) as? [[String: Any]] else {
                 throw NSError(
@@ -284,7 +284,7 @@ public class FLEURSBenchmark {
                 if fileName == "\(language).trans.txt" {
                     // Download transcript file
                     let downloadURL = try ModelRegistry.resolveDataset(datasetRepo, itemPath)
-                    let transData = try await DownloadUtils.fetchHuggingFaceFile(
+                    let transData = try await ModelHub.fetchFile(
                         from: downloadURL,
                         description: "\(language) transcript"
                     )
@@ -323,7 +323,7 @@ public class FLEURSBenchmark {
                 let downloadURL = try ModelRegistry.resolveDataset(datasetRepo, audioPath)
 
                 do {
-                    let audioData = try await DownloadUtils.fetchHuggingFaceFile(
+                    let audioData = try await ModelHub.fetchFile(
                         from: downloadURL,
                         description: "\(language)/\(fileName)"
                     )

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronBenchmark.swift
@@ -383,7 +383,7 @@ public class NemotronBenchmark {
         let repo = config.chunkSize.repo
 
         // Check default cache location
-        // Note: downloadRepo appends repo.folderName internally, so we use the parent dir
+        // Note: ModelHub.download appends repo.folderName internally, so we use the parent dir
         let modelsBaseDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".cache/fluidaudio/models")
         let cacheDir = modelsBaseDir.appendingPathComponent(repo.folderName)
@@ -396,7 +396,7 @@ public class NemotronBenchmark {
             return cacheDir
         }
 
-        // Download models (downloadRepo appends folderName internally)
+        // Download models (ModelHub.download appends folderName internally)
         logger.info("Downloading Nemotron \(config.chunkSize.rawValue)ms models from HuggingFace...")
         try await ModelHub.download(repo, to: modelsBaseDir)
 

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronBenchmark.swift
@@ -398,7 +398,7 @@ public class NemotronBenchmark {
 
         // Download models (downloadRepo appends folderName internally)
         logger.info("Downloading Nemotron \(config.chunkSize.rawValue)ms models from HuggingFace...")
-        try await DownloadUtils.downloadRepo(repo, to: modelsBaseDir)
+        try await ModelHub.download(repo, to: modelsBaseDir)
 
         return cacheDir
     }

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronTranscribe.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronTranscribe.swift
@@ -216,7 +216,7 @@ public class NemotronTranscribe {
 
         // Download models (downloadRepo appends folderName internally)
         logger.info("Downloading Nemotron \(config.chunkSize.rawValue)ms models from HuggingFace...")
-        try await DownloadUtils.downloadRepo(repo, to: modelsBaseDir)
+        try await ModelHub.download(repo, to: modelsBaseDir)
 
         return cacheDir
     }

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronTranscribe.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/NemotronTranscribe.swift
@@ -201,7 +201,7 @@ public class NemotronTranscribe {
         let repo = config.chunkSize.repo
 
         // Check default cache location
-        // Note: downloadRepo appends repo.folderName internally, so we use the parent dir
+        // Note: ModelHub.download appends repo.folderName internally, so we use the parent dir
         let modelsBaseDir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".cache/fluidaudio/models")
         let cacheDir = modelsBaseDir.appendingPathComponent(repo.folderName)
@@ -214,7 +214,7 @@ public class NemotronTranscribe {
             return cacheDir
         }
 
-        // Download models (downloadRepo appends folderName internally)
+        // Download models (ModelHub.download appends folderName internally)
         logger.info("Downloading Nemotron \(config.chunkSize.rawValue)ms models from HuggingFace...")
         try await ModelHub.download(repo, to: modelsBaseDir)
 

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/ParakeetEouCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/ParakeetEouCommand.swift
@@ -194,7 +194,7 @@ struct ParakeetEouCommand {
         print("Fetching \(chunkSize.modelSubdirectory) models from \(repo.remotePath)...")
         fflush(stdout)
 
-        // Use DownloadUtils to download - handles auth, rate limiting, retries
+        // Use ModelHub to download - handles auth, rate limiting, retries
         // Downloads to: directory/repo.folderName (e.g., .../parakeet-eou-streaming/160ms)
         let modelsDir = destination.deletingLastPathComponent().deletingLastPathComponent()
         try await ModelHub.download(repo, to: modelsDir)

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/ParakeetEouCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/Streaming/ParakeetEouCommand.swift
@@ -197,7 +197,7 @@ struct ParakeetEouCommand {
         // Use DownloadUtils to download - handles auth, rate limiting, retries
         // Downloads to: directory/repo.folderName (e.g., .../parakeet-eou-streaming/160ms)
         let modelsDir = destination.deletingLastPathComponent().deletingLastPathComponent()
-        try await DownloadUtils.downloadRepo(repo, to: modelsDir)
+        try await ModelHub.download(repo, to: modelsDir)
         print("Models downloaded to \(destination.path)")
     }
 

--- a/Sources/FluidAudioCLI/Commands/MinimaxCorpusCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/MinimaxCorpusCommand.swift
@@ -9,7 +9,7 @@ import Foundation
 /// corpus format (strip `<cloning_audio_filename>|` prefix, prepend a
 /// header documenting source + revision + license).
 ///
-/// Reuses `DownloadUtils.fetchHuggingFaceFile` so we get the same auth
+/// Reuses `ModelHub.fetchFile` so we get the same auth
 /// (HF_TOKEN env), retry, and backoff treatment as every other HF asset
 /// pull in the project — no hardcoded URLs, no swift-transformers
 /// dependency added just for one corpus fetch.
@@ -102,7 +102,7 @@ public enum MinimaxCorpusCommand {
                 exit(1)
             }
             do {
-                let data = try await DownloadUtils.fetchHuggingFaceFile(
+                let data = try await ModelHub.fetchFile(
                     from: url, description: "minimax TTS corpus (\(lang))")
                 guard let raw = String(data: data, encoding: .utf8) else {
                     logger.error("[\(lang)] response was not valid UTF-8")

--- a/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
@@ -1065,7 +1065,7 @@ public enum TtsBenchmarkCommand {
         let appSupport = try FileManager.default.url(
             for: .applicationSupportDirectory,
             in: .userDomainMask, appropriateFor: nil, create: true)
-        // `downloadRepo` appends `repo.folderName` (cohere-transcribe/q8), so
+        // `ModelHub.download` appends `repo.folderName` (cohere-transcribe/q8), so
         // pass the Models base dir and let it land the bundle at `target`.
         let modelsBase = appSupport.appendingPathComponent("FluidAudio/Models")
         let target = modelsBase.appendingPathComponent("cohere-transcribe/q8")

--- a/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
@@ -1056,7 +1056,7 @@ public enum TtsBenchmarkCommand {
     ///
     /// `Repo.cohereTranscribeCoreml` ships `vocab.json` in `requiredModels`, and
     /// that file lives at the repo root rather than under the `q8/` subPath.
-    /// `DownloadUtils.downloadRepo` now sweeps the repo root for required
+    /// `ModelHub.download` now sweeps the repo root for required
     /// auxiliary files (issue #649), so auto-download resolves it correctly.
     private static func resolveCohereModelDir(_ override: String?) async throws -> URL {
         if let override {
@@ -1081,7 +1081,7 @@ public enum TtsBenchmarkCommand {
             }
         }
         if !missingFiles().isEmpty {
-            try await DownloadUtils.downloadRepo(.cohereTranscribeCoreml, to: modelsBase)
+            try await ModelHub.download(.cohereTranscribeCoreml, to: modelsBase)
         }
         let missing = missingFiles()
         guard missing.isEmpty else {

--- a/Sources/FluidAudioCLI/DatasetParsers/DatasetDownloader.swift
+++ b/Sources/FluidAudioCLI/DatasetParsers/DatasetDownloader.swift
@@ -132,7 +132,7 @@ struct DatasetDownloader {
             }
 
             do {
-                let (data, response) = try await DownloadUtils.sharedSession.data(from: url)
+                let (data, response) = try await ModelHub.session.data(from: url)
 
                 if let httpResponse = response as? HTTPURLResponse {
                     if httpResponse.statusCode == 200 {
@@ -254,7 +254,7 @@ struct DatasetDownloader {
         }
 
         do {
-            let (data, response) = try await DownloadUtils.sharedSession.data(from: url)
+            let (data, response) = try await ModelHub.session.data(from: url)
 
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == 200 {
@@ -603,7 +603,7 @@ struct DatasetDownloader {
                 userInfo: [NSLocalizedDescriptionKey: "Invalid API URL"])
         }
 
-        let (data, _) = try await DownloadUtils.sharedSession.data(from: url)
+        let (data, _) = try await ModelHub.session.data(from: url)
 
         // Parse the JSON response to extract file names
         if let json = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
@@ -658,7 +658,7 @@ struct DatasetDownloader {
         )
 
         // Download using URLSession
-        let (data, _) = try await DownloadUtils.sharedSession.data(from: url)
+        let (data, _) = try await ModelHub.session.data(from: url)
         try data.write(to: destination)
 
         // Verify it's valid audio
@@ -717,7 +717,7 @@ struct DatasetDownloader {
 
         do {
             // Download the tar.gz file
-            let (downloadURL, response) = try await DownloadUtils.sharedSession.download(
+            let (downloadURL, response) = try await ModelHub.session.download(
                 from: URL(string: musanURL)!)
 
             // Check response
@@ -874,7 +874,7 @@ struct DatasetDownloader {
             }
 
             do {
-                let (data, response) = try await DownloadUtils.sharedSession.data(from: apiURL)
+                let (data, response) = try await ModelHub.session.data(from: apiURL)
 
                 guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                     let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
@@ -906,7 +906,7 @@ struct DatasetDownloader {
                         continue
                     }
 
-                    let (audioData, audioResponse) = try await DownloadUtils.sharedSession.data(from: audioURL)
+                    let (audioData, audioResponse) = try await ModelHub.session.data(from: audioURL)
                     guard let audioHTTP = audioResponse as? HTTPURLResponse, audioHTTP.statusCode == 200 else {
                         logger.warning("Failed to download audio for \(fileId)")
                         continue

--- a/Sources/FluidAudioCLI/DatasetParsers/JapaneseDatasetDownloader.swift
+++ b/Sources/FluidAudioCLI/DatasetParsers/JapaneseDatasetDownloader.swift
@@ -44,7 +44,7 @@ extension DatasetDownloader {
             // Download transcript_utf8.txt (format: "FILENAME:transcription text")
             logger.info("📄 Downloading transcripts...")
             let transcriptURL = try ModelRegistry.resolveDataset(dataset, "basic5000/transcript_utf8.txt")
-            let (transcriptData, _) = try await DownloadUtils.sharedSession.data(from: transcriptURL)
+            let (transcriptData, _) = try await ModelHub.session.data(from: transcriptURL)
             let transcriptContent = String(data: transcriptData, encoding: .utf8) ?? ""
 
             // Parse transcripts and build metadata
@@ -182,7 +182,7 @@ extension DatasetDownloader {
             // Download TSV metadata (format: client_id\tpath\tsentence_id\tsentence\t...)
             logger.info("📄 Downloading metadata TSV...")
             let tsvURL = try ModelRegistry.resolveDataset(dataset, "ja/\(split.rawValue).tsv")
-            let (tsvData, _) = try await DownloadUtils.sharedSession.data(from: tsvURL)
+            let (tsvData, _) = try await ModelHub.session.data(from: tsvURL)
             let tsvContent = String(data: tsvData, encoding: .utf8) ?? ""
 
             // Parse TSV to extract entries

--- a/Tests/FluidAudioTests/ASR/Parakeet/ModelNamesTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/ModelNamesTests.swift
@@ -74,7 +74,7 @@ final class ModelNamesTests: XCTestCase {
         XCTAssertTrue(offlineFp16.contains(ModelNames.ParakeetUnified.offlineEncoderFp16File))
         // ...but the streaming encoder is context-specific ([L,C,R] tier), so it
         // is NOT in the base set — the streaming manager adds its exact encoder
-        // via downloadRepo(additionalModelNames:), avoiding a default over-fetch.
+        // via ModelHub.download(additionalModelNames:), avoiding a default over-fetch.
         for set in [streaming, streamingFp16] {
             XCTAssertEqual(set.filter { $0.contains("encoder") }.count, 0)
         }

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
@@ -388,7 +388,7 @@ final class AsrModelsTests: XCTestCase {
     /// default required set is the standalone CTC frontend
     /// (`MelSpectrogram` + `AudioEncoder`) and does NOT include the CTC head.
     /// `ModelHub.loadModels` threads the caller's `modelNames` into
-    /// `downloadRepo` via `additionalModelNames` so the HF filter recurses
+    /// `ModelHub.download` via `additionalModelNames` so the HF filter recurses
     /// into the `CtcHead.mlmodelc/` directory.
     func testParakeetCtc110mRequiredSetExcludesCtcHead() {
         let required = ModelNames.getRequiredModelNames(for: .parakeetCtc110m, variant: nil)
@@ -403,7 +403,7 @@ final class AsrModelsTests: XCTestCase {
     }
 
     /// Verifies that the cache-validity check in `loadModelsOnce` (and the
-    /// matching filter in `downloadRepo`) sees `CtcHead.mlmodelc` as
+    /// matching filter in `ModelHub.download`) sees `CtcHead.mlmodelc` as
     /// missing even when the baseline required set is fully present on
     /// disk. Pre-fix, the local cache check returned `true` here and the
     /// download was skipped, leading to a silent `fileNoSuchFile` in the

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrModelsTests.swift
@@ -387,7 +387,7 @@ final class AsrModelsTests: XCTestCase {
     /// `CtcHead.mlmodelc` from the `parakeet-ctc-110m` repo, but that repo's
     /// default required set is the standalone CTC frontend
     /// (`MelSpectrogram` + `AudioEncoder`) and does NOT include the CTC head.
-    /// `DownloadUtils.loadModels` threads the caller's `modelNames` into
+    /// `ModelHub.loadModels` threads the caller's `modelNames` into
     /// `downloadRepo` via `additionalModelNames` so the HF filter recurses
     /// into the `CtcHead.mlmodelc/` directory.
     func testParakeetCtc110mRequiredSetExcludesCtcHead() {
@@ -397,7 +397,7 @@ final class AsrModelsTests: XCTestCase {
         XCTAssertFalse(
             required.contains(ModelNames.ASR.ctcHeadFile),
             "CtcHead must not be in the parakeet-ctc-110m baseline required set; "
-                + "callers needing it must pass it via DownloadUtils.loadModels' "
+                + "callers needing it must pass it via ModelHub.loadModels' "
                 + "modelNames parameter."
         )
     }

--- a/Tests/FluidAudioTests/Shared/DownloadArtifactValidationTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadArtifactValidationTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import FluidAudio
 
-/// `DownloadUtils.validateDownloadedArtifact` rejects HTML error pages and
+/// `FileDownloader.validateDownloadedArtifact` rejects HTML error pages and
 /// truncated bodies before they reach the cache (issue #740).
 final class DownloadArtifactValidationTests: XCTestCase {
 
@@ -48,7 +48,7 @@ final class DownloadArtifactValidationTests: XCTestCase {
         do {
             try body()
             XCTFail("expected invalidArtifact to be thrown", file: file, line: line)
-        } catch let DownloadUtils.HuggingFaceDownloadError.invalidArtifact(_, reason) {
+        } catch let DownloadError.invalidArtifact(_, reason) {
             XCTAssertTrue(
                 reason.lowercased().contains(reasonContains.lowercased()),
                 "reason \"\(reason)\" should mention \"\(reasonContains)\"",
@@ -62,25 +62,25 @@ final class DownloadArtifactValidationTests: XCTestCase {
     // MARK: - looksLikeHTML
 
     func testLooksLikeHTMLDetectsDoctype() {
-        XCTAssertTrue(DownloadUtils.looksLikeHTML(Data("<!DOCTYPE html><html></html>".utf8)))
+        XCTAssertTrue(HFClient.looksLikeHTML(Data("<!DOCTYPE html><html></html>".utf8)))
     }
 
     func testLooksLikeHTMLDetectsLeadingWhitespaceAndCasing() {
-        XCTAssertTrue(DownloadUtils.looksLikeHTML(Data("\n\n   <HTML lang=\"en\">".utf8)))
+        XCTAssertTrue(HFClient.looksLikeHTML(Data("\n\n   <HTML lang=\"en\">".utf8)))
     }
 
     func testLooksLikeHTMLDetectsXMLProxyEnvelope() {
-        XCTAssertTrue(DownloadUtils.looksLikeHTML(Data("<?xml version=\"1.0\"?><error/>".utf8)))
+        XCTAssertTrue(HFClient.looksLikeHTML(Data("<?xml version=\"1.0\"?><error/>".utf8)))
     }
 
     func testLooksLikeHTMLAllowsBinaryWeights() {
         // Markup-like bytes mid-stream ('<h') must not trip the leading-byte check.
         let binary = Data([0x00, 0x01, 0x02, 0xFF, 0xFE, 0x3C, 0x68])
-        XCTAssertFalse(DownloadUtils.looksLikeHTML(binary))
+        XCTAssertFalse(HFClient.looksLikeHTML(binary))
     }
 
     func testLooksLikeHTMLAllowsJSON() {
-        XCTAssertFalse(DownloadUtils.looksLikeHTML(Data("{\"vocab\": 1}".utf8)))
+        XCTAssertFalse(HFClient.looksLikeHTML(Data("{\"vocab\": 1}".utf8)))
     }
 
     // MARK: - validateDownloadedArtifact
@@ -89,7 +89,7 @@ final class DownloadArtifactValidationTests: XCTestCase {
         let payload = Data(repeating: 0xAB, count: 1024)
         let url = try writeTemp(payload)
         XCTAssertNoThrow(
-            try DownloadUtils.validateDownloadedArtifact(
+            try FileDownloader.validateDownloadedArtifact(
                 at: url, response: response(), path: "Model.mlmodelc/weights/weight.bin",
                 expectedSize: 1024))
     }
@@ -97,14 +97,14 @@ final class DownloadArtifactValidationTests: XCTestCase {
     func testValidArtifactWithUnknownSizeSkipsSizeCheck() throws {
         let url = try writeTemp(Data(repeating: 0x01, count: 50))
         XCTAssertNoThrow(
-            try DownloadUtils.validateDownloadedArtifact(
+            try FileDownloader.validateDownloadedArtifact(
                 at: url, response: response(), path: "file.json", expectedSize: -1))
     }
 
     func testRejectsHTMLContentType() throws {
         let url = try writeTemp(Data(repeating: 0xAB, count: 1024))
         assertInvalid(
-            try DownloadUtils.validateDownloadedArtifact(
+            try FileDownloader.validateDownloadedArtifact(
                 at: url, response: response(contentType: "text/html; charset=utf-8"),
                 path: "Model.mlmodelc/coremldata.bin", expectedSize: 1024),
             reasonContains: "content-type")
@@ -113,7 +113,7 @@ final class DownloadArtifactValidationTests: XCTestCase {
     func testRejectsEmptyBody() throws {
         let url = try writeTemp(Data())
         assertInvalid(
-            try DownloadUtils.validateDownloadedArtifact(
+            try FileDownloader.validateDownloadedArtifact(
                 at: url, response: response(), path: "file.bin", expectedSize: 0),
             reasonContains: "empty")
     }
@@ -122,7 +122,7 @@ final class DownloadArtifactValidationTests: XCTestCase {
         let html = Data("<!DOCTYPE html>\n<html><body>Proxy error</body></html>".utf8)
         let url = try writeTemp(html)
         assertInvalid(
-            try DownloadUtils.validateDownloadedArtifact(
+            try FileDownloader.validateDownloadedArtifact(
                 at: url, response: response(contentType: "application/octet-stream"),
                 path: "Model.mlmodelc/weights/weight.bin", expectedSize: -1),
             reasonContains: "html")
@@ -131,7 +131,7 @@ final class DownloadArtifactValidationTests: XCTestCase {
     func testRejectsTruncatedBody() throws {
         let url = try writeTemp(Data(repeating: 0x7F, count: 500))
         assertInvalid(
-            try DownloadUtils.validateDownloadedArtifact(
+            try FileDownloader.validateDownloadedArtifact(
                 at: url, response: response(), path: "Model.mlmodelc/weights/weight.bin",
                 expectedSize: 1000),
             reasonContains: "size mismatch")
@@ -140,7 +140,7 @@ final class DownloadArtifactValidationTests: XCTestCase {
     func testRejectsOversizedBody() throws {
         let url = try writeTemp(Data(repeating: 0x7F, count: 2000))
         assertInvalid(
-            try DownloadUtils.validateDownloadedArtifact(
+            try FileDownloader.validateDownloadedArtifact(
                 at: url, response: response(), path: "file.bin", expectedSize: 1000),
             reasonContains: "size mismatch")
     }
@@ -148,7 +148,7 @@ final class DownloadArtifactValidationTests: XCTestCase {
     // MARK: - error description
 
     func testInvalidArtifactErrorDescription() {
-        let err = DownloadUtils.HuggingFaceDownloadError.invalidArtifact(
+        let err = DownloadError.invalidArtifact(
             path: "Encoder.mlmodelc/weights/weight.bin", reason: "empty file")
         XCTAssertEqual(
             err.errorDescription,

--- a/Tests/FluidAudioTests/Shared/DownloadCancellationTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadCancellationTests.swift
@@ -10,7 +10,7 @@ import XCTest
 ///
 /// These tests validate the `isCancellationError` classifier that gates
 /// the delete-and-redownload fallback.
-final class DownloadUtilsCancellationTests: XCTestCase {
+final class DownloadCancellationTests: XCTestCase {
 
     // MARK: - cancellation shapes that must be detected
 

--- a/Tests/FluidAudioTests/Shared/DownloadClassifierTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadClassifierTests.swift
@@ -10,7 +10,7 @@ import XCTest
 /// verdicts, so they are locked in against the current behavior first.
 final class DownloadClassifierTests: XCTestCase {
 
-    typealias HFError = DownloadUtils.HuggingFaceDownloadError
+    typealias HFError = DownloadError
 
     // MARK: - isRetryableDownloadError: transient (retry)
 
@@ -21,28 +21,28 @@ final class DownloadClassifierTests: XCTestCase {
         ]
         for code in transient {
             XCTAssertTrue(
-                DownloadUtils.isRetryableDownloadError(URLError(code)),
+                RetryPolicy.isRetryable(URLError(code)),
                 "URLError.\(code) should be retryable")
         }
     }
 
     func testRateLimitedIsRetryable() {
         XCTAssertTrue(
-            DownloadUtils.isRetryableDownloadError(HFError.rateLimited(statusCode: 429, message: "x")))
+            RetryPolicy.isRetryable(HFError.rateLimited(statusCode: 429, message: "x")))
         XCTAssertTrue(
-            DownloadUtils.isRetryableDownloadError(HFError.rateLimited(statusCode: 503, message: "x")))
+            RetryPolicy.isRetryable(HFError.rateLimited(statusCode: 503, message: "x")))
     }
 
     func testInvalidArtifactIsRetryable() {
         // An HTML error page / truncated body is usually a transient bad network path.
         XCTAssertTrue(
-            DownloadUtils.isRetryableDownloadError(HFError.invalidArtifact(path: "p", reason: "html")))
+            RetryPolicy.isRetryable(HFError.invalidArtifact(path: "p", reason: "html")))
     }
 
     func testDownloadFailedWith5xxIsRetryable() {
         for code in [500, 502, 503, 599] {
             let err = HFError.downloadFailed(path: "p", underlying: NSError(domain: "HTTP", code: code))
-            XCTAssertTrue(DownloadUtils.isRetryableDownloadError(err), "HTTP \(code) should be retryable")
+            XCTAssertTrue(RetryPolicy.isRetryable(err), "HTTP \(code) should be retryable")
         }
     }
 
@@ -51,7 +51,7 @@ final class DownloadClassifierTests: XCTestCase {
     func testPermanentURLErrorsAreNotRetryable() {
         for code in [URLError.Code.badURL, .unsupportedURL, .badServerResponse, .cancelled, .fileDoesNotExist] {
             XCTAssertFalse(
-                DownloadUtils.isRetryableDownloadError(URLError(code)),
+                RetryPolicy.isRetryable(URLError(code)),
                 "URLError.\(code) should not be retryable")
         }
     }
@@ -59,7 +59,7 @@ final class DownloadClassifierTests: XCTestCase {
     func testDownloadFailedWith4xxIsNotRetryable() {
         for code in [400, 401, 403, 404, 410] {
             let err = HFError.downloadFailed(path: "p", underlying: NSError(domain: "HTTP", code: code))
-            XCTAssertFalse(DownloadUtils.isRetryableDownloadError(err), "HTTP \(code) should not retry")
+            XCTAssertFalse(RetryPolicy.isRetryable(err), "HTTP \(code) should not retry")
         }
     }
 
@@ -67,48 +67,48 @@ final class DownloadClassifierTests: XCTestCase {
         // Only the synthetic "HTTP" domain drives the 5xx rule; a 5xx code in some
         // other domain must not be mistaken for a retryable status.
         let err = HFError.downloadFailed(path: "p", underlying: NSError(domain: "Other", code: 500))
-        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(err))
+        XCTAssertFalse(RetryPolicy.isRetryable(err))
     }
 
     func testOtherErrorsAreNotRetryable() {
-        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(HFError.invalidResponse))
-        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(HFError.modelNotFound(path: "p")))
+        XCTAssertFalse(RetryPolicy.isRetryable(HFError.invalidResponse))
+        XCTAssertFalse(RetryPolicy.isRetryable(HFError.modelNotFound(path: "p")))
         XCTAssertFalse(
-            DownloadUtils.isRetryableDownloadError(HFError.htmlErrorResponse(path: "p", snippet: "s")))
-        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(CancellationError()))
-        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(NSError(domain: "x", code: 1)))
+            RetryPolicy.isRetryable(HFError.htmlErrorResponse(path: "p", snippet: "s")))
+        XCTAssertFalse(RetryPolicy.isRetryable(CancellationError()))
+        XCTAssertFalse(RetryPolicy.isRetryable(NSError(domain: "x", code: 1)))
     }
 
     // MARK: - isCancellationError
 
     func testRecognizesCancellation() {
-        XCTAssertTrue(DownloadUtils.isCancellationError(CancellationError()))
-        XCTAssertTrue(DownloadUtils.isCancellationError(URLError(.cancelled)))
+        XCTAssertTrue(RetryPolicy.isCancellation(CancellationError()))
+        XCTAssertTrue(RetryPolicy.isCancellation(URLError(.cancelled)))
         XCTAssertTrue(
-            DownloadUtils.isCancellationError(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)))
+            RetryPolicy.isCancellation(NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)))
         XCTAssertTrue(
-            DownloadUtils.isCancellationError(NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)))
+            RetryPolicy.isCancellation(NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)))
     }
 
     func testRecognizesCancellationNestedInUnderlyingError() {
         let wrapped = NSError(
             domain: "Wrapper", code: 1,
             userInfo: [NSUnderlyingErrorKey: URLError(.cancelled) as NSError])
-        XCTAssertTrue(DownloadUtils.isCancellationError(wrapped))
+        XCTAssertTrue(RetryPolicy.isCancellation(wrapped))
     }
 
     func testNonCancellationErrorsAreNotCancellation() {
-        XCTAssertFalse(DownloadUtils.isCancellationError(URLError(.timedOut)))
-        XCTAssertFalse(DownloadUtils.isCancellationError(NSError(domain: "x", code: 1)))
+        XCTAssertFalse(RetryPolicy.isCancellation(URLError(.timedOut)))
+        XCTAssertFalse(RetryPolicy.isCancellation(NSError(domain: "x", code: 1)))
         XCTAssertFalse(
-            DownloadUtils.isCancellationError(HFError.downloadFailed(path: "p", underlying: URLError(.timedOut))))
+            RetryPolicy.isCancellation(HFError.downloadFailed(path: "p", underlying: URLError(.timedOut))))
     }
 
     // MARK: - Cross-check: a cancelled download is neither retryable nor treated as corruption
 
     func testCancellationIsNotRetryableButIsCancellation() {
         let cancelled = URLError(.cancelled)
-        XCTAssertFalse(DownloadUtils.isRetryableDownloadError(cancelled))
-        XCTAssertTrue(DownloadUtils.isCancellationError(cancelled))
+        XCTAssertFalse(RetryPolicy.isRetryable(cancelled))
+        XCTAssertTrue(RetryPolicy.isCancellation(cancelled))
     }
 }

--- a/Tests/FluidAudioTests/Shared/DownloadFilterCharacterizationTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadFilterCharacterizationTests.swift
@@ -84,7 +84,7 @@ final class DownloadFilterCharacterizationTests: XCTestCase {
         ]
         TreeStubURLProtocol.fileBody = body(10)
 
-        try await DownloadUtils.downloadRepo(
+        try await ModelHub.download(
             .vad, to: workDir, configuration: stubConfiguration)
 
         // Pinned: required-model subtree + root .json/.txt come down;
@@ -139,7 +139,7 @@ final class DownloadFilterCharacterizationTests: XCTestCase {
         ]
         TreeStubURLProtocol.fileBody = body(10)
 
-        try await DownloadUtils.downloadRepo(
+        try await ModelHub.download(
             .parakeetEou160, to: workDir, configuration: stubConfiguration)
 
         // Pinned: subPath prefix is stripped locally; .json/.model/.bin under the
@@ -199,10 +199,10 @@ final class DownloadFilterCharacterizationTests: XCTestCase {
         TreeStubURLProtocol.fileBody = body(10)
 
         do {
-            try await DownloadUtils.downloadRepo(
+            try await ModelHub.download(
                 .kokoroAneZh, to: workDir, configuration: stubConfiguration)
             XCTFail("expected modelNotFound for the missing voice")
-        } catch DownloadUtils.HuggingFaceDownloadError.modelNotFound(let path) {
+        } catch DownloadError.modelNotFound(let path) {
             XCTAssertEqual(path, voice)
         }
 
@@ -241,7 +241,7 @@ final class DownloadFilterCharacterizationTests: XCTestCase {
         ]
         TreeStubURLProtocol.fileBody = body(10)
 
-        try await DownloadUtils.downloadRepo(
+        try await ModelHub.download(
             .parakeetCtc110m, to: workDir,
             additionalModelNames: ["CtcHead.mlmodelc"],
             configuration: stubConfiguration)

--- a/Tests/FluidAudioTests/Shared/DownloadFilterCharacterizationTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadFilterCharacterizationTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import FluidAudio
 
-/// Characterization tests for `downloadRepo`'s file-selection rules (#765
+/// Characterization tests for `ModelHub.download`'s file-selection rules (#765
 /// Wave 1). These pin CURRENT behavior — quirks included — so the Wave 3
 /// lister extraction can prove the rules moved verbatim. They are not a
 /// statement of what the rules *should* be; deliberate changes belong in a

--- a/Tests/FluidAudioTests/Shared/DownloadResumeTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadResumeTests.swift
@@ -48,7 +48,7 @@ final class DownloadResumeTests: XCTestCase {
         partial: URL? = nil,
         maxAttempts: Int = 3
     ) async throws -> Data {
-        let url = try await DownloadUtils.downloadFileWithRetry(
+        let url = try await FileDownloader.download(
             request: request,
             path: "model.bin",
             expectedSize: expectedSize,
@@ -65,7 +65,7 @@ final class DownloadResumeTests: XCTestCase {
         try data.write(to: partialURL())
         if let validator {
             try validator.write(
-                to: DownloadUtils.resumeValidatorURL(for: partialURL()),
+                to: FileDownloader.resumeValidatorURL(for: partialURL()),
                 atomically: true, encoding: .utf8)
         }
     }
@@ -85,7 +85,7 @@ final class DownloadResumeTests: XCTestCase {
         // Validator sidecar is cleaned up after a completed download.
         XCTAssertFalse(
             FileManager.default.fileExists(
-                atPath: DownloadUtils.resumeValidatorURL(for: partialURL()).path))
+                atPath: FileDownloader.resumeValidatorURL(for: partialURL()).path))
     }
 
     func testMidStreamDropResumesWithRangeAndAppends() async throws {
@@ -223,7 +223,7 @@ final class DownloadResumeTests: XCTestCase {
                 chunks: [Data(Self.fullBody.dropFirst(splitAt))]))
 
         let recorded = ProgressRecorder()
-        _ = try await DownloadUtils.downloadFileWithRetry(
+        _ = try await FileDownloader.download(
             request: request,
             path: "model.bin",
             expectedSize: Self.fullBody.count,

--- a/Tests/FluidAudioTests/Shared/DownloadSmokeTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadSmokeTests.swift
@@ -20,7 +20,7 @@ final class DownloadSmokeTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: dir) }
 
         // Cold: no cache exists at `dir`, so this exercises the full pipeline.
-        let models = try await DownloadUtils.loadModels(
+        let models = try await ModelHub.loadModels(
             .vad,
             modelNames: [ModelNames.VAD.sileroVadFile],
             directory: dir,

--- a/Tests/FluidAudioTests/Shared/DownloadUtilsCancellationTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadUtilsCancellationTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import FluidAudio
 
-/// `DownloadUtils.loadModels` treats a failed first load as a corrupted
+/// `ModelHub.loadModels` treats a failed first load as a corrupted
 /// cache and deletes the repo folder before re-downloading. Cancellation
 /// (task cancelled during app teardown, user abort mid-load) must NOT be
 /// classified as corruption — a cancelled load once wiped a fully
@@ -15,21 +15,21 @@ final class DownloadUtilsCancellationTests: XCTestCase {
     // MARK: - cancellation shapes that must be detected
 
     func testSwiftCancellationErrorDetected() {
-        XCTAssertTrue(DownloadUtils.isCancellationError(CancellationError()))
+        XCTAssertTrue(RetryPolicy.isCancellation(CancellationError()))
     }
 
     func testURLErrorCancelledDetected() {
-        XCTAssertTrue(DownloadUtils.isCancellationError(URLError(.cancelled)))
+        XCTAssertTrue(RetryPolicy.isCancellation(URLError(.cancelled)))
     }
 
     func testRawNSURLErrorCancelledDetected() {
         let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)
-        XCTAssertTrue(DownloadUtils.isCancellationError(error))
+        XCTAssertTrue(RetryPolicy.isCancellation(error))
     }
 
     func testCocoaUserCancelledDetected() {
         let error = NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError)
-        XCTAssertTrue(DownloadUtils.isCancellationError(error))
+        XCTAssertTrue(RetryPolicy.isCancellation(error))
     }
 
     func testUnderlyingCancellationDetected() {
@@ -37,7 +37,7 @@ final class DownloadUtilsCancellationTests: XCTestCase {
         let wrapper = NSError(
             domain: "com.example.wrapper", code: 1,
             userInfo: [NSUnderlyingErrorKey: underlying])
-        XCTAssertTrue(DownloadUtils.isCancellationError(wrapper))
+        XCTAssertTrue(RetryPolicy.isCancellation(wrapper))
     }
 
     func testDeeplyNestedCancellationDetected() {
@@ -48,24 +48,24 @@ final class DownloadUtilsCancellationTests: XCTestCase {
         let top = NSError(
             domain: "com.example.top", code: 3,
             userInfo: [NSUnderlyingErrorKey: mid])
-        XCTAssertTrue(DownloadUtils.isCancellationError(top))
+        XCTAssertTrue(RetryPolicy.isCancellation(top))
     }
 
     // MARK: - genuine failures must NOT be classified as cancellation
 
     func testTimeoutNotCancellation() {
-        XCTAssertFalse(DownloadUtils.isCancellationError(URLError(.timedOut)))
+        XCTAssertFalse(RetryPolicy.isCancellation(URLError(.timedOut)))
     }
 
     func testGenericCocoaErrorNotCancellation() {
         let error = NSError(domain: NSCocoaErrorDomain, code: NSFileReadCorruptFileError)
-        XCTAssertFalse(DownloadUtils.isCancellationError(error))
+        XCTAssertFalse(RetryPolicy.isCancellation(error))
     }
 
     func testMatchingCodeWrongDomainNotCancellation() {
         // -999 only means "cancelled" inside NSURLErrorDomain.
         let error = NSError(domain: "com.example.custom", code: NSURLErrorCancelled)
-        XCTAssertFalse(DownloadUtils.isCancellationError(error))
+        XCTAssertFalse(RetryPolicy.isCancellation(error))
     }
 
     func testNonCancellationUnderlyingChainNotClassified() {
@@ -75,7 +75,7 @@ final class DownloadUtilsCancellationTests: XCTestCase {
         let outer = NSError(
             domain: "com.example.b", code: 2,
             userInfo: [NSUnderlyingErrorKey: inner])
-        XCTAssertFalse(DownloadUtils.isCancellationError(outer))
+        XCTAssertFalse(RetryPolicy.isCancellation(outer))
     }
 
     func testDeeplyBuriedCancellationDetected() {
@@ -88,7 +88,7 @@ final class DownloadUtilsCancellationTests: XCTestCase {
                 domain: "com.example.wrap\(i)", code: i,
                 userInfo: [NSUnderlyingErrorKey: error])
         }
-        XCTAssertTrue(DownloadUtils.isCancellationError(error))
+        XCTAssertTrue(RetryPolicy.isCancellation(error))
     }
 
     func testSelfReferentialChainTerminates() {
@@ -96,7 +96,7 @@ final class DownloadUtilsCancellationTests: XCTestCase {
         // Plain `NSError` can't form a cycle (its `userInfo` is fixed at
         // init), so a subclass whose underlying error is itself is the only
         // honest way to construct one. No cancellation on the cycle → false.
-        XCTAssertFalse(DownloadUtils.isCancellationError(SelfReferentialError()))
+        XCTAssertFalse(RetryPolicy.isCancellation(SelfReferentialError()))
     }
 }
 

--- a/Tests/FluidAudioTests/Shared/DownloadUtilsOfflineTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadUtilsOfflineTests.swift
@@ -2,28 +2,28 @@ import XCTest
 
 @testable import FluidAudio
 
-/// `DownloadUtils.enforceOffline` short-circuits every public download
+/// `ModelHub.offlineMode` short-circuits every public download
 /// surface and the `loadModels` retry-with-redownload fallback. Validate
 /// the toggle behaviour without spinning up a real HuggingFace fetch.
 ///
 /// Each test toggles the flag on, asserts the relevant entry point
-/// throws `DownloadUtils.OfflineError.networkDisabled`, and resets the
+/// throws `DownloadError.networkDisabled`, and resets the
 /// flag in `tearDown` so cross-test order does not leak state.
 final class DownloadUtilsOfflineTests: XCTestCase {
 
     override func tearDown() {
-        DownloadUtils.enforceOffline = false
+        ModelHub.offlineMode = false
         super.tearDown()
     }
 
     func testFetchWithAuthThrowsNetworkDisabledInOfflineMode() async {
-        DownloadUtils.enforceOffline = true
+        ModelHub.offlineMode = true
         let url = URL(string: "https://huggingface.co/test/file")!
 
         do {
-            _ = try await DownloadUtils.fetchWithAuth(from: url)
+            _ = try await ModelHub.fetchWithAuth(from: url)
             XCTFail("expected OfflineError.networkDisabled")
-        } catch let DownloadUtils.OfflineError.networkDisabled(operation) {
+        } catch let DownloadError.networkDisabled(operation) {
             XCTAssertTrue(
                 operation.hasPrefix("fetchWithAuth("),
                 "operation tag should identify the blocked path, got: \(operation)"
@@ -34,68 +34,68 @@ final class DownloadUtilsOfflineTests: XCTestCase {
     }
 
     func testFetchHuggingFaceFileThrowsNetworkDisabledInOfflineMode() async {
-        DownloadUtils.enforceOffline = true
+        ModelHub.offlineMode = true
         let url = URL(string: "https://huggingface.co/test/file")!
 
         do {
-            _ = try await DownloadUtils.fetchHuggingFaceFile(
+            _ = try await ModelHub.fetchFile(
                 from: url,
                 description: "test-file",
                 maxAttempts: 1,
                 minBackoff: 0.01
             )
             XCTFail("expected OfflineError.networkDisabled")
-        } catch let DownloadUtils.OfflineError.networkDisabled(operation) {
-            XCTAssertEqual(operation, "fetchHuggingFaceFile(test-file)")
+        } catch let DownloadError.networkDisabled(operation) {
+            XCTAssertEqual(operation, "fetchFile(test-file)")
         } catch {
             XCTFail("expected OfflineError.networkDisabled, got: \(error)")
         }
     }
 
     func testDownloadRepoThrowsNetworkDisabledInOfflineMode() async {
-        DownloadUtils.enforceOffline = true
+        ModelHub.offlineMode = true
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("offline-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: dir) }
 
         do {
-            try await DownloadUtils.downloadRepo(.vad, to: dir)
+            try await ModelHub.download(.vad, to: dir)
             XCTFail("expected OfflineError.networkDisabled")
-        } catch let DownloadUtils.OfflineError.networkDisabled(operation) {
-            XCTAssertTrue(operation.hasPrefix("downloadRepo("), "got: \(operation)")
+        } catch let DownloadError.networkDisabled(operation) {
+            XCTAssertTrue(operation.hasPrefix("download("), "got: \(operation)")
         } catch {
             XCTFail("expected OfflineError.networkDisabled, got: \(error)")
         }
     }
 
     func testDownloadSubdirectoryThrowsNetworkDisabledInOfflineMode() async {
-        DownloadUtils.enforceOffline = true
+        ModelHub.offlineMode = true
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("offline-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: dir) }
 
         do {
-            try await DownloadUtils.downloadSubdirectory(
+            try await ModelHub.download(
                 .vad, subdirectory: "anything", to: dir)
             XCTFail("expected OfflineError.networkDisabled")
-        } catch let DownloadUtils.OfflineError.networkDisabled(operation) {
-            XCTAssertTrue(operation.hasPrefix("downloadSubdirectory("), "got: \(operation)")
+        } catch let DownloadError.networkDisabled(operation) {
+            XCTAssertTrue(operation.hasPrefix("download("), "got: \(operation)")
         } catch {
             XCTFail("expected OfflineError.networkDisabled, got: \(error)")
         }
     }
 
     func testLoadModelsSurfacesTypedMissingModelsInOfflineMode() async {
-        DownloadUtils.enforceOffline = true
+        ModelHub.offlineMode = true
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("offline-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: dir) }
 
         do {
-            _ = try await DownloadUtils.loadModels(
+            _ = try await ModelHub.loadModels(
                 .vad, modelNames: [ModelNames.VAD.sileroVadFile], directory: dir)
             XCTFail("expected OfflineError.modelMissing")
-        } catch let DownloadUtils.OfflineError.modelMissing(repo, missing) {
+        } catch let DownloadError.modelMissing(repo, missing) {
             // Pinned: offline + empty cache surfaces the typed error with the
             // missing file list — it must NOT attempt a download or purge.
             XCTAssertEqual(repo, Repo.vad.folderName)
@@ -110,7 +110,7 @@ final class DownloadUtilsOfflineTests: XCTestCase {
         // (the unit-test environment has no offline guarantees about HF
         // reachability), but we confirm the gate itself does not throw
         // when the flag is off.
-        XCTAssertFalse(DownloadUtils.enforceOffline)
+        XCTAssertFalse(ModelHub.offlineMode)
         do {
             try Self.callEnsureOnlineAllowed("test.no-op")
         } catch {
@@ -119,15 +119,15 @@ final class DownloadUtilsOfflineTests: XCTestCase {
     }
 
     func testOfflineErrorDescriptionsFormat() {
-        let blocked = DownloadUtils.OfflineError.networkDisabled(
-            operation: "downloadRepo(parakeet)"
+        let blocked = DownloadError.networkDisabled(
+            operation: "download(parakeet)"
         )
         XCTAssertEqual(
             blocked.errorDescription,
-            "FluidAudio offline mode: downloadRepo(parakeet) blocked"
+            "FluidAudio offline mode: download(parakeet) blocked"
         )
 
-        let missing = DownloadUtils.OfflineError.modelMissing(
+        let missing = DownloadError.modelMissing(
             repo: "parakeet",
             missing: ["A.mlmodelc", "B.mlmodelc"]
         )
@@ -143,8 +143,8 @@ final class DownloadUtilsOfflineTests: XCTestCase {
     /// check shape in the test to validate the contract — the
     /// behaviour matters more than the exact symbol being addressable.
     private static func callEnsureOnlineAllowed(_ operation: String) throws {
-        if DownloadUtils.enforceOffline {
-            throw DownloadUtils.OfflineError.networkDisabled(operation: operation)
+        if ModelHub.offlineMode {
+            throw DownloadError.networkDisabled(operation: operation)
         }
     }
 }

--- a/Tests/FluidAudioTests/Shared/DownloadUtilsProgressTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadUtilsProgressTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class DownloadUtilsProgressTests: XCTestCase {
 
     func testSubdirectoryProgressUsesByteWeightingDuringLargeFile() {
-        let fraction = DownloadUtils.subdirectoryProgressFraction(
+        let fraction = ProgressReporter.downloadFraction(
             completedBytes: 399,
             totalBytes: 665,
             completedFiles: 9,
@@ -18,37 +18,37 @@ final class DownloadUtilsProgressTests: XCTestCase {
 
     func testSubdirectoryProgressIsMonotonicForRealisticSequence() {
         let progress = [
-            DownloadUtils.subdirectoryProgressFraction(
+            ProgressReporter.downloadFraction(
                 completedBytes: 0,
                 totalBytes: 665,
                 completedFiles: 0,
                 totalFiles: 22
             ),
-            DownloadUtils.subdirectoryProgressFraction(
+            ProgressReporter.downloadFraction(
                 completedBytes: 40,
                 totalBytes: 665,
                 completedFiles: 4,
                 totalFiles: 22
             ),
-            DownloadUtils.subdirectoryProgressFraction(
+            ProgressReporter.downloadFraction(
                 completedBytes: 120,
                 totalBytes: 665,
                 completedFiles: 9,
                 totalFiles: 22
             ),
-            DownloadUtils.subdirectoryProgressFraction(
+            ProgressReporter.downloadFraction(
                 completedBytes: 399,
                 totalBytes: 665,
                 completedFiles: 9,
                 totalFiles: 22
             ),
-            DownloadUtils.subdirectoryProgressFraction(
+            ProgressReporter.downloadFraction(
                 completedBytes: 565,
                 totalBytes: 665,
                 completedFiles: 10,
                 totalFiles: 22
             ),
-            DownloadUtils.subdirectoryProgressFraction(
+            ProgressReporter.downloadFraction(
                 completedBytes: 665,
                 totalBytes: 665,
                 completedFiles: 22,
@@ -60,7 +60,7 @@ final class DownloadUtilsProgressTests: XCTestCase {
     }
 
     func testSubdirectoryProgressClampsToOne() {
-        let fraction = DownloadUtils.subdirectoryProgressFraction(
+        let fraction = ProgressReporter.downloadFraction(
             completedBytes: 700,
             totalBytes: 665,
             completedFiles: 22,
@@ -71,7 +71,7 @@ final class DownloadUtilsProgressTests: XCTestCase {
     }
 
     func testSubdirectoryProgressFallsBackToFileCountWhenTotalBytesUnknown() {
-        let fraction = DownloadUtils.subdirectoryProgressFraction(
+        let fraction = ProgressReporter.downloadFraction(
             completedBytes: 0,
             totalBytes: 0,
             completedFiles: 9,
@@ -82,7 +82,7 @@ final class DownloadUtilsProgressTests: XCTestCase {
     }
 
     func testSubdirectoryProgressIsCompleteWhenThereAreNoFiles() {
-        let fraction = DownloadUtils.subdirectoryProgressFraction(
+        let fraction = ProgressReporter.downloadFraction(
             completedBytes: 0,
             totalBytes: 0,
             completedFiles: 0,

--- a/Tests/FluidAudioTests/Shared/FetchHuggingFaceFileTests.swift
+++ b/Tests/FluidAudioTests/Shared/FetchHuggingFaceFileTests.swift
@@ -4,7 +4,7 @@ import os
 
 @testable import FluidAudio
 
-/// Wave 5 behavior tests (#765): `fetchHuggingFaceFile` converges onto the
+/// Wave 5 behavior tests (#765): `fetchFile` converges onto the
 /// shared retry policy and artifact validation. These pin the DELIBERATE
 /// behavior changes this wave introduces:
 ///   - permanent errors (404) fail fast instead of consuming the backoff budget

--- a/Tests/FluidAudioTests/Shared/FetchHuggingFaceFileTests.swift
+++ b/Tests/FluidAudioTests/Shared/FetchHuggingFaceFileTests.swift
@@ -32,7 +32,7 @@ final class FetchHuggingFaceFileTests: XCTestCase {
     }
 
     private func fetch(maxAttempts: Int = 4) async throws -> Data {
-        try await DownloadUtils.fetchHuggingFaceFile(
+        try await ModelHub.fetchFile(
             from: url, description: "vocab.json",
             maxAttempts: maxAttempts, minBackoff: 0.01,
             configuration: stubConfiguration)
@@ -50,7 +50,7 @@ final class FetchHuggingFaceFileTests: XCTestCase {
         do {
             _ = try await fetch()
             XCTFail("expected downloadFailed")
-        } catch HFDownload.DownloadError.downloadFailed(let path, let underlying) {
+        } catch DownloadError.downloadFailed(let path, let underlying) {
             XCTAssertEqual(path, "vocab.json")
             XCTAssertEqual((underlying as NSError).code, 404)
         } catch {
@@ -78,7 +78,7 @@ final class FetchHuggingFaceFileTests: XCTestCase {
         do {
             _ = try await fetch(maxAttempts: 1)
             XCTFail("expected invalidArtifact")
-        } catch HFDownload.DownloadError.invalidArtifact(_, let reason) {
+        } catch DownloadError.invalidArtifact(_, let reason) {
             XCTAssertTrue(reason.contains("HTML"), "got: \(reason)")
         } catch {
             XCTFail("expected invalidArtifact, got \(error)")
@@ -91,7 +91,7 @@ final class FetchHuggingFaceFileTests: XCTestCase {
         do {
             _ = try await fetch(maxAttempts: 1)
             XCTFail("expected invalidArtifact")
-        } catch HFDownload.DownloadError.invalidArtifact(_, let reason) {
+        } catch DownloadError.invalidArtifact(_, let reason) {
             XCTAssertEqual(reason, "empty file")
         } catch {
             XCTFail("expected invalidArtifact, got \(error)")
@@ -120,7 +120,7 @@ final class FetchHuggingFaceFileTests: XCTestCase {
         do {
             _ = try await fetch(maxAttempts: 1)
             XCTFail("expected invalidArtifact")
-        } catch HFDownload.DownloadError.invalidArtifact(_, let reason) {
+        } catch DownloadError.invalidArtifact(_, let reason) {
             XCTAssertTrue(reason.contains("text/html"), "got: \(reason)")
         } catch {
             XCTFail("expected invalidArtifact, got \(error)")
@@ -155,7 +155,7 @@ final class FetchHuggingFaceFileTests: XCTestCase {
         do {
             _ = try await fetch(maxAttempts: 2)
             XCTFail("expected rateLimited")
-        } catch HFDownload.DownloadError.rateLimited(let statusCode, let message) {
+        } catch DownloadError.rateLimited(let statusCode, let message) {
             XCTAssertEqual(statusCode, 429)
             XCTAssertTrue(message.contains("fetching vocab.json"), "got: \(message)")
         } catch {

--- a/Tests/FluidAudioTests/Shared/HFTreeListerTests.swift
+++ b/Tests/FluidAudioTests/Shared/HFTreeListerTests.swift
@@ -7,7 +7,7 @@ import XCTest
 /// include-based pruning, Link-header pagination (confirmed against the live
 /// HF API in Wave 0), and typed errors for rate-limit/HTML/malformed pages.
 /// The repo-specific filter *rules* are pinned separately by
-/// `DownloadFilterCharacterizationTests` through `downloadRepo`.
+/// `DownloadFilterCharacterizationTests` through `ModelHub.download`.
 final class HFTreeListerTests: XCTestCase {
 
     private static let repo = "FluidInference/test-repo"
@@ -175,7 +175,7 @@ final class HFTreeListerTests: XCTestCase {
 
     // MARK: - Pagination through the real fetch path
 
-    /// End-to-end: downloadRepo → configuration seam → HFTreeLister.fetch →
+    /// End-to-end: ModelHub.download → configuration seam → HFTreeLister.fetch →
     /// URLSession → Link cursor. The unit tests above bypass the session via
     /// an injected Fetch; this pins the production wiring.
     func testDownloadRepoFollowsPaginationThroughRealFetchPath() async throws {

--- a/Tests/FluidAudioTests/Shared/HFTreeListerTests.swift
+++ b/Tests/FluidAudioTests/Shared/HFTreeListerTests.swift
@@ -41,7 +41,7 @@ final class HFTreeListerTests: XCTestCase {
             { url in
                 self.requested.append(url.absoluteString)
                 guard let page = self.pages[url.absoluteString] else {
-                    throw HFDownload.DownloadError.invalidResponse
+                    throw DownloadError.invalidResponse
                 }
                 return page
             }
@@ -205,7 +205,7 @@ final class HFTreeListerTests: XCTestCase {
 
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [LinkedTreeStubURLProtocol.self]
-        try await DownloadUtils.downloadRepo(.vad, to: workDir, configuration: config)
+        try await ModelHub.download(.vad, to: workDir, configuration: config)
 
         let repoPath = workDir.appendingPathComponent(Repo.vad.folderName)
         XCTAssertTrue(
@@ -227,7 +227,7 @@ final class HFTreeListerTests: XCTestCase {
             _ = try await HFTreeLister.listTree(
                 repoRemotePath: Self.repo, include: { _, _ in true }, fetch: server.fetch)
             XCTFail("expected rateLimited")
-        } catch HFDownload.DownloadError.rateLimited(let statusCode, _) {
+        } catch DownloadError.rateLimited(let statusCode, _) {
             XCTAssertEqual(statusCode, 429)
         }
     }
@@ -240,7 +240,7 @@ final class HFTreeListerTests: XCTestCase {
             _ = try await HFTreeLister.listTree(
                 repoRemotePath: Self.repo, include: { _, _ in true }, fetch: server.fetch)
             XCTFail("expected htmlErrorResponse")
-        } catch HFDownload.DownloadError.htmlErrorResponse {
+        } catch DownloadError.htmlErrorResponse {
             // expected
         }
     }
@@ -253,7 +253,7 @@ final class HFTreeListerTests: XCTestCase {
             _ = try await HFTreeLister.listTree(
                 repoRemotePath: Self.repo, include: { _, _ in true }, fetch: server.fetch)
             XCTFail("expected invalidResponse")
-        } catch HFDownload.DownloadError.invalidResponse {
+        } catch DownloadError.invalidResponse {
             // expected
         }
     }

--- a/Tests/FluidAudioTests/Shared/ModelHubOfflineTests.swift
+++ b/Tests/FluidAudioTests/Shared/ModelHubOfflineTests.swift
@@ -9,7 +9,7 @@ import XCTest
 /// Each test toggles the flag on, asserts the relevant entry point
 /// throws `DownloadError.networkDisabled`, and resets the
 /// flag in `tearDown` so cross-test order does not leak state.
-final class DownloadUtilsOfflineTests: XCTestCase {
+final class ModelHubOfflineTests: XCTestCase {
 
     override func tearDown() {
         ModelHub.offlineMode = false
@@ -22,14 +22,14 @@ final class DownloadUtilsOfflineTests: XCTestCase {
 
         do {
             _ = try await ModelHub.fetchWithAuth(from: url)
-            XCTFail("expected OfflineError.networkDisabled")
+            XCTFail("expected DownloadError.networkDisabled")
         } catch let DownloadError.networkDisabled(operation) {
             XCTAssertTrue(
                 operation.hasPrefix("fetchWithAuth("),
                 "operation tag should identify the blocked path, got: \(operation)"
             )
         } catch {
-            XCTFail("expected OfflineError.networkDisabled, got: \(error)")
+            XCTFail("expected DownloadError.networkDisabled, got: \(error)")
         }
     }
 
@@ -44,11 +44,11 @@ final class DownloadUtilsOfflineTests: XCTestCase {
                 maxAttempts: 1,
                 minBackoff: 0.01
             )
-            XCTFail("expected OfflineError.networkDisabled")
+            XCTFail("expected DownloadError.networkDisabled")
         } catch let DownloadError.networkDisabled(operation) {
             XCTAssertEqual(operation, "fetchFile(test-file)")
         } catch {
-            XCTFail("expected OfflineError.networkDisabled, got: \(error)")
+            XCTFail("expected DownloadError.networkDisabled, got: \(error)")
         }
     }
 
@@ -60,11 +60,11 @@ final class DownloadUtilsOfflineTests: XCTestCase {
 
         do {
             try await ModelHub.download(.vad, to: dir)
-            XCTFail("expected OfflineError.networkDisabled")
+            XCTFail("expected DownloadError.networkDisabled")
         } catch let DownloadError.networkDisabled(operation) {
             XCTAssertTrue(operation.hasPrefix("download("), "got: \(operation)")
         } catch {
-            XCTFail("expected OfflineError.networkDisabled, got: \(error)")
+            XCTFail("expected DownloadError.networkDisabled, got: \(error)")
         }
     }
 
@@ -77,11 +77,11 @@ final class DownloadUtilsOfflineTests: XCTestCase {
         do {
             try await ModelHub.download(
                 .vad, subdirectory: "anything", to: dir)
-            XCTFail("expected OfflineError.networkDisabled")
+            XCTFail("expected DownloadError.networkDisabled")
         } catch let DownloadError.networkDisabled(operation) {
             XCTAssertTrue(operation.hasPrefix("download("), "got: \(operation)")
         } catch {
-            XCTFail("expected OfflineError.networkDisabled, got: \(error)")
+            XCTFail("expected DownloadError.networkDisabled, got: \(error)")
         }
     }
 
@@ -94,14 +94,14 @@ final class DownloadUtilsOfflineTests: XCTestCase {
         do {
             _ = try await ModelHub.loadModels(
                 .vad, modelNames: [ModelNames.VAD.sileroVadFile], directory: dir)
-            XCTFail("expected OfflineError.modelMissing")
+            XCTFail("expected DownloadError.modelMissing")
         } catch let DownloadError.modelMissing(repo, missing) {
             // Pinned: offline + empty cache surfaces the typed error with the
             // missing file list — it must NOT attempt a download or purge.
             XCTAssertEqual(repo, Repo.vad.folderName)
             XCTAssertEqual(missing, [ModelNames.VAD.sileroVadFile])
         } catch {
-            XCTFail("expected OfflineError.modelMissing, got: \(error)")
+            XCTFail("expected DownloadError.modelMissing, got: \(error)")
         }
     }
 
@@ -114,7 +114,7 @@ final class DownloadUtilsOfflineTests: XCTestCase {
         do {
             try Self.callEnsureOnlineAllowed("test.no-op")
         } catch {
-            XCTFail("ensureOnlineAllowed must not throw when enforceOffline=false; got: \(error)")
+            XCTFail("ensureOnlineAllowed must not throw when offlineMode=false; got: \(error)")
         }
     }
 

--- a/Tests/FluidAudioTests/Shared/ProgressReporterTests.swift
+++ b/Tests/FluidAudioTests/Shared/ProgressReporterTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import FluidAudio
 
-final class DownloadUtilsProgressTests: XCTestCase {
+final class ProgressReporterTests: XCTestCase {
 
     func testSubdirectoryProgressUsesByteWeightingDuringLargeFile() {
         let fraction = ProgressReporter.downloadFraction(

--- a/Tests/FluidAudioTests/Shared/ProgressSequenceTests.swift
+++ b/Tests/FluidAudioTests/Shared/ProgressSequenceTests.swift
@@ -4,7 +4,7 @@ import os
 
 @testable import FluidAudio
 
-/// Characterization tests for `downloadRepo`'s progress emissions (#765
+/// Characterization tests for `ModelHub.download`'s progress emissions (#765
 /// Wave 1). Pins the CURRENT convention that UIs depend on: the download
 /// phase of a repo operation occupies `fractionCompleted` 0.0–0.5 (compile
 /// occupies 0.5–1.0 and needs real models, so it is pinned by inspection,

--- a/Tests/FluidAudioTests/Shared/ProgressSequenceTests.swift
+++ b/Tests/FluidAudioTests/Shared/ProgressSequenceTests.swift
@@ -45,7 +45,7 @@ final class ProgressSequenceTests: XCTestCase {
         TreeStubURLProtocol.fileBody = Data(String(repeating: "x", count: 40).utf8)
 
         let recorder = ProgressStreamRecorder()
-        try await DownloadUtils.downloadRepo(
+        try await ModelHub.download(
             .vad, to: workDir,
             progressHandler: { recorder.append($0) },
             configuration: stubConfiguration)
@@ -88,7 +88,7 @@ final class ProgressSequenceTests: XCTestCase {
         TreeStubURLProtocol.fileBody = Data(String(repeating: "x", count: 10).utf8)
 
         let recorder = ProgressStreamRecorder()
-        try await DownloadUtils.downloadRepo(
+        try await ModelHub.download(
             .vad, to: workDir,
             progressHandler: { recorder.append($0) },
             configuration: stubConfiguration)
@@ -107,13 +107,13 @@ final class ProgressSequenceTests: XCTestCase {
 
 /// Lock-guarded recorder for progress emissions (tests only).
 final class ProgressStreamRecorder: Sendable {
-    private let events = OSAllocatedUnfairLock<[DownloadUtils.DownloadProgress]>(initialState: [])
+    private let events = OSAllocatedUnfairLock<[DownloadProgress]>(initialState: [])
 
-    func append(_ event: DownloadUtils.DownloadProgress) {
+    func append(_ event: DownloadProgress) {
         events.withLock { $0.append(event) }
     }
 
-    func snapshot() -> [DownloadUtils.DownloadProgress] {
+    func snapshot() -> [DownloadProgress] {
         events.withLock { $0 }
     }
 }

--- a/Tests/FluidAudioTests/Shared/RetryPolicyTests.swift
+++ b/Tests/FluidAudioTests/Shared/RetryPolicyTests.swift
@@ -6,7 +6,7 @@ import os
 
 /// Unit tests for the extracted retry primitive (#765 Wave 2). Classification
 /// itself is characterized by `DownloadClassifierTests` (which now runs
-/// through the `DownloadUtils.isRetryableDownloadError` forward); these tests
+/// through the `RetryPolicy.isRetryable` forward); these tests
 /// pin the loop mechanics: attempt counting, fail-fast on permanent errors,
 /// and error propagation.
 final class RetryPolicyTests: XCTestCase {
@@ -47,7 +47,7 @@ final class RetryPolicyTests: XCTestCase {
                 label: "permanent", maxAttempts: 4, minBackoff: 0.01
             ) { _ in
                 _ = counter.increment()
-                throw DownloadUtils.HuggingFaceDownloadError.downloadFailed(
+                throw DownloadError.downloadFailed(
                     path: "missing.bin", underlying: NSError(domain: "HTTP", code: 404))
             }
             XCTFail("expected error")
@@ -64,7 +64,7 @@ final class RetryPolicyTests: XCTestCase {
         ) { attempt -> Int in
             XCTAssertEqual(attempt, counter.increment(), "closure must receive the 1-based attempt")
             if attempt < 3 {
-                throw DownloadUtils.HuggingFaceDownloadError.rateLimited(
+                throw DownloadError.rateLimited(
                     statusCode: 503, message: "busy")
             }
             return attempt
@@ -83,12 +83,12 @@ final class RetryPolicyTests: XCTestCase {
             ) { _ in
                 _ = counter.increment()
                 throw RetryPolicy.RetryAfterHint(
-                    underlying: DownloadUtils.HuggingFaceDownloadError.downloadFailed(
+                    underlying: DownloadError.downloadFailed(
                         path: "missing.bin", underlying: NSError(domain: "HTTP", code: 404)),
                     retryAfter: 60)
             }
             XCTFail("expected error")
-        } catch DownloadUtils.HuggingFaceDownloadError.downloadFailed(let path, _) {
+        } catch DownloadError.downloadFailed(let path, _) {
             XCTAssertEqual(path, "missing.bin")
         } catch {
             XCTFail("envelope escaped or wrong error: \(error)")


### PR DESCRIPTION
The final wave of #765 — **the API cutover, targeting 0.16.0**. Pure rename/re-plumb: **zero behavior**. Every mechanism was already extracted (waves 2–4) and every behavior change already shipped (wave 5, mergeable to 0.15.x users via a tag on that commit); this PR only renames the surface and deletes the 6-year-old god class.

## Migration table (all mechanical)

| 0.15.x | 0.16.0 |
|---|---|
| `DownloadUtils.loadModels(...)` | `ModelHub.loadModels(...)` |
| `DownloadUtils.downloadRepo(_:to:...)` | `ModelHub.download(_:to:...)` |
| `DownloadUtils.downloadSubdirectory(_:subdirectory:to:...)` | `ModelHub.download(_:subdirectory:to:...)` |
| `DownloadUtils.fetchHuggingFaceFile(...)` | `ModelHub.fetchFile(...)` |
| `DownloadUtils.fetchWithAuth(...)` | `ModelHub.fetchWithAuth(...)` |
| `DownloadUtils.clearModelCache(forRepo:directory:)` | `ModelHub.clearCache(for:directory:)` |
| `DownloadUtils.clearAllModelCaches()` | `ModelHub.clearAllCaches()` |
| `DownloadUtils.enforceOffline` | `ModelHub.offlineMode` |
| `DownloadUtils.sharedSession` | `ModelHub.session` |
| `DownloadUtils.HuggingFaceDownloadError` / `DownloadUtils.OfflineError` | one top-level **`DownloadError`** (all case names preserved; `networkDisabled`/`modelMissing` absorbed) |
| `DownloadUtils.DownloadProgress` / `.DownloadPhase` / `.ProgressHandler` / `.DownloadConfig` | top-level types, same names |

Catch-pattern migration is case-name-preserving: `catch DownloadUtils.HuggingFaceDownloadError.rateLimited` → `catch DownloadError.rateLimited`.

## What else is in the diff

- **73 files migrated** across the library, CLI, tests, docs, and README
- Offline **operation tags follow the new API names** (`"download(…)"`, `"fetchFile(…)"`) — the one string-level delta, with the offline-suite assertions updated in-diff
- Test suites **re-pointed at the primitives** (`FileDownloader.download`, `RetryPolicy.isRetryable`/`.isCancellation`, `HFClient.looksLikeHTML`, `ProgressReporter.downloadFraction`) — the test-pin forwards died with the façade, and the characterization suites now guard the code that actually runs
- Workflow cache keys drop the deleted `DownloadUtils.swift` path — **which also rotates every model cache, so this PR runs the full nine-repo cold sweep through the finished stack**
- `HFDownload` namespace dissolved (its existence was a workaround for a type/module name collision inside the now-deleted class)
- Log category `"DownloadUtils"` deliberately **retained** for diagnostic continuity — existing log predicates keep working across 0.16; renaming it is a separate, opt-in decision

## Documented deviation from the Wave-6 sketch

`session` and `fetchWithAuth` stay **public** on `ModelHub` (the sketch had them going internal): the FluidAudio CLI is a separate target consuming both (dataset downloads, authenticated API listings), so internal was never viable without duplicating the proxy-configured session.

## Verification

- Clean full build (library + CLI), lint clean
- **Cold silero download through `ModelHub` → byte-identical cache layout, model loads** (the same snapshot check Wave 4 used)
- CI on this PR: the untouched-in-substance characterization suites against the new spellings, `download-smoke`, and the full cold sweep at baseline

## Post-merge

Tag **0.16.0**. The #765 acceptance criteria are all met: one lister, one downloader, one retry policy; byte-level progress + retry everywhere; validated artifacts everywhere; one documented progress semantics; 429/503 + Retry-After handling in exactly one place; and the tests that didn't exist when the issue was filed now number ~40 across seven suites. Closes #765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Self-review pass applied (`a7d8efcb`)

Zero correctness bugs (bodies verified byte-parity against main; no ambiguous overloads; all test seams signature-matched) — the findings were hygiene plus one structural finish, all applied:

- **Layering completed**: `HFClient` now owns the shared session, offline-mode storage, and `fetchWithAuth`; `ModelHub` forwards (public spellings and the lazily-created session instance unchanged). The primitives read `HFClient` directly — the surface←primitive cycle the waves dismantled doesn't survive its own cutover respelled.
- `ensureOnlineAllowed` re-privatized (accidental widening in the extraction).
- **Restored load-bearing docs the extraction dropped**: `offlineMode`'s bundle-your-own-assets recipe (manual loading so corrupt caches never silently re-download) and `clearAllCaches`' concrete paths.
- Log-category retention (`"DownloadUtils"`) is now stated as the decision with rationale on all three loggers — the old comments promised a rename this wave deliberately didn't do.
- Migration breadcrumb repaired (the blind rename had made `DownloadTypes`' header self-referential; it now names the literal pre-0.16 enums), module headers rewritten in present tense, the stale session-ownership comment fixed, and a 25-file sweep of stale names in comments.
- Test files renamed to their subjects: `ModelHubOfflineTests`, `DownloadCancellationTests`, `ProgressReporterTests`.

Remaining deliberate retentions: the `"DownloadUtils"` log category (diagnostic continuity; documented) and the offline operation tags following the new API names (the PR's declared string-level delta).
