### PR TITLE
feat(asr): add language hint to SlidingWindowAsrConfig

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -445,7 +445,8 @@ public actor SlidingWindowAsrManager {
                     windowSamples,
                     decoderState: &state,
                     previousTokens: accumulatedTokens,
-                    isLastChunk: isLastChunk
+                    isLastChunk: isLastChunk,
+                    language: config.language
                 )
             else { return }
 
@@ -727,6 +728,16 @@ public struct SlidingWindowAsrConfig: Sendable {
     /// `AsrManager`'s internal blank-token auto-adaptation.
     public let tdtConfig: TdtConfig?
 
+    /// Optional language hint for script-aware token filtering (v3 joint decoder only).
+    ///
+    /// Streaming windows carry much less acoustic context than offline chunks, which
+    /// makes the multilingual v3 model prone to emitting wrong-script tokens (e.g.
+    /// Cyrillic while transcribing German — see issue #512). Batch transcription
+    /// already accepts a `language` hint via `AsrManager.transcribe(_:language:)`;
+    /// this extends the same filter to the sliding-window path. Ignored by v2 and
+    /// tdtJa models (same behavior as the batch API).
+    public let language: Language?
+
     /// Default configuration using the proven 11+2+2 window layout.
     /// The assembled window (left + chunk + right) must fit the model's fixed
     /// 15 s input (`ASRConstants.maxModelSamples`); 2 + 11 + 2 = 15 s fits exactly.
@@ -758,7 +769,8 @@ public struct SlidingWindowAsrConfig: Sendable {
         rightContextSeconds: TimeInterval = 2.0,
         minContextForConfirmation: TimeInterval = 10.0,
         confirmationThreshold: Double = 0.85,
-        tdtConfig: TdtConfig? = nil
+        tdtConfig: TdtConfig? = nil,
+        language: Language? = nil
     ) {
         self.chunkSeconds = chunkSeconds
         self.hypothesisChunkSeconds = hypothesisChunkSeconds
@@ -767,6 +779,7 @@ public struct SlidingWindowAsrConfig: Sendable {
         self.minContextForConfirmation = minContextForConfirmation
         self.confirmationThreshold = confirmationThreshold
         self.tdtConfig = tdtConfig
+        self.language = language
     }
 
     /// Returns a copy of this config with the given TDT configuration applied.
@@ -778,7 +791,22 @@ public struct SlidingWindowAsrConfig: Sendable {
             rightContextSeconds: rightContextSeconds,
             minContextForConfirmation: minContextForConfirmation,
             confirmationThreshold: confirmationThreshold,
-            tdtConfig: tdtConfig
+            tdtConfig: tdtConfig,
+            language: language
+        )
+    }
+
+    /// Returns a copy of this config with the given language hint applied.
+    public func applying(language: Language?) -> SlidingWindowAsrConfig {
+        SlidingWindowAsrConfig(
+            chunkSeconds: chunkSeconds,
+            hypothesisChunkSeconds: hypothesisChunkSeconds,
+            leftContextSeconds: leftContextSeconds,
+            rightContextSeconds: rightContextSeconds,
+            minContextForConfirmation: minContextForConfirmation,
+            confirmationThreshold: confirmationThreshold,
+            tdtConfig: tdtConfig,
+            language: language
         )
     }
 

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
@@ -40,6 +40,34 @@ final class SlidingWindowAsrManagerTests: XCTestCase {
 
     // MARK: - Configuration Tests
 
+    func testConfigDefaultsToNilLanguage() {
+        XCTAssertNil(SlidingWindowAsrConfig.default.language)
+        XCTAssertNil(SlidingWindowAsrConfig.streaming.language)
+        XCTAssertNil(SlidingWindowAsrConfig().language)
+    }
+
+    func testConfigCarriesLanguageHint() {
+        let config = SlidingWindowAsrConfig(language: .german)
+        XCTAssertEqual(config.language, .german)
+    }
+
+    func testApplyingLanguageKeepsOtherFields() {
+        let base = SlidingWindowAsrConfig.streaming
+        let localized = base.applying(language: .polish)
+
+        XCTAssertEqual(localized.language, .polish)
+        XCTAssertEqual(localized.chunkSeconds, base.chunkSeconds)
+        XCTAssertEqual(localized.leftContextSeconds, base.leftContextSeconds)
+        XCTAssertEqual(localized.rightContextSeconds, base.rightContextSeconds)
+        XCTAssertEqual(localized.confirmationThreshold, base.confirmationThreshold)
+    }
+
+    func testApplyingTdtConfigKeepsLanguage() {
+        let base = SlidingWindowAsrConfig(language: .german)
+        let adapted = base.applying(tdtConfig: TdtConfig())
+        XCTAssertEqual(adapted.language, .german)
+    }
+
     func testConfigPresets() {
         // Test default config
         let defaultConfig = SlidingWindowAsrConfig.default


### PR DESCRIPTION
## Summary

The batch path (`AsrManager.transcribe(_:language:)`) already accepts a `language` hint for script-aware token filtering, but the sliding-window streaming path has no way to pass one.

Streaming windows carry much less acoustic context than offline chunks, which makes the multilingual v3 model especially prone to emitting wrong-script tokens — e.g. Cyrillic (`ЛСТБ`, `Ну, не фер`) while transcribing German. This is the streaming variant of #512.

## Changes

- Add optional `language: Language?` to `SlidingWindowAsrConfig` (default `nil` → behavior unchanged)
- Forward it from `processWindow()` to `transcribeChunk(...)`, which already accepted `language` but was never given one
- `applying(language:)` copy helper, mirroring `applying(tdtConfig:)`
- `applying(tdtConfig:)` now preserves the language hint
- Tests for default nil, carrying the hint, and both `applying` helpers

v2/tdtJa models keep ignoring the hint exactly like the batch API does (existing `tdtDecodeWithTimings` routing handles this).

## Testing

- `swift build` clean
- `swift test --filter SlidingWindowAsrManagerTests` — all pass
- `swift format lint` clean