### PR TITLE
fix(sortformer): streaming mel emits phantom frames, drifting all timestamps late

### DIFF
--- a/Sources/FluidAudio/Diarizer/Sortformer/SortformerDiarizer.swift
+++ b/Sources/FluidAudio/Diarizer/Sortformer/SortformerDiarizer.swift
@@ -79,6 +79,7 @@ public final class SortformerDiarizer: Diarizer {
     internal private(set) var melFramesEmitted: Int = 0
     /// Set once `padAndEmitRemainingMelLocked` has flushed the final frames.
     private var melInputExhausted: Bool = false
+    private var warnedDroppedAudio: Bool = false
 
     // Feature buffering
     internal var featureBuffer: [Float] = []
@@ -194,7 +195,6 @@ public final class SortformerDiarizer: Diarizer {
         resetMelStreamLocked()
         diarizerChunkIndex = 0
         _numFramesProcessed = 0
-        _realSamplesReceived = 0
         _finalized = false
         _timeline.reset(keepingSpeakers: keepingSpeakers)
 
@@ -210,8 +210,23 @@ public final class SortformerDiarizer: Diarizer {
         lastAudioSample = 0
         melFramesEmitted = 0
         melInputExhausted = false
+        warnedDroppedAudio = false
+        _realSamplesReceived = 0
         audioBuffer.removeAll(keepingCapacity: true)
         audioBuffer.append(contentsOf: [Float](repeating: 0, count: melSpectrogram.nFFT / 2))
+    }
+
+    /// True (after a one-time warning) when the mel stream is exhausted and
+    /// incoming audio must be dropped; buffering it would grow without bound
+    /// since nothing consumes audio after `finalizeSession` - caller must
+    /// hold lock.
+    private func shouldDropAudioLocked() -> Bool {
+        guard melInputExhausted else { return false }
+        if !warnedDroppedAudio {
+            warnedDroppedAudio = true
+            logger.warning("Audio added after finalizeSession is ignored; call reset() to start a new session")
+        }
+        return true
     }
 
     /// Cleanup resources.
@@ -305,6 +320,16 @@ public final class SortformerDiarizer: Diarizer {
             _timeline.reset(keepingSpeakers: true)
             var occupiedIndices = Set(_timeline.speakers.keys)
 
+            // Every exit (guard failures and thrown errors included) must
+            // clear the enrollment clip's mel stream: padAndEmitRemainingMel
+            // sets the exhausted latch, which would otherwise silently
+            // disable all further streaming until reset().
+            defer {
+                resetMelStreamLocked()
+                diarizerChunkIndex = 0
+                _numFramesProcessed = 0
+            }
+
             // Clear audio and feature buffers to avoid enrolling this speaker with stale audio.
             resetMelStreamLocked()
             diarizerChunkIndex = 0
@@ -353,10 +378,6 @@ public final class SortformerDiarizer: Diarizer {
                                 + "at index \(bestSlot) and overwritingAssignedSpeakerName=false"
                         )
                         _timeline.reset(keepingSpeakersWhere: { occupiedIndices.contains($0.index) })
-                        _numFramesProcessed = 0
-                        diarizerChunkIndex = 0
-                        resetMelStreamLocked()
-                        _realSamplesReceived = 0
                         return nil
                     }
                     logger.warning(
@@ -375,10 +396,6 @@ public final class SortformerDiarizer: Diarizer {
             }
 
             _timeline.reset(keepingSpeakersWhere: { occupiedIndices.contains($0.index) })
-            _numFramesProcessed = 0
-            diarizerChunkIndex = 0
-            resetMelStreamLocked()
-            _realSamplesReceived = 0
 
             logger.info(
                 "Enrolled speaker \(description) with \(normalized.count) samples "
@@ -399,6 +416,7 @@ public final class SortformerDiarizer: Diarizer {
     ///   - sourceSampleRate: Source audio sample rate
     public func addAudio(_ samples: [Float]) {
         lock.withLock {
+            guard !shouldDropAudioLocked() else { return }
             audioBuffer.append(contentsOf: samples)
             _realSamplesReceived += samples.count
             preprocessAudioToFeaturesLocked()
@@ -416,6 +434,7 @@ public final class SortformerDiarizer: Diarizer {
     ) throws {
         let normalized = try normalizeSamples(samples, sourceSampleRate: sourceSampleRate)
         lock.withLock {
+            guard !shouldDropAudioLocked() else { return }
             audioBuffer.append(contentsOf: normalized)
             _realSamplesReceived += normalized.count
             preprocessAudioToFeaturesLocked()
@@ -432,6 +451,7 @@ public final class SortformerDiarizer: Diarizer {
         sourceSampleRate: Double? = nil
     ) throws where C.Element == Float {
         try lock.withLock {
+            guard !shouldDropAudioLocked() else { return }
             if let sourceSampleRate, sourceSampleRate != Double(config.sampleRate) {
                 let normalized = try normalizeSamples(Array(samples), sourceSampleRate: sourceSampleRate)
                 audioBuffer.append(contentsOf: normalized)
@@ -466,6 +486,7 @@ public final class SortformerDiarizer: Diarizer {
     ) throws -> DiarizerTimelineUpdate?
     where C.Element == Float {
         return try lock.withLock {
+            guard !shouldDropAudioLocked() else { return nil }
             if let sourceSampleRate, sourceSampleRate != Double(config.sampleRate) {
                 let normalized = try normalizeSamples(Array(samples), sourceSampleRate: sourceSampleRate)
                 audioBuffer.append(contentsOf: normalized)
@@ -839,7 +860,8 @@ public final class SortformerDiarizer: Diarizer {
             paddingMode: .prePadded,
             expectedFrameCount: count
         )
-        featureBuffer.append(contentsOf: mel.prefix(melLength * config.melFeatures))
+        assert(melLength == count && mel.count == count * config.melFeatures)
+        featureBuffer.append(contentsOf: mel)
 
         let samplesConsumed = count * config.melStride
         lastAudioSample = audioBuffer[samplesConsumed - 1]

--- a/Sources/FluidAudio/Diarizer/Sortformer/SortformerDiarizer.swift
+++ b/Sources/FluidAudio/Diarizer/Sortformer/SortformerDiarizer.swift
@@ -69,9 +69,16 @@ public final class SortformerDiarizer: Diarizer {
     // Native mel spectrogram (used when useNativePreprocessing is enabled)
     private let melSpectrogram = AudioMelSpectrogram()
 
-    // Audio buffering
+    // Audio buffering. `audioBuffer` always starts at sample
+    // `melFramesEmitted * melStride - nFFT/2` of the session's virtually
+    // center-padded stream; it is seeded with the nFFT/2-zero batch left pad
+    // at reset.
     private var audioBuffer: [Float] = []
     private var lastAudioSample: Float = 0
+    /// Frames of the session's mel stream emitted so far.
+    internal private(set) var melFramesEmitted: Int = 0
+    /// Set once `padAndEmitRemainingMelLocked` has flushed the final frames.
+    private var melInputExhausted: Bool = false
 
     // Feature buffering
     internal var featureBuffer: [Float] = []
@@ -92,6 +99,7 @@ public final class SortformerDiarizer: Diarizer {
         self.stateUpdater = SortformerStateUpdater(config: config)
         self._state = SortformerStreamingState(config: config)
         self._timeline = DiarizerTimeline(config: timelineConfig)
+        resetMelStreamLocked()
     }
 
     /// Initialize with CoreML models (combined pipeline mode).
@@ -183,10 +191,7 @@ public final class SortformerDiarizer: Diarizer {
 
     /// Internal reset - caller must hold lock
     private func resetBuffersLocked(keepingSpeakers: Bool = false) {
-        audioBuffer = []
-        featureBuffer = []
-        lastAudioSample = 0
-        startFeat = 0
+        resetMelStreamLocked()
         diarizerChunkIndex = 0
         _numFramesProcessed = 0
         _realSamplesReceived = 0
@@ -194,6 +199,19 @@ public final class SortformerDiarizer: Diarizer {
         _timeline.reset(keepingSpeakers: keepingSpeakers)
 
         featureBuffer.reserveCapacity((config.chunkMelFrames + config.coreFrames) * config.melFeatures)
+    }
+
+    /// Reset the incremental mel stream: an empty feature buffer and an audio
+    /// buffer seeded with the batch left pad (nFFT/2 zeros) - caller must
+    /// hold lock.
+    private func resetMelStreamLocked() {
+        featureBuffer.removeAll(keepingCapacity: true)
+        startFeat = 0
+        lastAudioSample = 0
+        melFramesEmitted = 0
+        melInputExhausted = false
+        audioBuffer.removeAll(keepingCapacity: true)
+        audioBuffer.append(contentsOf: [Float](repeating: 0, count: melSpectrogram.nFFT / 2))
     }
 
     /// Cleanup resources.
@@ -288,15 +306,14 @@ public final class SortformerDiarizer: Diarizer {
             var occupiedIndices = Set(_timeline.speakers.keys)
 
             // Clear audio and feature buffers to avoid enrolling this speaker with stale audio.
-            startFeat = 0
-            lastAudioSample = 0
+            resetMelStreamLocked()
             diarizerChunkIndex = 0
-            audioBuffer.removeAll(keepingCapacity: true)
-            featureBuffer.removeAll(keepingCapacity: true)
-            _realSamplesReceived = 0
+            _realSamplesReceived = normalized.count
             audioBuffer.append(contentsOf: normalized)
 
-            preprocessAudioToFeaturesLocked()
+            // The enrollment clip is a complete utterance: emit its full
+            // mel stream, right pad included.
+            padAndEmitRemainingMelLocked()
 
             // Accumulate per-slot speech frames from the diarizer updates rather than
             // from persisted timeline segments, so enrollment works even when the
@@ -338,10 +355,7 @@ public final class SortformerDiarizer: Diarizer {
                         _timeline.reset(keepingSpeakersWhere: { occupiedIndices.contains($0.index) })
                         _numFramesProcessed = 0
                         diarizerChunkIndex = 0
-                        startFeat = 0
-                        lastAudioSample = 0
-                        audioBuffer.removeAll(keepingCapacity: true)
-                        featureBuffer.removeAll(keepingCapacity: true)
+                        resetMelStreamLocked()
                         _realSamplesReceived = 0
                         return nil
                     }
@@ -363,10 +377,7 @@ public final class SortformerDiarizer: Diarizer {
             _timeline.reset(keepingSpeakersWhere: { occupiedIndices.contains($0.index) })
             _numFramesProcessed = 0
             diarizerChunkIndex = 0
-            startFeat = 0
-            lastAudioSample = 0
-            audioBuffer.removeAll(keepingCapacity: true)
-            featureBuffer.removeAll(keepingCapacity: true)
+            resetMelStreamLocked()
             _realSamplesReceived = 0
 
             logger.info(
@@ -565,20 +576,17 @@ public final class SortformerDiarizer: Diarizer {
             }
             guard !_finalized else { return nil }
 
-            // Drain every remaining full-rc chunk. preprocessAudioToFeaturesLocked
-            // only emits one chunk's worth of mel features per call, so loop:
-            // preprocess audio → drain feature chunks → repeat until the audio
-            // buffer can't yield another full chunk.
+            // Emit the trailing mel frames (whose windows overlap the batch
+            // right pad), then drain every remaining full-rc chunk.
             var aggFinalized: [Float] = []
             var aggTentative: [Float] = []
             var didDrain = false
-            preprocessAudioToFeaturesLocked()
+            padAndEmitRemainingMelLocked()
             while let chunk = try makeStreamingChunkLocked() {
                 aggFinalized.append(contentsOf: chunk.finalizedPredictions)
                 aggTentative = chunk.tentativePredictions
                 _numFramesProcessed += chunk.finalizedFrameCount
                 didDrain = true
-                preprocessAudioToFeaturesLocked()
             }
 
             // Absorb trailing tentative as finalized — mirrors offline
@@ -712,7 +720,7 @@ public final class SortformerDiarizer: Diarizer {
             }
 
             // Reset for fresh processing
-            let keepSpeakers = keepSpeakers ?? (featureBuffer.isEmpty && audioBuffer.isEmpty && diarizerChunkIndex == 0)
+            let keepSpeakers = keepSpeakers ?? (_realSamplesReceived == 0 && diarizerChunkIndex == 0)
             if !keepSpeakers {
                 _state = SortformerStreamingState(config: config)
             }
@@ -801,50 +809,73 @@ public final class SortformerDiarizer: Diarizer {
 
     // MARK: - Helpers
 
-    /// Preprocess audio into mel features - caller must hold lock
+    /// Preprocess audio into mel features - caller must hold lock.
+    ///
+    /// Emits every frame of the session's batch-equivalent (center-padded)
+    /// mel stream whose window is already covered by received samples, so
+    /// frame count and values do not depend on how the audio was batched
+    /// into `addAudio` calls. Frame k spans samples
+    /// `[k * melStride - melWindow/2, k * melStride + melWindow/2)`; the
+    /// trailing frames whose windows overlap the batch right pad are emitted
+    /// by `padAndEmitRemainingMelLocked` at session end.
     private func preprocessAudioToFeaturesLocked() {
-        let targetFeatureFrames = startFeat + config.coreFrames + config.chunkRightContext * config.subsamplingFactor
-        preprocessAudioToFeatureTargetLocked(targetFeatureFrames: targetFeatureFrames)
+        guard !melInputExhausted else { return }
+        let halfWindow = config.melWindow / 2
+        guard _realSamplesReceived >= halfWindow else { return }
+        let computableFrames = (_realSamplesReceived - halfWindow) / config.melStride + 1
+        let count = computableFrames - melFramesEmitted
+        guard count > 0 else { return }
+        emitMelFramesLocked(count)
     }
 
-    private func preprocessAudioToFeatureTargetLocked(targetFeatureFrames: Int) {
-        guard !audioBuffer.isEmpty else { return }
-        if audioBuffer.count < config.melWindow { return }
-
-        let featLength = featureBuffer.count / config.melFeatures
-        let framesNeeded = targetFeatureFrames - featLength
-        guard framesNeeded > 0 else { return }
-
-        let samplesNeeded: Int
-        if featureBuffer.isEmpty {
-            samplesNeeded = (framesNeeded - 1) * config.melStride + config.melWindow
-        } else {
-            samplesNeeded = framesNeeded * config.melStride
-        }
-
-        guard audioBuffer.count >= samplesNeeded else { return }
-
+    /// Compute the next `count` frames of the mel stream from `audioBuffer`
+    /// and append them to `featureBuffer`, consuming `count * melStride`
+    /// samples - caller must hold lock and guarantee the buffer covers the
+    /// frames' windows.
+    private func emitMelFramesLocked(_ count: Int) {
         let (mel, melLength, _) = melSpectrogram.computeFlatTransposed(
             audio: audioBuffer,
-            lastAudioSample: lastAudioSample
+            lastAudioSample: lastAudioSample,
+            paddingMode: .prePadded,
+            expectedFrameCount: count
         )
+        featureBuffer.append(contentsOf: mel.prefix(melLength * config.melFeatures))
 
-        guard melLength > 0 else { return }
+        let samplesConsumed = count * config.melStride
+        lastAudioSample = audioBuffer[samplesConsumed - 1]
+        audioBuffer.removeFirst(samplesConsumed)
+        melFramesEmitted += count
+    }
 
-        featureBuffer.append(contentsOf: mel)
+    /// Emit the remaining frames of the mel stream by appending the batch
+    /// right pad, reaching the exact frame count batch (`.center`) mode
+    /// produces for the complete session audio - caller must hold lock.
+    /// Idempotent; further audio is ignored once called.
+    private func padAndEmitRemainingMelLocked() {
+        guard !melInputExhausted else { return }
+        melInputExhausted = true
+        guard _realSamplesReceived > 0 else { return }
 
-        // Invert the center-padded frame count formula to compute samples consumed.
-        // This ensures samplesConsumed ≤ audioBuffer.count, preserving leftover samples
-        // and maintaining preemphasis continuity across streaming chunks.
-        let samplesConsumed = (melLength - 1) * config.melStride + config.melWindow - melSpectrogram.nFFT
+        let totalFrames =
+            1 + (_realSamplesReceived + melSpectrogram.nFFT - config.melWindow) / config.melStride
+        let remaining = totalFrames - melFramesEmitted
+        guard remaining > 0 else { return }
 
-        if samplesConsumed <= audioBuffer.count {
-            lastAudioSample = audioBuffer[samplesConsumed - 1]
-            audioBuffer.removeFirst(samplesConsumed)
-        } else {
-            lastAudioSample = 0
-            audioBuffer.removeAll()
+        // The pad is a preemphasis-cancelling decay rather than literal
+        // zeros: the in-place preemphasis filter turns it into the exact
+        // zeros of the batch right pad.
+        let padLength = melSpectrogram.nFFT / 2
+        var tail = [Float](repeating: 0, count: padLength)
+        if melSpectrogram.preemph != 0, let lastReal = audioBuffer.last {
+            var value = lastReal
+            for i in 0..<padLength {
+                value *= melSpectrogram.preemph
+                tail[i] = value
+            }
         }
+        audioBuffer.append(contentsOf: tail)
+
+        emitMelFramesLocked(remaining)
     }
 
     private func normalizeSamples(
@@ -866,6 +897,14 @@ public final class SortformerDiarizer: Diarizer {
         lock.lock()
         defer { lock.unlock() }
         return getNextChunkFeaturesLocked()
+    }
+
+    /// Emit the trailing mel frames as `finalizeSession` would, without
+    /// requiring loaded models (for testing).
+    internal func padAndEmitRemainingMel() {
+        lock.lock()
+        defer { lock.unlock() }
+        padAndEmitRemainingMelLocked()
     }
 
     /// Get next chunk features - caller must hold lock

--- a/Sources/FluidAudio/Shared/AudioMelSpectrogram.swift
+++ b/Sources/FluidAudio/Shared/AudioMelSpectrogram.swift
@@ -33,7 +33,7 @@ public final class AudioMelSpectrogram {
     private let winLength: Int  // window_size * sample_rate
     private let fMin: Float = 0.0
     private let fMax: Float  // sample_rate / 2
-    private let preemph: Float  // NeMo preemphasis coefficient
+    internal let preemph: Float  // NeMo preemphasis coefficient
     private let logFloor: Float
     private let logFloorMode: LogFloorMode
     private let padValue: Float = 0

--- a/Tests/FluidAudioTests/Diarizer/Sortformer/SortformerStreamingMelTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Sortformer/SortformerStreamingMelTests.swift
@@ -131,6 +131,29 @@ final class SortformerStreamingMelTests: XCTestCase {
         }
     }
 
+    /// After the mel stream is exhausted, further audio is dropped (not
+    /// buffered) and reset() must fully restart the stream.
+    func testResetAfterExhaustionRestartsMelStream() throws {
+        let audio = makeAudio(seconds: 6)
+        let reference = streamChunks(audio: audio, batchSize: audio.count, finalize: false)
+
+        let diarizer = SortformerDiarizer(config: config)
+        diarizer.addAudio(audio)
+        diarizer.padAndEmitRemainingMel()
+        let exhaustedFrames = diarizer.melFramesEmitted
+        diarizer.addAudio(audio)
+        XCTAssertEqual(diarizer.melFramesEmitted, exhaustedFrames, "Audio after exhaustion must be ignored")
+
+        diarizer.reset()
+        diarizer.addAudio(audio)
+        var chunks: [[Float]] = []
+        while let (mel, _) = diarizer.getNextChunkFeatures() { chunks.append(mel) }
+        XCTAssertEqual(chunks.count, reference.chunks.count)
+        for (i, (chunk, referenceChunk)) in zip(chunks, reference.chunks).enumerated() {
+            XCTAssertEqual(chunk, referenceChunk, "Chunk \(i) differs after reset from exhaustion")
+        }
+    }
+
     /// A reset diarizer must reproduce the session from scratch (the left pad
     /// is re-seeded, counters cleared).
     func testResetRestartsMelStream() throws {

--- a/Tests/FluidAudioTests/Diarizer/Sortformer/SortformerStreamingMelTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Sortformer/SortformerStreamingMelTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Incremental (streaming) mel preprocessing must reproduce the batch
+/// center-padded mel stream frame-for-frame, no matter how the audio is
+/// batched into `addAudio` calls. Re-padding on every preprocess call used
+/// to emit ~17 ms of phantom timeline per call, so with real-time feeding
+/// the finalized frame stream ran ~3.5% faster than the audio and every
+/// frame-derived timestamp drifted progressively late.
+final class SortformerStreamingMelTests: XCTestCase {
+
+    private let config = SortformerConfig.fastV2_1
+
+    /// Deterministic audio with speech-like structure (tones + noise), sized
+    /// to not be a multiple of the mel hop so edge handling is exercised.
+    private func makeAudio(seconds: Double) -> [Float] {
+        let count = Int(16000 * seconds) + 137
+        srand48(7)
+        return (0..<count).map { i in
+            let t = Float(i) / 16000
+            let tone = 0.3 * sin(2 * .pi * 220 * t) + 0.15 * sin(2 * .pi * 517 * t)
+            return tone + Float(drand48() - 0.5) * 0.05
+        }
+    }
+
+    /// Feed `audio` in `batchSize`-sample calls, draining every available
+    /// feature chunk after each call; optionally flush the trailing frames
+    /// the way `finalizeSession` does. Returns the extracted chunks.
+    private func streamChunks(
+        audio: [Float], batchSize: Int, finalize: Bool
+    ) -> (chunks: [[Float]], framesEmitted: Int) {
+        let diarizer = SortformerDiarizer(config: config)
+        var chunks: [[Float]] = []
+        var fed = 0
+        while fed < audio.count {
+            let end = min(fed + batchSize, audio.count)
+            diarizer.addAudio(Array(audio[fed..<end]))
+            fed = end
+            while let (mel, _) = diarizer.getNextChunkFeatures() {
+                chunks.append(mel)
+            }
+        }
+        if finalize {
+            diarizer.padAndEmitRemainingMel()
+            while let (mel, _) = diarizer.getNextChunkFeatures() {
+                chunks.append(mel)
+            }
+        }
+        return (chunks, diarizer.melFramesEmitted)
+    }
+
+    /// Any feeding granularity must produce the identical chunk sequence and
+    /// the identical total mel frame count.
+    func testFeedingGranularityDoesNotChangeFramesOrChunks() throws {
+        let audio = makeAudio(seconds: 12)
+        let reference = streamChunks(audio: audio, batchSize: audio.count, finalize: true)
+
+        // 160 = one hop; 1600 = 100 ms (typical mic callback); 4093 = prime,
+        // misaligned with every internal boundary; 16000 = 1 s.
+        for batchSize in [160, 1600, 4093, 16000] {
+            let result = streamChunks(audio: audio, batchSize: batchSize, finalize: true)
+
+            XCTAssertEqual(
+                result.framesEmitted, reference.framesEmitted,
+                "Mel frame count depends on feeding granularity (batchSize \(batchSize))")
+            XCTAssertEqual(
+                result.chunks.count, reference.chunks.count,
+                "Chunk count depends on feeding granularity (batchSize \(batchSize))")
+            for (i, (chunk, referenceChunk)) in zip(result.chunks, reference.chunks).enumerated() {
+                XCTAssertEqual(chunk.count, referenceChunk.count, "Chunk \(i) size mismatch")
+                for j in 0..<chunk.count where chunk[j] != referenceChunk[j] {
+                    XCTFail(
+                        "Chunk \(i) differs at \(j) for batchSize \(batchSize): "
+                            + "\(chunk[j]) != \(referenceChunk[j])")
+                    return
+                }
+            }
+        }
+    }
+
+    /// The finalized stream must contain exactly the frames batch
+    /// center-padded computation produces: `1 + (n + nFFT - melWindow) / hop`.
+    func testFinalizedFrameCountIsBatchExact() throws {
+        let audio = makeAudio(seconds: 9)
+        let melSpectrogram = AudioMelSpectrogram()
+        let expected = 1 + (audio.count + melSpectrogram.nFFT - config.melWindow) / config.melStride
+
+        for batchSize in [1600, audio.count] {
+            let result = streamChunks(audio: audio, batchSize: batchSize, finalize: true)
+            XCTAssertEqual(
+                result.framesEmitted, expected,
+                "Finalized mel frame count must match batch formula (batchSize \(batchSize))")
+        }
+    }
+
+    /// Streamed values must equal the batch center-padded mel of the whole
+    /// audio, including the session-final frames whose windows overlap the
+    /// right pad.
+    func testStreamedMelMatchesBatchValues() throws {
+        let audio = makeAudio(seconds: 9)
+        let melSpectrogram = AudioMelSpectrogram()
+        let (batchMel, batchFrames, _) = melSpectrogram.computeFlatTransposed(
+            audio: audio, lastAudioSample: 0, paddingMode: .center, expectedFrameCount: nil)
+
+        let diarizer = SortformerDiarizer(config: config)
+        for start in stride(from: 0, to: audio.count, by: 1600) {
+            diarizer.addAudio(Array(audio[start..<min(start + 1600, audio.count)]))
+        }
+        diarizer.padAndEmitRemainingMel()
+        XCTAssertEqual(diarizer.melFramesEmitted, batchFrames)
+
+        // First chunk covers mel frames [0, core + rc) with no left context,
+        // an absolute anchor to the start of the batch stream.
+        guard let (firstChunk, firstLength) = diarizer.getNextChunkFeatures() else {
+            return XCTFail("No chunk available")
+        }
+        XCTAssertEqual(firstLength, config.coreFrames + config.chunkRightContext * config.subsamplingFactor)
+        for i in 0..<(firstLength * config.melFeatures) {
+            XCTAssertEqual(firstChunk[i], batchMel[i], accuracy: 1e-5, "First chunk mismatch at \(i)")
+        }
+
+        // Drain the rest; the feature buffer's tail must then equal the batch
+        // stream's tail, which pins the right-pad frames emitted at finalize.
+        while diarizer.getNextChunkFeatures() != nil {}
+        let tail = diarizer.featureBuffer.suffix(64 * config.melFeatures)
+        let batchTail = batchMel.prefix(batchFrames * config.melFeatures).suffix(tail.count)
+        XCTAssertFalse(tail.isEmpty)
+        for (i, (streamed, batch)) in zip(tail, batchTail).enumerated() {
+            XCTAssertEqual(streamed, batch, accuracy: 1e-5, "Tail mismatch at \(i)")
+        }
+    }
+
+    /// A reset diarizer must reproduce the session from scratch (the left pad
+    /// is re-seeded, counters cleared).
+    func testResetRestartsMelStream() throws {
+        let audio = makeAudio(seconds: 6)
+        let diarizer = SortformerDiarizer(config: config)
+
+        diarizer.addAudio(audio)
+        var firstRun: [[Float]] = []
+        while let (mel, _) = diarizer.getNextChunkFeatures() { firstRun.append(mel) }
+
+        diarizer.reset()
+        diarizer.addAudio(audio)
+        var secondRun: [[Float]] = []
+        while let (mel, _) = diarizer.getNextChunkFeatures() { secondRun.append(mel) }
+
+        XCTAssertEqual(firstRun.count, secondRun.count)
+        for (i, (first, second)) in zip(firstRun, secondRun).enumerated() {
+            XCTAssertEqual(first, second, "Chunk \(i) differs after reset")
+        }
+    }
+}

--- a/Tests/FluidAudioTests/Diarizer/Sortformer/SortformerTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Sortformer/SortformerTests.swift
@@ -132,10 +132,8 @@ final class SortformerTests: XCTestCase {
         }
     }
 
-    // Note: Incremental audio feeding (adding audio in small chunks during real-time streaming)
-    // produces different mel features than batch mode due to NeMo's center padding being applied
-    // at each audio boundary. This is a known architectural limitation.
-    // For exact batch-matching results, feed all audio at once via addAudio() before extracting chunks.
+    // Incremental audio feeding matches batch mode exactly regardless of
+    // feeding granularity; see SortformerStreamingMelTests.
 
     func testBufferBounds() throws {
         var config = DiarizerTimelineConfig.sortformerDefault

--- a/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/SpeakerEnrollmentTests.swift
@@ -223,6 +223,37 @@ final class SpeakerEnrollmentTests: XCTestCase {
         XCTAssertEqual(namedSpeakerIndices(in: diarizer.timeline), [speaker?.index].compactMap { $0 })
     }
 
+    func testSortformerFailedEnrollmentDoesNotDisableStreaming() async throws {
+        let config = SortformerConfig.default
+        let diarizer = SortformerDiarizer(config: config)
+        let models: SortformerModels
+        do {
+            models = try await loadSortformerModelsForTest(config: config)
+        } catch {
+            throw XCTSkip("Unable to load Sortformer test models: \(error)")
+        }
+        diarizer.initialize(models: models)
+
+        // Too short to fill one chunk: enrollment fails with nil. The
+        // failure must not leave the mel stream exhausted, or all later
+        // streaming would be silently ignored until reset().
+        let tooShort = try DiarizationTestFixtures.fixtureAudio(
+            sampleRate: config.sampleRate, startSeconds: 0.0, durationSeconds: 0.5)
+        XCTAssertNil(try diarizer.enrollSpeaker(withAudio: tooShort, named: "Alice"))
+
+        let liveAudio = try DiarizationTestFixtures.fixtureAudio(
+            sampleRate: config.sampleRate, startSeconds: 5.0, durationSeconds: 3.0)
+        var update: DiarizerTimelineUpdate?
+        for chunk in DiarizationTestFixtures.chunk(liveAudio, sizes: [7_680, 9_600, 11_520]) {
+            diarizer.addAudio(chunk)
+            if let next = try diarizer.process() {
+                update = next
+                break
+            }
+        }
+        XCTAssertNotNil(update, "Streaming must keep working after a failed enrollment")
+    }
+
     func testSortformerEnrollmentClearsDiscardedSampleCountBeforeFinalize() async throws {
         XCTExpectFailure("Download might fail in CI environment", strict: false)
 


### PR DESCRIPTION
## Problem

The streaming preprocessor (`addAudio` / `process`) center-pads the buffered audio on every `computeFlatTransposed` call, but the `samplesConsumed` inversion only accounts for one pad. Each preprocess call therefore emits frames covering `nFFT - (nFFT - melWindow)/2` = 272 samples (17 ms) more timeline than the audio it consumes.

With real-time feeding that is roughly one call per 6-frame chunk, so the finalized frame stream runs ~3.5% faster than the audio, and every frame-derived timestamp (speaker turns, segment boundaries) lags further behind the audio as the session runs. Feeding the whole file in a single `addAudio` call only pads once, which is why batch-fed tests and `processComplete` (which uses `SortformerFeatureLoader`) never hit this. It is the same padding-accounting family as #441 / #422 / #444, but silent: there is no static shape to trip a CoreML error, the feature buffer just absorbs the extra frames. The closest acknowledgment was the "known architectural limitation" note in `SortformerTests`.

I hit this in a real app: on a 2.5 minute two-speaker recording, the finalized speaker turns were stamped 2.7 s late at the first turn and 4.5 s late a minute later, so each turn's opening seconds were attributed to the previous speaker, while the tentative (real-time) predictions looked fine.

Same demo script, same audio, against current `main` and this branch:

![frame count vs feeding granularity, before and after](https://raw.githubusercontent.com/predict-woo/FluidAudio/assets/mel-drift-demo.png)

## Fix

Emit the session-global, batch-equivalent mel stream incrementally instead of re-padding per call:

- `audioBuffer` always keeps `nFFT/2` samples of left context, seeded with the batch left pad at reset. Mid-stream frames are computed from real samples only (`.prePadded` + `expectedFrameCount`), consuming exactly `count * melStride` samples, so feeding granularity cannot change frame count or values.
- A frame is emitted once its window `[k*hop - win/2, k*hop + win/2)` is covered by received samples.
- `finalizeSession` (and speaker enrollment, which feeds a complete clip) appends the batch right pad and emits the trailing frames, reaching the exact `.center`-mode frame count. The pad is a preemphasis-cancelling decay so the in-place preemphasis filter reproduces the batch pad's exact zeros.

Streaming output now matches `computeFlatTransposed(paddingMode: .center)` of the whole session frame-for-frame at any feeding granularity, so the limitation note is gone too. No public API changes.

## Test plan

- New `SortformerStreamingMelTests`: identical chunk sequences and frame counts across feeding granularities (160 / 1600 / 4093 / 16000 / one-shot), finalized frame count matches the batch formula, streamed values match batch center-padded mel including the padded tail, and clean restart after `reset()`.
- Existing Sortformer, enrollment, timeline, and streaming-integration suites pass unchanged.
- Verified on the real 154 s recording above: finalized speaker turns now land within one frame of the tentative detections.
