### PR TITLE
Remove redundant audio decoding in CLI `transcribe` path

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -470,7 +470,7 @@ public actor SlidingWindowAsrManager {
                     timestamps: adjustedTimestamps,
                     confidences: confidences,
                     encoderSequenceLength: 0,
-                    audioSamples: windowSamples,
+                    audioSampleCount: windowSamples.count,
                     processingTime: processingTime
                 )
             else { return }
@@ -498,7 +498,7 @@ public actor SlidingWindowAsrManager {
                     timestamps: timestamps,  // Original chunk-local timestamps (not adjusted)
                     confidences: confidences,
                     encoderSequenceLength: 0,
-                    audioSamples: windowSamples,
+                    audioSampleCount: windowSamples.count,
                     processingTime: processingTime
                 )
             {

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -30,7 +30,7 @@ extension AsrManager {
                 confidences: hypothesis.tokenConfidences,
                 tokenDurations: hypothesis.tokenDurations,
                 encoderSequenceLength: encoderSequenceLength,
-                audioSamples: audioSamples,
+                audioSampleCount: audioSamples.count,
                 processingTime: Date().timeIntervalSince(startTime)
             )
 
@@ -96,12 +96,12 @@ extension AsrManager {
         confidences: [Float] = [],
         tokenDurations: [Int] = [],
         encoderSequenceLength: Int,
-        audioSamples: [Float],
+        audioSampleCount: Int,
         processingTime: TimeInterval
     ) -> ASRResult {
 
         let text = convertTokensToText(tokenIds)
-        let duration = TimeInterval(audioSamples.count) / TimeInterval(config.sampleRate)
+        let duration = TimeInterval(audioSampleCount) / TimeInterval(config.sampleRate)
 
         let resultTimings = createTokenTimings(
             from: tokenIds, timestamps: timestamps, confidences: confidences, tokenDurations: tokenDurations)

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
@@ -573,7 +573,7 @@ struct ChunkProcessor {
                 timestamps: [],
                 confidences: [],
                 encoderSequenceLength: 0,
-                audioSamples: [],
+                audioSampleCount: totalSamples,
                 processingTime: Date().timeIntervalSince(startTime)
             )
         }
@@ -627,7 +627,7 @@ struct ChunkProcessor {
             confidences: allConfidences,
             tokenDurations: allDurations,
             encoderSequenceLength: 0,  // Not relevant for chunk processing
-            audioSamples: [],
+            audioSampleCount: totalSamples,
             processingTime: Date().timeIntervalSince(startTime)
         )
     }

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/DualDecodeArbitration.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/DualDecodeArbitration.swift
@@ -96,7 +96,7 @@ extension ChunkProcessor {
                 timestamps: [],
                 confidences: [],
                 encoderSequenceLength: 0,
-                audioSamples: [],
+                audioSampleCount: totalSamples,
                 processingTime: Date().timeIntervalSince(startTime)
             )
         }
@@ -306,7 +306,7 @@ extension ChunkProcessor {
                 timestamps: [],
                 confidences: [],
                 encoderSequenceLength: 0,
-                audioSamples: [],
+                audioSampleCount: totalSamples,
                 processingTime: Date().timeIntervalSince(startTime)
             )
         }
@@ -342,7 +342,7 @@ extension ChunkProcessor {
             confidences: allConfidences,
             tokenDurations: allDurations,
             encoderSequenceLength: 0,
-            audioSamples: [],
+            audioSampleCount: totalSamples,
             processingTime: Date().timeIntervalSince(startTime)
         )
     }

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -465,31 +465,31 @@ enum TranscribeCommand {
             logger.info("ASR Manager initialized successfully")
 
             let audioFileURL = URL(fileURLWithPath: audioFile)
-            let audioFileHandle = try AVAudioFile(forReading: audioFileURL)
-            let format = audioFileHandle.processingFormat
-            let frameCount = AVAudioFrameCount(audioFileHandle.length)
-
-            guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)
-            else {
-                logger.error("Failed to create audio buffer")
-                return
-            }
-
-            try audioFileHandle.read(into: buffer)
-
-            let samples = try AudioConverter().resampleAudioFile(path: audioFile)
-            let duration = Double(audioFileHandle.length) / format.sampleRate
-            logger.info("Processing \(String(format: "%.2f", duration))s of audio (\(samples.count) samples)\n")
-
             logger.info("Transcribing file: \(audioFileURL) ...")
             var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
             let startTime = Date()
