### PR TITLE
fix(itn): protect natural-language ambiguous words from native normalization

### DIFF
--- a/Sources/FluidAudio/ITN/TextNormalizer.swift
+++ b/Sources/FluidAudio/ITN/TextNormalizer.swift
@@ -281,8 +281,8 @@ public final class TextNormalizer: Sendable {
             return input
         }
 
-        let filtered = filterAmbiguousWords(in: input)
-        return callNormalizeSentence(filtered)
+        let (masked, restore) = maskAmbiguousWords(in: input)
+        return restoreMaskedWords(callNormalizeSentence(masked), restore)
     }
 
     /// Normalize a full sentence with a configurable max span size.
@@ -296,8 +296,9 @@ public final class TextNormalizer: Sendable {
             return input
         }
 
-        let filtered = filterAmbiguousWords(in: input)
-        return callNormalizeSentenceWithMaxSpan(filtered, maxSpanTokens: maxSpanTokens)
+        let (masked, restore) = maskAmbiguousWords(in: input)
+        return restoreMaskedWords(
+            callNormalizeSentenceWithMaxSpan(masked, maxSpanTokens: maxSpanTokens), restore)
     }
 
     /// Normalize an ASR result, returning a new result with normalized text.
@@ -390,7 +391,15 @@ public final class TextNormalizer: Sendable {
     ///
     /// - Parameter input: The raw sentence
     /// - Returns: Sentence with ambiguous natural-language words preserved
-    private func filterAmbiguousWords(in input: String) -> String {
+    /// Mask ambiguous words that NLTagger identifies as natural language, so the
+    /// native normalizer can't rewrite them (e.g. the noun "period" → ".").
+    ///
+    /// Each protected word is replaced with a unique Private-Use-Area sentinel
+    /// character; the native normalizer passes those through unchanged, and the
+    /// caller restores them via the returned map. Returns the (possibly)
+    /// rewritten string and a sentinel→original map (empty when nothing was
+    /// masked).
+    private func maskAmbiguousWords(in input: String) -> (masked: String, restore: [Character: String]) {
         let words = input.split(separator: " ", omittingEmptySubsequences: true)
 
         // Quick check: are there any ambiguous words at all?
@@ -398,13 +407,17 @@ public final class TextNormalizer: Sendable {
             Self.ambiguousWords.contains(word.lowercased())
         }
         guard hasAmbiguous else {
-            return input
+            return (input, [:])
         }
 
         let tagger = NLTagger(tagSchemes: [.lexicalClass])
         tagger.string = input
 
         var result: [String] = []
+        var restore: [Character: String] = [:]
+        // Private Use Area (U+E000…) — never appears in real ASR text and is
+        // passed through untouched by the native normalizer.
+        var nextSentinel: UInt32 = 0xE000
         for word in words {
             let wordLower = word.lowercased()
 
@@ -421,21 +434,33 @@ public final class TextNormalizer: Sendable {
 
             let tag = tagger.tag(at: wordRange.lowerBound, unit: .word, scheme: .lexicalClass).0
 
-            // If NLTagger identifies it as a noun, verb, adjective, or adverb,
-            // it's being used as natural language — keep it as-is.
-            // If it's "other" or unrecognized, treat it as a potential punctuation command.
+            // A noun/verb/adjective/adverb in a multi-word sentence is being used
+            // as natural language — mask it so the normalizer leaves it alone.
+            // Standalone or "other" usage is a potential punctuation command;
+            // leave it for the normalizer to process.
             let isNaturalLanguage = tag == .noun || tag == .verb || tag == .adjective || tag == .adverb
 
-            if isNaturalLanguage && words.count > 1 {
-                // Keep the original word — don't let the normalizer touch it
-                result.append(String(word))
+            if isNaturalLanguage && words.count > 1, let scalar = UnicodeScalar(nextSentinel) {
+                let sentinel = Character(scalar)
+                nextSentinel += 1
+                restore[sentinel] = String(word)
+                result.append(String(sentinel))
             } else {
-                // Standalone or non-NL usage — let normalizer process it
                 result.append(String(word))
             }
         }
 
-        return result.joined(separator: " ")
+        return (result.joined(separator: " "), restore)
+    }
+
+    /// Restore sentinel characters produced by ``maskAmbiguousWords(in:)``.
+    private func restoreMaskedWords(_ text: String, _ restore: [Character: String]) -> String {
+        guard !restore.isEmpty else { return text }
+        var out = text
+        for (sentinel, original) in restore {
+            out = out.replacingOccurrences(of: String(sentinel), with: original)
+        }
+        return out
     }
 
     // MARK: - Private FFI Helpers

--- a/Tests/FluidAudioTests/TTS/TextNormalizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/TextNormalizerTests.swift
@@ -334,16 +334,28 @@ final class TextNormalizerTests: XCTestCase {
         XCTAssertEqual(result, input)
     }
 
-    func testFilterWithAmbiguousWordInSentence() throws {
+    func testFilterWithAmbiguousWordInSentence() {
         let normalizer = TextNormalizer()
-        // Fallback path: "period" (a noun) passes through unchanged.
-        // NOTE: when the native ITN lib is linked, "period" is currently reduced
-        // to "." — the NLTagger ambiguous-word guard does not yet cover the
-        // native ITN path (tracked as a separate ITN fix), so skip here.
-        try XCTSkipIf(normalizer.isNativeAvailable, "native ITN reduces the noun 'period' to '.'")
-        let input = "the period of growth was remarkable"
-        let result = normalizer.normalizeSentence(input)
-        XCTAssertEqual(result, input)
+        // Ambiguous words used as natural language (nouns) must survive
+        // normalization: the native ITN would otherwise rewrite "period" → ".",
+        // "dash" → "-". Passes with the native lib (masked + restored) and
+        // without it (fallback returns the input unchanged).
+        let unchanged = [
+            "the period of growth was remarkable",
+            "add a period here",
+            "the dash between them",
+        ]
+        for input in unchanged {
+            XCTAssertEqual(normalizer.normalizeSentence(input), input)
+        }
+    }
+
+    func testStandaloneAmbiguousWordStillNormalizes() throws {
+        let normalizer = TextNormalizer()
+        // The mask only protects natural-language usage; a standalone spoken
+        // command still normalizes when the native lib is linked.
+        try XCTSkipIf(!normalizer.isNativeAvailable, "requires the native normalizer")
+        XCTAssertEqual(normalizer.normalizeSentence("period"), ".")
     }
 
     func testFilterWithStandalonePunctuationWord() {


### PR DESCRIPTION
## Summary

`TextNormalizer.filterAmbiguousWords` was a **no-op** — both branches of the natural-language check appended the word verbatim:

```swift
if isNaturalLanguage && words.count > 1 {
    result.append(String(word))   // "keep it"
} else {
    result.append(String(word))   // identical
}
```

The NLTagger part-of-speech result was computed and thrown away, so nothing was ever protected. The native ITN pass then rewrote **nouns to punctuation**:

- `"the period of growth was remarkable"` → `"the . of growth was remarkable"`
- `"the dash between them"` → `"the - between them"`

This never surfaced because **nothing linked `libtext_processing_rs` until #790**. With the lib now linked (`isNativeAvailable = true`), the bug is live — it's what the two `TextNormalizerTests` I skipped in #790 were flagging.

## Fix

Mask each ambiguous word NLTagger tags as natural language (noun/verb/adjective/adverb in a multi-word sentence) with a unique **Private-Use-Area sentinel** before normalization, then restore it after. The native normalizer passes PUA characters through untouched (verified), so protected words round-trip while genuine spoken forms still normalize.

- `maskAmbiguousWords` replaces the no-op `filterAmbiguousWords`; `restoreMaskedWords` swaps sentinels back. Both `normalizeSentence` overloads now mask → normalize → restore.
- `testFilterWithAmbiguousWordInSentence` un-skipped + strengthened (period/dash nouns preserved); adds `testStandaloneAmbiguousWordStillNormalizes`.

## Verification

Against the linked v0.3.0 xcframework (a harness that links the framework so `isNativeAvailable = true`):

```
ok  [the period of growth was remarkable] -> [the period of growth was remarkable]
ok  [add a period here]                   -> [add a period here]
ok  [the dash between them]               -> [the dash between them]
ok  [I have twenty one apples]            -> [I have 21 apples]     (real ITN preserved)
ok  [period]                              -> [.]                    (standalone command)
```

Builds (FluidAudio) + `swift-format` lint pass. XCTest runs in CI.