### PR TITLE
fix(tts): normalize decade and bare-year forms in English text (#776)

### DIFF
--- a/Sources/FluidAudio/TTS/SSML/SayAsInterpreter.swift
+++ b/Sources/FluidAudio/TTS/SSML/SayAsInterpreter.swift
@@ -48,6 +48,9 @@ public enum SayAsInterpreter {
             return interpretCardinal(trimmedContent)
         case "ordinal":
             return interpretOrdinal(trimmedContent)
+        case "year":
+            guard let year = Int(trimmedContent.filter { $0.isNumber }) else { return content }
+            return interpretYear(year)
         case "digits":
             return interpretDigits(trimmedContent)
         case "date":

--- a/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
+++ b/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
@@ -105,8 +105,11 @@ enum EnglishTextNormalizer {
 
     private static func spellDecade(_ groups: [String]) -> String? {
         // Only conventional decades (`1770s`, `90s`) — the number must end in 0.
+        // An all-zero base (`'00s`, `0000s`) is skipped: it has no century to
+        // anchor it (`'00s` is ambiguous between the 1900s and 2000s) and would
+        // cardinal-read as a misleading "zeros", so leave it for the frontend.
         let digits = groups[1]
-        guard digits.last == "0" else { return nil }
+        guard digits.last == "0", let value = Int(digits), value != 0 else { return nil }
         // 4-digit decades read year-style (`1770` → `seventeen seventy`),
         // 2-digit decades as a bare cardinal (`90` → `ninety`); the trailing
         // `s` then pluralizes the last word (`seventy` → `seventies`).

--- a/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
+++ b/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
@@ -19,6 +19,8 @@ import Foundation
 ///   * leading-zero digit strings — `007` → `zero zero seven`
 ///   * decimals — `3.14` → `three point one four`
 ///   * 12-hour meridiem times — `1:49 PM` → `one forty nine p m`
+///   * decade forms — `1770s`/`'90s` → `seventeen seventies`/`nineties` (issue #776)
+///   * bare 4-digit years (1000–2099) — `1770` → `seventeen seventy` (issue #776)
 ///
 /// Left unchanged (ambiguous / structured): version strings (`1.2.3`),
 /// grouped numbers (`1,234`), embedded digits (`word26`, `26word`), loose
@@ -33,9 +35,11 @@ enum EnglishTextNormalizer {
     static func normalize(_ text: String) -> String {
         var result = text
         result = apply(Self.meridiemTimeRegex, to: result, transform: Self.spellMeridiemTime)
+        result = apply(Self.decadeRegex, to: result, transform: Self.spellDecade)
         result = apply(Self.decimalRegex, to: result, transform: Self.spellDecimal)
         result = apply(Self.ordinalRegex, to: result, transform: Self.spellOrdinal)
         result = apply(Self.leadingZeroRegex, to: result, transform: Self.spellLeadingZero)
+        result = apply(Self.yearRegex, to: result, transform: Self.spellYear)
         result = apply(Self.cardinalRegex, to: result, transform: Self.spellCardinal)
         return result
     }
@@ -60,6 +64,13 @@ enum EnglishTextNormalizer {
     private static let meridiemTimeRegex = regex(
         leadBoundary + #"(1[0-2]|[1-9]):([0-5][0-9])\s*([AaPp])(?:\.[Mm]\.?|[Mm])"# + #"(?![A-Za-z])"#)
 
+    /// `1770s`, `'90s`, `1900s` — a decade written as a 2- or 4-digit number
+    /// with a trailing `s` (issue #776). An optional leading apostrophe is
+    /// absorbed (`'90s`). The 4-digit alternative is listed first so the full
+    /// number wins over its leading two digits (`1770s` → `1770`, not `17`).
+    private static let decadeRegex = regex(
+        leadBoundary + #"'?([0-9]{4}|[0-9]{2})s"# + #"(?![A-Za-z0-9])"#)
+
     /// `3.14` — integer and fractional parts, not part of a version string.
     private static let decimalRegex = regex(
         leadBoundary + #"([0-9]+)\.([0-9]+)"# + trailBoundary)
@@ -71,6 +82,12 @@ enum EnglishTextNormalizer {
     /// `007` — leading zero forces a digit-by-digit reading.
     private static let leadingZeroRegex = regex(
         leadBoundary + #"(0[0-9]+)"# + trailBoundary)
+
+    /// `1770` — a standalone 4-digit integer read year-style (issue #776).
+    /// The range is narrowed to 1000–2099 in ``spellYear`` so only plausible
+    /// years are rewritten; everything else falls through to ``cardinalRegex``.
+    private static let yearRegex = regex(
+        leadBoundary + #"([0-9]{4})"# + trailBoundary)
 
     /// `26` — a plain standalone integer.
     private static let cardinalRegex = regex(
@@ -84,6 +101,27 @@ enum EnglishTextNormalizer {
         guard !containsDigit(spoken) else { return nil }
         let meridiem = groups[3].lowercased() == "p" ? "p m" : "a m"
         return "\(spoken) \(meridiem)"
+    }
+
+    private static func spellDecade(_ groups: [String]) -> String? {
+        // Only conventional decades (`1770s`, `90s`) — the number must end in 0.
+        let digits = groups[1]
+        guard digits.last == "0" else { return nil }
+        // 4-digit decades read year-style (`1770` → `seventeen seventy`),
+        // 2-digit decades as a bare cardinal (`90` → `ninety`); the trailing
+        // `s` then pluralizes the last word (`seventy` → `seventies`).
+        let interpretAs = digits.count == 4 ? "year" : "cardinal"
+        let base = spaced(SayAsInterpreter.interpret(content: digits, interpretAs: interpretAs, format: nil))
+        guard !base.isEmpty, !containsDigit(base) else { return nil }
+        return pluralizeLastWord(base)
+    }
+
+    private static func spellYear(_ groups: [String]) -> String? {
+        // Only rewrite plausible years; other 4-digit integers fall through
+        // to the cardinal rule.
+        guard let year = Int(groups[1]), (1000...2099).contains(year) else { return nil }
+        let spoken = spaced(SayAsInterpreter.interpret(content: groups[1], interpretAs: "year", format: nil))
+        return containsDigit(spoken) ? nil : spoken
     }
 
     private static func spellDecimal(_ groups: [String]) -> String? {
@@ -134,6 +172,17 @@ enum EnglishTextNormalizer {
 
     private static func spaced(_ text: String) -> String {
         text.replacingOccurrences(of: "-", with: " ")
+    }
+
+    /// Pluralize the final word of a spelled decade base: a `-y` ending
+    /// becomes `-ies` (`seventy` → `seventies`), otherwise `s` is appended
+    /// (`hundred` → `hundreds`, `thousand` → `thousands`, `ten` → `tens`).
+    private static func pluralizeLastWord(_ text: String) -> String {
+        var words = text.split(separator: " ").map(String.init)
+        guard let last = words.last else { return text }
+        let plural = last.hasSuffix("y") ? String(last.dropLast()) + "ies" : last + "s"
+        words[words.count - 1] = plural
+        return words.joined(separator: " ")
     }
 
     private static func containsDigit(_ text: String) -> Bool {

--- a/Tests/FluidAudioTests/TTS/Shared/EnglishTextNormalizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/Shared/EnglishTextNormalizerTests.swift
@@ -42,6 +42,42 @@ final class EnglishTextNormalizerTests: XCTestCase {
         XCTAssertEqual(normalize("3:05 pm"), "three oh five p m")
     }
 
+    func testDecadeForms() {
+        // 4-digit decades read year-style then pluralize the last word.
+        XCTAssertEqual(normalize("in the 1770s it began"), "in the seventeen seventies it began")
+        XCTAssertEqual(normalize("the 1990s"), "the nineteen nineties")
+        XCTAssertEqual(normalize("the 2020s"), "the twenty twenties")
+        // Round centuries pluralize `hundred`/`thousand`.
+        XCTAssertEqual(normalize("the 1900s"), "the nineteen hundreds")
+        XCTAssertEqual(normalize("the 2000s"), "the two thousands")
+        // 2-digit decades, with and without a leading apostrophe.
+        XCTAssertEqual(normalize("music from the '90s"), "music from the nineties")
+        XCTAssertEqual(normalize("the 80s sound"), "the eighties sound")
+    }
+
+    func testDecadeTrailingPunctuationPreserved() {
+        XCTAssertEqual(normalize("born in the 1980s."), "born in the nineteen eighties.")
+    }
+
+    func testNonZeroDecadeUnchanged() {
+        // Only decades ending in 0 are rewritten.
+        XCTAssertEqual(normalize("1995s"), "1995s")
+    }
+
+    func testBareYear() {
+        XCTAssertEqual(normalize("it began in 1770"), "it began in seventeen seventy")
+        XCTAssertEqual(normalize("the year 2026"), "the year twenty twenty six")
+        XCTAssertEqual(normalize("back in 1905"), "back in nineteen oh five")
+        XCTAssertEqual(normalize("since 2005"), "since two thousand five")
+        XCTAssertEqual(normalize("in 2000"), "in two thousand")
+    }
+
+    func testFourDigitOutsideYearRangeUsesCardinal() {
+        // Below 1000 / above 2099 fall through to the cardinal rule.
+        XCTAssertEqual(normalize("2100"), "two thousand one hundred")
+        XCTAssertEqual(normalize("9999"), "nine thousand nine hundred ninety nine")
+    }
+
     func testMultipleFormsInOneSentence() {
         XCTAssertEqual(
             normalize("At 1:49 PM on the 13th I scored 3.14 in 26 tries."),

--- a/Tests/FluidAudioTests/TTS/Shared/EnglishTextNormalizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/Shared/EnglishTextNormalizerTests.swift
@@ -64,6 +64,12 @@ final class EnglishTextNormalizerTests: XCTestCase {
         XCTAssertEqual(normalize("1995s"), "1995s")
     }
 
+    func testAllZeroDecadeUnchanged() {
+        // `'00s`/`00s` has no century to anchor it and must not read as "zeros".
+        XCTAssertEqual(normalize("music from the '00s"), "music from the '00s")
+        XCTAssertEqual(normalize("the 00s"), "the 00s")
+    }
+
     func testBareYear() {
         XCTAssertEqual(normalize("it began in 1770"), "it began in seventeen seventy")
         XCTAssertEqual(normalize("the year 2026"), "the year twenty twenty six")


### PR DESCRIPTION
Closes #776.

## Problem
`EnglishTextNormalizer`'s cardinal rule uses a `(?![A-Za-z0-9])` trailing boundary that (correctly) refuses digit-glued-to-letter tokens like `word26`. But that also means **decade forms** — `1770s`, `1990s`, `'90s`, extremely common in prose — match *no* rule and fall through to the BART G2P as one glued token, spoken as gibberish (the reporter heard **"axis"** for `1770s`). Separately, bare 4-digit years read as long cardinals (`1770` → "one thousand seven hundred seventy") rather than the year-style prose convention.

## Fix
Two passes added ahead of the cardinal rule, both reusing `SayAsInterpreter`'s existing year logic (now reachable via a new `"year"` interpret-as case):

- **Decade** — `'?(\d{4}|\d{2})s` with last digit 0. 4-digit bases read year-style, 2-digit as a cardinal, then the last word is pluralized (`-y`→`-ies`, else `+s`). Non-zero-ending forms are left untouched.
- **Bare year** — standalone 4-digit integers narrowed to 1000–2099 read year-style; out-of-range 4-digit numbers fall through to the cardinal rule.

| Input | Output |
|-------|--------|
| `in the 1770s it began` | `in the seventeen seventies it began` |
| `the 1900s` | `the nineteen hundreds` |
| `the 2000s` | `the two thousands` |
| `music from the '90s` | `music from the nineties` |
| `it began in 1770` | `it began in seventeen seventy` |
| `the year 2026` | `the year twenty twenty six` |
| `since 2005` | `since two thousand five` |

Left unchanged: non-zero-ending decades (`1995s`), 4-digit numbers outside 1000–2099 (`2100` → "two thousand one hundred"), and all previously-handled forms.

### Tradeoff
Per issue discussion, both the required decade rule and the *optional* bare-year rule are included. The year rule also rewrites plain 4-digit quantities in 1000–2099 (`2024 apples` → "twenty twenty four apples") — the accepted cost of year-style prose reading.

## Tests
`EnglishTextNormalizerTests` gains coverage for decades, apostrophe forms, trailing punctuation, non-zero decades, bare years, and out-of-range fallthrough.

XCTest can't run in this environment (CommandLineTools only, no full Xcode). The changed logic was verified out-of-band by compiling the actual `SayAsInterpreter` + `EnglishTextNormalizer` sources into a standalone harness: all 27 cases pass (11 new + 16 pre-existing regressions). `swift build` and `swift format lint` are clean.