-            var result = try await asrManager.transcribe(
-                audioFileURL, decoderState: &decoderState, language: args.language)
+
+            let customVocabularySamples: [Float]?
+            var result: ASRResult
+            if args.customVocabPath != nil {
+                let samples = try AudioConverter().resampleAudioFile(audioFileURL)
+                customVocabularySamples = samples
+                result = try await asrManager.transcribe(
+                    samples,
+                    decoderState: &decoderState,
+                    language: args.language
+                )
+            } else {
+                customVocabularySamples = nil
+                result = try await asrManager.transcribe(
+                    audioFileURL, decoderState: &decoderState, language: args.language)
+            }
             let processingTime = Date().timeIntervalSince(startTime)
+            let duration = result.duration
+            logger.info("Processed \(String(format: "%.2f", duration))s of audio\n")
 
             // Apply vocabulary rescoring if custom vocab is provided
-            if let vocabPath = args.customVocabPath {
+            if let vocabPath = args.customVocabPath, let samples = customVocabularySamples {
                 logger.info("Applying vocabulary boosting from: \(vocabPath)")
 
                 let (customVocab, ctcModels) = try await CustomVocabularyContext.loadWithCtcTokens(from: vocabPath)

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrTranscriptionTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/AsrTranscriptionTests.swift
@@ -90,7 +90,7 @@ final class AsrTranscriptionTests: XCTestCase {
             tokenIds: tokenIds,
             confidences: [0.63, 0.63, 0.63, 0.63, 0.63],  // Mean 0.63 (pure model confidence)
             encoderSequenceLength: 100,
-            audioSamples: audioSamples,
+            audioSampleCount: audioSamples.count,
             processingTime: processingTime
         )
 
@@ -113,7 +113,7 @@ final class AsrTranscriptionTests: XCTestCase {
             timestamps: timestamps,
             confidences: confidences,
             encoderSequenceLength: 150,
-            audioSamples: audioSamples,
+            audioSampleCount: audioSamples.count,
             processingTime: 1.2
         )
 
@@ -134,7 +134,7 @@ final class AsrTranscriptionTests: XCTestCase {
             timestamps: timestamps,
             confidences: [0.51, 0.51, 0.51],  // Mean 0.51 (pure model confidence)
             encoderSequenceLength: 100,
-            audioSamples: audioSamples,
+            audioSampleCount: audioSamples.count,
             processingTime: processingTime
         )
 


### PR DESCRIPTION
### Why is this change needed?

`fluidaudiocli transcribe` currently decodes batch audio three times: once into an unused buffer, once during unconditional resampling, and once inside `AsrManager.transcribe`.

```swift
try audioFileHandle.read(into: buffer)                           // Full decode #1
let samples = try AudioConverter().resampleAudioFile(...)        // Full decode #2
let result = try await asrManager.transcribe(audioFileURL, ...)  // Full decode #3
```

The decoded `buffer` was never used, so that read is removed. The second decode only supplied the sample-count log (removed) and custom-vocabulary samples. The CLI now passes normal files directly to `AsrManager`; with custom vocabulary, it decodes once and shares the samples between ASR and CTC.

An existing long-form duration bug was also fixed, alongside the above main patch. `ChunkProcessor` passed an empty sample array when building its result to avoid materializing disk-backed audio, which produced a zero duration. The result builder now accepts a sample count instead, allowing chunked paths to pass their existing `totalSamples` value.

### Validation

Benchmarked Parakeet V3 on Apple M3 using a 1 hr mp3:

| | Upstream | PR branch |
| --- | ---: | ---: |
| Time | 44.09 s | 18.50 s |
| Peak memory | 2,664 MiB | 354 MiB |

Yields a ~2.4x speedup with an 87% reduction in peak memory. The resulting transcript was byte-for-byte identical.

The equivalent WAV test showed no performance regression (15.29 s vs. 15.07 s) and also produced an identical transcript. A custom-vocabulary test likewise produced byte-identical output while improving from 2.50 s to 1.75 s.