### PR TITLE
fix(tts): make LuxTTS resources signable on iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
             ],
             path: "Sources/FluidAudio",
             resources: [
-                .copy("TTS/LuxTts/G2p/Resources")
+                .process("TTS/LuxTts/G2p/Resources")
             ]
         ),
         // Byte-exact NeMo text normalization (FST engine, all 7 languages).

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
             ],
             path: "Sources/FluidAudio",
             resources: [
+                // Keep .process: .copy of a Resources-named directory breaks Apple code signing on iOS.
                 .process("TTS/LuxTts/G2p/Resources")
             ]
         ),
@@ -66,7 +67,7 @@ let package = Package(
                 "FluidAudioCLI",
             ],
             resources: [
-                .copy("TTS/LuxTts/Resources")
+                .process("TTS/LuxTts/Resources")
             ]
         ),
     ],

--- a/Sources/FluidAudio/TTS/LuxTts/G2p/LuxTtsG2p.swift
+++ b/Sources/FluidAudio/TTS/LuxTts/G2p/LuxTtsG2p.swift
@@ -77,11 +77,9 @@ public struct LuxTtsG2p: Sendable {
     public init() throws {
         guard
             let lexiconURL = Bundle.module.url(
-                forResource: "luxtts_en_us_lexicon.tsv", withExtension: "zz",
-                subdirectory: "Resources"),
+                forResource: "luxtts_en_us_lexicon.tsv", withExtension: "zz"),
             let auxURL = Bundle.module.url(
-                forResource: "luxtts_en_us_g2p_aux", withExtension: "json",
-                subdirectory: "Resources")
+                forResource: "luxtts_en_us_g2p_aux", withExtension: "json")
         else {
             throw LuxTtsError.tokenizerFailed("bundled G2P resources missing")
         }

--- a/Tests/FluidAudioTests/TTS/LuxTts/LuxTtsFixtures.swift
+++ b/Tests/FluidAudioTests/TTS/LuxTts/LuxTtsFixtures.swift
@@ -120,10 +120,7 @@ struct LuxTtsFixtures: Decodable {
     // MARK: - Loading
 
     static func resourceURL(_ name: String) throws -> URL {
-        guard
-            let url = Bundle.module.url(
-                forResource: name, withExtension: nil, subdirectory: "Resources")
-        else {
+        guard let url = Bundle.module.url(forResource: name, withExtension: nil) else {
             throw XCTSkip("LuxTts fixture resource missing: \(name)")
         }
         return url

--- a/Tests/FluidAudioTests/TTS/LuxTts/LuxTtsG2pTests.swift
+++ b/Tests/FluidAudioTests/TTS/LuxTts/LuxTtsG2pTests.swift
@@ -12,6 +12,21 @@ import XCTest
 /// the mobius worktree; these tests pin representative behaviors.
 final class LuxTtsG2pTests: XCTestCase {
 
+    func testFixtureResourcesAreProcessedAtBundleRoot() {
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: Bundle.module.bundleURL
+                    .appendingPathComponent("Resources", isDirectory: true).path
+            ),
+            "LuxTTS test resources must not create a reserved top-level Resources directory"
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: Bundle.module.bundleURL.appendingPathComponent("luxtts_fixtures.json").path
+            )
+        )
+    }
+
     private static let g2p: LuxTtsG2p = {
         do {
             return try LuxTtsG2p()


### PR DESCRIPTION
### Why is this change needed?

The LuxTTS G2P resources are currently copied as a top-level directory named `Resources`. In iOS resource bundles, Apple code signing interprets that reserved layout as a malformed legacy bundle and fails with `bundle format unrecognized, invalid, or unsuitable`. This prevents any signed iOS consumer build from using current FluidAudio `main`.

This change lets SwiftPM process the production and test resources into their bundle roots and updates the corresponding lookups. The resource contents and LuxTTS behavior are unchanged. A manifest comment and regression test protect the signing-sensitive layout from being reverted to `.copy`.

### Validation

- Changed-file `swift format lint`: clean; repository-wide lint exits 0 with existing warnings
- Clean `swift test --filter LuxTts`: 33 tests executed, 1 model-gated test skipped, 0 failures
- Full `swift test --parallel --num-workers 8`: exited 0 across 2,111 XCTest cases and 45 Swift Testing cases
- Signed generic iOS `FluidAudio` scheme build: passed
- Generated iOS production and test resource bundles contain their files at the bundle root and no nested `Resources` directory
- `codesign --verify --strict` passed for both generated iOS resource bundles
