### PR TITLE
fix(download): preserve model cache on transient network errors

### DIFF
--- a/Sources/FluidAudio/Shared/Download/ModelHub.swift
+++ b/Sources/FluidAudio/Shared/Download/ModelHub.swift
@@ -115,6 +115,20 @@ public enum ModelHub {
                 throw error
             }
 
+            // Transient network failures are not corruption either. An error
+            // reaching here has already exhausted RetryPolicy's in-flight
+            // retries, but the bytes on disk are valid and resumable
+            // (FileDownloader streams into `.partial` files with HTTP Range
+            // resume). Wiping would discard exactly the bytes that make the
+            // caller's next attempt cheap — on the flaky networks most
+            // likely to land here.
+            if RetryPolicy.isRetryable(error) {
+                logger.warning(
+                    "Load failed with transient network error; preserving model cache for resume. \(error.localizedDescription)"
+                )
+                throw error
+            }
+
             logger.warning("First load failed: \(error.localizedDescription)")
             logger.info("Deleting cache and re-downloading…")
             let repoPath = directory.appendingPathComponent(repo.folderName)


### PR DESCRIPTION
## Problem

`ModelHub.loadModels`' catch-all wipes the repo cache and re-downloads on any error. The offline and cancellation guards already carve out two "not corruption" cases — but a **transient network failure** that exhausts `RetryPolicy`'s in-flight retries still lands in the wipe path.

That wipe discards exactly the bytes that make the next attempt cheap: `FileDownloader` streams into `.partial` files with HTTP Range resume, so partial content from a flaky connection is valid and resumable. Users on the networks most likely to exhaust retries (hotel Wi-Fi, throttled cellular, rate-limited endpoints) currently restart multi-hundred-MB downloads from zero on every failure cycle.

## Field evidence

From a production app (Dreamtime) on iPhone 17 Pro / iOS 26.5 via TestFlight: a `parakeet-tdt-0.6b-v3` download died mid-encoder twice in a row; each retry re-downloaded the identical first ~23 MB before dying again. The app's diagnostics show **byte-for-byte identical progress sequences across both attempts** — the signature of the cache being wiped between them:

```
transition → downloading(0.02442320663224099)   // attempt 1
...
transition → downloading(0.024441141292233286)  // stalls, wiped
transition → downloading(0.02442320663224099)   // attempt 2: same bytes again
...
transition → downloading(0.024441141292233286)  // stalls again
```

## Fix

Classify with the existing `RetryPolicy.isRetryable` before wiping — transient errors preserve the cache and rethrow (mirroring the cancellation guard); corruption-class failures (missing/corrupt files, compile errors) keep today's wipe-and-retry-once behavior.

One hunk, no API changes. `swift build --target FluidAudio` passes.