### PR TITLE
feat(asr): expose non-mutating vocabulary candidate evidence

### DIFF
--- a/Documentation/ASR/CustomVocabulary.md
+++ b/Documentation/ASR/CustomVocabulary.md
@@ -306,25 +306,64 @@ let output = rescorer.ctcTokenEvaluateCandidates(
 
 // Always identical to the supplied decoder transcript.
 let untouchedText = output.baseText
+print(output.baseWords) // Exact source-word sequence indexed by every wordRange.
 
 for candidate in output.candidates {
-    print(candidate.basePhrase, candidate.canonicalTerm)
+    print(candidate.candidateID, candidate.origin)
+    print(candidate.basePhrase, candidate.canonicalTerm, candidate.matchedAlias as Any)
     print(candidate.rawOriginalCTCScore, candidate.rawVocabularyCTCScore)
-    print(candidate.effectiveBoost, candidate.legacyDecision)
+    print(candidate.effectiveBoost as Any, candidate.comparisonPassed)
+    print(candidate.legacyOutcome, candidate.wordRange, candidate.tokenRange as Any)
+    print(candidate.baseTextUTF8Range as Any)
 }
 ```
 
 The candidate API runs the same discovery, guards, and CTC comparison as legacy rescoring, but it
-returns both accepted and rejected evaluations without returning a rewritten transcript. Each
-candidate identifies the canonical term, the exact alias that produced the best string match (or
-`nil` for the canonical form), string similarity, raw CTC scores before context biasing, the
-effective boost, and FluidAudio's legacy accept/reject decision and reason.
+returns every comparison evaluation without rewriting `baseText`. Each candidate identifies the
+canonical term, the exact alias that produced the best string match (or `nil` for the canonical
+form), string similarity, raw CTC scores before context biasing, and the effective boost.
 
-`wordRange` and `tokenRange` are half-open ranges into the base transcript's word sequence and the
-supplied `tokenTimings`, respectively. `tokenRange` is `nil` when the source tokens are not
-contiguous. Scores and timestamps are optional rather than sentinel values when the corresponding
-evidence is unavailable. Candidate order is diagnostic; callers should use the reported ranges and
-scores rather than array position to arbitrate overlapping proposals.
+`comparisonPassed` reports only the numeric, pre-arbitration comparison: boosted vocabulary score
+greater than original score. `legacyOutcome` reports what the compatibility `ctcTokenRescore()`
+path finally did after overlap arbitration:
+
+- `applied` — comparison passed and the candidate was written to the legacy transcript.
+- `rejectedByComparison` — the legacy floating-point comparison ran and rejected the candidate.
+- `unavailableEvidence` — the comparison could not run, for example because tokenizer evidence was
+  unavailable.
+- `supersededByOverlap` — comparison passed, but an overlapping candidate won final arbitration.
+
+`comparisonPassed` and `legacyOutcome` preserve the comparison FluidAudio actually performed. A
+raw score remains `nil` when the underlying scorer produced a non-finite diagnostic value, but that
+does not retroactively turn a completed legacy comparison into `unavailableEvidence`. In that case
+the structured outcome remains authoritative and the display reason omits non-finite score text.
+
+`candidateID` is a non-negative correlation identifier unique only within one
+`CandidateEvidenceOutput`. It connects an evaluated row to its final overlap outcome; callers must
+not compare its numeric value across outputs or repeated evaluations. Duplicate-looking rows are
+intentional: separate word-centric, term-centric-single-word, term-centric-multiword, and
+spotter-rescue evaluations retain distinct IDs and `origin` values so diagnostics can attribute
+their discovery paths.
+
+`wordRange` is a half-open range into the returned `output.baseWords` array exactly as FluidAudio
+built it from token timings. It does not index a whitespace split or another caller-derived view of
+`baseText`. `tokenRange` is a half-open range into the supplied `tokenTimings`; it is `nil` when the
+source tokens are not contiguous.
+
+`baseTextUTF8Range` is a half-open UTF-8 byte range into untouched `baseText`. FluidAudio emits it
+only when the complete `baseWords` sequence has one byte-exact ordered alignment, the candidate span
+lands on valid String boundaries, and the aligned substring normalizes to `basePhrase`. Recognized
+quotation wrappers and recognized terminal punctuation remain outside the range; technical boundary
+operators, currency signs, and punctuation such as `+`, `#`, `@`, `$`, and a leading `.` remain
+inside it. Unrelated symbols such as emoji and trademarks, plus ambiguous edge syntax, produce `nil`
+instead of a guessed span, while punctuation and separators inside a multiword span are preserved.
+A `nil` range is explicit missing provenance: callers must not guess a replacement span or mutate
+text through a fabricated range.
+
+Scores and timestamps are likewise optional rather than sentinel values when evidence is
+unavailable. Downstream applications should apply their own candidate policy using the structured
+evidence. They must not replay every `comparisonPassed` row, infer missing scores/ranges, or treat
+candidate array order as a stable identity.
 
 ### 5. CustomVocabularyContext (`CustomVocabularyContext.swift`)
 

--- a/Documentation/ASR/CustomVocabulary.md
+++ b/Documentation/ASR/CustomVocabulary.md
@@ -290,6 +290,42 @@ Performs principled comparison between original transcript words and vocabulary 
 - `VocabularyRescorer+TokenEvaluation.swift` — per-candidate scoring and guard logic
 - `VocabularyRescorer+Utilities.swift` — string similarity, normalization, token boundary helpers
 
+#### Non-Mutating Candidate Evidence
+
+`ctcTokenRescore()` remains the compatibility API for callers that want FluidAudio to apply its
+existing replacement decision. Call `ctcTokenEvaluateCandidates()` instead when the application
+needs to preserve the decoder transcript and make the final replacement decision itself:
+
+```swift
+let output = rescorer.ctcTokenEvaluateCandidates(
+    transcript: baseTranscript,
+    tokenTimings: tokenTimings,
+    logProbs: ctcLogProbs,
+    frameDuration: 0.04
+)
+
+// Always identical to the supplied decoder transcript.
+let untouchedText = output.baseText
+
+for candidate in output.candidates {
+    print(candidate.basePhrase, candidate.canonicalTerm)
+    print(candidate.rawOriginalCTCScore, candidate.rawVocabularyCTCScore)
+    print(candidate.effectiveBoost, candidate.legacyDecision)
+}
+```
+
+The candidate API runs the same discovery, guards, and CTC comparison as legacy rescoring, but it
+returns both accepted and rejected evaluations without returning a rewritten transcript. Each
+candidate identifies the canonical term, the exact alias that produced the best string match (or
+`nil` for the canonical form), string similarity, raw CTC scores before context biasing, the
+effective boost, and FluidAudio's legacy accept/reject decision and reason.
+
+`wordRange` and `tokenRange` are half-open ranges into the base transcript's word sequence and the
+supplied `tokenTimings`, respectively. `tokenRange` is `nil` when the source tokens are not
+contiguous. Scores and timestamps are optional rather than sentinel values when the corresponding
+evidence is unavailable. Candidate order is diagnostic; callers should use the reported ranges and
+scores rather than array position to arbitrate overlapping proposals.
+
 ### 5. CustomVocabularyContext (`CustomVocabularyContext.swift`)
 
 Defines vocabulary terms to boost:

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenEvaluation.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenEvaluation.swift
@@ -79,6 +79,7 @@ extension VocabularyRescorer {
             debugLog("  [WARN] No tokenizer - skipping CTC comparison for '\(candidate.originalPhrase)'")
             return CTCMatchResult(
                 shouldReplace: false,
+                comparisonWasPerformed: false,
                 originalScore: -Float.infinity,
                 boostedVocabScore: vocabCtcScore,
                 rawVocabularyCTCScore: vocabCtcScore.isFinite ? vocabCtcScore : nil,
@@ -94,6 +95,7 @@ extension VocabularyRescorer {
             debugLog("  [WARN] Empty tokens for '\(candidate.originalPhrase)' - skipping")
             return CTCMatchResult(
                 shouldReplace: false,
+                comparisonWasPerformed: false,
                 originalScore: -Float.infinity,
                 boostedVocabScore: vocabCtcScore,
                 rawVocabularyCTCScore: vocabCtcScore.isFinite ? vocabCtcScore : nil,
@@ -148,12 +150,18 @@ extension VocabularyRescorer {
         let replacement = preserveCapitalization(original: firstOriginalWord, replacement: candidate.vocabTerm)
 
         let reasonPrefix = candidate.spanLength > 1 ? "CTC-vs-CTC (multi-word)" : "CTC-vs-CTC"
-        let reason =
-            "\(reasonPrefix): '\(candidate.vocabTerm)'=\(String(format: "%.2f", boostedVocabScore)) "
-            + "> '\(candidate.originalPhrase)'=\(String(format: "%.2f", originalCtcScore))"
+        let reason = Self.ctcComparisonReason(
+            prefix: reasonPrefix,
+            vocabularyTerm: candidate.vocabTerm,
+            boostedVocabularyScore: boostedVocabScore,
+            originalPhrase: candidate.originalPhrase,
+            originalScore: originalCtcScore,
+            comparisonPassed: shouldReplace
+        )
 
         return CTCMatchResult(
             shouldReplace: shouldReplace,
+            comparisonWasPerformed: true,
             originalScore: originalCtcScore,
             boostedVocabScore: boostedVocabScore,
             rawVocabularyCTCScore: vocabCtcScore.isFinite ? vocabCtcScore : nil,
@@ -164,33 +172,89 @@ extension VocabularyRescorer {
         )
     }
 
+    /// Build a truthful display reason for an available numeric CTC comparison.
+    static func ctcComparisonReason(
+        prefix: String,
+        vocabularyTerm: String,
+        boostedVocabularyScore: Float,
+        originalPhrase: String,
+        originalScore: Float,
+        comparisonPassed: Bool
+    ) -> String {
+        let comparisonOperator = comparisonPassed ? ">" : "<="
+        return
+            "\(prefix): '\(vocabularyTerm)'=\(String(format: "%.2f", boostedVocabularyScore)) "
+            + "\(comparisonOperator) '\(originalPhrase)'=\(String(format: "%.2f", originalScore))"
+    }
+
     /// Convert the legacy CTC evaluation into stable, non-sentinel diagnostic evidence.
     static func makeCandidateEvidence(
+        candidateID: Int,
         candidate: CTCMatchCandidate,
-        result: CTCMatchResult
+        result: CTCMatchResult,
+        wordRange: Range<Int>,
+        baseTextUTF8Range: Range<Int>?
     ) -> CandidateEvidence {
-        let wordRange: Range<Int>
-        if let firstIndex = candidate.spanIndices.first, let lastIndex = candidate.spanIndices.last {
-            wordRange = firstIndex..<(lastIndex + 1)
+        let rawVocabularyScore = finite(result.rawVocabularyCTCScore)
+        let rawOriginalScore = finite(result.rawOriginalCTCScore)
+        let effectiveBoost = finite(result.effectiveBoost)
+        let finiteScoresAvailable =
+            rawVocabularyScore != nil && rawOriginalScore != nil && effectiveBoost != nil
+        let comparisonPassed = result.comparisonWasPerformed && result.shouldReplace
+
+        let legacyOutcome: LegacyApplicationOutcome
+        if !result.comparisonWasPerformed {
+            legacyOutcome = .unavailableEvidence
+        } else if comparisonPassed {
+            // The final overlap pass rewrites this to `.supersededByOverlap` when another candidate wins.
+            legacyOutcome = .applied
         } else {
-            wordRange = 0..<0
+            legacyOutcome = .rejectedByComparison
         }
+        let reason =
+            finiteScoresAvailable
+            ? result.reason
+            : nonNumericComparisonReason(
+                legacyReason: result.reason,
+                comparisonWasPerformed: result.comparisonWasPerformed,
+                comparisonPassed: comparisonPassed
+            )
 
         return CandidateEvidence(
+            candidateID: candidateID,
+            origin: candidate.origin,
             basePhrase: candidate.originalPhrase,
             canonicalTerm: candidate.vocabTerm,
             matchedAlias: candidate.matchedAlias,
             similarity: candidate.similarity,
-            rawVocabularyCTCScore: finite(result.rawVocabularyCTCScore),
-            rawOriginalCTCScore: finite(result.rawOriginalCTCScore),
-            effectiveBoost: finite(result.effectiveBoost),
+            rawVocabularyCTCScore: rawVocabularyScore,
+            rawOriginalCTCScore: rawOriginalScore,
+            effectiveBoost: effectiveBoost,
             wordRange: wordRange,
             tokenRange: candidate.tokenRange,
+            baseTextUTF8Range: baseTextUTF8Range,
             startTime: candidate.spanStartTime.isFinite ? candidate.spanStartTime : nil,
             endTime: candidate.spanEndTime.isFinite ? candidate.spanEndTime : nil,
-            legacyDecision: result.shouldReplace ? .accepted : .rejected,
-            reason: result.reason
+            comparisonPassed: comparisonPassed,
+            legacyOutcome: legacyOutcome,
+            reason: reason
         )
+    }
+
+    private static func nonNumericComparisonReason(
+        legacyReason: String,
+        comparisonWasPerformed: Bool,
+        comparisonPassed: Bool
+    ) -> String {
+        guard legacyReason.contains(" > ") || legacyReason.contains(" <= ") else {
+            return legacyReason
+        }
+        if comparisonWasPerformed {
+            return
+                "CTC comparison \(comparisonPassed ? "passed" : "rejected"): "
+                + "one or more finite diagnostic scores were unavailable"
+        }
+        return "CTC comparison unavailable: required finite score evidence was missing"
     }
 
     private static func finite(_ value: Float?) -> Float? {

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenEvaluation.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenEvaluation.swift
@@ -81,6 +81,9 @@ extension VocabularyRescorer {
                 shouldReplace: false,
                 originalScore: -Float.infinity,
                 boostedVocabScore: vocabCtcScore,
+                rawVocabularyCTCScore: vocabCtcScore.isFinite ? vocabCtcScore : nil,
+                rawOriginalCTCScore: nil,
+                effectiveBoost: nil,
                 replacement: candidate.vocabTerm,
                 reason: "No tokenizer available"
             )
@@ -93,6 +96,9 @@ extension VocabularyRescorer {
                 shouldReplace: false,
                 originalScore: -Float.infinity,
                 boostedVocabScore: vocabCtcScore,
+                rawVocabularyCTCScore: vocabCtcScore.isFinite ? vocabCtcScore : nil,
+                rawOriginalCTCScore: nil,
+                effectiveBoost: nil,
                 replacement: candidate.vocabTerm,
                 reason: "Empty tokens for original phrase"
             )
@@ -150,9 +156,46 @@ extension VocabularyRescorer {
             shouldReplace: shouldReplace,
             originalScore: originalCtcScore,
             boostedVocabScore: boostedVocabScore,
+            rawVocabularyCTCScore: vocabCtcScore.isFinite ? vocabCtcScore : nil,
+            rawOriginalCTCScore: originalCtcScore.isFinite ? originalCtcScore : nil,
+            effectiveBoost: adaptiveCbwValue.isFinite ? adaptiveCbwValue : nil,
             replacement: replacement,
             reason: reason
         )
+    }
+
+    /// Convert the legacy CTC evaluation into stable, non-sentinel diagnostic evidence.
+    static func makeCandidateEvidence(
+        candidate: CTCMatchCandidate,
+        result: CTCMatchResult
+    ) -> CandidateEvidence {
+        let wordRange: Range<Int>
+        if let firstIndex = candidate.spanIndices.first, let lastIndex = candidate.spanIndices.last {
+            wordRange = firstIndex..<(lastIndex + 1)
+        } else {
+            wordRange = 0..<0
+        }
+
+        return CandidateEvidence(
+            basePhrase: candidate.originalPhrase,
+            canonicalTerm: candidate.vocabTerm,
+            matchedAlias: candidate.matchedAlias,
+            similarity: candidate.similarity,
+            rawVocabularyCTCScore: finite(result.rawVocabularyCTCScore),
+            rawOriginalCTCScore: finite(result.rawOriginalCTCScore),
+            effectiveBoost: finite(result.effectiveBoost),
+            wordRange: wordRange,
+            tokenRange: candidate.tokenRange,
+            startTime: candidate.spanStartTime.isFinite ? candidate.spanStartTime : nil,
+            endTime: candidate.spanEndTime.isFinite ? candidate.spanEndTime : nil,
+            legacyDecision: result.shouldReplace ? .accepted : .rejected,
+            reason: result.reason
+        )
+    }
+
+    private static func finite(_ value: Float?) -> Float? {
+        guard let value, value.isFinite else { return nil }
+        return value
     }
 
     // MARK: - Replacement Application

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
@@ -68,6 +68,7 @@ extension VocabularyRescorer {
 
     /// Parameters for evaluating a CTC match candidate.
     struct CTCMatchCandidate {
+        let origin: CandidateOrigin
         let originalPhrase: String
         let vocabTerm: String
         let matchedAlias: String?
@@ -83,6 +84,7 @@ extension VocabularyRescorer {
     /// Result of CTC match evaluation.
     struct CTCMatchResult {
         let shouldReplace: Bool
+        let comparisonWasPerformed: Bool
         let originalScore: Float
         let boostedVocabScore: Float
         let rawVocabularyCTCScore: Float?
@@ -95,13 +97,28 @@ extension VocabularyRescorer {
     /// Pending replacement candidate for two-pass selection.
     /// Stores all info needed to apply the replacement later.
     struct PendingReplacement {
+        let candidateID: Int?
         let candidate: CTCMatchCandidate
         let result: CTCMatchResult
         let similarity: Float  // String similarity for sorting
     }
 
+    /// Evidence-only state. Legacy rescoring keeps this optional `nil` and allocates none of its arrays.
+    struct CandidateEvidenceCollector {
+        var baseText: String = ""
+        var baseWords: [String] = []
+        var alignedWordRanges: [Range<Int>?] = []
+        var candidates: [CandidateEvidence] = []
+    }
+
+    /// Result of the legacy greedy overlap pass before text mutation is applied.
+    struct PendingReplacementArbitration {
+        let applied: [PendingReplacement]
+        let supersededCandidateIDs: Set<Int>
+    }
+
     /// Return a half-open token range when the word span has contiguous token provenance.
-    private static func tokenRange(
+    static func tokenRange(
         for spanIndices: [Int],
         in wordTimings: [WordTiming]
     ) -> Range<Int>? {
@@ -126,6 +143,49 @@ extension VocabularyRescorer {
         return firstRange.lowerBound..<tokenEnd
     }
 
+    /// Append one evidence row only when the caller requested evidence collection.
+    @discardableResult
+    static func recordCandidateEvidence(
+        candidate: CTCMatchCandidate,
+        result: CTCMatchResult,
+        candidateEvidence: inout CandidateEvidenceCollector?
+    ) -> Int? {
+        guard let candidateID = candidateEvidence?.candidates.count else { return nil }
+
+        let wordRange: Range<Int>
+        if let firstIndex = candidate.spanIndices.first,
+            let lastIndex = candidate.spanIndices.last,
+            candidate.spanIndices == Array(firstIndex...lastIndex)
+        {
+            wordRange = firstIndex..<(lastIndex + 1)
+        } else {
+            wordRange = 0..<0
+        }
+
+        let textRange: Range<Int>?
+        if let collector = candidateEvidence {
+            textRange = candidateBaseTextUTF8Range(
+                wordRange: wordRange,
+                alignedWordRanges: collector.alignedWordRanges,
+                baseText: collector.baseText,
+                basePhrase: candidate.originalPhrase
+            )
+        } else {
+            textRange = nil
+        }
+
+        candidateEvidence?.candidates.append(
+            makeCandidateEvidence(
+                candidateID: candidateID,
+                candidate: candidate,
+                result: result,
+                wordRange: wordRange,
+                baseTextUTF8Range: textRange
+            )
+        )
+        return candidateID
+    }
+
     // MARK: - Shared Finalization
 
     /// Finalize replacements: sort by span length, apply greedily, reconstruct transcript.
@@ -135,7 +195,8 @@ extension VocabularyRescorer {
         pendingReplacements: [PendingReplacement],
         modifiedWords: inout [(word: String, startTime: Double, endTime: Double)],
         replacedIndices: inout Set<Int>,
-        replacements: inout [RescoringResult]
+        replacements: inout [RescoringResult],
+        candidateEvidence: inout CandidateEvidenceCollector?
     ) -> RescoreOutput {
         // PASS 2: Sort by similarity (descending), with span length used
         // only as a tiebreak.
@@ -163,26 +224,14 @@ extension VocabularyRescorer {
         // non-transitive: e.g. for similarities 0.70/0.66/0.62 across span
         // lengths 3/2/1, A vs B and B vs C dispatch to the span tiebreaker
         // while A vs C dispatches to similarity, producing a cycle.
-        let quantized: (Float) -> Int = { Int(($0 / 0.05).rounded()) }
-        let sortedReplacements = pendingReplacements.sorted { a, b in
-            let aBucket = quantized(a.similarity)
-            let bBucket = quantized(b.similarity)
-            if aBucket != bBucket {
-                return aBucket > bBucket  // Prefer higher similarity bucket
-            }
-            if a.candidate.spanLength != b.candidate.spanLength {
-                return a.candidate.spanLength < b.candidate.spanLength  // Prefer shorter spans within a bucket
-            }
-            return a.similarity > b.similarity
-        }
+        let arbitration = Self.arbitratePendingReplacements(
+            pendingReplacements,
+            occupiedIndices: replacedIndices
+        )
 
         // PASS 3: Greedily apply non-overlapping replacements
-        for pending in sortedReplacements {
-            // Check if any index in this span is already replaced
-            guard pending.candidate.spanIndices.allSatisfy({ !replacedIndices.contains($0) }) else {
-                continue  // Skip - overlaps with already-accepted replacement
-            }
-
+        var appliedCandidateIDs = Set<Int>()
+        for pending in arbitration.applied {
             applyReplacement(
                 result: pending.result,
                 candidate: pending.candidate,
@@ -190,6 +239,17 @@ extension VocabularyRescorer {
                 replacedIndices: &replacedIndices,
                 replacements: &replacements
             )
+            if let candidateID = pending.candidateID {
+                appliedCandidateIDs.insert(candidateID)
+            }
+        }
+
+        if var collector = candidateEvidence {
+            Self.reconcileLegacyOutcomes(
+                candidates: &collector.candidates,
+                appliedCandidateIDs: appliedCandidateIDs
+            )
+            candidateEvidence = collector
         }
 
         // Reconstruct transcript from modified words (filter empty strings from multi-word replacements)
@@ -206,6 +266,58 @@ extension VocabularyRescorer {
             replacements: replacements,
             wasModified: wasModified
         )
+    }
+
+    /// Run the legacy similarity ordering and greedy overlap selection without mutating text.
+    static func arbitratePendingReplacements(
+        _ pendingReplacements: [PendingReplacement],
+        occupiedIndices: Set<Int> = []
+    ) -> PendingReplacementArbitration {
+        let quantized: (Float) -> Int = { Int(($0 / 0.05).rounded()) }
+        let sortedReplacements = pendingReplacements.sorted { a, b in
+            let aBucket = quantized(a.similarity)
+            let bBucket = quantized(b.similarity)
+            if aBucket != bBucket {
+                return aBucket > bBucket
+            }
+            if a.candidate.spanLength != b.candidate.spanLength {
+                return a.candidate.spanLength < b.candidate.spanLength
+            }
+            return a.similarity > b.similarity
+        }
+
+        var occupiedIndices = occupiedIndices
+        var applied: [PendingReplacement] = []
+        var supersededCandidateIDs = Set<Int>()
+        for pending in sortedReplacements {
+            guard pending.candidate.spanIndices.allSatisfy({ !occupiedIndices.contains($0) }) else {
+                if let candidateID = pending.candidateID {
+                    supersededCandidateIDs.insert(candidateID)
+                }
+                continue
+            }
+            applied.append(pending)
+            occupiedIndices.formUnion(pending.candidate.spanIndices)
+        }
+
+        return PendingReplacementArbitration(
+            applied: applied,
+            supersededCandidateIDs: supersededCandidateIDs
+        )
+    }
+
+    /// Resolve final outcomes after the legacy greedy overlap pass has selected its winners.
+    static func reconcileLegacyOutcomes(
+        candidates: inout [CandidateEvidence],
+        appliedCandidateIDs: Set<Int>
+    ) {
+        for index in candidates.indices where candidates[index].comparisonPassed {
+            let outcome: LegacyApplicationOutcome =
+                appliedCandidateIDs.contains(candidates[index].candidateID)
+                ? .applied
+                : .supersededByOverlap
+            candidates[index] = candidates[index].replacingLegacyOutcome(outcome)
+        }
     }
 
     // MARK: - Public API
@@ -233,7 +345,7 @@ extension VocabularyRescorer {
         marginSeconds: Double = ContextBiasingConstants.defaultMarginSeconds,
         minSimilarity: Float = ContextBiasingConstants.minSimilarityFloor
     ) -> RescoreOutput {
-        var candidateEvidence: [CandidateEvidence]?
+        var candidateEvidence: CandidateEvidenceCollector?
         return evaluateTokenCandidates(
             transcript: transcript,
             tokenTimings: tokenTimings,
@@ -250,7 +362,8 @@ extension VocabularyRescorer {
     ///
     /// This runs the same candidate discovery and CTC comparison as ``ctcTokenRescore`` while
     /// preserving the supplied transcript as ``CandidateEvidenceOutput/baseText``. The output
-    /// includes candidates rejected by the legacy comparison as well as accepted candidates.
+    /// includes comparison failures, unavailable comparisons, applied candidates, and candidates
+    /// superseded by the legacy overlap pass.
     ///
     /// - Parameters:
     ///   - transcript: Untouched transcript from the TDT decoder.
@@ -260,7 +373,8 @@ extension VocabularyRescorer {
     ///   - cbw: Context-biasing weight.
     ///   - marginSeconds: Temporal margin around TDT words for CTC search.
     ///   - minSimilarity: Minimum string similarity to consider a match.
-    /// - Returns: The untouched base transcript and evidence for every CTC-evaluated candidate.
+    /// - Returns: Untouched base text, its exact internal word sequence, and finalized evidence for
+    ///   every CTC-evaluated candidate.
     public func ctcTokenEvaluateCandidates(
         transcript: String,
         tokenTimings: [TokenTiming],
@@ -270,7 +384,7 @@ extension VocabularyRescorer {
         marginSeconds: Double = ContextBiasingConstants.defaultMarginSeconds,
         minSimilarity: Float = ContextBiasingConstants.minSimilarityFloor
     ) -> CandidateEvidenceOutput {
-        var candidateEvidence: [CandidateEvidence]? = []
+        var candidateEvidence: CandidateEvidenceCollector? = CandidateEvidenceCollector()
         _ = evaluateTokenCandidates(
             transcript: transcript,
             tokenTimings: tokenTimings,
@@ -281,7 +395,11 @@ extension VocabularyRescorer {
             minSimilarity: minSimilarity,
             candidateEvidence: &candidateEvidence
         )
-        return CandidateEvidenceOutput(baseText: transcript, candidates: candidateEvidence ?? [])
+        return CandidateEvidenceOutput(
+            baseText: transcript,
+            baseWords: candidateEvidence?.baseWords ?? [],
+            candidates: candidateEvidence?.candidates ?? []
+        )
     }
 
     private func evaluateTokenCandidates(
@@ -292,7 +410,7 @@ extension VocabularyRescorer {
         cbw: Float,
         marginSeconds: Double,
         minSimilarity: Float,
-        candidateEvidence: inout [CandidateEvidence]?
+        candidateEvidence: inout CandidateEvidenceCollector?
     ) -> RescoreOutput {
         // Build word-level timings once at the entrypoint and pass into both
         // dispatch paths. Computing this once instead of twice avoids
@@ -301,6 +419,15 @@ extension VocabularyRescorer {
         // `[TokenTiming]` (cleaner contract; useful if a caller ever wants
         // to supply pre-computed timings from another source).
         let wordTimings = Self.buildWordTimings(from: tokenTimings)
+        if candidateEvidence != nil {
+            let baseWords = wordTimings.map(\.word)
+            candidateEvidence?.baseText = transcript
+            candidateEvidence?.baseWords = baseWords
+            candidateEvidence?.alignedWordRanges = Self.alignBaseWordsToUTF8Ranges(
+                baseText: transcript,
+                baseWords: baseWords
+            )
+        }
 
         if useBKTree {
             return rescoreWithConstrainedCTCWordCentric(
@@ -345,7 +472,7 @@ extension VocabularyRescorer {
         cbw: Float = ContextBiasingConstants.defaultCbw,
         marginSeconds: Double = ContextBiasingConstants.defaultMarginSeconds,
         minSimilarity: Float = ContextBiasingConstants.minSimilarityFloor,
-        candidateEvidence: inout [CandidateEvidence]?
+        candidateEvidence: inout CandidateEvidenceCollector?
     ) -> RescoreOutput {
         guard !wordTimings.isEmpty, !logProbs.isEmpty else {
             return RescoreOutput(text: transcript, replacements: [], wasModified: false)
@@ -504,6 +631,7 @@ extension VocabularyRescorer {
 
                 // Evaluate CTC match using shared helper
                 let matchCandidate = CTCMatchCandidate(
+                    origin: .wordCentric,
                     originalPhrase: originalPhrase,
                     vocabTerm: vocabTerm,
                     matchedAlias: nil,
@@ -523,11 +651,16 @@ extension VocabularyRescorer {
                     cbw: cbw,
                     marginSeconds: marginSeconds
                 )
-                candidateEvidence?.append(Self.makeCandidateEvidence(candidate: matchCandidate, result: result))
+                let candidateID = Self.recordCandidateEvidence(
+                    candidate: matchCandidate,
+                    result: result,
+                    candidateEvidence: &candidateEvidence
+                )
 
                 if result.shouldReplace {
                     pendingReplacements.append(
                         PendingReplacement(
+                            candidateID: candidateID,
                             candidate: matchCandidate,
                             result: result,
                             similarity: similarity
@@ -542,7 +675,8 @@ extension VocabularyRescorer {
             pendingReplacements: pendingReplacements,
             modifiedWords: &modifiedWords,
             replacedIndices: &replacedIndices,
-            replacements: &replacements
+            replacements: &replacements,
+            candidateEvidence: &candidateEvidence
         )
     }
 
@@ -564,7 +698,7 @@ extension VocabularyRescorer {
         cbw: Float = ContextBiasingConstants.defaultCbw,
         marginSeconds: Double = ContextBiasingConstants.defaultMarginSeconds,
         minSimilarity: Float = ContextBiasingConstants.minSimilarityFloor,
-        candidateEvidence: inout [CandidateEvidence]?
+        candidateEvidence: inout CandidateEvidenceCollector?
     ) -> RescoreOutput {
         guard !wordTimings.isEmpty, !logProbs.isEmpty else {
             return RescoreOutput(text: transcript, replacements: [], wasModified: false)
@@ -679,6 +813,7 @@ extension VocabularyRescorer {
 
                         // Evaluate CTC match using shared helper
                         let matchCandidate = CTCMatchCandidate(
+                            origin: .termCentricMultiWord,
                             originalPhrase: tdtPhrase,
                             vocabTerm: vocabTerm,
                             matchedAlias: matchedAlias,
@@ -698,12 +833,17 @@ extension VocabularyRescorer {
                             cbw: cbw,
                             marginSeconds: marginSeconds
                         )
-                        candidateEvidence?.append(Self.makeCandidateEvidence(candidate: matchCandidate, result: result))
+                        let candidateID = Self.recordCandidateEvidence(
+                            candidate: matchCandidate,
+                            result: result,
+                            candidateEvidence: &candidateEvidence
+                        )
 
                         if result.shouldReplace {
                             // Collect candidate instead of applying immediately
                             pendingReplacements.append(
                                 PendingReplacement(
+                                    candidateID: candidateID,
                                     candidate: matchCandidate,
                                     result: result,
                                     similarity: bestSimilarity
@@ -852,6 +992,7 @@ extension VocabularyRescorer {
 
                     // Evaluate CTC match using shared helper
                     let matchCandidate = CTCMatchCandidate(
+                        origin: .termCentricSingleWord,
                         originalPhrase: originalPhrase,
                         vocabTerm: vocabTerm,
                         matchedAlias: matchedAlias,
@@ -871,12 +1012,17 @@ extension VocabularyRescorer {
                         cbw: cbw,
                         marginSeconds: marginSeconds
                     )
-                    candidateEvidence?.append(Self.makeCandidateEvidence(candidate: matchCandidate, result: result))
+                    let candidateID = Self.recordCandidateEvidence(
+                        candidate: matchCandidate,
+                        result: result,
+                        candidateEvidence: &candidateEvidence
+                    )
 
                     if result.shouldReplace {
                         // Collect candidate instead of applying immediately
                         pendingReplacements.append(
                             PendingReplacement(
+                                candidateID: candidateID,
                                 candidate: matchCandidate,
                                 result: result,
                                 similarity: bestSimilarity
@@ -928,7 +1074,8 @@ extension VocabularyRescorer {
             pendingReplacements: pendingReplacements,
             modifiedWords: &modifiedWords,
             replacedIndices: &replacedIndices,
-            replacements: &replacements
+            replacements: &replacements,
+            candidateEvidence: &candidateEvidence
         )
     }
 
@@ -956,7 +1103,7 @@ extension VocabularyRescorer {
         marginSeconds: Double,
         vocabularyNormalizedSet: Set<String>,
         pendingReplacements: inout [PendingReplacement],
-        candidateEvidence: inout [CandidateEvidence]?
+        candidateEvidence: inout CandidateEvidenceCollector?
     ) {
         let result = spotter.spotKeywordsFromLogProbs(
             logProbs: logProbs,
@@ -1073,6 +1220,7 @@ extension VocabularyRescorer {
             let firstIdx = span.first!
             let lastIdx = span.last!
             let candidate = CTCMatchCandidate(
+                origin: .spotterRescue,
                 originalPhrase: originalPhrase,
                 vocabTerm: vocabTerm,
                 matchedAlias: matchedAlias,
@@ -1092,7 +1240,11 @@ extension VocabularyRescorer {
                 cbw: cbw,
                 marginSeconds: marginSeconds
             )
-            candidateEvidence?.append(Self.makeCandidateEvidence(candidate: candidate, result: evalResult))
+            let candidateID = Self.recordCandidateEvidence(
+                candidate: candidate,
+                result: evalResult,
+                candidateEvidence: &candidateEvidence
+            )
             guard evalResult.shouldReplace else { continue }
 
             debugLog(
@@ -1103,6 +1255,7 @@ extension VocabularyRescorer {
 
             pendingReplacements.append(
                 PendingReplacement(
+                    candidateID: candidateID,
                     candidate: candidate,
                     result: evalResult,
                     similarity: bestSimilarity

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
@@ -70,10 +70,12 @@ extension VocabularyRescorer {
     struct CTCMatchCandidate {
         let originalPhrase: String
         let vocabTerm: String
+        let matchedAlias: String?
         let vocabTokens: [Int]
         let similarity: Float
         let spanLength: Int
         let spanIndices: [Int]
+        let tokenRange: Range<Int>?
         let spanStartTime: Double
         let spanEndTime: Double
     }
@@ -83,6 +85,9 @@ extension VocabularyRescorer {
         let shouldReplace: Bool
         let originalScore: Float
         let boostedVocabScore: Float
+        let rawVocabularyCTCScore: Float?
+        let rawOriginalCTCScore: Float?
+        let effectiveBoost: Float?
         let replacement: String
         let reason: String
     }
@@ -93,6 +98,32 @@ extension VocabularyRescorer {
         let candidate: CTCMatchCandidate
         let result: CTCMatchResult
         let similarity: Float  // String similarity for sorting
+    }
+
+    /// Return a half-open token range when the word span has contiguous token provenance.
+    private static func tokenRange(
+        for spanIndices: [Int],
+        in wordTimings: [WordTiming]
+    ) -> Range<Int>? {
+        guard let firstIndex = spanIndices.first,
+            spanIndices.allSatisfy({ wordTimings.indices.contains($0) })
+        else {
+            return nil
+        }
+
+        guard let firstRange = wordTimings[firstIndex].tokenRange else { return nil }
+        var tokenEnd = firstRange.upperBound
+        for (leftIndex, rightIndex) in zip(spanIndices, spanIndices.dropFirst()) {
+            guard rightIndex == leftIndex + 1 else { return nil }
+            guard let rightRange = wordTimings[rightIndex].tokenRange,
+                rightRange.lowerBound == tokenEnd
+            else {
+                return nil
+            }
+            tokenEnd = rightRange.upperBound
+        }
+
+        return firstRange.lowerBound..<tokenEnd
     }
 
     // MARK: - Shared Finalization
@@ -202,13 +233,74 @@ extension VocabularyRescorer {
         marginSeconds: Double = ContextBiasingConstants.defaultMarginSeconds,
         minSimilarity: Float = ContextBiasingConstants.minSimilarityFloor
     ) -> RescoreOutput {
+        var candidateEvidence: [CandidateEvidence]?
+        return evaluateTokenCandidates(
+            transcript: transcript,
+            tokenTimings: tokenTimings,
+            logProbs: logProbs,
+            frameDuration: frameDuration,
+            cbw: cbw,
+            marginSeconds: marginSeconds,
+            minSimilarity: minSimilarity,
+            candidateEvidence: &candidateEvidence
+        )
+    }
+
+    /// Evaluate vocabulary candidates without returning the rewritten transcript.
+    ///
+    /// This runs the same candidate discovery and CTC comparison as ``ctcTokenRescore`` while
+    /// preserving the supplied transcript as ``CandidateEvidenceOutput/baseText``. The output
+    /// includes candidates rejected by the legacy comparison as well as accepted candidates.
+    ///
+    /// - Parameters:
+    ///   - transcript: Untouched transcript from the TDT decoder.
+    ///   - tokenTimings: Token-level timings from the TDT decoder.
+    ///   - logProbs: CTC log-probabilities from the spotter.
+    ///   - frameDuration: Duration of each CTC frame in seconds.
+    ///   - cbw: Context-biasing weight.
+    ///   - marginSeconds: Temporal margin around TDT words for CTC search.
+    ///   - minSimilarity: Minimum string similarity to consider a match.
+    /// - Returns: The untouched base transcript and evidence for every CTC-evaluated candidate.
+    public func ctcTokenEvaluateCandidates(
+        transcript: String,
+        tokenTimings: [TokenTiming],
+        logProbs: [[Float]],
+        frameDuration: Double,
+        cbw: Float = ContextBiasingConstants.defaultCbw,
+        marginSeconds: Double = ContextBiasingConstants.defaultMarginSeconds,
+        minSimilarity: Float = ContextBiasingConstants.minSimilarityFloor
+    ) -> CandidateEvidenceOutput {
+        var candidateEvidence: [CandidateEvidence]? = []
+        _ = evaluateTokenCandidates(
+            transcript: transcript,
+            tokenTimings: tokenTimings,
+            logProbs: logProbs,
+            frameDuration: frameDuration,
+            cbw: cbw,
+            marginSeconds: marginSeconds,
+            minSimilarity: minSimilarity,
+            candidateEvidence: &candidateEvidence
+        )
+        return CandidateEvidenceOutput(baseText: transcript, candidates: candidateEvidence ?? [])
+    }
+
+    private func evaluateTokenCandidates(
+        transcript: String,
+        tokenTimings: [TokenTiming],
+        logProbs: [[Float]],
+        frameDuration: Double,
+        cbw: Float,
+        marginSeconds: Double,
+        minSimilarity: Float,
+        candidateEvidence: inout [CandidateEvidence]?
+    ) -> RescoreOutput {
         // Build word-level timings once at the entrypoint and pass into both
         // dispatch paths. Computing this once instead of twice avoids
         // duplicate work for the BK-tree branch and keeps the private
         // functions parameterized by `[WordTiming]` rather than the raw
         // `[TokenTiming]` (cleaner contract; useful if a caller ever wants
         // to supply pre-computed timings from another source).
-        let wordTimings = buildWordTimings(from: tokenTimings)
+        let wordTimings = Self.buildWordTimings(from: tokenTimings)
 
         if useBKTree {
             return rescoreWithConstrainedCTCWordCentric(
@@ -218,7 +310,8 @@ extension VocabularyRescorer {
                 frameDuration: frameDuration,
                 cbw: cbw,
                 marginSeconds: marginSeconds,
-                minSimilarity: minSimilarity
+                minSimilarity: minSimilarity,
+                candidateEvidence: &candidateEvidence
             )
         } else {
             return rescoreWithConstrainedCTCTermCentric(
@@ -228,7 +321,8 @@ extension VocabularyRescorer {
                 frameDuration: frameDuration,
                 cbw: cbw,
                 marginSeconds: marginSeconds,
-                minSimilarity: minSimilarity
+                minSimilarity: minSimilarity,
+                candidateEvidence: &candidateEvidence
             )
         }
     }
@@ -250,7 +344,8 @@ extension VocabularyRescorer {
         frameDuration: Double,
         cbw: Float = ContextBiasingConstants.defaultCbw,
         marginSeconds: Double = ContextBiasingConstants.defaultMarginSeconds,
-        minSimilarity: Float = ContextBiasingConstants.minSimilarityFloor
+        minSimilarity: Float = ContextBiasingConstants.minSimilarityFloor,
+        candidateEvidence: inout [CandidateEvidence]?
     ) -> RescoreOutput {
         guard !wordTimings.isEmpty, !logProbs.isEmpty else {
             return RescoreOutput(text: transcript, replacements: [], wasModified: false)
@@ -411,10 +506,12 @@ extension VocabularyRescorer {
                 let matchCandidate = CTCMatchCandidate(
                     originalPhrase: originalPhrase,
                     vocabTerm: vocabTerm,
+                    matchedAlias: nil,
                     vocabTokens: vocabTokens,
                     similarity: similarity,
                     spanLength: spanLength,
                     spanIndices: spanIndices,
+                    tokenRange: Self.tokenRange(for: spanIndices, in: wordTimings),
                     spanStartTime: spanStartTime,
                     spanEndTime: spanEndTime
                 )
@@ -426,6 +523,7 @@ extension VocabularyRescorer {
                     cbw: cbw,
                     marginSeconds: marginSeconds
                 )
+                candidateEvidence?.append(Self.makeCandidateEvidence(candidate: matchCandidate, result: result))
 
                 if result.shouldReplace {
                     pendingReplacements.append(
@@ -465,7 +563,8 @@ extension VocabularyRescorer {
         frameDuration: Double,
         cbw: Float = ContextBiasingConstants.defaultCbw,
         marginSeconds: Double = ContextBiasingConstants.defaultMarginSeconds,
-        minSimilarity: Float = ContextBiasingConstants.minSimilarityFloor
+        minSimilarity: Float = ContextBiasingConstants.minSimilarityFloor,
+        candidateEvidence: inout [CandidateEvidence]?
     ) -> RescoreOutput {
         guard !wordTimings.isEmpty, !logProbs.isEmpty else {
             return RescoreOutput(text: transcript, replacements: [], wasModified: false)
@@ -543,9 +642,13 @@ extension VocabularyRescorer {
 
                         // Check similarity against ALL forms (canonical + aliases)
                         var bestSimilarity: Float = 0
+                        var matchedAlias: String?
                         for form in multiWordForms {
                             let similarity = Self.stringSimilarity(normalizedPhrase, form.normalized)
-                            bestSimilarity = max(bestSimilarity, similarity)
+                            if similarity > bestSimilarity {
+                                bestSimilarity = similarity
+                                matchedAlias = form.matchedAlias
+                            }
                         }
 
                         // Skip if already exact match to canonical (no replacement needed)
@@ -578,10 +681,12 @@ extension VocabularyRescorer {
                         let matchCandidate = CTCMatchCandidate(
                             originalPhrase: tdtPhrase,
                             vocabTerm: vocabTerm,
+                            matchedAlias: matchedAlias,
                             vocabTokens: vocabTokens,
                             similarity: bestSimilarity,
                             spanLength: spanLength,
                             spanIndices: spanIndices,
+                            tokenRange: Self.tokenRange(for: spanIndices, in: wordTimings),
                             spanStartTime: spanStartTime,
                             spanEndTime: spanEndTime
                         )
@@ -593,6 +698,7 @@ extension VocabularyRescorer {
                             cbw: cbw,
                             marginSeconds: marginSeconds
                         )
+                        candidateEvidence?.append(Self.makeCandidateEvidence(candidate: matchCandidate, result: result))
 
                         if result.shouldReplace {
                             // Collect candidate instead of applying immediately
@@ -633,9 +739,13 @@ extension VocabularyRescorer {
                     // Check similarity against ALL forms (single word)
                     var bestSimilarity: Float = 0
                     var matchedSpanLength = 1
+                    var matchedAlias: String?
                     for form in singleWordForms {
                         let similarity = Self.stringSimilarity(normalizedWord, form.normalized)
-                        bestSimilarity = max(bestSimilarity, similarity)
+                        if similarity > bestSimilarity {
+                            bestSimilarity = similarity
+                            matchedAlias = form.matchedAlias
+                        }
                     }
 
                     // COMPOUND WORD MATCHING: For single-word vocabulary terms, also try
@@ -668,7 +778,7 @@ extension VocabularyRescorer {
                                 if concatSimilarity > bestSimilarity {
                                     bestSimilarity = concatSimilarity
                                     matchedSpanLength = 2
-
+                                    matchedAlias = form.matchedAlias
                                 }
                             }
                         }
@@ -690,7 +800,7 @@ extension VocabularyRescorer {
                                 if concatSimilarity > bestSimilarity {
                                     bestSimilarity = concatSimilarity
                                     matchedSpanLength = 3
-
+                                    matchedAlias = form.matchedAlias
                                 }
                             }
                         }
@@ -744,10 +854,12 @@ extension VocabularyRescorer {
                     let matchCandidate = CTCMatchCandidate(
                         originalPhrase: originalPhrase,
                         vocabTerm: vocabTerm,
+                        matchedAlias: matchedAlias,
                         vocabTokens: vocabTokens,
                         similarity: bestSimilarity,
                         spanLength: matchedSpanLength,
                         spanIndices: spanIndices,
+                        tokenRange: Self.tokenRange(for: spanIndices, in: wordTimings),
                         spanStartTime: spanStartTime,
                         spanEndTime: spanEndTime
                     )
@@ -759,6 +871,7 @@ extension VocabularyRescorer {
                         cbw: cbw,
                         marginSeconds: marginSeconds
                     )
+                    candidateEvidence?.append(Self.makeCandidateEvidence(candidate: matchCandidate, result: result))
 
                     if result.shouldReplace {
                         // Collect candidate instead of applying immediately
@@ -805,7 +918,8 @@ extension VocabularyRescorer {
                 cbw: cbw,
                 marginSeconds: marginSeconds,
                 vocabularyNormalizedSet: vocabularyNormalizedSet,
-                pendingReplacements: &pendingReplacements
+                pendingReplacements: &pendingReplacements,
+                candidateEvidence: &candidateEvidence
             )
         }
 
@@ -841,7 +955,8 @@ extension VocabularyRescorer {
         cbw: Float,
         marginSeconds: Double,
         vocabularyNormalizedSet: Set<String>,
-        pendingReplacements: inout [PendingReplacement]
+        pendingReplacements: inout [PendingReplacement],
+        candidateEvidence: inout [CandidateEvidence]?
     ) {
         let result = spotter.spotKeywordsFromLogProbs(
             logProbs: logProbs,
@@ -924,8 +1039,13 @@ extension VocabularyRescorer {
 
             // Compute similarity (best over canonical + aliases).
             var bestSimilarity: Float = 0
+            var matchedAlias: String?
             for form in normalizedForms {
-                bestSimilarity = max(bestSimilarity, Self.stringSimilarity(normalizedPhrase, form.normalized))
+                let similarity = Self.stringSimilarity(normalizedPhrase, form.normalized)
+                if similarity > bestSimilarity {
+                    bestSimilarity = similarity
+                    matchedAlias = form.matchedAlias
+                }
             }
 
             // SIMILARITY FLOOR for the acoustic rescue path. The spotter
@@ -955,10 +1075,12 @@ extension VocabularyRescorer {
             let candidate = CTCMatchCandidate(
                 originalPhrase: originalPhrase,
                 vocabTerm: vocabTerm,
+                matchedAlias: matchedAlias,
                 vocabTokens: vocabTokens,
                 similarity: bestSimilarity,
                 spanLength: span.count,
                 spanIndices: span,
+                tokenRange: Self.tokenRange(for: span, in: wordTimings),
                 spanStartTime: wordTimings[firstIdx].startTime,
                 spanEndTime: wordTimings[lastIdx].endTime
             )
@@ -970,6 +1092,7 @@ extension VocabularyRescorer {
                 cbw: cbw,
                 marginSeconds: marginSeconds
             )
+            candidateEvidence?.append(Self.makeCandidateEvidence(candidate: candidate, result: evalResult))
             guard evalResult.shouldReplace else { continue }
 
             debugLog(

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+Utilities.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+Utilities.swift
@@ -130,6 +130,193 @@ extension VocabularyRescorer {
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    /// Align the complete internal word sequence to one byte-exact occurrence in the untouched transcript.
+    ///
+    /// Each returned range is half-open in UTF-8 bytes. It excludes recognized quotation wrappers
+    /// and terminal punctuation while retaining technical boundary symbols such as `+`, `#`, `@`,
+    /// `$`, and a leading `.`. When a lexical boundary is ambiguous, the complete sequence is
+    /// absent, or more than one valid alignment exists, the affected range is `nil` rather than a
+    /// guess.
+    static func alignBaseWordsToUTF8Ranges(baseText: String, baseWords: [String]) -> [Range<Int>?] {
+        guard !baseWords.isEmpty else { return [] }
+        guard baseWords.allSatisfy({ !$0.isEmpty }) else {
+            return Array(repeating: nil, count: baseWords.count)
+        }
+
+        var alignments: [[Range<String.Index>]] = []
+
+        func search(
+            wordIndex: Int,
+            cursor: String.Index,
+            ranges: [Range<String.Index>]
+        ) {
+            guard alignments.count < 2 else { return }
+            guard wordIndex < baseWords.count else {
+                guard isDelimiterOnly(baseText[cursor..<baseText.endIndex]) else { return }
+                alignments.append(ranges)
+                return
+            }
+
+            let word = baseWords[wordIndex]
+            var searchStart = cursor
+            while searchStart < baseText.endIndex,
+                let match = baseText.range(
+                    of: word,
+                    options: .literal,
+                    range: searchStart..<baseText.endIndex
+                )
+            {
+                if isDelimiterOnly(baseText[cursor..<match.lowerBound]) {
+                    search(
+                        wordIndex: wordIndex + 1,
+                        cursor: match.upperBound,
+                        ranges: ranges + [match]
+                    )
+                }
+                guard alignments.count < 2, match.lowerBound < baseText.endIndex else { return }
+                searchStart = baseText.index(after: match.lowerBound)
+            }
+        }
+
+        search(wordIndex: 0, cursor: baseText.startIndex, ranges: [])
+        guard alignments.count == 1, let alignment = alignments.first else {
+            return Array(repeating: nil, count: baseWords.count)
+        }
+
+        return alignment.map { lexicalUTF8Range(for: $0, in: baseText) }
+    }
+
+    /// Build one candidate span from aligned source words and validate it against the evaluated phrase.
+    static func candidateBaseTextUTF8Range(
+        wordRange: Range<Int>,
+        alignedWordRanges: [Range<Int>?],
+        baseText: String,
+        basePhrase: String
+    ) -> Range<Int>? {
+        guard !wordRange.isEmpty,
+            wordRange.lowerBound >= 0,
+            wordRange.upperBound <= alignedWordRanges.count,
+            let first = alignedWordRanges[wordRange.lowerBound],
+            let last = alignedWordRanges[wordRange.upperBound - 1]
+        else {
+            return nil
+        }
+
+        for index in wordRange where alignedWordRanges[index] == nil {
+            return nil
+        }
+
+        let candidateRange = first.lowerBound..<last.upperBound
+        guard let candidateText = substring(in: baseText, utf8Range: candidateRange),
+            normalizeForSimilarity(String(candidateText)) == normalizeForSimilarity(basePhrase)
+        else {
+            return nil
+        }
+        return candidateRange
+    }
+
+    /// Return a substring only when both UTF-8 offsets are valid `String` boundaries.
+    static func substring(in text: String, utf8Range: Range<Int>) -> Substring? {
+        guard utf8Range.lowerBound >= 0,
+            utf8Range.upperBound >= utf8Range.lowerBound,
+            utf8Range.upperBound <= text.utf8.count,
+            let lowerUTF8 = text.utf8.index(
+                text.utf8.startIndex,
+                offsetBy: utf8Range.lowerBound,
+                limitedBy: text.utf8.endIndex
+            ),
+            let upperUTF8 = text.utf8.index(
+                text.utf8.startIndex,
+                offsetBy: utf8Range.upperBound,
+                limitedBy: text.utf8.endIndex
+            ),
+            let lower = String.Index(lowerUTF8, within: text),
+            let upper = String.Index(upperUTF8, within: text)
+        else {
+            return nil
+        }
+        return text[lower..<upper]
+    }
+
+    private static func lexicalUTF8Range(
+        for exactRange: Range<String.Index>,
+        in text: String
+    ) -> Range<Int>? {
+        var lower = exactRange.lowerBound
+        var upper = exactRange.upperBound
+
+        while lower < upper, leadingQuotationWrappers.contains(text[lower]) {
+            lower = text.index(after: lower)
+        }
+        while lower < upper {
+            let previous = text.index(before: upper)
+            let character = text[previous]
+            guard
+                trailingQuotationWrappers.contains(character)
+                    || trailingSentencePunctuation.contains(character)
+            else { break }
+            upper = previous
+        }
+        guard lower < upper,
+            isSafeLexicalBoundary(text[lower]),
+            isSafeLexicalBoundary(text[text.index(before: upper)]),
+            let lowerUTF8 = lower.samePosition(in: text.utf8),
+            let upperUTF8 = upper.samePosition(in: text.utf8)
+        else {
+            return nil
+        }
+
+        let lowerOffset = text.utf8.distance(from: text.utf8.startIndex, to: lowerUTF8)
+        let upperOffset = text.utf8.distance(from: text.utf8.startIndex, to: upperUTF8)
+        return lowerOffset..<upperOffset
+    }
+
+    private static func isDelimiterOnly(_ text: Substring) -> Bool {
+        text.allSatisfy(isInterWordDelimiter)
+    }
+
+    private static func isInterWordDelimiter(_ character: Character) -> Bool {
+        !character.isLetter && !character.isNumber
+    }
+
+    private static func isSafeLexicalBoundary(_ character: Character) -> Bool {
+        if character.isLetter || character.isNumber || technicalPunctuation.contains(character) {
+            return true
+        }
+
+        var containsTechnicalSymbol = false
+        for scalar in character.unicodeScalars {
+            switch scalar.properties.generalCategory {
+            case .mathSymbol, .currencySymbol:
+                containsTechnicalSymbol = true
+            case .nonspacingMark, .spacingMark, .enclosingMark:
+                continue
+            default:
+                return false
+            }
+        }
+        return containsTechnicalSymbol
+    }
+
+    private static let leadingQuotationWrappers: Set<Character> = [
+        "\"", "“", "«", "‹", "「", "『",
+    ]
+
+    private static let trailingQuotationWrappers: Set<Character> = [
+        "\"", "”", "»", "›", "」", "』",
+    ]
+
+    private static let trailingSentencePunctuation: Set<Character> = [
+        ".", ",", ";", "…", "。", "、", "；",
+    ]
+
+    /// Punctuation that Unicode does not classify as a symbol but that commonly belongs to a
+    /// technical token. Unicode math and currency categories cover operators and currency signs
+    /// such as `+`, `=`, and `$` without admitting unrelated symbols such as emoji or trademarks.
+    private static let technicalPunctuation: Set<Character> = [
+        "#", ".", "@", "%", "&", "*", "/", "\\", "_", "-", "`", "'", "’", "^",
+    ]
+
     /// Build set of normalized vocabulary terms for guard checks
     func buildVocabularyNormalizedSet() -> Set<String> {
         var normalizedSet = Set<String>()

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+Utilities.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+Utilities.swift
@@ -36,38 +36,48 @@ extension VocabularyRescorer {
     struct NormalizedForm: Hashable {
         let normalized: String
         let wordCount: Int
+        let matchedAlias: String?
+    }
+
+    /// Build normalized canonical and alias forms while retaining the exact alias source.
+    static func normalizedForms(canonicalTerm: String, aliases: [String]) -> [NormalizedForm] {
+        let rawForms: [(text: String, matchedAlias: String?)] =
+            [(canonicalTerm, nil)] + aliases.map { ($0, $0) }
+        var seen = Set<String>()
+        var forms: [NormalizedForm] = []
+
+        for rawForm in rawForms {
+            let normalized = normalizeForSimilarity(rawForm.text)
+            guard !normalized.isEmpty, seen.insert(normalized).inserted else { continue }
+
+            forms.append(
+                NormalizedForm(
+                    normalized: normalized,
+                    wordCount: normalized.split(separator: " ").count,
+                    matchedAlias: rawForm.matchedAlias
+                ))
+        }
+
+        return forms
     }
 
     /// Build all normalized forms (canonical + aliases) for a vocabulary term
     func buildNormalizedForms(for term: CustomVocabularyTerm) -> [NormalizedForm] {
-        var rawForms: [String] = [term.text]
+        var aliases: [String] = []
         let termLower = term.textLowercased
 
         // Look up canonical term in vocabulary to get ALL aliases
         for vocabTerm in vocabulary.terms where vocabTerm.textLowercased == termLower {
-            if let aliases = vocabTerm.aliases {
-                rawForms.append(contentsOf: aliases)
+            if let vocabularyAliases = vocabTerm.aliases {
+                aliases.append(contentsOf: vocabularyAliases)
             }
         }
         // Also add aliases from the term itself
-        if let aliases = term.aliases {
-            rawForms.append(contentsOf: aliases)
+        if let termAliases = term.aliases {
+            aliases.append(contentsOf: termAliases)
         }
 
-        var seen = Set<String>()
-        var forms: [NormalizedForm] = []
-
-        for raw in rawForms {
-            let normalized = Self.normalizeForSimilarity(raw)
-            guard !normalized.isEmpty else { continue }
-            guard !seen.contains(normalized) else { continue }
-            seen.insert(normalized)
-
-            let wordCount = normalized.split(separator: " ").count
-            forms.append(NormalizedForm(normalized: normalized, wordCount: wordCount))
-        }
-
-        return forms
+        return Self.normalizedForms(canonicalTerm: term.text, aliases: aliases)
     }
 
     // MARK: - Similarity Thresholds

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer.swift
@@ -213,17 +213,44 @@ public struct VocabularyRescorer: Sendable {
         public let wasModified: Bool
     }
 
-    /// The replacement decision made by the legacy CTC token rescorer.
-    public enum LegacyDecision: String, Sendable, Equatable {
-        /// The candidate passed the legacy CTC comparison.
-        case accepted
+    /// The discovery path that produced a vocabulary candidate.
+    public enum CandidateOrigin: String, Sendable, Equatable {
+        /// Candidate discovered while searching vocabulary terms around one TDT word.
+        case wordCentric
 
-        /// The candidate failed or could not complete the legacy CTC comparison.
-        case rejected
+        /// Candidate discovered from a single-word term-centric match.
+        case termCentricSingleWord
+
+        /// Candidate discovered from a multi-word term-centric match.
+        case termCentricMultiWord
+
+        /// Candidate discovered from the CTC keyword-spotter rescue pass.
+        case spotterRescue
+    }
+
+    /// The final action taken by the legacy CTC token rescorer for a candidate.
+    public enum LegacyApplicationOutcome: String, Sendable, Equatable {
+        /// The candidate passed comparison and was applied to the legacy transcript.
+        case applied
+
+        /// The legacy floating-point comparison ran and rejected the candidate.
+        case rejectedByComparison
+
+        /// The legacy comparison could not be completed because required evidence was unavailable.
+        case unavailableEvidence
+
+        /// The candidate passed comparison but an overlapping candidate won final arbitration.
+        case supersededByOverlap
     }
 
     /// Diagnostic evidence for one candidate evaluated by the legacy CTC token rescorer.
     public struct CandidateEvidence: Sendable, Equatable {
+        /// Non-negative correlation identifier unique only within one evidence output.
+        public let candidateID: Int
+
+        /// Discovery path that produced this candidate evaluation.
+        public let origin: CandidateOrigin
+
         /// The untouched phrase from the base transcript that was evaluated.
         public let basePhrase: String
 
@@ -245,11 +272,14 @@ public struct VocabularyRescorer: Sendable {
         /// Context-biasing boost added to the vocabulary score, when available.
         public let effectiveBoost: Float?
 
-        /// Half-open word-index range in the base transcript.
+        /// Half-open word-index range into ``CandidateEvidenceOutput/baseWords``.
         public let wordRange: Range<Int>
 
         /// Half-open token-index range in the supplied token timings, when available and contiguous.
         public let tokenRange: Range<Int>?
+
+        /// Half-open UTF-8 byte range into ``CandidateEvidenceOutput/baseText``, when exact alignment is available.
+        public let baseTextUTF8Range: Range<Int>?
 
         /// Start time of the evaluated base phrase, when available.
         public let startTime: TimeInterval?
@@ -257,14 +287,19 @@ public struct VocabularyRescorer: Sendable {
         /// End time of the evaluated base phrase, when available.
         public let endTime: TimeInterval?
 
-        /// Decision made by the existing replacement behavior.
-        public let legacyDecision: LegacyDecision
+        /// Whether the boosted vocabulary score passed the pre-arbitration acoustic comparison.
+        public let comparisonPassed: Bool
+
+        /// Final action taken by the legacy rescorer after overlap arbitration.
+        public let legacyOutcome: LegacyApplicationOutcome
 
         /// Human-readable reason emitted by the existing replacement behavior.
         public let reason: String
 
         /// Creates diagnostic evidence for one evaluated vocabulary candidate.
         public init(
+            candidateID: Int,
+            origin: CandidateOrigin,
             basePhrase: String,
             canonicalTerm: String,
             matchedAlias: String?,
@@ -274,11 +309,15 @@ public struct VocabularyRescorer: Sendable {
             effectiveBoost: Float?,
             wordRange: Range<Int>,
             tokenRange: Range<Int>?,
+            baseTextUTF8Range: Range<Int>?,
             startTime: TimeInterval?,
             endTime: TimeInterval?,
-            legacyDecision: LegacyDecision,
+            comparisonPassed: Bool,
+            legacyOutcome: LegacyApplicationOutcome,
             reason: String
         ) {
+            self.candidateID = candidateID
+            self.origin = origin
             self.basePhrase = basePhrase
             self.canonicalTerm = canonicalTerm
             self.matchedAlias = matchedAlias
@@ -288,10 +327,35 @@ public struct VocabularyRescorer: Sendable {
             self.effectiveBoost = effectiveBoost
             self.wordRange = wordRange
             self.tokenRange = tokenRange
+            self.baseTextUTF8Range = baseTextUTF8Range
             self.startTime = startTime
             self.endTime = endTime
-            self.legacyDecision = legacyDecision
+            self.comparisonPassed = comparisonPassed
+            self.legacyOutcome = legacyOutcome
             self.reason = reason
+        }
+
+        /// Returns the same evidence with its final legacy arbitration outcome replaced.
+        func replacingLegacyOutcome(_ outcome: LegacyApplicationOutcome) -> CandidateEvidence {
+            CandidateEvidence(
+                candidateID: candidateID,
+                origin: origin,
+                basePhrase: basePhrase,
+                canonicalTerm: canonicalTerm,
+                matchedAlias: matchedAlias,
+                similarity: similarity,
+                rawVocabularyCTCScore: rawVocabularyCTCScore,
+                rawOriginalCTCScore: rawOriginalCTCScore,
+                effectiveBoost: effectiveBoost,
+                wordRange: wordRange,
+                tokenRange: tokenRange,
+                baseTextUTF8Range: baseTextUTF8Range,
+                startTime: startTime,
+                endTime: endTime,
+                comparisonPassed: comparisonPassed,
+                legacyOutcome: outcome,
+                reason: reason
+            )
         }
     }
 
@@ -300,12 +364,16 @@ public struct VocabularyRescorer: Sendable {
         /// The untouched transcript supplied to the rescorer.
         public let baseText: String
 
+        /// Exact internal word sequence that every candidate ``CandidateEvidence/wordRange`` indexes.
+        public let baseWords: [String]
+
         /// Every candidate that reached the legacy CTC evaluation, including rejections.
         public let candidates: [CandidateEvidence]
 
         /// Creates diagnostic output for an untouched base transcript.
-        public init(baseText: String, candidates: [CandidateEvidence]) {
+        public init(baseText: String, baseWords: [String], candidates: [CandidateEvidence]) {
             self.baseText = baseText
+            self.baseWords = baseWords
             self.candidates = candidates
         }
     }

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer.swift
@@ -213,6 +213,103 @@ public struct VocabularyRescorer: Sendable {
         public let wasModified: Bool
     }
 
+    /// The replacement decision made by the legacy CTC token rescorer.
+    public enum LegacyDecision: String, Sendable, Equatable {
+        /// The candidate passed the legacy CTC comparison.
+        case accepted
+
+        /// The candidate failed or could not complete the legacy CTC comparison.
+        case rejected
+    }
+
+    /// Diagnostic evidence for one candidate evaluated by the legacy CTC token rescorer.
+    public struct CandidateEvidence: Sendable, Equatable {
+        /// The untouched phrase from the base transcript that was evaluated.
+        public let basePhrase: String
+
+        /// The canonical vocabulary term proposed as a replacement.
+        public let canonicalTerm: String
+
+        /// The exact alias that produced the best string match, or `nil` when the canonical term matched.
+        public let matchedAlias: String?
+
+        /// String similarity used to rank and gate the candidate.
+        public let similarity: Float
+
+        /// Raw CTC score for the vocabulary term, before context biasing, when available.
+        public let rawVocabularyCTCScore: Float?
+
+        /// Raw CTC score for the original phrase, when available.
+        public let rawOriginalCTCScore: Float?
+
+        /// Context-biasing boost added to the vocabulary score, when available.
+        public let effectiveBoost: Float?
+
+        /// Half-open word-index range in the base transcript.
+        public let wordRange: Range<Int>
+
+        /// Half-open token-index range in the supplied token timings, when available and contiguous.
+        public let tokenRange: Range<Int>?
+
+        /// Start time of the evaluated base phrase, when available.
+        public let startTime: TimeInterval?
+
+        /// End time of the evaluated base phrase, when available.
+        public let endTime: TimeInterval?
+
+        /// Decision made by the existing replacement behavior.
+        public let legacyDecision: LegacyDecision
+
+        /// Human-readable reason emitted by the existing replacement behavior.
+        public let reason: String
+
+        /// Creates diagnostic evidence for one evaluated vocabulary candidate.
+        public init(
+            basePhrase: String,
+            canonicalTerm: String,
+            matchedAlias: String?,
+            similarity: Float,
+            rawVocabularyCTCScore: Float?,
+            rawOriginalCTCScore: Float?,
+            effectiveBoost: Float?,
+            wordRange: Range<Int>,
+            tokenRange: Range<Int>?,
+            startTime: TimeInterval?,
+            endTime: TimeInterval?,
+            legacyDecision: LegacyDecision,
+            reason: String
+        ) {
+            self.basePhrase = basePhrase
+            self.canonicalTerm = canonicalTerm
+            self.matchedAlias = matchedAlias
+            self.similarity = similarity
+            self.rawVocabularyCTCScore = rawVocabularyCTCScore
+            self.rawOriginalCTCScore = rawOriginalCTCScore
+            self.effectiveBoost = effectiveBoost
+            self.wordRange = wordRange
+            self.tokenRange = tokenRange
+            self.startTime = startTime
+            self.endTime = endTime
+            self.legacyDecision = legacyDecision
+            self.reason = reason
+        }
+    }
+
+    /// Non-mutating diagnostic output from candidate evaluation.
+    public struct CandidateEvidenceOutput: Sendable, Equatable {
+        /// The untouched transcript supplied to the rescorer.
+        public let baseText: String
+
+        /// Every candidate that reached the legacy CTC evaluation, including rejections.
+        public let candidates: [CandidateEvidence]
+
+        /// Creates diagnostic output for an untouched base transcript.
+        public init(baseText: String, candidates: [CandidateEvidence]) {
+            self.baseText = baseText
+            self.candidates = candidates
+        }
+    }
+
     // MARK: - Word Timing Utilities
 
     /// Word timing information built from TDT token timings
@@ -220,17 +317,21 @@ public struct VocabularyRescorer: Sendable {
         public let word: String
         public let startTime: Double
         public let endTime: Double
+        let tokenRange: Range<Int>?
     }
 
     /// Build word-level timings from token timings.
     /// Tokens starting with space " " or "▁" (SentencePiece) begin new words.
-    func buildWordTimings(from tokenTimings: [TokenTiming]) -> [WordTiming] {
+    static func buildWordTimings(from tokenTimings: [TokenTiming]) -> [WordTiming] {
         var wordTimings: [WordTiming] = []
         var currentWord = ""
         var wordStart: Double = 0
         var wordEnd: Double = 0
+        var wordTokenStart = 0
+        var wordTokenEnd = 0
+        var wordTokensAreContiguous = true
 
-        for timing in tokenTimings {
+        for (tokenIndex, timing) in tokenTimings.enumerated() {
             let token = timing.token
 
             // Skip special tokens
@@ -249,7 +350,8 @@ public struct VocabularyRescorer: Sendable {
                         WordTiming(
                             word: trimmedWord,
                             startTime: wordStart,
-                            endTime: wordEnd
+                            endTime: wordEnd,
+                            tokenRange: wordTokensAreContiguous ? wordTokenStart..<wordTokenEnd : nil
                         ))
                 }
                 currentWord = ""
@@ -258,10 +360,16 @@ public struct VocabularyRescorer: Sendable {
             if startsNewWord {
                 currentWord = stripWordBoundaryPrefix(token)
                 wordStart = timing.startTime
+                wordTokenStart = tokenIndex
+                wordTokensAreContiguous = true
             } else {
+                if tokenIndex != wordTokenEnd {
+                    wordTokensAreContiguous = false
+                }
                 currentWord += token
             }
             wordEnd = timing.endTime
+            wordTokenEnd = tokenIndex + 1
         }
 
         // Save final word
@@ -271,7 +379,8 @@ public struct VocabularyRescorer: Sendable {
                 WordTiming(
                     word: trimmedWord,
                     startTime: wordStart,
-                    endTime: wordEnd
+                    endTime: wordEnd,
+                    tokenRange: wordTokensAreContiguous ? wordTokenStart..<wordTokenEnd : nil
                 ))
         }
 

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyCandidateArbitrationEvidenceTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyCandidateArbitrationEvidenceTests.swift
@@ -1,0 +1,409 @@
+import XCTest
+
+@testable import FluidAudio
+
+final class VocabularyCandidateArbitrationEvidenceTests: XCTestCase {
+    func testEveryDiscoveryPathRetainsASeparateOutputLocalIdentity() {
+        let baseText = "rom vimza"
+        let baseWords = ["rom", "vimza"]
+        var collector: VocabularyRescorer.CandidateEvidenceCollector? = .init(
+            baseText: baseText,
+            baseWords: baseWords,
+            alignedWordRanges: VocabularyRescorer.alignBaseWordsToUTF8Ranges(
+                baseText: baseText,
+                baseWords: baseWords
+            ),
+            candidates: []
+        )
+        let origins: [VocabularyRescorer.CandidateOrigin] = [
+            .wordCentric,
+            .termCentricSingleWord,
+            .termCentricMultiWord,
+            .spotterRescue,
+        ]
+
+        for origin in origins {
+            _ = VocabularyRescorer.recordCandidateEvidence(
+                candidate: candidate(
+                    origin: origin,
+                    phrase: "rom vimza",
+                    term: "Romvimza",
+                    indices: [0, 1]
+                ),
+                result: passingResult(replacement: "Romvimza"),
+                candidateEvidence: &collector
+            )
+        }
+
+        let evidence = collector?.candidates ?? []
+        XCTAssertEqual(evidence.map(\.candidateID), [0, 1, 2, 3])
+        XCTAssertEqual(evidence.map(\.origin), origins)
+        XCTAssertEqual(Set(evidence.map(\.candidateID)).count, evidence.count)
+        XCTAssertTrue(evidence.allSatisfy(\.comparisonPassed))
+        XCTAssertTrue(evidence.allSatisfy { $0.wordRange == 0..<2 })
+        XCTAssertTrue(evidence.allSatisfy { $0.baseTextUTF8Range == 0..<baseText.utf8.count })
+    }
+
+    func testRejectedNumericReasonsUseLessThanOrEqualAndAcceptedReasonsUseGreaterThan() {
+        let accepted = VocabularyRescorer.ctcComparisonReason(
+            prefix: "CTC-vs-CTC",
+            vocabularyTerm: "ESLint",
+            boostedVocabularyScore: -2,
+            originalPhrase: "testing",
+            originalScore: -4,
+            comparisonPassed: true
+        )
+        let rejected = VocabularyRescorer.ctcComparisonReason(
+            prefix: "CTC-vs-CTC",
+            vocabularyTerm: "Azure",
+            boostedVocabularyScore: -8,
+            originalPhrase: "as your",
+            originalScore: -3,
+            comparisonPassed: false
+        )
+
+        XCTAssertTrue(accepted.contains("'ESLint'=-2.00 > 'testing'=-4.00"))
+        XCTAssertTrue(rejected.contains("'Azure'=-8.00 <= 'as your'=-3.00"))
+        XCTAssertFalse(rejected.contains("-8.00 >"))
+    }
+
+    func testUnavailableComparisonDoesNotInventScoresOrANumericReason() {
+        let evidence = makeEvidence(
+            id: 0,
+            origin: .spotterRescue,
+            phrase: "ordinary",
+            term: "Azure",
+            indices: [0],
+            result: VocabularyRescorer.CTCMatchResult(
+                shouldReplace: false,
+                comparisonWasPerformed: false,
+                originalScore: -.infinity,
+                boostedVocabScore: -.infinity,
+                rawVocabularyCTCScore: nil,
+                rawOriginalCTCScore: nil,
+                effectiveBoost: nil,
+                replacement: "Azure",
+                reason: "No tokenizer available"
+            )
+        )
+
+        XCTAssertFalse(evidence.comparisonPassed)
+        XCTAssertEqual(evidence.legacyOutcome, .unavailableEvidence)
+        XCTAssertNil(evidence.rawVocabularyCTCScore)
+        XCTAssertNil(evidence.rawOriginalCTCScore)
+        XCTAssertNil(evidence.effectiveBoost)
+        XCTAssertEqual(evidence.reason, "No tokenizer available")
+        XCTAssertFalse(evidence.reason.contains(" > "))
+        XCTAssertFalse(evidence.reason.contains(" <= "))
+
+        let nonFiniteNumericReason = makeEvidence(
+            id: 1,
+            origin: .wordCentric,
+            phrase: "ordinary",
+            term: "Azure",
+            indices: [0],
+            result: VocabularyRescorer.CTCMatchResult(
+                shouldReplace: false,
+                comparisonWasPerformed: true,
+                originalScore: -.infinity,
+                boostedVocabScore: -7,
+                rawVocabularyCTCScore: -8,
+                rawOriginalCTCScore: nil,
+                effectiveBoost: 1,
+                replacement: "Azure",
+                reason: "CTC-vs-CTC: 'Azure'=-7.00 > 'ordinary'=-inf"
+            )
+        )
+        XCTAssertFalse(nonFiniteNumericReason.comparisonPassed)
+        XCTAssertEqual(nonFiniteNumericReason.legacyOutcome, .rejectedByComparison)
+        XCTAssertEqual(
+            nonFiniteNumericReason.reason,
+            "CTC comparison rejected: one or more finite diagnostic scores were unavailable"
+        )
+    }
+
+    func testPerformedComparisonRetainsLegacyPassWhenRawOriginalScoreIsNonFinite() {
+        let evidence = makeEvidence(
+            id: 0,
+            origin: .wordCentric,
+            phrase: "testing",
+            term: "ESLint",
+            indices: [0],
+            result: VocabularyRescorer.CTCMatchResult(
+                shouldReplace: true,
+                comparisonWasPerformed: true,
+                originalScore: -.infinity,
+                boostedVocabScore: -7,
+                rawVocabularyCTCScore: -8,
+                rawOriginalCTCScore: nil,
+                effectiveBoost: 1,
+                replacement: "ESLint",
+                reason: "CTC-vs-CTC: 'ESLint'=-7.00 > 'testing'=-inf"
+            )
+        )
+
+        XCTAssertTrue(evidence.comparisonPassed)
+        XCTAssertEqual(evidence.legacyOutcome, .applied)
+        XCTAssertEqual(evidence.rawVocabularyCTCScore, -8)
+        XCTAssertNil(evidence.rawOriginalCTCScore)
+        XCTAssertEqual(evidence.effectiveBoost, 1)
+        XCTAssertEqual(
+            evidence.reason,
+            "CTC comparison passed: one or more finite diagnostic scores were unavailable"
+        )
+        XCTAssertFalse(evidence.reason.lowercased().contains("inf"))
+    }
+
+    func testLegacyPathLeavesEvidenceCollectorUnallocated() {
+        var collector: VocabularyRescorer.CandidateEvidenceCollector?
+        let candidateID = VocabularyRescorer.recordCandidateEvidence(
+            candidate: candidate(
+                origin: .wordCentric,
+                phrase: "testing",
+                term: "ESLint",
+                indices: [0]
+            ),
+            result: passingResult(replacement: "ESLint"),
+            candidateEvidence: &collector
+        )
+
+        XCTAssertNil(candidateID)
+        XCTAssertNil(collector)
+    }
+
+    func testRomvimzaCimziaOverlapHasOneAppliedAndOneSupersededOutcome() {
+        let romvimza = pending(
+            id: 0,
+            origin: .termCentricSingleWord,
+            phrase: "rom vimza",
+            term: "Romvimza",
+            indices: [0, 1],
+            similarity: 0.89
+        )
+        let cimzia = pending(
+            id: 1,
+            origin: .termCentricSingleWord,
+            phrase: "vimza",
+            term: "Cimzia",
+            indices: [1],
+            similarity: 0.67
+        )
+
+        let arbitration = VocabularyRescorer.arbitratePendingReplacements([cimzia, romvimza])
+        XCTAssertEqual(arbitration.applied.compactMap(\.candidateID), [0])
+        XCTAssertEqual(arbitration.applied.map { $0.result.replacement }, ["Romvimza"])
+        XCTAssertEqual(arbitration.supersededCandidateIDs, [1])
+
+        var evidence = [
+            makeEvidence(
+                id: 0,
+                origin: .termCentricSingleWord,
+                phrase: "rom vimza",
+                term: "Romvimza",
+                indices: [0, 1],
+                result: passingResult(replacement: "Romvimza")
+            ),
+            makeEvidence(
+                id: 1,
+                origin: .termCentricSingleWord,
+                phrase: "vimza",
+                term: "Cimzia",
+                indices: [1],
+                result: passingResult(replacement: "Cimzia")
+            ),
+        ]
+        VocabularyRescorer.reconcileLegacyOutcomes(
+            candidates: &evidence,
+            appliedCandidateIDs: Set(arbitration.applied.compactMap(\.candidateID))
+        )
+
+        XCTAssertEqual(evidence.map(\.comparisonPassed), [true, true])
+        XCTAssertEqual(evidence.map(\.legacyOutcome), [.applied, .supersededByOverlap])
+    }
+
+    func testNonOverlappingPassesApplyWhileFailuresKeepTheirTerminalOutcomes() {
+        let first = pending(
+            id: 0,
+            origin: .wordCentric,
+            phrase: "testing",
+            term: "ESLint",
+            indices: [0],
+            similarity: 0.9
+        )
+        let second = pending(
+            id: 1,
+            origin: .spotterRescue,
+            phrase: "jay son",
+            term: "JSON",
+            indices: [2, 3],
+            similarity: 0.7
+        )
+        let arbitration = VocabularyRescorer.arbitratePendingReplacements([second, first])
+        XCTAssertEqual(Set(arbitration.applied.compactMap(\.candidateID)), [0, 1])
+        XCTAssertTrue(arbitration.supersededCandidateIDs.isEmpty)
+
+        var evidence = [
+            makeEvidence(
+                id: 0,
+                origin: .wordCentric,
+                phrase: "testing",
+                term: "ESLint",
+                indices: [0],
+                result: passingResult(replacement: "ESLint")
+            ),
+            makeEvidence(
+                id: 1,
+                origin: .spotterRescue,
+                phrase: "jay son",
+                term: "JSON",
+                indices: [2, 3],
+                result: passingResult(replacement: "JSON")
+            ),
+            makeEvidence(
+                id: 2,
+                origin: .termCentricSingleWord,
+                phrase: "track",
+                term: "Slack",
+                indices: [4],
+                result: rejectedResult(replacement: "Slack")
+            ),
+            makeEvidence(
+                id: 3,
+                origin: .termCentricMultiWord,
+                phrase: "as your",
+                term: "Azure",
+                indices: [5, 6],
+                result: unavailableResult(replacement: "Azure")
+            ),
+        ]
+        VocabularyRescorer.reconcileLegacyOutcomes(
+            candidates: &evidence,
+            appliedCandidateIDs: Set(arbitration.applied.compactMap(\.candidateID))
+        )
+
+        XCTAssertEqual(
+            evidence.map(\.legacyOutcome),
+            [.applied, .applied, .rejectedByComparison, .unavailableEvidence]
+        )
+    }
+
+    func testEvidenceOutputKeepsUntouchedBaseText() {
+        let baseText = "Please keep testing, not ESLint."
+        let output = VocabularyRescorer.CandidateEvidenceOutput(
+            baseText: baseText,
+            baseWords: ["Please", "keep", "testing,", "not", "ESLint."],
+            candidates: []
+        )
+
+        XCTAssertEqual(Array(output.baseText.utf8), Array(baseText.utf8))
+        XCTAssertFalse(output.baseText.isEmpty)
+    }
+
+    private func pending(
+        id: Int,
+        origin: VocabularyRescorer.CandidateOrigin,
+        phrase: String,
+        term: String,
+        indices: [Int],
+        similarity: Float
+    ) -> VocabularyRescorer.PendingReplacement {
+        VocabularyRescorer.PendingReplacement(
+            candidateID: id,
+            candidate: candidate(
+                origin: origin,
+                phrase: phrase,
+                term: term,
+                indices: indices,
+                similarity: similarity
+            ),
+            result: passingResult(replacement: term),
+            similarity: similarity
+        )
+    }
+
+    private func makeEvidence(
+        id: Int,
+        origin: VocabularyRescorer.CandidateOrigin,
+        phrase: String,
+        term: String,
+        indices: [Int],
+        result: VocabularyRescorer.CTCMatchResult
+    ) -> VocabularyRescorer.CandidateEvidence {
+        VocabularyRescorer.makeCandidateEvidence(
+            candidateID: id,
+            candidate: candidate(
+                origin: origin,
+                phrase: phrase,
+                term: term,
+                indices: indices
+            ),
+            result: result,
+            wordRange: (indices.first ?? 0)..<((indices.last ?? -1) + 1),
+            baseTextUTF8Range: nil
+        )
+    }
+
+    private func candidate(
+        origin: VocabularyRescorer.CandidateOrigin,
+        phrase: String,
+        term: String,
+        indices: [Int],
+        similarity: Float = 0.8
+    ) -> VocabularyRescorer.CTCMatchCandidate {
+        VocabularyRescorer.CTCMatchCandidate(
+            origin: origin,
+            originalPhrase: phrase,
+            vocabTerm: term,
+            matchedAlias: nil,
+            vocabTokens: [1, 2],
+            similarity: similarity,
+            spanLength: indices.count,
+            spanIndices: indices,
+            tokenRange: nil,
+            spanStartTime: 0,
+            spanEndTime: 1
+        )
+    }
+
+    private func passingResult(replacement: String) -> VocabularyRescorer.CTCMatchResult {
+        VocabularyRescorer.CTCMatchResult(
+            shouldReplace: true,
+            comparisonWasPerformed: true,
+            originalScore: -5,
+            boostedVocabScore: -1,
+            rawVocabularyCTCScore: -2,
+            rawOriginalCTCScore: -5,
+            effectiveBoost: 1,
+            replacement: replacement,
+            reason: "vocabulary > original"
+        )
+    }
+
+    private func rejectedResult(replacement: String) -> VocabularyRescorer.CTCMatchResult {
+        VocabularyRescorer.CTCMatchResult(
+            shouldReplace: false,
+            comparisonWasPerformed: true,
+            originalScore: -3,
+            boostedVocabScore: -7,
+            rawVocabularyCTCScore: -8,
+            rawOriginalCTCScore: -3,
+            effectiveBoost: 1,
+            replacement: replacement,
+            reason: "vocabulary <= original"
+        )
+    }
+
+    private func unavailableResult(replacement: String) -> VocabularyRescorer.CTCMatchResult {
+        VocabularyRescorer.CTCMatchResult(
+            shouldReplace: false,
+            comparisonWasPerformed: false,
+            originalScore: -.infinity,
+            boostedVocabScore: -.infinity,
+            rawVocabularyCTCScore: nil,
+            rawOriginalCTCScore: nil,
+            effectiveBoost: nil,
+            replacement: replacement,
+            reason: "No tokenizer available"
+        )
+    }
+}

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyCandidateEvidenceTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyCandidateEvidenceTests.swift
@@ -3,31 +3,35 @@ import XCTest
 @testable import FluidAudio
 
 final class VocabularyCandidateEvidenceTests: XCTestCase {
-    func testCandidateEvidenceOutputPreservesBaseAndAcceptedRejectedCandidates() {
+    func testCandidateEvidenceOutputExposesExactBaseWordsAndTwoStageOutcomes() {
         let accepted = makeEvidence(
+            candidateID: 0,
+            origin: .termCentricSingleWord,
             basePhrase: "testing",
             canonicalTerm: "ESLint",
             matchedAlias: "E S lint",
             rawVocabularyScore: -2.5,
             rawOriginalScore: -5.0,
             effectiveBoost: 1.25,
-            legacyShouldReplace: true,
-            wordRange: 1..<2,
+            wordRange: 2..<3,
             tokenRange: 3..<5,
+            baseTextUTF8Range: 12..<19,
             startTime: 0.4,
             endTime: 0.8,
             reason: "accepted"
         )
         let rejected = makeEvidence(
+            candidateID: 1,
+            origin: .spotterRescue,
             basePhrase: "document",
             canonicalTerm: "DOCX",
             matchedAlias: nil,
             rawVocabularyScore: -8.0,
             rawOriginalScore: -3.0,
             effectiveBoost: 1.0,
-            legacyShouldReplace: false,
-            wordRange: 3..<4,
-            tokenRange: 7..<8,
+            wordRange: 4..<5,
+            tokenRange: nil,
+            baseTextUTF8Range: nil,
             startTime: 1.2,
             endTime: 1.6,
             reason: "rejected"
@@ -35,78 +39,122 @@ final class VocabularyCandidateEvidenceTests: XCTestCase {
 
         let output = VocabularyRescorer.CandidateEvidenceOutput(
             baseText: "Please keep testing this document",
+            baseWords: ["Please", "keep", "testing", "this", "document"],
             candidates: [accepted, rejected]
         )
 
         XCTAssertEqual(output.baseText, "Please keep testing this document")
-        XCTAssertEqual(output.candidates.count, 2)
-        XCTAssertEqual(output.candidates.map(\.legacyDecision), [.accepted, .rejected])
+        XCTAssertEqual(output.baseWords, ["Please", "keep", "testing", "this", "document"])
+        XCTAssertEqual(output.candidates.map(\.candidateID), [0, 1])
+        XCTAssertEqual(output.candidates.map(\.comparisonPassed), [true, false])
+        XCTAssertEqual(output.candidates.map(\.legacyOutcome), [.applied, .rejectedByComparison])
+        XCTAssertEqual(output.candidates.map(\.origin), [.termCentricSingleWord, .spotterRescue])
         XCTAssertEqual(output.candidates[0].matchedAlias, "E S lint")
-        XCTAssertNil(output.candidates[1].matchedAlias, "nil must mean the canonical form matched")
+        XCTAssertNil(output.candidates[1].matchedAlias, "nil means the canonical form matched")
     }
 
-    func testCandidateEvidenceMapsScoresAndHalfOpenSpansWithoutMutatingBaseText() {
-        let evidence = makeEvidence(
-            basePhrase: "test ing",
-            canonicalTerm: "Testing",
-            matchedAlias: "test-ing",
-            rawVocabularyScore: -3.25,
-            rawOriginalScore: -4.75,
-            effectiveBoost: 0.5,
-            legacyShouldReplace: true,
-            wordRange: 2..<4,
-            tokenRange: 5..<9,
-            startTime: 0.75,
-            endTime: 1.5,
-            reason: "legacy accepted"
+    func testCandidateIDsAreNonNegativeSequentialAndOutputLocal() {
+        var firstCollector: VocabularyRescorer.CandidateEvidenceCollector? = collector(
+            baseText: "testing document",
+            baseWords: ["testing", "document"]
+        )
+        let firstID = VocabularyRescorer.recordCandidateEvidence(
+            candidate: makeCandidate(
+                origin: .termCentricSingleWord,
+                basePhrase: "testing",
+                canonicalTerm: "ESLint",
+                spanIndices: [0],
+                tokenRange: 0..<1
+            ),
+            result: passingResult(replacement: "ESLint"),
+            candidateEvidence: &firstCollector
+        )
+        let secondID = VocabularyRescorer.recordCandidateEvidence(
+            candidate: makeCandidate(
+                origin: .spotterRescue,
+                basePhrase: "document",
+                canonicalTerm: "DOCX",
+                spanIndices: [1],
+                tokenRange: nil
+            ),
+            result: passingResult(replacement: "DOCX"),
+            candidateEvidence: &firstCollector
         )
 
-        XCTAssertEqual(evidence.basePhrase, "test ing")
-        XCTAssertEqual(evidence.canonicalTerm, "Testing")
-        XCTAssertEqual(evidence.matchedAlias, "test-ing")
-        XCTAssertEqual(evidence.similarity, 0.875, accuracy: 0.0001)
-        XCTAssertEqual(evidence.rawVocabularyCTCScore, -3.25)
-        XCTAssertEqual(evidence.rawOriginalCTCScore, -4.75)
-        XCTAssertEqual(evidence.effectiveBoost, 0.5)
-        XCTAssertEqual(evidence.wordRange, 2..<4, "wordRange is half-open")
-        XCTAssertEqual(evidence.tokenRange, 5..<9, "tokenRange is half-open")
-        XCTAssertEqual(evidence.startTime, 0.75)
-        XCTAssertEqual(evidence.endTime, 1.5)
-        XCTAssertEqual(evidence.legacyDecision, .accepted)
-        XCTAssertEqual(evidence.reason, "legacy accepted")
+        var secondCollector: VocabularyRescorer.CandidateEvidenceCollector? = collector(
+            baseText: "testing",
+            baseWords: ["testing"]
+        )
+        let restartedID = VocabularyRescorer.recordCandidateEvidence(
+            candidate: makeCandidate(
+                origin: .wordCentric,
+                basePhrase: "testing",
+                canonicalTerm: "ESLint",
+                spanIndices: [0],
+                tokenRange: 0..<1
+            ),
+            result: passingResult(replacement: "ESLint"),
+            candidateEvidence: &secondCollector
+        )
+
+        XCTAssertEqual([firstID, secondID], [0, 1])
+        XCTAssertEqual(firstCollector?.candidates.map(\.candidateID), [0, 1])
+        XCTAssertTrue(firstCollector?.candidates.allSatisfy { $0.candidateID >= 0 } == true)
+        XCTAssertEqual(restartedID, 0, "IDs restart for each CandidateEvidenceOutput")
     }
 
-    func testUnavailableScoresRemainNilInsteadOfUsingLegacySentinels() {
-        let candidate = VocabularyRescorer.CTCMatchCandidate(
-            originalPhrase: "ordinary",
-            vocabTerm: "Azure",
-            matchedAlias: nil,
-            vocabTokens: [10, 11],
-            similarity: 0.625,
-            spanLength: 1,
+    func testEmptySourceWordOutputIsExplicit() {
+        let output = VocabularyRescorer.CandidateEvidenceOutput(
+            baseText: "",
+            baseWords: [],
+            candidates: []
+        )
+
+        XCTAssertEqual(output.baseText, "")
+        XCTAssertTrue(output.baseWords.isEmpty)
+        XCTAssertTrue(output.candidates.isEmpty)
+    }
+
+    func testUnavailableScoresAndMissingAlignmentRemainNil() {
+        var evidenceCollector: VocabularyRescorer.CandidateEvidenceCollector? = .init(
+            baseText: "ordinary",
+            baseWords: ["ordinary"],
+            alignedWordRanges: [nil],
+            candidates: []
+        )
+        let candidate = makeCandidate(
+            origin: .spotterRescue,
+            basePhrase: "ordinary",
+            canonicalTerm: "Azure",
             spanIndices: [0],
-            tokenRange: nil,
-            spanStartTime: 0.0,
-            spanEndTime: 0.4
+            tokenRange: nil
         )
         let result = VocabularyRescorer.CTCMatchResult(
             shouldReplace: false,
+            comparisonWasPerformed: false,
             originalScore: -.infinity,
             boostedVocabScore: -.infinity,
             rawVocabularyCTCScore: nil,
             rawOriginalCTCScore: nil,
             effectiveBoost: nil,
             replacement: "Azure",
-            reason: "Tokenizer unavailable"
+            reason: "No tokenizer available"
         )
 
-        let evidence = VocabularyRescorer.makeCandidateEvidence(candidate: candidate, result: result)
+        _ = VocabularyRescorer.recordCandidateEvidence(
+            candidate: candidate,
+            result: result,
+            candidateEvidence: &evidenceCollector
+        )
+        let evidence = try! XCTUnwrap(evidenceCollector?.candidates.first)
 
         XCTAssertNil(evidence.rawVocabularyCTCScore)
         XCTAssertNil(evidence.rawOriginalCTCScore)
         XCTAssertNil(evidence.effectiveBoost)
         XCTAssertNil(evidence.tokenRange)
-        XCTAssertEqual(evidence.legacyDecision, .rejected)
+        XCTAssertNil(evidence.baseTextUTF8Range)
+        XCTAssertFalse(evidence.comparisonPassed)
+        XCTAssertEqual(evidence.legacyOutcome, .unavailableEvidence)
     }
 
     func testNormalizedFormsDistinguishCanonicalFromExactAlias() {
@@ -145,21 +193,183 @@ final class VocabularyCandidateEvidenceTests: XCTestCase {
         XCTAssertNil(timings[0].tokenRange)
     }
 
+    func testExactAlignmentHandlesPunctuationContractionsHyphensAndUnicode() throws {
+        let baseText = "“Hello,” don't re-enter Café ☕️."
+        let baseWords = ["“Hello,”", "don't", "re-enter", "Café"]
+        let ranges = VocabularyRescorer.alignBaseWordsToUTF8Ranges(
+            baseText: baseText,
+            baseWords: baseWords
+        )
+
+        XCTAssertEqual(try text(in: baseText, range: ranges[0]), "Hello")
+        XCTAssertEqual(try text(in: baseText, range: ranges[1]), "don't")
+        XCTAssertEqual(try text(in: baseText, range: ranges[2]), "re-enter")
+        XCTAssertEqual(try text(in: baseText, range: ranges[3]), "Café")
+
+        let phraseRange = VocabularyRescorer.candidateBaseTextUTF8Range(
+            wordRange: 1..<3,
+            alignedWordRanges: ranges,
+            baseText: baseText,
+            basePhrase: "don't re-enter"
+        )
+        XCTAssertEqual(try text(in: baseText, range: phraseRange), "don't re-enter")
+        XCTAssertEqual(baseText, "“Hello,” don't re-enter Café ☕️.")
+    }
+
+    func testExactAlignmentPreservesTechnicalBoundarySymbols() throws {
+        let baseText = "Use C++, C#, .NET, @MainActor, #if, and $PATH."
+        let baseWords = ["Use", "C++,", "C#,", ".NET,", "@MainActor,", "#if,", "and", "$PATH."]
+        let ranges = VocabularyRescorer.alignBaseWordsToUTF8Ranges(
+            baseText: baseText,
+            baseWords: baseWords
+        )
+
+        XCTAssertEqual(try text(in: baseText, range: ranges[1]), "C++")
+        XCTAssertEqual(try text(in: baseText, range: ranges[2]), "C#")
+        XCTAssertEqual(try text(in: baseText, range: ranges[3]), ".NET")
+        XCTAssertEqual(try text(in: baseText, range: ranges[4]), "@MainActor")
+        XCTAssertEqual(try text(in: baseText, range: ranges[5]), "#if")
+        XCTAssertEqual(try text(in: baseText, range: ranges[7]), "$PATH")
+        XCTAssertEqual(baseText, "Use C++, C#, .NET, @MainActor, #if, and $PATH.")
+    }
+
+    func testExactAlignmentFailsClosedForAmbiguousBoundarySyntax() {
+        let cases = ["String?", "func()", "[Azure]"]
+
+        for baseText in cases {
+            let ranges = VocabularyRescorer.alignBaseWordsToUTF8Ranges(
+                baseText: baseText,
+                baseWords: [baseText]
+            )
+
+            XCTAssertEqual(ranges.count, 1)
+            XCTAssertNil(ranges[0], "Ambiguous boundary syntax must not produce a mutation range: \(baseText)")
+        }
+    }
+
+    func testExactAlignmentFailsClosedForNonTechnicalSymbols() {
+        let cases = ["Azure™", "Azure☕️"]
+
+        for baseText in cases {
+            let ranges = VocabularyRescorer.alignBaseWordsToUTF8Ranges(
+                baseText: baseText,
+                baseWords: [baseText]
+            )
+
+            XCTAssertEqual(ranges.count, 1)
+            XCTAssertNil(ranges[0], "Non-technical symbols must not become part of a mutation range: \(baseText)")
+        }
+    }
+
+    func testBlankAndPadGapsDoNotFabricateTokenRangesOrBreakTextAlignment() throws {
+        let timings = VocabularyRescorer.buildWordTimings(from: [
+            makeTokenTiming(token: "▁hello", tokenID: 1, start: 0.0, end: 0.2),
+            makeTokenTiming(token: "<blank>", tokenID: 0, start: 0.2, end: 0.3),
+            makeTokenTiming(token: "▁world", tokenID: 2, start: 0.3, end: 0.5),
+            makeTokenTiming(token: "<pad>", tokenID: 0, start: 0.5, end: 0.6),
+        ])
+        let baseWords = timings.map(\.word)
+        let ranges = VocabularyRescorer.alignBaseWordsToUTF8Ranges(
+            baseText: "hello world",
+            baseWords: baseWords
+        )
+
+        XCTAssertEqual(baseWords, ["hello", "world"])
+        XCTAssertEqual(timings[0].tokenRange, 0..<1)
+        XCTAssertEqual(timings[1].tokenRange, 2..<3)
+        XCTAssertNil(
+            VocabularyRescorer.tokenRange(for: [0, 1], in: timings),
+            "A blank-token gap must not become a fabricated contiguous multiword token range"
+        )
+        XCTAssertEqual(try text(in: "hello world", range: ranges[0]), "hello")
+        XCTAssertEqual(try text(in: "hello world", range: ranges[1]), "world")
+    }
+
+    func testRepeatedWordsResolveOnlyThroughTheCompleteSequence() throws {
+        let resolved = VocabularyRescorer.alignBaseWordsToUTF8Ranges(
+            baseText: "go go",
+            baseWords: ["go", "go"]
+        )
+        XCTAssertEqual(try text(in: "go go", range: resolved[0]), "go")
+        XCTAssertEqual(try text(in: "go go", range: resolved[1]), "go")
+
+        let ambiguous = VocabularyRescorer.alignBaseWordsToUTF8Ranges(
+            baseText: "go go",
+            baseWords: ["go"]
+        )
+        XCTAssertEqual(ambiguous.count, 1)
+        XCTAssertNil(ambiguous[0])
+    }
+
+    func testMissingReorderedAndNormalizationOnlyMatchesFailClosed() {
+        let cases: [(String, [String])] = [
+            ("one two", ["two", "one"]),
+            ("one", ["one", "two"]),
+            ("Azure", ["azure"]),
+            ("Café", ["Cafe"]),
+            ("Café", ["Cafe\u{301}"]),
+        ]
+
+        for (baseText, baseWords) in cases {
+            let ranges = VocabularyRescorer.alignBaseWordsToUTF8Ranges(
+                baseText: baseText,
+                baseWords: baseWords
+            )
+            XCTAssertEqual(ranges.count, baseWords.count)
+            XCTAssertTrue(ranges.allSatisfy { $0 == nil }, "Unexpected alignment for \(baseText) / \(baseWords)")
+        }
+    }
+
+    func testCandidateRangeRejectsPhraseMismatchAndInvalidUTF8Boundaries() {
+        let baseText = "Café noir"
+        let ranges = VocabularyRescorer.alignBaseWordsToUTF8Ranges(
+            baseText: baseText,
+            baseWords: ["Café", "noir"]
+        )
+
+        XCTAssertNil(
+            VocabularyRescorer.candidateBaseTextUTF8Range(
+                wordRange: 0..<1,
+                alignedWordRanges: ranges,
+                baseText: baseText,
+                basePhrase: "coffee"
+            ))
+        XCTAssertNil(VocabularyRescorer.substring(in: baseText, utf8Range: 4..<5))
+    }
+
+    private func collector(
+        baseText: String,
+        baseWords: [String]
+    ) -> VocabularyRescorer.CandidateEvidenceCollector {
+        VocabularyRescorer.CandidateEvidenceCollector(
+            baseText: baseText,
+            baseWords: baseWords,
+            alignedWordRanges: VocabularyRescorer.alignBaseWordsToUTF8Ranges(
+                baseText: baseText,
+                baseWords: baseWords
+            ),
+            candidates: []
+        )
+    }
+
     private func makeEvidence(
+        candidateID: Int,
+        origin: VocabularyRescorer.CandidateOrigin,
         basePhrase: String,
         canonicalTerm: String,
         matchedAlias: String?,
         rawVocabularyScore: Float,
         rawOriginalScore: Float,
         effectiveBoost: Float,
-        legacyShouldReplace: Bool,
         wordRange: Range<Int>,
-        tokenRange: Range<Int>,
+        tokenRange: Range<Int>?,
+        baseTextUTF8Range: Range<Int>?,
         startTime: TimeInterval,
         endTime: TimeInterval,
         reason: String
     ) -> VocabularyRescorer.CandidateEvidence {
         let candidate = VocabularyRescorer.CTCMatchCandidate(
+            origin: origin,
             originalPhrase: basePhrase,
             vocabTerm: canonicalTerm,
             matchedAlias: matchedAlias,
@@ -172,7 +382,8 @@ final class VocabularyCandidateEvidenceTests: XCTestCase {
             spanEndTime: endTime
         )
         let result = VocabularyRescorer.CTCMatchResult(
-            shouldReplace: legacyShouldReplace,
+            shouldReplace: rawVocabularyScore + effectiveBoost > rawOriginalScore,
+            comparisonWasPerformed: true,
             originalScore: rawOriginalScore,
             boostedVocabScore: rawVocabularyScore + effectiveBoost,
             rawVocabularyCTCScore: rawVocabularyScore,
@@ -181,7 +392,54 @@ final class VocabularyCandidateEvidenceTests: XCTestCase {
             replacement: canonicalTerm,
             reason: reason
         )
-        return VocabularyRescorer.makeCandidateEvidence(candidate: candidate, result: result)
+        return VocabularyRescorer.makeCandidateEvidence(
+            candidateID: candidateID,
+            candidate: candidate,
+            result: result,
+            wordRange: wordRange,
+            baseTextUTF8Range: baseTextUTF8Range
+        )
+    }
+
+    private func makeCandidate(
+        origin: VocabularyRescorer.CandidateOrigin,
+        basePhrase: String,
+        canonicalTerm: String,
+        spanIndices: [Int],
+        tokenRange: Range<Int>?
+    ) -> VocabularyRescorer.CTCMatchCandidate {
+        VocabularyRescorer.CTCMatchCandidate(
+            origin: origin,
+            originalPhrase: basePhrase,
+            vocabTerm: canonicalTerm,
+            matchedAlias: nil,
+            vocabTokens: [10, 11],
+            similarity: 0.875,
+            spanLength: spanIndices.count,
+            spanIndices: spanIndices,
+            tokenRange: tokenRange,
+            spanStartTime: 0,
+            spanEndTime: 0.5
+        )
+    }
+
+    private func passingResult(replacement: String) -> VocabularyRescorer.CTCMatchResult {
+        VocabularyRescorer.CTCMatchResult(
+            shouldReplace: true,
+            comparisonWasPerformed: true,
+            originalScore: -5,
+            boostedVocabScore: -1,
+            rawVocabularyCTCScore: -2,
+            rawOriginalCTCScore: -5,
+            effectiveBoost: 1,
+            replacement: replacement,
+            reason: "vocabulary > original"
+        )
+    }
+
+    private func text(in baseText: String, range: Range<Int>?) throws -> String {
+        let range = try XCTUnwrap(range)
+        return String(try XCTUnwrap(VocabularyRescorer.substring(in: baseText, utf8Range: range)))
     }
 
     private func makeTokenTiming(

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyCandidateEvidenceTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyCandidateEvidenceTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+
+@testable import FluidAudio
+
+final class VocabularyCandidateEvidenceTests: XCTestCase {
+    func testCandidateEvidenceOutputPreservesBaseAndAcceptedRejectedCandidates() {
+        let accepted = makeEvidence(
+            basePhrase: "testing",
+            canonicalTerm: "ESLint",
+            matchedAlias: "E S lint",
+            rawVocabularyScore: -2.5,
+            rawOriginalScore: -5.0,
+            effectiveBoost: 1.25,
+            legacyShouldReplace: true,
+            wordRange: 1..<2,
+            tokenRange: 3..<5,
+            startTime: 0.4,
+            endTime: 0.8,
+            reason: "accepted"
+        )
+        let rejected = makeEvidence(
+            basePhrase: "document",
+            canonicalTerm: "DOCX",
+            matchedAlias: nil,
+            rawVocabularyScore: -8.0,
+            rawOriginalScore: -3.0,
+            effectiveBoost: 1.0,
+            legacyShouldReplace: false,
+            wordRange: 3..<4,
+            tokenRange: 7..<8,
+            startTime: 1.2,
+            endTime: 1.6,
+            reason: "rejected"
+        )
+
+        let output = VocabularyRescorer.CandidateEvidenceOutput(
+            baseText: "Please keep testing this document",
+            candidates: [accepted, rejected]
+        )
+
+        XCTAssertEqual(output.baseText, "Please keep testing this document")
+        XCTAssertEqual(output.candidates.count, 2)
+        XCTAssertEqual(output.candidates.map(\.legacyDecision), [.accepted, .rejected])
+        XCTAssertEqual(output.candidates[0].matchedAlias, "E S lint")
+        XCTAssertNil(output.candidates[1].matchedAlias, "nil must mean the canonical form matched")
+    }
+
+    func testCandidateEvidenceMapsScoresAndHalfOpenSpansWithoutMutatingBaseText() {
+        let evidence = makeEvidence(
+            basePhrase: "test ing",
+            canonicalTerm: "Testing",
+            matchedAlias: "test-ing",
+            rawVocabularyScore: -3.25,
+            rawOriginalScore: -4.75,
+            effectiveBoost: 0.5,
+            legacyShouldReplace: true,
+            wordRange: 2..<4,
+            tokenRange: 5..<9,
+            startTime: 0.75,
+            endTime: 1.5,
+            reason: "legacy accepted"
+        )
+
+        XCTAssertEqual(evidence.basePhrase, "test ing")
+        XCTAssertEqual(evidence.canonicalTerm, "Testing")
+        XCTAssertEqual(evidence.matchedAlias, "test-ing")
+        XCTAssertEqual(evidence.similarity, 0.875, accuracy: 0.0001)
+        XCTAssertEqual(evidence.rawVocabularyCTCScore, -3.25)
+        XCTAssertEqual(evidence.rawOriginalCTCScore, -4.75)
+        XCTAssertEqual(evidence.effectiveBoost, 0.5)
+        XCTAssertEqual(evidence.wordRange, 2..<4, "wordRange is half-open")
+        XCTAssertEqual(evidence.tokenRange, 5..<9, "tokenRange is half-open")
+        XCTAssertEqual(evidence.startTime, 0.75)
+        XCTAssertEqual(evidence.endTime, 1.5)
+        XCTAssertEqual(evidence.legacyDecision, .accepted)
+        XCTAssertEqual(evidence.reason, "legacy accepted")
+    }
+
+    func testUnavailableScoresRemainNilInsteadOfUsingLegacySentinels() {
+        let candidate = VocabularyRescorer.CTCMatchCandidate(
+            originalPhrase: "ordinary",
+            vocabTerm: "Azure",
+            matchedAlias: nil,
+            vocabTokens: [10, 11],
+            similarity: 0.625,
+            spanLength: 1,
+            spanIndices: [0],
+            tokenRange: nil,
+            spanStartTime: 0.0,
+            spanEndTime: 0.4
+        )
+        let result = VocabularyRescorer.CTCMatchResult(
+            shouldReplace: false,
+            originalScore: -.infinity,
+            boostedVocabScore: -.infinity,
+            rawVocabularyCTCScore: nil,
+            rawOriginalCTCScore: nil,
+            effectiveBoost: nil,
+            replacement: "Azure",
+            reason: "Tokenizer unavailable"
+        )
+
+        let evidence = VocabularyRescorer.makeCandidateEvidence(candidate: candidate, result: result)
+
+        XCTAssertNil(evidence.rawVocabularyCTCScore)
+        XCTAssertNil(evidence.rawOriginalCTCScore)
+        XCTAssertNil(evidence.effectiveBoost)
+        XCTAssertNil(evidence.tokenRange)
+        XCTAssertEqual(evidence.legacyDecision, .rejected)
+    }
+
+    func testNormalizedFormsDistinguishCanonicalFromExactAlias() {
+        let forms = VocabularyRescorer.normalizedForms(
+            canonicalTerm: "ESLint",
+            aliases: ["E S lint", "es-lint"]
+        )
+
+        XCTAssertEqual(forms[0].normalized, "eslint")
+        XCTAssertNil(forms[0].matchedAlias)
+        XCTAssertEqual(forms[1].normalized, "e s lint")
+        XCTAssertEqual(forms[1].matchedAlias, "E S lint")
+        XCTAssertEqual(forms[2].normalized, "es-lint")
+        XCTAssertEqual(forms[2].matchedAlias, "es-lint")
+    }
+
+    func testWordTimingsRetainContiguousHalfOpenTokenRanges() {
+        let timings = VocabularyRescorer.buildWordTimings(from: [
+            makeTokenTiming(token: "▁test", tokenID: 1, start: 0.0, end: 0.2),
+            makeTokenTiming(token: "ing", tokenID: 2, start: 0.2, end: 0.4),
+            makeTokenTiming(token: "▁again", tokenID: 3, start: 0.4, end: 0.8),
+        ])
+
+        XCTAssertEqual(timings.map(\.word), ["testing", "again"])
+        XCTAssertEqual(timings.map(\.tokenRange), [0..<2, 2..<3].map(Optional.some))
+    }
+
+    func testWordTimingsUseNilForNoncontiguousTokenProvenance() {
+        let timings = VocabularyRescorer.buildWordTimings(from: [
+            makeTokenTiming(token: "▁test", tokenID: 1, start: 0.0, end: 0.2),
+            makeTokenTiming(token: "<blank>", tokenID: 0, start: 0.2, end: 0.3),
+            makeTokenTiming(token: "ing", tokenID: 2, start: 0.3, end: 0.5),
+        ])
+
+        XCTAssertEqual(timings.map(\.word), ["testing"])
+        XCTAssertNil(timings[0].tokenRange)
+    }
+
+    private func makeEvidence(
+        basePhrase: String,
+        canonicalTerm: String,
+        matchedAlias: String?,
+        rawVocabularyScore: Float,
+        rawOriginalScore: Float,
+        effectiveBoost: Float,
+        legacyShouldReplace: Bool,
+        wordRange: Range<Int>,
+        tokenRange: Range<Int>,
+        startTime: TimeInterval,
+        endTime: TimeInterval,
+        reason: String
+    ) -> VocabularyRescorer.CandidateEvidence {
+        let candidate = VocabularyRescorer.CTCMatchCandidate(
+            originalPhrase: basePhrase,
+            vocabTerm: canonicalTerm,
+            matchedAlias: matchedAlias,
+            vocabTokens: [10, 11],
+            similarity: 0.875,
+            spanLength: wordRange.count,
+            spanIndices: Array(wordRange),
+            tokenRange: tokenRange,
+            spanStartTime: startTime,
+            spanEndTime: endTime
+        )
+        let result = VocabularyRescorer.CTCMatchResult(
+            shouldReplace: legacyShouldReplace,
+            originalScore: rawOriginalScore,
+            boostedVocabScore: rawVocabularyScore + effectiveBoost,
+            rawVocabularyCTCScore: rawVocabularyScore,
+            rawOriginalCTCScore: rawOriginalScore,
+            effectiveBoost: effectiveBoost,
+            replacement: canonicalTerm,
+            reason: reason
+        )
+        return VocabularyRescorer.makeCandidateEvidence(candidate: candidate, result: result)
+    }
+
+    private func makeTokenTiming(
+        token: String,
+        tokenID: Int,
+        start: TimeInterval,
+        end: TimeInterval
+    ) -> TokenTiming {
+        TokenTiming(
+            token: token,
+            tokenId: tokenID,
+            startTime: start,
+            endTime: end,
+            confidence: 1.0
+        )
+    }
+}


### PR DESCRIPTION
### Why is this change needed?

VocabularyRescorer currently exposes only RescoreOutput after legacy vocabulary replacements have already been applied. Applications that need a different precision and recall policy cannot preserve the decoder transcript while inspecting the accepted and rejected CTC comparisons that produced those replacements.

PR #722 added useful opt-in safety controls, but a global threshold still cannot express context-aware arbitration for collision-prone technical terms without sacrificing accented and domain-term recall. This additive API lets callers retain the untouched transcript and make their own final selection from FluidAudio evidence without changing existing scoring defaults or legacy output.

This is an additive follow-up to #702 and #722; it does not claim to change the default false-positive behavior.

### Summary

- Add public Sendable candidate-evidence and output types.
- Add ctcTokenEvaluateCandidates, which returns the untouched base transcript plus every candidate that reaches CTC evaluation, including legacy rejections.
- Report canonical term, exact matched alias, string similarity, raw vocabulary and original CTC scores, effective boost, half-open word and token ranges, timestamps, legacy decision, and reason.
- Preserve canonical-versus-alias provenance and contiguous token provenance across word-centric, term-centric, and spotter-rescue paths.
- Keep ctcTokenRescore source-compatible and avoid allocating an evidence buffer on the legacy path.
- Document the non-mutating API and add focused unit coverage for score mapping, alias identity, unavailable values, decisions, and span semantics.

### Compatibility

- No existing public API is removed or renamed.
- No scoring threshold, model, configuration default, or legacy replacement rule changes.
- Existing ctcTokenRescore callers continue to receive the same rewritten output contract.

### Test Plan

- [x] swift format lint on every changed Swift file
- [x] swift build
- [x] swift test --parallel --num-workers 8: 2,116 XCTest cases and 45 Swift Testing cases passed
- [x] VocabularyCandidateEvidenceTests: 6 of 6 passed
- [x] xcodebuild -scheme FluidAudio -destination generic/platform=iOS build
- [x] Full branch diff reviewed against current canonical main with no blocking findings