### PR TITLE
feat(tts): route English frontends through native NeMo TN when available

### DIFF
--- a/Sources/FluidAudio/ITN/TextNormalizer.swift
+++ b/Sources/FluidAudio/ITN/TextNormalizer.swift
@@ -47,6 +47,14 @@ public final class TextNormalizer: Sendable {
         (
             @convention(c) (UnsafePointer<CChar>?, UInt32) -> UnsafeMutablePointer<CChar>?
         )?
+    private let nemoTnNormalize:
+        (
+            @convention(c) (UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+        )?
+    private let nemoTnNormalizeSentence:
+        (
+            @convention(c) (UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?
+        )?
     private let nemoFreeString:
         (
             @convention(c) (UnsafeMutablePointer<CChar>?) -> Void
@@ -78,6 +86,8 @@ public final class TextNormalizer: Sendable {
             self.nemoNormalize = nil
             self.nemoNormalizeSentence = nil
             self.nemoNormalizeSentenceMaxSpan = nil
+            self.nemoTnNormalize = nil
+            self.nemoTnNormalizeSentence = nil
             self.nemoFreeString = nil
             self.nemoAddRule = nil
             self.nemoRemoveRule = nil
@@ -95,6 +105,8 @@ public final class TextNormalizer: Sendable {
             self.nemoNormalize = nil
             self.nemoNormalizeSentence = nil
             self.nemoNormalizeSentenceMaxSpan = nil
+            self.nemoTnNormalize = nil
+            self.nemoTnNormalizeSentence = nil
             self.nemoFreeString = nil
             self.nemoAddRule = nil
             self.nemoRemoveRule = nil
@@ -134,6 +146,27 @@ public final class TextNormalizer: Sendable {
             )
         } else {
             self.nemoNormalizeSentenceMaxSpan = nil
+        }
+
+        // Text-normalization (written → spoken) functions — optional; present
+        // only when the linked library exposes the TN surface (issue #711
+        // follow-up). Used by the TTS frontends for richer normalization.
+        if let tnPtr = dlsym(handle, "nemo_tn_normalize") {
+            self.nemoTnNormalize = unsafeBitCast(
+                tnPtr,
+                to: (@convention(c) (UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?).self
+            )
+        } else {
+            self.nemoTnNormalize = nil
+        }
+
+        if let tnSentencePtr = dlsym(handle, "nemo_tn_normalize_sentence") {
+            self.nemoTnNormalizeSentence = unsafeBitCast(
+                tnSentencePtr,
+                to: (@convention(c) (UnsafePointer<CChar>?) -> UnsafeMutablePointer<CChar>?).self
+            )
+        } else {
+            self.nemoTnNormalizeSentence = nil
         }
 
         // Custom rules functions (optional)
@@ -194,6 +227,43 @@ public final class TextNormalizer: Sendable {
             return input
         }
 
+        defer { freeFn(resultPtr) }
+        return String(cString: resultPtr)
+    }
+
+    // MARK: - Text Normalization (written → spoken)
+
+    /// Whether the linked library exposes the TN (written→spoken) surface used
+    /// by the TTS frontends. False when no native library is linked or it only
+    /// provides the ITN symbols.
+    public var isTnAvailable: Bool {
+        isNativeAvailable && nemoTnNormalizeSentence != nil
+    }
+
+    /// Normalize written-form text to spoken form (single expression), e.g.
+    /// `"$5.50"` → `"five dollars fifty cents"`. Returns the input unchanged
+    /// when the native TN surface is unavailable.
+    public func tnNormalize(_ input: String) -> String {
+        guard let tnFn = nemoTnNormalize, let freeFn = nemoFreeString else {
+            return input
+        }
+        guard let resultPtr = input.withCString({ tnFn($0) }) else {
+            return input
+        }
+        defer { freeFn(resultPtr) }
+        return String(cString: resultPtr)
+    }
+
+    /// Normalize a full sentence to spoken form, rewriting written-form spans
+    /// in place (`"I paid $5"` → `"I paid five dollars"`). Returns the input
+    /// unchanged when the native TN surface is unavailable.
+    public func tnNormalizeSentence(_ input: String) -> String {
+        guard let tnFn = nemoTnNormalizeSentence, let freeFn = nemoFreeString else {
+            return input
+        }
+        guard let resultPtr = input.withCString({ tnFn($0) }) else {
+            return input
+        }
         defer { freeFn(resultPtr) }
         return String(cString: resultPtr)
     }

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -321,7 +321,7 @@ public actor KokoroAneManager {
     /// G2P fallback for OOV words and vocab-supported punctuation kept as
     /// prosody/pause tokens.
     private func phonemize(text: String) async throws -> String {
-        let normalized = EnglishTextNormalizer.normalize(text)
+        let normalized = EnglishTextNormalizer.normalizeForFrontend(text)
         let phonemizer = await ensureEnglishPhonemizer()
         return try await phonemizer.phonemize(normalized) { word in
             try await G2PModel.shared.phonemize(word: word)

--- a/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
+++ b/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
@@ -40,6 +40,16 @@ enum EnglishTextNormalizer {
         return result
     }
 
+    /// TTS-frontend entry point shared by KokoroAne and StyleTTS2. Prefers the
+    /// native NeMo TN pass (`text-processing-rs`, much richer: currency,
+    /// measures, dates, ranges, fractions, …) when the host app has linked
+    /// `libtext_processing_rs`; otherwise falls back to the conservative
+    /// always-available baseline in ``normalize(_:)``.
+    static func normalizeForFrontend(_ text: String) -> String {
+        let normalizer = TextNormalizer.shared
+        return normalizer.isTnAvailable ? normalizer.tnNormalizeSentence(text) : normalize(text)
+    }
+
     // MARK: - Boundaries
     //
     // A standalone number must not be glued to a letter, another digit, or

--- a/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/Tokenizer/StyleTTS2Phonemizer.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Pipeline/Tokenizer/StyleTTS2Phonemizer.swift
@@ -69,11 +69,11 @@ public struct StyleTTS2Phonemizer: Sendable {
             return ""
         }
 
-        // Conservative raw-text normalization first (issue #711): strict
-        // standalone numbers, ordinals, decimals, and 12-hour times become
-        // spoken words before tokenization. Ambiguous/structured forms are
-        // left untouched. Shared with KokoroAne via `EnglishTextNormalizer`.
-        let normalized = EnglishTextNormalizer.normalize(trimmed)
+        // Raw-text normalization first: the native NeMo TN pass when the host
+        // links `libtext_processing_rs`, else the conservative always-on
+        // baseline (issue #711). Shared with KokoroAne via
+        // ``EnglishTextNormalizer/normalizeForFrontend(_:)``.
+        let normalized = EnglishTextNormalizer.normalizeForFrontend(trimmed)
 
         let words = splitWords(normalized)
         var ipaParts: [String] = []

--- a/Tests/FluidAudioTests/TTS/TextNormalizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/TextNormalizerTests.swift
@@ -398,4 +398,30 @@ final class TextNormalizerTests: XCTestCase {
         let result = normalizer.normalizeSentence(input, maxSpanTokens: 8)
         XCTAssertEqual(result, input)
     }
+
+    // MARK: - TN (written → spoken) surface
+
+    func testTnPassthroughWithoutNativeLib() {
+        let normalizer = TextNormalizer()
+        guard !normalizer.isNativeAvailable else { return }
+
+        // No native library linked → TN unavailable and inputs pass through.
+        XCTAssertFalse(normalizer.isTnAvailable)
+        XCTAssertEqual(normalizer.tnNormalize("$5.50"), "$5.50")
+        XCTAssertEqual(normalizer.tnNormalizeSentence("I paid $5"), "I paid $5")
+    }
+
+    /// When the native TN surface is unavailable (the default), the shared TTS
+    /// entry point must equal the conservative baseline so spoken output is
+    /// unchanged.
+    func testFrontendNormalizationFallsBackToBaseline() {
+        guard !TextNormalizer.shared.isTnAvailable else { return }
+
+        for input in ["I am 26 years old.", "The score is 3.14.", "Agent 007", "hello world"] {
+            XCTAssertEqual(
+                EnglishTextNormalizer.normalizeForFrontend(input),
+                EnglishTextNormalizer.normalize(input),
+                "frontend normalization should match the baseline without the native lib")
+        }
+    }
 }


### PR DESCRIPTION
## What
Wires the [text-processing-rs](https://github.com/FluidInference/text-processing-rs) **TN** (written→spoken) surface into the KokoroAne and StyleTTS2 English frontends — the optional richer normalization path (issue #711 follow-up).

Until now `ITN/TextNormalizer` bound only the **ITN** symbols; the TN functions the crate exports were unused, and the TTS frontends always used the hand-rolled `EnglishTextNormalizer`.

## Changes
- **`ITN/TextNormalizer`** — `dlsym`-binds `nemo_tn_normalize` and `nemo_tn_normalize_sentence` alongside the existing ITN symbols; adds `isTnAvailable`, `tnNormalize`, `tnNormalizeSentence` (passthrough when the native lib isn't linked).
- **`EnglishTextNormalizer.normalizeForFrontend`** — shared TTS entry point: prefers the native NeMo TN pass (currency, measures, dates, ranges, fractions, …) when `libtext_processing_rs` is linked; otherwise the conservative always-on baseline.
- **`KokoroAneManager`** and **`StyleTTS2Phonemizer`** route English text through it.

## Default behavior is unchanged
The wrapper is `dlopen(nil)`-based, so with **no native library linked** none of the `nemo_*` symbols resolve → `isTnAvailable == false` → the frontends use `EnglishTextNormalizer` exactly as before. Verified out-of-band that a process without the lib resolves neither `nemo_normalize` nor `nemo_tn_*`:

```
nemo_tn_normalize present = false, nemo_tn_normalize_sentence present = false
=> isTnAvailable would be false (=> TTS uses baseline EnglishTextNormalizer)
```

When a host app **does** link the lib, it gets the full NeMo TN coverage (recently expanded in the crate: cardinal/decimal/fraction/money/date/ordinal/math/roman). ⚠️ This changes spoken output for hosts that opt in — worth a listen-through on numbers/currency/dates.

## Tests
Adds `testTnPassthroughWithoutNativeLib` and `testFrontendNormalizationFallsBackToBaseline` (frontend == baseline without the lib). Library builds cleanly; swift-format passes. (XCTest can't run in my CommandLineTools-only env; the added tests run in CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)