### PR TITLE
fix(tts/kokoro-ane): smart-apostrophe contractions + hyphenated lexicon lookups (#774, #775)

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/G2P/English/KokoroAneEnglishPhonemizer.swift
@@ -73,9 +73,13 @@ struct KokoroAneEnglishPhonemizer: Sendable {
             throw KokoroAneError.inputProcessingFailed("(empty input)")
         }
 
+        // Fold typographic apostrophes to ASCII so in-word smart-quote
+        // contractions (`we’re`) survive tokenization intact (issue #774).
+        let prepared = Self.normalizeApostrophes(trimmed)
+
         var parts: [String] = []
 
-        for token in Self.splitWords(trimmed) {
+        for token in Self.splitWords(prepared) {
             if token.isEmpty { continue }
 
             // Punctuation token (single non-word char from the splitter).
@@ -112,6 +116,10 @@ struct KokoroAneEnglishPhonemizer: Sendable {
         fallback: (String) async throws -> [String]?
     ) async throws -> String? {
         let normalized = Self.normalizeKey(word)
+        // Raw lower-cased spelling with hyphens intact. `normalizeKey` strips
+        // hyphens, so this is the only form that can reach the lexicon's 3,459
+        // hyphenated keys (`twenty-one`, `a-frame`, …) (issue #775).
+        let lowered = word.lowercased()
 
         if let custom = customLexicon[word] ?? customLexicon[normalized] {
             return custom
@@ -138,6 +146,7 @@ struct KokoroAneEnglishPhonemizer: Sendable {
 
         if let phonemes = caseSensitiveWordToPhonemes[word]
             ?? caseSensitiveWordToPhonemes[normalized]
+            ?? wordToPhonemes[lowered]
             ?? wordToPhonemes[normalized],
             !phonemes.isEmpty
         {
@@ -153,6 +162,17 @@ struct KokoroAneEnglishPhonemizer: Sendable {
             return spelled
         }
 
+        // A hyphenated compound that missed every lexicon as a whole
+        // (`tales-to-amaze`) — resolve each part and join, so it reads as
+        // `tales to amaze` instead of BART G2P on the glued `talestoamaze`
+        // (issue #775). Real lexicon compounds (`twenty-one`) already returned
+        // above, so only genuine misses reach here.
+        if word.contains("-"),
+            let compound = try await resolveHyphenatedCompound(word, fallback: fallback)
+        {
+            return compound
+        }
+
         guard !normalized.isEmpty else { return nil }
         do {
             if let phonemes = try await fallback(normalized), !phonemes.isEmpty {
@@ -166,6 +186,30 @@ struct KokoroAneEnglishPhonemizer: Sendable {
         }
     }
 
+    /// Resolve a hyphenated compound that missed the lexicon by splitting on
+    /// hyphens and resolving each part, joining the phoneme strings with a
+    /// space (word boundary). Returns `nil` if the token isn't a multi-part
+    /// compound or any part is unresolvable, so the caller falls back to
+    /// whole-word G2P (issue #775). Parts contain no hyphens, so this does not
+    /// recurse back into itself.
+    private func resolveHyphenatedCompound(
+        _ word: String,
+        fallback: (String) async throws -> [String]?
+    ) async throws -> String? {
+        let parts = word.split(separator: "-", omittingEmptySubsequences: true).map(String.init)
+        guard parts.count >= 2 else { return nil }
+
+        var resolved: [String] = []
+        resolved.reserveCapacity(parts.count)
+        for part in parts {
+            guard let ipa = try await resolveWord(part, fallback: fallback), !ipa.isEmpty else {
+                return nil
+            }
+            resolved.append(ipa)
+        }
+        return resolved.joined(separator: " ")
+    }
+
     // MARK: - Letter-name initialisms (issue #710)
 
     /// Spell a token as a sequence of letter names using the per-letter
@@ -175,6 +219,20 @@ struct KokoroAneEnglishPhonemizer: Sendable {
     /// to its normal fallback rather than emitting a partial word.
     private func spellAsLetterNames(_ word: String) -> String? {
         EnglishInitialisms.spell(word) { caseSensitiveWordToPhonemes[$0] }
+    }
+
+    /// Typographic apostrophes that iOS smart punctuation and web/ebook
+    /// content use in place of the ASCII `'` (issue #774).
+    private static let smartApostrophes: Set<Character> = ["\u{2019}", "\u{2018}", "\u{02BC}"]
+
+    /// Fold typographic apostrophes (`’` `‘` `ʼ`) to the ASCII apostrophe so
+    /// `splitWords` and `normalizeKey` — which keep only U+0027 word-internal
+    /// — don't split contractions like `we’re` into `we` + `re` (issue #774).
+    static func normalizeApostrophes(_ text: String) -> String {
+        guard text.contains(where: { smartApostrophes.contains($0) }) else {
+            return text
+        }
+        return String(text.map { smartApostrophes.contains($0) ? "'" : $0 })
     }
 
     /// Lowercase + strip non-letter/digit/apostrophe chars so we hit the

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneEnglishPhonemizerTests.swift
@@ -292,6 +292,66 @@ final class KokoroAneEnglishPhonemizerTests: XCTestCase {
         }
     }
 
+    // MARK: - Smart apostrophes (issue #774)
+
+    func testSmartApostropheContractionStaysIntact() async throws {
+        let recorder = FallbackRecorder()
+        // U+2019 curly apostrophe must fold to ASCII so `we’re` hits the
+        // lexicon intact instead of splitting into `we` + `re`.
+        let phonemizer = KokoroAneEnglishPhonemizer(
+            wordToPhonemes: ["we're": ["w", "ɪ", "ɹ"]],
+            allowedPunctuation: punctuation
+        )
+        let result = try await phonemizer.phonemize("we\u{2019}re here") { await recorder.g2p($0) }
+        XCTAssertEqual(result, "wɪɹ <g2p:here>")
+        let recorded = await recorder.words
+        XCTAssertFalse(recorded.contains("re"), "contraction must not split into a standalone `re`")
+    }
+
+    func testNormalizeApostrophesFoldsTypographicForms() {
+        XCTAssertEqual(KokoroAneEnglishPhonemizer.normalizeApostrophes("we\u{2019}re"), "we're")
+        XCTAssertEqual(KokoroAneEnglishPhonemizer.normalizeApostrophes("\u{2018}tis"), "'tis")
+        XCTAssertEqual(KokoroAneEnglishPhonemizer.normalizeApostrophes("we\u{02BC}re"), "we're")
+        // No smart apostrophe → unchanged.
+        XCTAssertEqual(KokoroAneEnglishPhonemizer.normalizeApostrophes("plain"), "plain")
+    }
+
+    // MARK: - Hyphenated words (issue #775)
+
+    func testHyphenatedLexiconKeyResolvesWithHyphenIntact() async throws {
+        let recorder = FallbackRecorder()
+        // The Misaki cache stores `twenty-one` WITH the hyphen; the lookup must
+        // try the raw lowercased token before `normalizeKey` strips it.
+        let phonemizer = KokoroAneEnglishPhonemizer(
+            wordToPhonemes: ["twenty-one": ["t", "w", "ˈ", "ɛ", "n", "t", "i", "w", "ˈ", "ʌ", "n"]],
+            allowedPunctuation: punctuation
+        )
+        let result = try await phonemizer.phonemize("twenty-one") { await recorder.g2p($0) }
+        XCTAssertEqual(result, "twˈɛntiwˈʌn")
+        let recorded = await recorder.words
+        XCTAssertTrue(recorded.isEmpty, "should hit the lexicon, not G2P")
+    }
+
+    func testHyphenatedCompoundMissSplitsIntoParts() async throws {
+        let recorder = FallbackRecorder()
+        // `tales-to-amaze` isn't a lexicon entry; each part resolves separately
+        // (`to` via lexicon, `tales`/`amaze` via G2P) instead of gluing into
+        // `talestoamaze`.
+        let result = try await makePhonemizer().phonemize("tales-to-amaze") { await recorder.g2p($0) }
+        XCTAssertEqual(result, "<g2p:tales> tu <g2p:amaze>")
+        let recorded = await recorder.words
+        XCTAssertEqual(recorded, ["tales", "amaze"])
+    }
+
+    func testHyphenatedCompoundFallsBackToWholeWordWhenPartUnresolved() async throws {
+        // If any part can't be resolved, the compound aborts and the whole
+        // glued token goes to G2P — no partial output.
+        let result = try await makePhonemizer().phonemize("go-zzz") { word in
+            word == "zzz" ? nil : ["<g2p:\(word)>"]
+        }
+        XCTAssertEqual(result, "<g2p:gozzz>")
+    }
+
     // MARK: - Without lexicon (pre-#691 behavior preserved)
 
     func testEmptyLexiconFallsBackToG2PForEveryWord() async throws {


### PR DESCRIPTION
Closes #774. Closes #775.

Two KokoroAne English tokenization gaps (`KokoroAneEnglishPhonemizer`) that sent common prose to the BART G2P as garbled glued tokens.

## #774 — smart-apostrophe contractions split
`splitWords` and `normalizeKey` keep only the **ASCII** apostrophe (U+0027) word-internal. The typographic right single quote **U+2019** — which iOS smart punctuation inserts into virtually all typed text, and which dominates web/ebook content — fell into the punctuation branch, so `we’re` tokenized as `we` + `’` + `re` and `re` was spoken like the solfège note ("we-ray").

**Fix:** fold `U+2019` `U+2018` `U+02BC` → ASCII `'` via a new `normalizeApostrophes` pass *before* tokenization, so the contraction survives intact and hits the Misaki lexicon (which stores contractions under ASCII apostrophes). Same class of bug #584 fixed in the PocketTTS French normalizer.

## #775 — hyphenated lexicon entries unreachable
`normalizeKey` strips hyphens for lookup (allowed set = letters + digits + apostrophe), so the lexicon's **3,459 hyphen-bearing keys** (`twenty-one`, `a-frame`, …) could never match, and multi-word compounds glued into one G2P token (`tales-to-amaze` → G2P on `talestoamaze`).

**Fix (both halves suggested in the issue):**
1. Try the **raw lower-cased token** (hyphens intact) against the lexicon before the hyphen-stripped form — makes the 3,459 hyphenated keys reachable (`twenty-one` resolves directly).
2. When a hyphenated token still misses everything, **split on hyphens and resolve each part** (`tales-to-amaze` → `tales to amaze`). If any part is unresolvable the compound aborts and the whole token falls back to whole-word G2P — no partial output. Parts contain no hyphens, so no recursion.

| Input | Before | After |
|-------|--------|-------|
| `we’re here` (U+2019) | `we` + `re` → "we-ray" | `wɪɹ …` (contraction intact) |
| `twenty-one` | G2P on `twentyone` | lexicon hit `twenty-one` |
| `tales-to-amaze` | G2P on `talestoamaze` | `tales to amaze` (parts) |

## Tests
Adds coverage for: typographic-apostrophe folding, contraction survival through `phonemize`, hyphenated lexicon hit (no G2P), compound hyphen-split into parts, and whole-word G2P fallback when a part is unresolvable.

XCTest can't run in this environment (CommandLineTools only, no full Xcode), so behavior was verified out-of-band by compiling faithful copies of the real methods into a harness — all cases pass. `swift build` and `swift format lint` are clean.

## Related
#776 (decade/year normalization) is addressed separately by #780.

🤖 Generated with [Claude Code](https://claude.com/claude-code)