### PR TITLE
Feat/diar python alignment

### DIFF
--- a/Sources/FluidAudio/Diarizer/Core/DiarizerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/Core/DiarizerTypes.swift
@@ -35,7 +35,7 @@ public struct DiarizerConfig: Sendable {
     public static let `default` = DiarizerConfig()
 
     public init(
-        clusteringThreshold: Float = 0.7,
+        clusteringThreshold: Float = 0.5,
         minSpeechDuration: Float = 1.0,
         minEmbeddingUpdateDuration: Float = 2.0,
         minSilenceGap: Float = 0.5,

--- a/Sources/FluidAudio/Diarizer/Core/DiarizerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/Core/DiarizerTypes.swift
@@ -138,6 +138,10 @@ public struct ChunkEmbedding: Sendable, Codable {
     public let endTimeSeconds: Double
     public let embedding256: [Float]
     public let rho128: [Double]
+    /// Clean solo-speech seconds pooled behind this embedding (Python `retained_s`).
+    /// Lets consumers (upload → backend) use the true retained duration instead of
+    /// approximating it from the raw span. 0 when unknown.
+    public let retainedSeconds: Double
 
     public init(
         speakerId: String,
@@ -146,7 +150,8 @@ public struct ChunkEmbedding: Sendable, Codable {
         startTimeSeconds: Double,
         endTimeSeconds: Double,
         embedding256: [Float],
-        rho128: [Double] = []
+        rho128: [Double] = [],
+        retainedSeconds: Double = 0
     ) {
         self.speakerId = speakerId
         self.chunkIndex = chunkIndex
@@ -155,6 +160,7 @@ public struct ChunkEmbedding: Sendable, Codable {
         self.endTimeSeconds = endTimeSeconds
         self.embedding256 = embedding256
         self.rho128 = rho128
+        self.retainedSeconds = retainedSeconds
     }
 }
 

--- a/Sources/FluidAudio/Diarizer/Offline/Clustering/NMESCClustering.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Clustering/NMESCClustering.swift
@@ -102,7 +102,43 @@ struct NMESCClustering {
             nInit: 10,
             baseSeed: 0
         )
-        return labels
+        return collapseIfSingleVoice(labels: labels, features: embeddingFeatures)
+    }
+
+    // MARK: - Single-voice collapse
+
+    /// All-pairs centroid-similarity collapse: the eigengap search never
+    /// hypothesizes k=1 (it starts at 2), so a solo voice is force-split into
+    /// pure sub-clusters of the SAME speaker. If every pair of cluster
+    /// centroids exceeds this cosine, the split is within-voice — collapse.
+    private let singleVoiceCentroidCosine = 0.80
+
+    private func collapseIfSingleVoice(labels: [Int], features: [[Double]]) -> [Int] {
+        let ids = Set(labels)
+        guard ids.count > 1, let dim = features.first?.count else { return labels }
+        var centroids: [[Double]] = []
+        for id in ids.sorted() {
+            var sum = [Double](repeating: 0, count: dim)
+            var count = 0
+            for (i, lab) in labels.enumerated() where lab == id {
+                for j in 0..<dim { sum[j] += features[i][j] }
+                count += 1
+            }
+            guard count > 0 else { continue }
+            var norm = 0.0
+            for v in sum { norm += v * v }
+            norm = norm.squareRoot()
+            centroids.append(norm > 0 ? sum.map { $0 / norm } : sum)
+        }
+        for i in 0..<centroids.count {
+            for j in (i + 1)..<centroids.count {
+                var dot = 0.0
+                for d in 0..<centroids[i].count { dot += centroids[i][d] * centroids[j][d] }
+                if dot < singleVoiceCentroidCosine { return labels }  // a genuinely distinct pair exists
+            }
+        }
+        logger.debug("NME-SC single-voice collapse: \(ids.count) clusters -> 1")
+        return [Int](repeating: 0, count: labels.count)
     }
 
     // MARK: - Affinity construction

--- a/Sources/FluidAudio/Diarizer/Offline/Clustering/NMESCClustering.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Clustering/NMESCClustering.swift
@@ -1,0 +1,233 @@
+import Accelerate
+import Foundation
+
+/// Normalized Maximum Eigengap Spectral Clustering (NME-SC).
+///
+/// Drop-in alternative to `AHCClustering` for the offline pipeline's initial
+/// cluster assignment. Instead of cutting a linkage dendrogram at a fixed
+/// similarity threshold, NME-SC:
+///  1. builds a cosine affinity matrix over the embeddings,
+///  2. sweeps a grid of per-row pruning levels `p` (keep only each row's
+///     strongest `p·n` edges — this severs the weak "bridge" links that make
+///     centroid-linkage AHC chain distinct speakers together),
+///  3. for each `p`, estimates the cluster count from the eigengap of the
+///     normalized graph Laplacian, scoring the candidate by the normalized
+///     eigengap ratio (gap / p),
+///  4. clusters the spectral embedding of the best candidate with K-Means.
+///
+/// The cluster count therefore adapts per recording — there is no global
+/// similarity threshold to tune, which is what makes the same configuration
+/// work on both clean multi-speaker audio and far-field meeting audio.
+struct NMESCClustering {
+
+    private let logger = AppLogger(category: "OfflineNMESC")
+
+    /// Pruning grid: fraction of each row's edges to keep.
+    private let pGrid: [Double] = [0.02, 0.04, 0.06, 0.08, 0.10, 0.15, 0.20, 0.25]
+    /// Upper bound on the estimated speaker count.
+    private let maxSpeakers: Int
+
+    init(maxSpeakers: Int = 8) {
+        self.maxSpeakers = maxSpeakers
+    }
+
+    /// Returns a cluster index per embedding, like `AHCClustering.cluster`.
+    func cluster(embeddingFeatures: [[Double]]) -> [Int] {
+        let n = embeddingFeatures.count
+        guard n > 0 else { return [] }
+        guard let dim = embeddingFeatures.first?.count, dim > 0 else {
+            return Array(repeating: 0, count: n)
+        }
+        // Too few points for spectral structure estimation.
+        guard n >= 8 else { return Array(repeating: 0, count: n) }
+
+        let similarity = cosineMatrix(embeddingFeatures, n: n, dim: dim)
+
+        var best: (score: Double, p: Double, k: Int, affinity: [Double])?
+        for p in pGrid {
+            let keep = max(2, Int(Double(n) * p))
+            guard keep < n else { continue }
+            let affinity = prunedAffinity(similarity, n: n, keep: keep)
+            guard let eigenvalues = laplacianEigenvalues(
+                affinity: affinity, n: n, count: min(maxSpeakers + 1, n))
+            else { continue }
+            // Skip the trivial first eigenvalue; gap g_k = λ_{k+1} − λ_k
+            // (indices into the sorted spectrum) estimates k clusters.
+            var bestGap = -1.0
+            var bestK = 1
+            let usable = min(maxSpeakers, eigenvalues.count - 1)
+            for k in 2...max(2, usable) where k < eigenvalues.count {
+                let gap = eigenvalues[k] - eigenvalues[k - 1]
+                if gap > bestGap {
+                    bestGap = gap
+                    bestK = k
+                }
+            }
+            let score = bestGap / p  // normalized eigengap ratio
+            if best == nil || score > best!.score {
+                best = (score, p, bestK, affinity)
+            }
+        }
+
+        guard let chosen = best else {
+            logger.warning("NME-SC found no usable pruning level; single cluster")
+            return Array(repeating: 0, count: n)
+        }
+        logger.debug("NME-SC selected p=\(chosen.p) k=\(chosen.k) (score \(chosen.score))")
+        guard chosen.k > 1 else { return Array(repeating: 0, count: n) }
+
+        guard let spectral = laplacianEigenvectors(
+            affinity: chosen.affinity, n: n, k: chosen.k)
+        else {
+            logger.warning("NME-SC eigenvector computation failed; single cluster")
+            return Array(repeating: 0, count: n)
+        }
+
+        // Row-normalize the spectral embedding, then K-Means (deterministic
+        // n-init variant already used by the constrained-count path).
+        var rows: [[Double]] = []
+        rows.reserveCapacity(n)
+        for i in 0..<n {
+            var row = Array(spectral[(i * chosen.k)..<((i + 1) * chosen.k)])
+            var norm = 0.0
+            for v in row { norm += v * v }
+            let scale = norm > 0 ? 1.0 / sqrt(norm) : 0
+            for j in 0..<row.count { row[j] *= scale }
+            rows.append(row)
+        }
+        let (labels, _) = KMeansClustering.clusterWithCentroidsNInit(
+            embeddings: rows,
+            numClusters: chosen.k,
+            maxIterations: 100,
+            nInit: 10,
+            baseSeed: 0
+        )
+        return labels
+    }
+
+    // MARK: - Affinity construction
+
+    /// Dense cosine similarity via one syrk-style GEMM over L2-normalized rows.
+    private func cosineMatrix(_ features: [[Double]], n: Int, dim: Int) -> [Double] {
+        var normalized = [Double](repeating: 0, count: n * dim)
+        for (i, row) in features.enumerated() {
+            var norm = 0.0
+            row.withUnsafeBufferPointer { p in
+                vDSP_svesqD(p.baseAddress!, 1, &norm, vDSP_Length(dim))
+            }
+            var scale = norm > 0 ? 1.0 / sqrt(norm) : 0
+            row.withUnsafeBufferPointer { src in
+                normalized.withUnsafeMutableBufferPointer { dst in
+                    vDSP_vsmulD(src.baseAddress!, 1, &scale,
+                                dst.baseAddress!.advanced(by: i * dim), 1, vDSP_Length(dim))
+                }
+            }
+        }
+        var out = [Double](repeating: 0, count: n * n)
+        normalized.withUnsafeBufferPointer { a in
+            out.withUnsafeMutableBufferPointer { c in
+                cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                            Int32(n), Int32(n), Int32(dim),
+                            1.0, a.baseAddress!, Int32(dim),
+                            a.baseAddress!, Int32(dim),
+                            0.0, c.baseAddress!, Int32(n))
+            }
+        }
+        return out
+    }
+
+    /// Keep each row's `keep` strongest edges, symmetrize with max, zero diagonal.
+    private func prunedAffinity(_ S: [Double], n: Int, keep: Int) -> [Double] {
+        var A = [Double](repeating: 0, count: n * n)
+        var indices = Array(0..<n)
+        for i in 0..<n {
+            let row = Array(S[(i * n)..<((i + 1) * n)])
+            indices.sort { row[$0] > row[$1] }
+            var kept = 0
+            for j in indices {
+                if j == i { continue }
+                A[i * n + j] = row[j]
+                kept += 1
+                if kept >= keep { break }
+            }
+        }
+        for i in 0..<n {
+            for j in (i + 1)..<n {
+                let v = max(A[i * n + j], A[j * n + i])
+                A[i * n + j] = v
+                A[j * n + i] = v
+            }
+            A[i * n + i] = 0
+        }
+        return A
+    }
+
+    // MARK: - Laplacian spectrum (LAPACK)
+
+    /// Symmetric normalized Laplacian L = I − D^{-1/2} A D^{-1/2}.
+    private func normalizedLaplacian(affinity A: [Double], n: Int) -> [Double] {
+        var dInvSqrt = [Double](repeating: 0, count: n)
+        for i in 0..<n {
+            var deg = 0.0
+            for j in 0..<n { deg += A[i * n + j] }
+            dInvSqrt[i] = deg > 0 ? 1.0 / sqrt(deg) : 0
+        }
+        var L = [Double](repeating: 0, count: n * n)
+        for i in 0..<n {
+            for j in 0..<n {
+                let v = -dInvSqrt[i] * A[i * n + j] * dInvSqrt[j]
+                L[i * n + j] = i == j ? 1.0 + v : v
+            }
+        }
+        return L
+    }
+
+    /// Smallest `count` eigenvalues of the normalized Laplacian, ascending.
+    private func laplacianEigenvalues(affinity: [Double], n: Int, count: Int) -> [Double]? {
+        var matrix = normalizedLaplacian(affinity: affinity, n: n)
+        guard let w = symmetricEigen(&matrix, n: n, wantVectors: false)?.values else { return nil }
+        return Array(w.prefix(count))
+    }
+
+    /// Row-major n×k matrix of the eigenvectors for the k smallest eigenvalues.
+    private func laplacianEigenvectors(affinity: [Double], n: Int, k: Int) -> [Double]? {
+        var matrix = normalizedLaplacian(affinity: affinity, n: n)
+        guard let result = symmetricEigen(&matrix, n: n, wantVectors: true) else { return nil }
+        // dsyevd returns eigenvalues ascending with eigenvectors as columns of
+        // the (column-major) matrix — i.e. vector j occupies elements
+        // [j*n ..< (j+1)*n] of the storage we passed in.
+        var out = [Double](repeating: 0, count: n * k)
+        for j in 0..<k {
+            for i in 0..<n {
+                out[i * k + j] = result.vectors[j * n + i]
+            }
+        }
+        return out
+    }
+
+    /// LAPACK dsyevd on a symmetric matrix. `matrix` is destroyed; when
+    /// `wantVectors`, its storage holds the eigenvectors on return.
+    private func symmetricEigen(
+        _ matrix: inout [Double], n: Int, wantVectors: Bool
+    ) -> (values: [Double], vectors: [Double])? {
+        var jobz: Int8 = wantVectors ? Int8(UnicodeScalar("V").value) : Int8(UnicodeScalar("N").value)
+        var uplo: Int8 = Int8(UnicodeScalar("U").value)
+        var nn = __CLPK_integer(n)
+        var lda = __CLPK_integer(n)
+        var w = [Double](repeating: 0, count: n)
+        var info: __CLPK_integer = 0
+        var lwork: __CLPK_integer = -1
+        var liwork: __CLPK_integer = -1
+        var workQuery = 0.0
+        var iworkQuery: __CLPK_integer = 0
+        dsyevd_(&jobz, &uplo, &nn, &matrix, &lda, &w, &workQuery, &lwork, &iworkQuery, &liwork, &info)
+        guard info == 0 else { return nil }
+        lwork = __CLPK_integer(workQuery)
+        liwork = iworkQuery
+        var work = [Double](repeating: 0, count: max(1, Int(lwork)))
+        var iwork = [__CLPK_integer](repeating: 0, count: max(1, Int(liwork)))
+        dsyevd_(&jobz, &uplo, &nn, &matrix, &lda, &w, &work, &lwork, &iwork, &liwork, &info)
+        guard info == 0 else { return nil }
+        return (values: w, vectors: matrix)
+    }
+}

--- a/Sources/FluidAudio/Diarizer/Offline/Clustering/SpeakerClusterMerge.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Clustering/SpeakerClusterMerge.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+/// Agglomerative post-merge of over-split NME-SC clusters.
+///
+/// NME-SC's eigengap `k`-selection over-segments: it tends to slice a single
+/// speaker into several temporal sub-clusters because the voice drifts slowly
+/// over a recording. On near-field 1–2 speaker capture the within-speaker
+/// cross-cluster cosine sits at ~0.85–0.96 while true cross-speaker cosine is
+/// ~0.15–0.55, so a single threshold in the ~0.55–0.80 gap recovers the real
+/// speaker count. Well-separated speakers (large centroid gap) are never touched.
+///
+/// Greedy centroid-linkage, pure and deterministic: repeatedly fold the two
+/// clusters whose L2-normalized centroids are most similar while that similarity
+/// is ≥ `threshold`, recomputing the merged centroid from all member embeddings
+/// each step. This is the library-level twin of the app's `SpeakerClusterMerge`
+/// (which remaps segment speaker-ids); here it relabels the per-embedding cluster
+/// assignment directly, before reconstruction.
+enum SpeakerClusterMerge {
+
+    /// Fold over-split clusters together.
+    /// - Parameters:
+    ///   - embeddings: per-window embedding (parallel to `labels`).
+    ///   - labels: per-window cluster id from NME-SC (any integers).
+    ///   - threshold: merge while the most-similar centroid pair has cosine ≥ this.
+    /// - Returns: new per-window labels, renumbered to a contiguous `0..<k` in
+    ///   order of first appearance. Fewer than two clusters → labels unchanged
+    ///   (renumbered). Returns the input untouched if lengths mismatch.
+    static func mergedLabels(
+        embeddings: [[Double]],
+        labels: [Int],
+        threshold: Float
+    ) -> [Int] {
+        guard embeddings.count == labels.count, !labels.isEmpty else { return labels }
+
+        // 1. Group L2-normalized embeddings by cluster (stable first-seen order).
+        var members: [Int: [[Double]]] = [:]
+        var order: [Int] = []
+        for (emb, cid) in zip(embeddings, labels) {
+            guard let n = normed(emb) else { continue }
+            if members[cid] == nil { order.append(cid) }
+            members[cid, default: []].append(n)
+        }
+        guard order.count > 1 else { return renumber(labels) }
+
+        // 2. One group per cluster; each carries its member ids + centroid.
+        var groups: [(ids: Set<Int>, centroid: [Double])] =
+            order.map { (Set([$0]), centroidOf(members[$0]!)) }
+
+        // 3. Greedy: fold the most-similar pair while ≥ threshold.
+        let thr = Double(threshold)
+        while groups.count > 1 {
+            var bestI = -1
+            var bestJ = -1
+            var bestSim = -Double.greatestFiniteMagnitude
+            for i in 0..<groups.count {
+                for j in (i + 1)..<groups.count {
+                    let s = dot(groups[i].centroid, groups[j].centroid)
+                    if s > bestSim {
+                        bestSim = s
+                        bestI = i
+                        bestJ = j
+                    }
+                }
+            }
+            guard bestSim >= thr, bestI >= 0 else { break }
+            let mergedIds = groups[bestI].ids.union(groups[bestJ].ids)
+            let all = mergedIds.flatMap { members[$0]! }  // recompute from all members
+            groups[bestI] = (mergedIds, centroidOf(all))
+            groups.remove(at: bestJ)
+        }
+
+        // 4. Build oldCluster → canonicalCluster, then renumber contiguously.
+        var canonical: [Int: Int] = [:]
+        for group in groups {
+            let rep = group.ids.min()!
+            for id in group.ids { canonical[id] = rep }
+        }
+        let remapped = labels.map { canonical[$0] ?? $0 }
+        return renumber(remapped)
+    }
+
+    // MARK: - Helpers
+
+    /// Renumber arbitrary labels to a contiguous `0..<k` in first-appearance order.
+    private static func renumber(_ labels: [Int]) -> [Int] {
+        var map: [Int: Int] = [:]
+        var next = 0
+        return labels.map { l in
+            if let m = map[l] { return m }
+            map[l] = next
+            defer { next += 1 }
+            return next
+        }
+    }
+
+    /// L2-normalize; `nil` for empty or ~zero-energy vectors (garbage masks).
+    private static func normed(_ v: [Double]) -> [Double]? {
+        guard !v.isEmpty else { return nil }
+        var sq = 0.0
+        for x in v { sq += x * x }
+        let n = sq.squareRoot()
+        guard n > 1e-9 else { return nil }
+        return v.map { $0 / n }
+    }
+
+    /// Mean of already-normalized vectors, renormalized to unit length.
+    private static func centroidOf(_ vs: [[Double]]) -> [Double] {
+        let d = vs[0].count
+        var c = [Double](repeating: 0, count: d)
+        for v in vs where v.count == d {
+            for k in 0..<d { c[k] += v[k] }
+        }
+        return normed(c) ?? c
+    }
+
+    private static func dot(_ a: [Double], _ b: [Double]) -> Double {
+        let d = min(a.count, b.count)
+        var s = 0.0
+        for k in 0..<d { s += a[k] * b[k] }
+        return s
+    }
+}

--- a/Sources/FluidAudio/Diarizer/Offline/Clustering/SpeakerClusterMerge.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Clustering/SpeakerClusterMerge.swift
@@ -9,12 +9,16 @@ import Foundation
 /// ~0.15–0.55, so a single threshold in the ~0.55–0.80 gap recovers the real
 /// speaker count. Well-separated speakers (large centroid gap) are never touched.
 ///
-/// Greedy centroid-linkage, pure and deterministic: repeatedly fold the two
-/// clusters whose L2-normalized centroids are most similar while that similarity
-/// is ≥ `threshold`, recomputing the merged centroid from all member embeddings
-/// each step. This is the library-level twin of the app's `SpeakerClusterMerge`
-/// (which remaps segment speaker-ids); here it relabels the per-embedding cluster
-/// assignment directly, before reconstruction.
+/// Greedy AVERAGE-LINKAGE, pure and deterministic: repeatedly fold the two
+/// clusters whose linkage — the mean cosine over ALL cross-cluster member pairs —
+/// is highest, while it is ≥ `threshold`. This matches the Python reference
+/// `clustering.merge_oversplit` (`sim[ix_(ai,aj)].mean()`), which is deliberately
+/// NOT centroid-linkage: averaging over members is more robust to an off-centroid
+/// outlier than comparing two means. Note the threshold does NOT transfer from the
+/// old centroid-linkage tuning — average-linkage sits below centroid cosine for the
+/// same pair, so the operating point is the reference's ~0.80, pending the 14-clip
+/// A/B. This relabels the per-embedding cluster assignment directly, before
+/// reconstruction.
 enum SpeakerClusterMerge {
 
     /// Fold over-split clusters together.
@@ -42,38 +46,46 @@ enum SpeakerClusterMerge {
         }
         guard order.count > 1 else { return renumber(labels) }
 
-        // 2. One group per cluster; each carries its member ids + centroid.
-        var groups: [(ids: Set<Int>, centroid: [Double])] =
-            order.map { (Set([$0]), centroidOf(members[$0]!)) }
+        // 2. One group per cluster (a set of original cluster ids).
+        var groups: [Set<Int>] = order.map { Set([$0]) }
 
-        // 3. Greedy: fold the most-similar pair while ≥ threshold.
+        /// Average-linkage: mean cosine over every (member of g1) × (member of g2)
+        /// pair. Members are already unit-normalized, so dot == cosine.
+        func linkage(_ g1: Set<Int>, _ g2: Set<Int>) -> Double {
+            let m1 = g1.flatMap { members[$0]! }
+            let m2 = g2.flatMap { members[$0]! }
+            guard !m1.isEmpty, !m2.isEmpty else { return -Double.greatestFiniteMagnitude }
+            var sum = 0.0
+            for a in m1 { for b in m2 { sum += dot(a, b) } }
+            return sum / Double(m1.count * m2.count)
+        }
+
+        // 3. Greedy: fold the highest-linkage pair while ≥ threshold.
         let thr = Double(threshold)
         while groups.count > 1 {
             var bestI = -1
             var bestJ = -1
-            var bestSim = -Double.greatestFiniteMagnitude
+            var bestLink = -Double.greatestFiniteMagnitude
             for i in 0..<groups.count {
                 for j in (i + 1)..<groups.count {
-                    let s = dot(groups[i].centroid, groups[j].centroid)
-                    if s > bestSim {
-                        bestSim = s
+                    let s = linkage(groups[i], groups[j])
+                    if s > bestLink {
+                        bestLink = s
                         bestI = i
                         bestJ = j
                     }
                 }
             }
-            guard bestSim >= thr, bestI >= 0 else { break }
-            let mergedIds = groups[bestI].ids.union(groups[bestJ].ids)
-            let all = mergedIds.flatMap { members[$0]! }  // recompute from all members
-            groups[bestI] = (mergedIds, centroidOf(all))
+            guard bestLink >= thr, bestI >= 0 else { break }
+            groups[bestI].formUnion(groups[bestJ])
             groups.remove(at: bestJ)
         }
 
         // 4. Build oldCluster → canonicalCluster, then renumber contiguously.
         var canonical: [Int: Int] = [:]
         for group in groups {
-            let rep = group.ids.min()!
-            for id in group.ids { canonical[id] = rep }
+            let rep = group.min()!
+            for id in group { canonical[id] = rep }
         }
         let remapped = labels.map { canonical[$0] ?? $0 }
         return renumber(remapped)
@@ -101,16 +113,6 @@ enum SpeakerClusterMerge {
         let n = sq.squareRoot()
         guard n > 1e-9 else { return nil }
         return v.map { $0 / n }
-    }
-
-    /// Mean of already-normalized vectors, renormalized to unit length.
-    private static func centroidOf(_ vs: [[Double]]) -> [Double] {
-        let d = vs[0].count
-        var c = [Double](repeating: 0, count: d)
-        for v in vs where v.count == d {
-            for k in 0..<d { c[k] += v[k] }
-        }
-        return normed(c) ?? c
     }
 
     private static func dot(_ a: [Double], _ b: [Double]) -> Double {

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -502,7 +502,8 @@ public final class OfflineDiarizerManager {
                 startTimeSeconds: te.startTime,
                 endTimeSeconds: te.endTime,
                 embedding256: te.embedding256,
-                rho128: te.rho128
+                rho128: te.rho128,
+                retainedSeconds: te.retainedSeconds
             )
         }
     }
@@ -626,6 +627,21 @@ public final class OfflineDiarizerManager {
 
         if selected.isEmpty {
             return Array(timedEmbeddings.indices)
+        }
+
+        // Pristine-cluster gate (Python cluster_min_retained_s): only embeddings
+        // with ≥ gate clean solo-speech seconds SHAPE the clusters. The downstream
+        // assignEmbeddings pass places every embedding (incl. the excluded shorts)
+        // at its nearest resulting centroid, so gating narrows training only. No-op
+        // when the gate is off, excludes nothing, or would leave < 2 pristine.
+        let gate = config.clustering.minRetainedSeconds
+        if gate > 0 {
+            let pristine = selected.filter { timedEmbeddings[$0].retainedSeconds >= gate }
+            if pristine.count >= 2 && pristine.count < selected.count {
+                logger.info(
+                    "Pristine gate (≥\(gate)s): \(pristine.count)/\(selected.count) embeddings shape the clusters")
+                return pristine
+            }
         }
 
         return selected

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -246,16 +246,35 @@ public final class OfflineDiarizerManager {
 
         let initialClusters: [Int]
         if trainingEmbeddings.count >= 2 {
-            initialClusters = AHCClustering().cluster(
-                embeddingFeatures: trainingEmbeddings,
-                threshold: config.clusteringThreshold
-            )
+            switch config.clustering.algorithm {
+            case .ahc:
+                initialClusters = AHCClustering().cluster(
+                    embeddingFeatures: trainingEmbeddings,
+                    threshold: config.clusteringThreshold
+                )
+            case .nmesc:
+                initialClusters = NMESCClustering(
+                    maxSpeakers: config.clustering.maxSpeakers ?? 8
+                ).cluster(embeddingFeatures: trainingEmbeddings)
+            }
         } else {
             initialClusters = Array(repeating: 0, count: trainingEmbeddings.count)
         }
 
         let vbxOutput: VBxOutput
-        if !trainingRho.isEmpty, !initialClusters.isEmpty {
+        if config.clustering.algorithm == .nmesc {
+            // NME-SC's assignment is final: VBx's PLDA warm start assumes an
+            // AHC-shaped initialization and can re-fuse spectrally separated
+            // clusters, so the pipeline uses the spectral labels directly.
+            vbxOutput = VBxOutput(
+                gamma: [],
+                pi: [],
+                hardClusters: [initialClusters],
+                centroids: [],
+                numClusters: initialClusters.max().map { $0 + 1 } ?? 0,
+                elbos: []
+            )
+        } else if !trainingRho.isEmpty, !initialClusters.isEmpty {
             let hasConstraints =
                 config.clustering.numSpeakers != nil
                 || config.clustering.minSpeakers != nil

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -276,6 +276,50 @@ public final class OfflineDiarizerManager {
             initialClusters = Array(repeating: 0, count: trainingEmbeddings.count)
         }
 
+        // DEV: dump every clustered window embedding to the console for offline
+        // analysis (UMAP / cluster inspection / merge-threshold sweeps). Gated on
+        // the opt-in `debugDumpEmbeddings` flag (the CLI sets it via
+        // `--dump-embeddings`; the app never does) so release builds stay silent.
+        // Uses print so the 192-d vector lines are not truncated by unified logging.
+        if config.debugDumpEmbeddings {
+            let k = (initialClusters.max() ?? -1) + 1
+            print("[[EMB-DUMP-START]] count=\(trainingIndices.count) dim=\(embeddingFeatures.first?.count ?? 0) k=\(k)")
+            for (j, idx) in trainingIndices.enumerated() where idx < timedEmbeddings.count {
+                let te = timedEmbeddings[idx]
+                let cl = j < initialClusters.count ? initialClusters[j] : -1
+                let v = te.embedding256.map { String(format: "%.6f", $0) }.joined(separator: ",")
+                print(
+                    "[[EMB]] {\"j\":\(j),\"chunk\":\(te.chunkIndex),\"spk\":\(te.speakerIndex),"
+                        + "\"t0\":\(String(format: "%.3f", te.startTime)),\"t1\":\(String(format: "%.3f", te.endTime)),"
+                        + "\"cl\":\(cl),\"v\":[\(v)]}")
+            }
+            print("[[EMB-DUMP-END]]")
+        }
+
+        // Collapse NME-SC's temporal over-split of a single speaker: greedily
+        // fold clusters whose centroids are ≥ mergeThreshold cosine (opt-in via
+        // `clustering.mergeEnabled`). The [[EMB]] dump above intentionally keeps
+        // the RAW spectral labels (for offline threshold sweeps); this relabels
+        // the assignment used by every downstream stage.
+        let clusters: [Int]
+        if config.clustering.mergeEnabled {
+            clusters = SpeakerClusterMerge.mergedLabels(
+                embeddings: trainingEmbeddings,
+                labels: initialClusters,
+                threshold: config.clustering.mergeThreshold
+            )
+            let before = (initialClusters.max() ?? -1) + 1
+            let after = (clusters.max() ?? -1) + 1
+            logger.info(
+                "Cluster merge (thr=\(config.clustering.mergeThreshold)): \(before) → \(after) clusters"
+            )
+            if config.debugDumpEmbeddings {
+                print("[[MERGE]] thr=\(config.clustering.mergeThreshold) before=\(before) after=\(after)")
+            }
+        } else {
+            clusters = initialClusters
+        }
+
         let vbxOutput: VBxOutput
         if config.clustering.algorithm == .nmesc {
             // NME-SC's assignment is final: VBx's PLDA warm start assumes an
@@ -284,12 +328,12 @@ public final class OfflineDiarizerManager {
             vbxOutput = VBxOutput(
                 gamma: [],
                 pi: [],
-                hardClusters: [initialClusters],
+                hardClusters: [clusters],
                 centroids: [],
-                numClusters: initialClusters.max().map { $0 + 1 } ?? 0,
+                numClusters: clusters.max().map { $0 + 1 } ?? 0,
                 elbos: []
             )
-        } else if !trainingRho.isEmpty, !initialClusters.isEmpty {
+        } else if !trainingRho.isEmpty, !clusters.isEmpty {
             let hasConstraints =
                 config.clustering.numSpeakers != nil
                 || config.clustering.minSpeakers != nil
@@ -308,16 +352,16 @@ public final class OfflineDiarizerManager {
             vbxOutput = VBxClustering(config: config, pldaTransform: pldaTransform).refineWithConstraints(
                 rhoFeatures: trainingRho,
                 trainingEmbeddings: trainingEmbeddings,
-                initialClusters: initialClusters,
+                initialClusters: clusters,
                 constraints: constraints
             )
         } else {
             vbxOutput = VBxOutput(
                 gamma: [],
                 pi: [],
-                hardClusters: [initialClusters],
+                hardClusters: [clusters],
                 centroids: [],
-                numClusters: initialClusters.max().map { $0 + 1 } ?? 0,
+                numClusters: clusters.max().map { $0 + 1 } ?? 0,
                 elbos: []
             )
         }
@@ -325,7 +369,7 @@ public final class OfflineDiarizerManager {
         let centroidComputation = computeCentroids(
             trainingEmbeddings: trainingEmbeddings,
             vbxOutput: vbxOutput,
-            initialClusters: initialClusters
+            initialClusters: clusters
         )
         var centroids = centroidComputation.centroids
         if centroids.isEmpty {

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -357,6 +357,10 @@ public final class OfflineDiarizerManager {
             )
         }
 
+        if let dumpPath = config.segmentationDumpPath {
+            try exportSegmentation(segmentation, path: dumpPath)
+        }
+
         let publicChunkEmbeddings: [ChunkEmbedding]? =
             config.exposeChunkEmbeddings
             ? Self.buildPublicChunkEmbeddings(
@@ -815,6 +819,43 @@ public final class OfflineDiarizerManager {
         }
 
         return matrix
+    }
+
+    private func exportSegmentation(_ segmentation: SegmentationOutput, path: String) throws {
+        struct ChunkPayload: Codable {
+            let chunkIndex: Int
+            let offsetSeconds: Double
+            let speakerWeights: [[Float]]
+        }
+        struct Payload: Codable {
+            let frameDuration: Double
+            let numChunks: Int
+            let numFrames: Int
+            let numSpeakers: Int
+            let chunks: [ChunkPayload]
+        }
+        var chunks: [ChunkPayload] = []
+        chunks.reserveCapacity(segmentation.numChunks)
+        for index in 0..<segmentation.numChunks {
+            chunks.append(
+                ChunkPayload(
+                    chunkIndex: index,
+                    offsetSeconds: index < segmentation.chunkOffsets.count
+                        ? segmentation.chunkOffsets[index] : 0,
+                    speakerWeights: index < segmentation.speakerWeights.count
+                        ? segmentation.speakerWeights[index] : []
+                )
+            )
+        }
+        let payload = Payload(
+            frameDuration: segmentation.frameDuration,
+            numChunks: segmentation.numChunks,
+            numFrames: segmentation.numFrames,
+            numSpeakers: segmentation.numSpeakers,
+            chunks: chunks
+        )
+        try JSONEncoder().encode(payload).write(to: URL(fileURLWithPath: path))
+        logger.info("Segmentation dump written to \(path)")
     }
 
     private func exportEmbeddings(

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -189,17 +189,32 @@ public final class OfflineDiarizerManager {
 
         let embeddingTask = Task.detached(priority: .userInitiated) {
             [capturedModels, capturedConfig] () throws -> ([TimedEmbedding], TimeInterval) in
-            let extractor = OfflineEmbeddingExtractor(
-                fbankModel: capturedModels.fbankModel,
-                embeddingModel: capturedModels.embeddingModel,
-                pldaTransform: PLDATransform(pldaRhoModel: capturedModels.pldaRhoModel, psi: capturedModels.pldaPsi),
-                config: capturedConfig
-            )
             let start = Date()
-            let embeddings = try await extractor.extractEmbeddings(
-                audioSource: audioSource,
-                segmentationStream: chunkStream
-            )
+            let embeddings: [TimedEmbedding]
+            switch capturedConfig.embedding.backend {
+            case .titanet10s:
+                guard let directory = capturedConfig.titanetModelDirectory else {
+                    throw OfflineDiarizationError.invalidConfiguration(
+                        "titanet10s backend requires titanetModelDirectory")
+                }
+                let extractor = try await TitaNetMaskedExtractor(
+                    directory: directory, config: capturedConfig)
+                embeddings = try await extractor.extractEmbeddings(
+                    audioSource: audioSource,
+                    segmentationStream: chunkStream
+                )
+            case .wespeaker:
+                let extractor = OfflineEmbeddingExtractor(
+                    fbankModel: capturedModels.fbankModel,
+                    embeddingModel: capturedModels.embeddingModel,
+                    pldaTransform: PLDATransform(pldaRhoModel: capturedModels.pldaRhoModel, psi: capturedModels.pldaPsi),
+                    config: capturedConfig
+                )
+                embeddings = try await extractor.extractEmbeddings(
+                    audioSource: audioSource,
+                    segmentationStream: chunkStream
+                )
+            }
             return (embeddings, Date().timeIntervalSince(start))
         }
 
@@ -486,13 +501,6 @@ public final class OfflineDiarizerManager {
     }
 
     private func prewarmEmbeddingStack(models: OfflineDiarizerModels) async throws {
-        let extractor = OfflineEmbeddingExtractor(
-            fbankModel: models.fbankModel,
-            embeddingModel: models.embeddingModel,
-            pldaTransform: PLDATransform(pldaRhoModel: models.pldaRhoModel, psi: models.pldaPsi),
-            config: config
-        )
-
         let dummyAudio = [Float](repeating: 0, count: config.samplesPerWindow)
         let dummySegmentation = SegmentationOutput(
             logProbs: [[[0]]],
@@ -504,10 +512,29 @@ public final class OfflineDiarizerManager {
             frameDuration: max(1e-3, config.windowDuration)
         )
 
-        _ = try await extractor.extractEmbeddings(
-            audio: dummyAudio,
-            segmentation: dummySegmentation
-        )
+        switch config.embedding.backend {
+        case .titanet10s:
+            guard let directory = config.titanetModelDirectory else {
+                throw OfflineDiarizationError.invalidConfiguration(
+                    "titanet10s backend requires titanetModelDirectory")
+            }
+            let extractor = try await TitaNetMaskedExtractor(directory: directory, config: config)
+            _ = try await extractor.extractEmbeddings(
+                audio: dummyAudio,
+                segmentation: dummySegmentation
+            )
+        case .wespeaker:
+            let extractor = OfflineEmbeddingExtractor(
+                fbankModel: models.fbankModel,
+                embeddingModel: models.embeddingModel,
+                pldaTransform: PLDATransform(pldaRhoModel: models.pldaRhoModel, psi: models.pldaPsi),
+                config: config
+            )
+            _ = try await extractor.extractEmbeddings(
+                audio: dummyAudio,
+                segmentation: dummySegmentation
+            )
+        }
     }
 
     private func selectTrainingEmbeddings(

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -8,9 +8,9 @@ public final class OfflineDiarizerManager {
     private let logger = AppLogger(category: "OfflineDiarizer")
     private let config: OfflineDiarizerConfig
 
-    // CoreML models are not Sendable but are used read-only after initialization.
-    // We manage the safety ourselves by only writing during initialization.
-    nonisolated(unsafe) private var models: OfflineDiarizerModels?
+    /// CoreML models are not Sendable but are used read-only after initialization.
+    /// We manage the safety ourselves by only writing during initialization.
+    private nonisolated(unsafe) var models: OfflineDiarizerModels?
 
     public init(config: OfflineDiarizerConfig = .default) {
         self.config = config
@@ -38,51 +38,58 @@ public final class OfflineDiarizerManager {
 
         let targetDirectory =
             directory?.standardizedFileURL
-            ?? OfflineDiarizerModels.defaultModelsDirectory().standardizedFileURL
+                ?? OfflineDiarizerModels.defaultModelsDirectory().standardizedFileURL
 
         if forceRedownload {
             do {
                 try purgeDiarizerRepo(at: targetDirectory)
             } catch {
                 logger.warning(
-                    "Failed to purge diarizer cache during forced reload: \(error.localizedDescription)")
+                    "Failed to purge diarizer cache during forced reload: \(error.localizedDescription)"
+                )
             }
         }
 
         do {
             let loadedModels = try await OfflineDiarizerModels.load(
                 from: targetDirectory,
-                configuration: configuration
+                configuration: configuration,
+                backend: config.embedding.backend
             )
             initialize(models: loadedModels)
             await prewarmModelsIfNeeded(loadedModels)
             logger.info("Offline diarizer models loaded from \(targetDirectory.path)")
         } catch {
             logger.error(
-                "Initial offline diarizer model load failed: \(error.localizedDescription)")
+                "Initial offline diarizer model load failed: \(error.localizedDescription)"
+            )
             logger.info("Attempting fallback download and compilation")
 
             do {
                 try purgeDiarizerRepo(at: targetDirectory)
             } catch {
                 logger.warning(
-                    "Failed to remove cached diarizer repo before fallback: \(error.localizedDescription)")
+                    "Failed to remove cached diarizer repo before fallback: \(error.localizedDescription)"
+                )
             }
 
             do {
                 let reloadedModels = try await OfflineDiarizerModels.load(
                     from: targetDirectory,
-                    configuration: configuration
+                    configuration: configuration,
+                    backend: config.embedding.backend
                 )
                 initialize(models: reloadedModels)
                 await prewarmModelsIfNeeded(reloadedModels)
 
                 let durationText = String(format: "%.2f", reloadedModels.compilationDuration)
                 logger.info(
-                    "Fallback download + compile completed in \(durationText)s at \(targetDirectory.path)")
+                    "Fallback download + compile completed in \(durationText)s at \(targetDirectory.path)"
+                )
             } catch {
                 logger.error(
-                    "Fallback offline diarizer model load failed: \(error.localizedDescription)")
+                    "Fallback offline diarizer model load failed: \(error.localizedDescription)"
+                )
                 throw error
             }
         }
@@ -148,7 +155,8 @@ public final class OfflineDiarizerManager {
 
         let totalStart = Date()
         let totalChunks = max(
-            1, (audioSource.sampleCount + config.samplesPerStep - 1) / config.samplesPerStep)
+            1, (audioSource.sampleCount + config.samplesPerStep - 1) / config.samplesPerStep
+        )
 
         let streamPair = AsyncThrowingStream<SegmentationChunk, Error>.makeStream()
         let chunkStream = streamPair.stream
@@ -195,19 +203,29 @@ public final class OfflineDiarizerManager {
             case .titanet10s:
                 guard let directory = capturedConfig.titanetModelDirectory else {
                     throw OfflineDiarizationError.invalidConfiguration(
-                        "titanet10s backend requires titanetModelDirectory")
+                        "titanet10s backend requires titanetModelDirectory"
+                    )
                 }
                 let extractor = try await TitaNetMaskedExtractor(
-                    directory: directory, config: capturedConfig)
+                    directory: directory, config: capturedConfig
+                )
                 embeddings = try await extractor.extractEmbeddings(
                     audioSource: audioSource,
                     segmentationStream: chunkStream
                 )
             case .wespeaker:
+                guard let fbankModel = capturedModels.fbankModel,
+                      let embeddingModel = capturedModels.embeddingModel,
+                      let pldaRhoModel = capturedModels.pldaRhoModel
+                else {
+                    throw OfflineDiarizationError.modelNotLoaded(
+                        "wespeaker offline embedder (models not loaded for this backend)"
+                    )
+                }
                 let extractor = OfflineEmbeddingExtractor(
-                    fbankModel: capturedModels.fbankModel,
-                    embeddingModel: capturedModels.embeddingModel,
-                    pldaTransform: PLDATransform(pldaRhoModel: capturedModels.pldaRhoModel, psi: capturedModels.pldaPsi),
+                    fbankModel: fbankModel,
+                    embeddingModel: embeddingModel,
+                    pldaTransform: PLDATransform(pldaRhoModel: pldaRhoModel, psi: capturedModels.pldaPsi),
                     config: capturedConfig
                 )
                 embeddings = try await extractor.extractEmbeddings(
@@ -238,7 +256,11 @@ public final class OfflineDiarizerManager {
         let (timedEmbeddings, embeddingTime) = embeddingResult
         logger.debug("Embedding extraction produced \(timedEmbeddings.count) vectors in \(embeddingTime)s (async)")
 
-        let pldaTransform = PLDATransform(pldaRhoModel: models.pldaRhoModel, psi: models.pldaPsi)
+        // Only needed on the WeSpeaker/VBx (.ahc) path; nil under TitaNet+NME-SC,
+        // which never scores with PLDA (and doesn't load the PLDA model).
+        let pldaTransform = models.pldaRhoModel.map {
+            PLDATransform(pldaRhoModel: $0, psi: models.pldaPsi)
+        }
 
         guard !timedEmbeddings.isEmpty else {
             throw OfflineDiarizationError.noSpeechDetected
@@ -291,7 +313,8 @@ public final class OfflineDiarizerManager {
                 print(
                     "[[EMB]] {\"j\":\(j),\"chunk\":\(te.chunkIndex),\"spk\":\(te.speakerIndex),"
                         + "\"t0\":\(String(format: "%.3f", te.startTime)),\"t1\":\(String(format: "%.3f", te.endTime)),"
-                        + "\"cl\":\(cl),\"v\":[\(v)]}")
+                        + "\"cl\":\(cl),\"v\":[\(v)]}"
+                )
             }
             print("[[EMB-DUMP-END]]")
         }
@@ -333,21 +356,21 @@ public final class OfflineDiarizerManager {
                 numClusters: clusters.max().map { $0 + 1 } ?? 0,
                 elbos: []
             )
-        } else if !trainingRho.isEmpty, !clusters.isEmpty {
+        } else if let pldaTransform, !trainingRho.isEmpty, !clusters.isEmpty {
             let hasConstraints =
                 config.clustering.numSpeakers != nil
-                || config.clustering.minSpeakers != nil
-                || config.clustering.maxSpeakers != nil
+                    || config.clustering.minSpeakers != nil
+                    || config.clustering.maxSpeakers != nil
 
             let constraints: SpeakerCountConstraints? =
                 hasConstraints
-                ? SpeakerCountConstraints.resolve(
-                    numEmbeddings: trainingEmbeddings.count,
-                    numSpeakers: config.clustering.numSpeakers,
-                    minSpeakers: config.clustering.minSpeakers,
-                    maxSpeakers: config.clustering.maxSpeakers
-                )
-                : nil
+                    ? SpeakerCountConstraints.resolve(
+                        numEmbeddings: trainingEmbeddings.count,
+                        numSpeakers: config.clustering.numSpeakers,
+                        minSpeakers: config.clustering.minSpeakers,
+                        maxSpeakers: config.clustering.maxSpeakers
+                    )
+                    : nil
 
             vbxOutput = VBxClustering(config: config, pldaTransform: pldaTransform).refineWithConstraints(
                 rhoFeatures: trainingRho,
@@ -422,12 +445,12 @@ public final class OfflineDiarizerManager {
 
         let publicChunkEmbeddings: [ChunkEmbedding]? =
             config.exposeChunkEmbeddings
-            ? Self.buildPublicChunkEmbeddings(
-                timedEmbeddings: timedEmbeddings,
-                assignments: assignments,
-                logger: logger
-            )
-            : nil
+                ? Self.buildPublicChunkEmbeddings(
+                    timedEmbeddings: timedEmbeddings,
+                    assignments: assignments,
+                    logger: logger
+                )
+                : nil
 
         let totalProcessing = Date().timeIntervalSince(totalStart)
         let timings = PipelineTimings(
@@ -560,7 +583,8 @@ public final class OfflineDiarizerManager {
         case .titanet10s:
             guard let directory = config.titanetModelDirectory else {
                 throw OfflineDiarizationError.invalidConfiguration(
-                    "titanet10s backend requires titanetModelDirectory")
+                    "titanet10s backend requires titanetModelDirectory"
+                )
             }
             let extractor = try await TitaNetMaskedExtractor(directory: directory, config: config)
             _ = try await extractor.extractEmbeddings(
@@ -568,10 +592,14 @@ public final class OfflineDiarizerManager {
                 segmentation: dummySegmentation
             )
         case .wespeaker:
+            guard let fbankModel = models.fbankModel,
+                  let embeddingModel = models.embeddingModel,
+                  let pldaRhoModel = models.pldaRhoModel
+            else { return }
             let extractor = OfflineEmbeddingExtractor(
-                fbankModel: models.fbankModel,
-                embeddingModel: models.embeddingModel,
-                pldaTransform: PLDATransform(pldaRhoModel: models.pldaRhoModel, psi: models.pldaPsi),
+                fbankModel: fbankModel,
+                embeddingModel: embeddingModel,
+                pldaTransform: PLDATransform(pldaRhoModel: pldaRhoModel, psi: models.pldaPsi),
                 config: config
             )
             _ = try await extractor.extractEmbeddings(
@@ -616,7 +644,7 @@ public final class OfflineDiarizerManager {
         // use the K-Means centroids directly instead of computing from gamma/pi
         if vbxOutput.wasAdjusted, !vbxOutput.centroids.isEmpty {
             let mapping = Dictionary(
-                uniqueKeysWithValues: (0..<vbxOutput.centroids.count).map { ($0, $0) }
+                uniqueKeysWithValues: (0 ..< vbxOutput.centroids.count).map { ($0, $0) }
             )
             return (vbxOutput.centroids, mapping)
         }
@@ -639,7 +667,7 @@ public final class OfflineDiarizerManager {
                     var denominator = 0.0
                     let frameLimit = min(gamma.count, trainingEmbeddings.count)
 
-                    for frameIdx in 0..<frameLimit {
+                    for frameIdx in 0 ..< frameLimit {
                         let weight = gamma[frameIdx][speakerIdx]
                         guard weight > 0 else { continue }
                         denominator += weight
@@ -691,10 +719,13 @@ public final class OfflineDiarizerManager {
             return ([], [:])
         }
 
-        var grouped: [Int: (sum: [Double], count: Int)] = [:]
+        // Tuple element is named `n` (not `count`) so swiftformat's type-unaware
+        // `isEmpty` rule can't rewrite `entry.count > 0` into `!entry.isEmpty`
+        // (a tuple has no `isEmpty`).
+        var grouped: [Int: (sum: [Double], n: Int)] = [:]
         for (embedding, cluster) in zip(embeddings, clusters) {
             if grouped[cluster] == nil {
-                grouped[cluster] = (sum: [Double](repeating: 0, count: embedding.count), count: 0)
+                grouped[cluster] = (sum: [Double](repeating: 0, count: embedding.count), n: 0)
             }
             precondition(
                 embedding.count == grouped[cluster]!.sum.count,
@@ -717,7 +748,7 @@ public final class OfflineDiarizerManager {
                     )
                 }
             }
-            entry.count += 1
+            entry.n += 1
             grouped[cluster] = entry
         }
 
@@ -728,8 +759,8 @@ public final class OfflineDiarizerManager {
         for (newIndex, key) in sortedKeys.enumerated() {
             mapping[key] = newIndex
             let entry = grouped[key]!
-            if entry.count > 0 {
-                centroids.append(entry.sum.map { $0 / Double(entry.count) })
+            if entry.n > 0 {
+                centroids.append(entry.sum.map { $0 / Double(entry.n) })
             } else {
                 centroids.append(entry.sum)
             }
@@ -907,7 +938,7 @@ public final class OfflineDiarizerManager {
         }
         var chunks: [ChunkPayload] = []
         chunks.reserveCapacity(segmentation.numChunks)
-        for index in 0..<segmentation.numChunks {
+        for index in 0 ..< segmentation.numChunks {
             chunks.append(
                 ChunkPayload(
                     chunkIndex: index,
@@ -951,7 +982,7 @@ public final class OfflineDiarizerManager {
         for (index, embedding) in embeddings.enumerated() {
             let cluster =
                 assignments.indices.contains(index)
-                ? assignments[index] : -1
+                    ? assignments[index] : -1
             payload.append(
                 ExportPayload(
                     chunkIndex: embedding.chunkIndex,

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerModels.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerModels.swift
@@ -85,7 +85,7 @@ public struct OfflineDiarizerModels: Sendable {
         logger.info("Loading offline diarization models from \(modelsDirectory.path)")
 
         let loadStart = Date()
-        let inferenceComputeUnits: MLComputeUnits = .all
+        let inferenceComputeUnits: MLComputeUnits = .cpuAndNeuralEngine
 
         let segmentationAndEmbeddingNames: [String] = [
             ModelNames.OfflineDiarizer.segmentationPath,

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerModels.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerModels.swift
@@ -5,9 +5,13 @@ import OSLog
 @available(macOS 14.0, iOS 17.0, *)
 public struct OfflineDiarizerModels: Sendable {
     public let segmentationModel: MLModel
-    public let fbankModel: MLModel
-    public let embeddingModel: MLModel
-    public let pldaRhoModel: MLModel
+    /// WeSpeaker embedder stack — `nil` when the models are loaded for the
+    /// TitaNet-10s backend. NME-SC needs only segmentation; the 192-d TitaNet
+    /// embedder and its clustering never touch FBANK/WeSpeaker/PLDA, so those
+    /// files are neither downloaded nor compiled on the TitaNet path.
+    public let fbankModel: MLModel?
+    public let embeddingModel: MLModel?
+    public let pldaRhoModel: MLModel?
     public let pldaPsi: [Double]
 
     public let compilationDuration: TimeInterval
@@ -53,10 +57,10 @@ public struct OfflineDiarizerModels: Sendable {
 
     public init(
         segmentationModel: MLModel,
-        fbankModel: MLModel,
-        embeddingModel: MLModel,
-        pldaRhoModel: MLModel,
-        pldaPsi: [Double],
+        fbankModel: MLModel? = nil,
+        embeddingModel: MLModel? = nil,
+        pldaRhoModel: MLModel? = nil,
+        pldaPsi: [Double] = [],
         compilationDuration: TimeInterval
     ) {
         self.segmentationModel = segmentationModel
@@ -77,38 +81,68 @@ public struct OfflineDiarizerModels: Sendable {
 
     public static func load(
         from directory: URL? = nil,
-        configuration: MLModelConfiguration? = nil,
-        progressHandler: DownloadUtils.ProgressHandler? = nil
+        configuration _: MLModelConfiguration? = nil,
+        progressHandler: DownloadUtils.ProgressHandler? = nil,
+        backend: OfflineDiarizerConfig.Embedding.Backend = .wespeaker
     ) async throws -> OfflineDiarizerModels {
         let modelsDirectory = directory ?? defaultModelsDirectory()
         let logger = Self.logger
-        logger.info("Loading offline diarization models from \(modelsDirectory.path)")
+        logger.info(
+            "Loading offline diarization models from \(modelsDirectory.path) (backend: \(backend.rawValue))"
+        )
 
         let loadStart = Date()
         let inferenceComputeUnits: MLComputeUnits = .cpuAndNeuralEngine
 
-        let segmentationAndEmbeddingNames: [String] = [
-            ModelNames.OfflineDiarizer.segmentationPath,
+        // Segmentation is always required — it drives VAD + the per-speaker
+        // masks consumed by BOTH the WeSpeaker and TitaNet embedders. The variant
+        // controls the DOWNLOAD gate: `.titanet10s` uses "offline-titanet" so
+        // `downloadRepo` fetches ONLY Segmentation (not the WeSpeaker/FBANK/PLDA
+        // files), while `.wespeaker` keeps "offline" (full 5-file set).
+        let segmentationVariant = backend == .titanet10s ? "offline-titanet" : "offline"
+        let segmentationModels = try await DownloadUtils.loadModels(
+            .diarizer,
+            modelNames: [ModelNames.OfflineDiarizer.segmentationPath],
+            directory: modelsDirectory,
+            computeUnits: inferenceComputeUnits,
+            variant: segmentationVariant,
+            progressHandler: progressHandler
+        )
+        guard let segmentation = segmentationModels[ModelNames.OfflineDiarizer.segmentationPath] else {
+            throw OfflineDiarizationError.modelNotLoaded(ModelNames.OfflineDiarizer.segmentation)
+        }
+
+        // TitaNet-10s (NME-SC) uses only segmentation; the WeSpeaker embedder,
+        // FBANK frontend, and PLDA/VBx artifacts are never touched at inference,
+        // so skip downloading + compiling them entirely.
+        if backend == .titanet10s {
+            let compilationDuration = Date().timeIntervalSince(loadStart)
+            logger.info(
+                "Offline diarization models ready (TitaNet: segmentation only, compile: \(String(format: "%.3f", compilationDuration))s)"
+            )
+            return OfflineDiarizerModels(
+                segmentationModel: segmentation,
+                compilationDuration: compilationDuration
+            )
+        }
+
+        // WeSpeaker path — full stack: embedding + PLDA (rho) + FBANK + psi.
+        let embeddingAndPldaNames: [String] = [
             ModelNames.OfflineDiarizer.embeddingPath,
             ModelNames.OfflineDiarizer.pldaRhoPath,
         ]
-
-        let segmentationEmbeddingModels = try await DownloadUtils.loadModels(
+        let embeddingAndPldaModels = try await DownloadUtils.loadModels(
             .diarizer,
-            modelNames: segmentationAndEmbeddingNames,
+            modelNames: embeddingAndPldaNames,
             directory: modelsDirectory,
             computeUnits: inferenceComputeUnits,
             variant: "offline",
             progressHandler: progressHandler
         )
-
-        guard let segmentation = segmentationEmbeddingModels[ModelNames.OfflineDiarizer.segmentationPath] else {
-            throw OfflineDiarizationError.modelNotLoaded(ModelNames.OfflineDiarizer.segmentation)
-        }
-        guard let embedding = segmentationEmbeddingModels[ModelNames.OfflineDiarizer.embeddingPath] else {
+        guard let embedding = embeddingAndPldaModels[ModelNames.OfflineDiarizer.embeddingPath] else {
             throw OfflineDiarizationError.modelNotLoaded(ModelNames.OfflineDiarizer.embedding)
         }
-        guard let plda = segmentationEmbeddingModels[ModelNames.OfflineDiarizer.pldaRhoPath] else {
+        guard let plda = embeddingAndPldaModels[ModelNames.OfflineDiarizer.pldaRhoPath] else {
             throw OfflineDiarizationError.modelNotLoaded(ModelNames.OfflineDiarizer.pldaRho)
         }
 
@@ -143,8 +177,8 @@ public struct OfflineDiarizerModels: Sendable {
     }
 }
 
-extension MLComputeUnits {
-    fileprivate var label: String {
+private extension MLComputeUnits {
+    var label: String {
         switch self {
         case .cpuOnly:
             return ".cpuOnly"

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
@@ -103,6 +103,46 @@ public struct OfflineDiarizerConfig: Sendable {
 
         public var backend: Backend = .wespeaker
 
+        /// TitaNet pooling mode (only consulted when `backend == .titanet10s`).
+        /// `.maskedFull` runs the encoder ONCE per window and pools it with the
+        /// per-speaker mask. `.cleanRegion` crops clean single-speaker mel frames
+        /// BEFORE the encoder and pools with a contiguous mask (spec-style — the
+        /// encoder never convolves over overlap). `.cleanWaveform` (default) is
+        /// the reference-faithful fix — see below.
+        ///
+        /// The 3-file BundledAMI A/B (2026-07-10) is decisive: `.cleanRegion`
+        /// over-splits badly (avg DER 37.7% vs 14.6%, Speaker-Error ~29% vs ~7%),
+        /// because the per-(window,speaker) encoder pass over spliced/packed mel
+        /// injects variance the unchanged NME-SC reads as extra speakers. Kept
+        /// behind the flag only for the per-turn-aggregation rescue experiment.
+        ///
+        /// `.cleanWaveform` is the reference-faithful fix for that over-split
+        /// (2026-07-10 forensics): instead of cropping full-window MEL columns
+        /// (which inherit full-window mean/std normalization + STFT bleed at the
+        /// overlap boundary), it crops the clean single-speaker WAVEFORM and
+        /// re-featurizes each crop on its own (clean-only normalization, no
+        /// cross-talk in any STFT window), drops one edge mel frame per crop
+        /// (`joinFrameDrop`), concatenates in the feature domain, then runs the
+        /// encoder once. On the w0 slice this collapses the over-split back to
+        /// k=4 (matching WeSpeaker/masked) where `.cleanRegion` gave k=7; masked
+        /// still wins overall, so this stays behind the flag too.
+        public enum TitaNetPooling: String, Sendable {
+            case maskedFull
+            case cleanRegion
+            case cleanWaveform
+        }
+
+        public var titanetPooling: TitaNetPooling = .cleanWaveform
+
+        /// Clean-region extraction parameters (titanet10s + `.cleanRegion`), in
+        /// milliseconds at the 100 fps mel-frame grid. First-pass defaults from
+        /// PIPELINE_SPEC §5; all tunable.
+        public var collarLeadMs: Int = 50
+        public var collarTrailMs: Int = 50
+        public var regionMinMs: Int = 500
+        public var embedMinMs: Int = 2000
+        public var embedTargetMs: Int = 3000
+
         public var batchSize: Int
         public var excludeOverlap: Bool
         public var minSegmentDurationSeconds: Double
@@ -158,6 +198,21 @@ public struct OfflineDiarizerConfig: Sendable {
         /// Exact number of speakers. Overrides `minSpeakers` and `maxSpeakers` when set.
         public var numSpeakers: Int?
 
+        /// Agglomerative post-merge of over-split clusters. NME-SC's eigengap
+        /// `k`-selection tends to slice a single speaker into several temporal
+        /// sub-clusters (voice drifts slowly over a recording). When `true`, the
+        /// pipeline greedily folds clusters whose L2-normalized centroids are ≥
+        /// `mergeThreshold` cosine, recovering the real speaker count without
+        /// touching well-separated speakers. Default `false` (opt-in); the app's
+        /// TitaNet arm enables it. See `SpeakerClusterMerge`.
+        public var mergeEnabled: Bool = false
+
+        /// Merge while the most-similar surviving centroid pair has cosine ≥ this.
+        /// ~0.75 sits in the gap between within-speaker drift (~0.85–0.96) and true
+        /// cross-speaker cosine (~0.15–0.55) on near-field capture. Only consulted
+        /// when `mergeEnabled`.
+        public var mergeThreshold: Float = 0.75
+
         public static let community = Clustering(
             threshold: 0.6,
             warmStartFa: 0.07,
@@ -173,7 +228,9 @@ public struct OfflineDiarizerConfig: Sendable {
             warmStartFb: Double,
             minSpeakers: Int? = nil,
             maxSpeakers: Int? = nil,
-            numSpeakers: Int? = nil
+            numSpeakers: Int? = nil,
+            mergeEnabled: Bool = false,
+            mergeThreshold: Float = 0.75
         ) {
             self.threshold = threshold
             self.warmStartFa = warmStartFa
@@ -181,6 +238,8 @@ public struct OfflineDiarizerConfig: Sendable {
             self.minSpeakers = minSpeakers
             self.maxSpeakers = maxSpeakers
             self.numSpeakers = numSpeakers
+            self.mergeEnabled = mergeEnabled
+            self.mergeThreshold = mergeThreshold
         }
     }
 
@@ -250,6 +309,13 @@ public struct OfflineDiarizerConfig: Sendable {
     /// speaker weights + offsets) to this JSON path after processing — the
     /// mask source for offline experimentation (`--dump-masks` in the CLI).
     public var segmentationDumpPath: String?
+
+    /// DEV/experimentation only: when true, the manager `print`s the raw
+    /// per-window embeddings (`[[EMB]]`) and merge result (`[[MERGE]]`) to
+    /// stdout for offline analysis / merge-threshold sweeps. The CLI opts in via
+    /// `--dump-embeddings`; the app never sets it, so release builds stay silent.
+    /// Defaulted so existing initializers need not set it.
+    public var debugDumpEmbeddings: Bool = false
 
     /// Directory containing TitaNet10s_frontenc_fp16.mlmodelc and
     /// TitaNet10s_maskdec_fp16.mlmodelc. Required when

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
@@ -118,6 +118,19 @@ public struct OfflineDiarizerConfig: Sendable {
     }
 
     public struct Clustering: Sendable {
+        /// Initial clustering algorithm. `.ahc` (default) cuts a centroid-linkage
+        /// dendrogram at `threshold`; `.nmesc` estimates the cluster count per
+        /// recording via the normalized maximum eigengap (no threshold) and is
+        /// robust to the bridge-chunk chaining that fuses AHC on meeting audio.
+        /// NME-SC bypasses VBx refinement (VBx's warm start assumes AHC-shaped
+        /// initialization; NME-SC's assignment is used directly).
+        public enum Algorithm: String, Sendable {
+            case ahc
+            case nmesc
+        }
+
+        public var algorithm: Algorithm = .ahc
+
         /// Euclidean distance threshold for unit-normalized embeddings.
         public var threshold: Double
 

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
@@ -92,6 +92,17 @@ public struct OfflineDiarizerConfig: Sendable {
     }
 
     public struct Embedding: Sendable {
+        /// Embedding extractor backend. `.wespeaker` (default) = the bundled
+        /// masked WeSpeaker path. `.titanet10s` = TitaNet-large via the 10 s
+        /// mask-input CoreML pair (requires `titanetModelDirectory` and
+        /// `clustering.algorithm == .nmesc` — 192-d has no PLDA/VBx space).
+        public enum Backend: String, Sendable {
+            case wespeaker
+            case titanet10s
+        }
+
+        public var backend: Backend = .wespeaker
+
         public var batchSize: Int
         public var excludeOverlap: Bool
         public var minSegmentDurationSeconds: Double
@@ -240,6 +251,11 @@ public struct OfflineDiarizerConfig: Sendable {
     /// mask source for offline experimentation (`--dump-masks` in the CLI).
     public var segmentationDumpPath: String?
 
+    /// Directory containing TitaNet10s_frontenc_fp16.mlmodelc and
+    /// TitaNet10s_maskdec_fp16.mlmodelc. Required when
+    /// `embedding.backend == .titanet10s`.
+    public var titanetModelDirectory: URL?
+
     public init(
         segmentation: Segmentation = .community,
         embedding: Embedding = .community,
@@ -323,6 +339,16 @@ public struct OfflineDiarizerConfig: Sendable {
 
     /// Validate configuration values and throw if they fall outside expected ranges.
     public func validate() throws {
+        if embedding.backend == .titanet10s {
+            guard clustering.algorithm == .nmesc else {
+                throw OfflineDiarizationError.invalidConfiguration(
+                    "titanet10s backend requires clustering.algorithm == .nmesc (no PLDA/VBx for 192-d)")
+            }
+            guard titanetModelDirectory != nil else {
+                throw OfflineDiarizationError.invalidConfiguration(
+                    "titanet10s backend requires titanetModelDirectory")
+            }
+        }
         let maxClusteringThreshold = sqrt(2.0)
         guard clustering.threshold > 0, clustering.threshold <= maxClusteringThreshold else {
             throw OfflineDiarizationError.invalidConfiguration(

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
@@ -213,6 +213,14 @@ public struct OfflineDiarizerConfig: Sendable {
         /// when `mergeEnabled`.
         public var mergeThreshold: Float = 0.75
 
+        /// Pristine-cluster gate (Python `cluster_min_retained_s`). When > 0, only
+        /// embeddings backed by ≥ this many clean solo-speech seconds SHAPE the
+        /// clusters (NME-SC structure + centroids); shorter ones are excluded from
+        /// training and then assigned to the nearest resulting centroid — membership
+        /// without influence. 0 = off. No-op when it would exclude nothing or leave
+        /// < 2 pristine embeddings (the assignment pass still places every embedding).
+        public var minRetainedSeconds: Double = 0
+
         public static let community = Clustering(
             threshold: 0.6,
             warmStartFa: 0.07,
@@ -726,6 +734,10 @@ struct TimedEmbedding: Sendable {
     let endTime: Double
     let embedding256: [Float]
     let rho128: [Double]
+    /// Clean solo-speech seconds actually pooled behind this embedding (the Python
+    /// reference's `retained_s`). Drives the pristine-cluster gate + duration
+    /// weighting. Defaults to 0 for paths that don't compute it (e.g. WeSpeaker).
+    var retainedSeconds: Double = 0
 }
 
 // MARK: - Convenience Methods

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerTypes.swift
@@ -235,6 +235,11 @@ public struct OfflineDiarizerConfig: Sendable {
     /// PLDA payload) for callers that don't need them.
     public var exposeChunkEmbeddings: Bool
 
+    /// When set, the manager writes the raw segmentation output (per-chunk
+    /// speaker weights + offsets) to this JSON path after processing — the
+    /// mask source for offline experimentation (`--dump-masks` in the CLI).
+    public var segmentationDumpPath: String?
+
     public init(
         segmentation: Segmentation = .community,
         embedding: Embedding = .community,

--- a/Sources/FluidAudio/Diarizer/Offline/Extraction/CleanRegionSelector.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Extraction/CleanRegionSelector.swift
@@ -138,8 +138,15 @@ enum CleanRegionSelector {
                 let s0 = min(availableSamples, max(0, Int((Double(f) * spf).rounded())))
                 let s1 = min(availableSamples, max(0, Int((Double(j) * spf).rounded())))
                 if s1 - s0 >= regionMinSamples {
-                    regions.append((start: s0, end: s1))
-                    total += s1 - s0
+                    // Truncate the final region so the pooled total lands EXACTLY on
+                    // targetSamples, mirroring the Python reference
+                    // (regions.py: `if total + len(crop) > target: crop = crop[:target-total]`).
+                    // A region qualifies by its FULL length (the guard above), then the
+                    // last one is capped — without this a single long clean run overshoots
+                    // and pools more audio than the reference (retained_s > target/sr).
+                    let take = min(s1 - s0, targetSamples - total)
+                    regions.append((start: s0, end: s0 + take))
+                    total += take
                     if total >= targetSamples { break outer }
                 }
                 f = j

--- a/Sources/FluidAudio/Diarizer/Offline/Extraction/CleanRegionSelector.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Extraction/CleanRegionSelector.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+/// Clean single-speaker region selection for the TitaNet `.cleanRegion` pooling
+/// path (PIPELINE_SPEC §3.2). Operates purely on the 100 fps mel-frame grid, so
+/// it is unit-testable without any CoreML model.
+///
+/// Given a per-mel-frame clean weight for ONE speaker (overlap already excluded
+/// upstream), it returns the ordered mel-frame indices to pack contiguously into
+/// the encoder input — or `nil` to skip the speaker in this window.
+enum CleanRegionSelector {
+
+    /// - Parameters:
+    ///   - cleanMaskMel: per-mel-frame clean weight (~0..1), length = mel frames.
+    ///   - collarLead / collarTrail: frames eroded inward from each contiguous
+    ///     clean run's start / end (co-articulation, reverb tail, interferer onset).
+    ///   - regionMin: minimum run length (frames) AFTER erosion to keep it.
+    ///   - embedMin: skip the speaker (return `nil`) if fewer than this many clean
+    ///     frames survive.
+    ///   - embedTarget: accumulate clean frames in time order up to this many. A
+    ///     single contiguous kept run ≥ target is embedded IN FULL (maximizes
+    ///     clean seconds, avoids a splice), per spec §3.4/§5.
+    /// - Returns: ascending mel-frame indices to pack, or `nil` to skip.
+    static func selectCleanMelFrames(
+        cleanMaskMel: [Float],
+        collarLead: Int,
+        collarTrail: Int,
+        regionMin: Int,
+        embedMin: Int,
+        embedTarget: Int
+    ) -> [Int]? {
+        let n = cleanMaskMel.count
+        guard n > 0 else { return nil }
+
+        // 1. Binarize (>0.5) → contiguous clean runs [start, end).
+        var runs: [(start: Int, end: Int)] = []
+        var i = 0
+        while i < n {
+            if cleanMaskMel[i] > 0.5 {
+                var j = i + 1
+                while j < n, cleanMaskMel[j] > 0.5 { j += 1 }
+                runs.append((i, j))
+                i = j
+            } else {
+                i += 1
+            }
+        }
+
+        // 2. Collar-erode inward; keep runs still ≥ regionMin.
+        let minRun = max(1, regionMin)
+        var kept: [(start: Int, end: Int)] = []
+        for run in runs {
+            let s = run.start + max(0, collarLead)
+            let e = run.end - max(0, collarTrail)
+            if e - s >= minRun { kept.append((start: s, end: e)) }
+        }
+        guard !kept.isEmpty else { return nil }
+
+        // 3a. A single contiguous kept run ≥ target → embed it in full.
+        if let longest = kept.max(by: { ($0.end - $0.start) < ($1.end - $1.start) }),
+            longest.end - longest.start >= embedTarget
+        {
+            return Array(longest.start..<longest.end)  // ≥ embedTarget ≥ embedMin
+        }
+
+        // 3b. Otherwise concatenate kept runs in time order up to the target.
+        var frames: [Int] = []
+        frames.reserveCapacity(min(embedTarget, n))
+        outer: for run in kept {
+            for f in run.start..<run.end {
+                frames.append(f)
+                if frames.count >= embedTarget { break outer }
+            }
+        }
+
+        // 4. Skip if too little clean speech accumulated.
+        return frames.count >= embedMin ? frames : nil
+    }
+
+    /// Clean single-speaker WAVEFORM regions for the `.cleanWaveform` pooling path
+    /// (the reference-faithful fix). Unlike `selectCleanMelFrames` this works at
+    /// SAMPLE resolution and returns sample ranges to crop from the window audio,
+    /// so each crop can be re-featurized on its own. Mirrors the Python reference
+    /// `extract_clean_region_waveforms` / `build_wavecrop.clean_crops`.
+    ///
+    /// - Parameters:
+    ///   - weights: per-frame speaker posteriors `[frameCount][speakerCount]`.
+    ///   - speaker: the speaker column to extract.
+    ///   - availableSamples: window audio length (≤ 160k; the crop source).
+    ///   - regionMinSamples / targetSamples / embedMinSamples: min kept run,
+    ///     accumulation target, and skip floor — all in samples.
+    ///   - threshold: hard active/overlap threshold (reference uses 0.5, NOT the
+    ///     soft 1e-3 overlap threshold of the masked path).
+    /// - Returns: `(regions, firstFrame, lastFrame)` where regions are ascending,
+    ///   non-overlapping sample ranges `[start, end)`, and first/last frame index
+    ///   the extractor maps to segment timing — or `nil` to skip the speaker.
+    static func selectCleanSampleRegions(
+        weights: [[Float]],
+        speaker: Int,
+        availableSamples: Int,
+        regionMinSamples: Int,
+        targetSamples: Int,
+        embedMinSamples: Int,
+        threshold: Float
+    ) -> (regions: [(start: Int, end: Int)], firstFrame: Int, lastFrame: Int)? {
+        let frameCount = weights.count
+        guard frameCount > 0, availableSamples > 0,
+            let speakerCount = weights.first?.count, speaker < speakerCount
+        else { return nil }
+
+        // clean[f] = speaker active AND no overlap (≥2 speakers over threshold).
+        var clean = [Bool](repeating: false, count: frameCount)
+        var firstFrame = -1
+        var lastFrame = -1
+        for f in 0..<frameCount {
+            let row = weights[f]
+            guard row[speaker] > threshold else { continue }
+            var active = 0
+            for value in row where value > threshold {
+                active += 1
+                if active > 1 { break }
+            }
+            if active < 2 {
+                clean[f] = true
+                if firstFrame < 0 { firstFrame = f }
+                lastFrame = f
+            }
+        }
+        guard firstFrame >= 0 else { return nil }
+
+        let spf = Double(availableSamples) / Double(frameCount)
+        var regions: [(start: Int, end: Int)] = []
+        var total = 0
+        var f = 0
+        outer: while f < frameCount {
+            if clean[f] {
+                var j = f + 1
+                while j < frameCount, clean[j] { j += 1 }
+                let s0 = min(availableSamples, max(0, Int((Double(f) * spf).rounded())))
+                let s1 = min(availableSamples, max(0, Int((Double(j) * spf).rounded())))
+                if s1 - s0 >= regionMinSamples {
+                    regions.append((start: s0, end: s1))
+                    total += s1 - s0
+                    if total >= targetSamples { break outer }
+                }
+                f = j
+            } else {
+                f += 1
+            }
+        }
+
+        if total < embedMinSamples { return nil }
+        return (regions, firstFrame, lastFrame)
+    }
+
+    /// Concatenates per-crop mel-major `[melBins, frames_i]` buffers in the feature
+    /// (frame) domain into a fresh `[melBins, dstFrames]` buffer, zero-padded past
+    /// the total. Returns the packed buffer and the number of frames actually
+    /// written (`min(sum frames_i, dstFrames)`), which the mask spans. Pure/testable.
+    static func packConcatFeatures(
+        columns: [(feats: [Float], frames: Int)], melBins: Int, dstFrames: Int
+    ) -> (feats: [Float], usedFrames: Int) {
+        var dst = [Float](repeating: 0, count: melBins * dstFrames)
+        let total = columns.reduce(0) { $0 + $1.frames }
+        let used = min(total, dstFrames)
+        for m in 0..<melBins {
+            var pos = 0
+            let dstRow = m * dstFrames
+            for col in columns {
+                if pos >= used { break }
+                let srcRow = m * col.frames
+                var t = 0
+                while t < col.frames, pos < used {
+                    dst[dstRow + pos] = col.feats[srcRow + t]
+                    t += 1
+                    pos += 1
+                }
+            }
+        }
+        return (dst, used)
+    }
+
+    /// Packs the `frames` columns of a C-contiguous row-major `[melBins, srcFrames]`
+    /// buffer into a fresh `[melBins, dstFrames]` buffer, zero-padded past the
+    /// selected count. Pure/testable core of the extractor's mel-frame packer.
+    static func packColumns(
+        src: [Float], melBins: Int, srcFrames: Int, dstFrames: Int, frames: [Int]
+    ) -> [Float] {
+        var dst = [Float](repeating: 0, count: melBins * dstFrames)
+        let count = min(frames.count, dstFrames)
+        for c in 0..<melBins {
+            let srcRow = c * srcFrames
+            let dstRow = c * dstFrames
+            for p in 0..<count { dst[dstRow + p] = src[srcRow + frames[p]] }
+        }
+        return dst
+    }
+}

--- a/Sources/FluidAudio/Diarizer/Offline/Extraction/TitaNetMaskedExtractor.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Extraction/TitaNetMaskedExtractor.swift
@@ -222,6 +222,9 @@ struct TitaNetMaskedExtractor {
                 // Explicit frame bounds for segment timing; only .cleanWaveform sets
                 // it (its clean frames use a 0.5 threshold, not metaMask's soft one).
                 var explicitBounds: (first: Int, last: Int)?
+                // Clean solo-speech seconds pooled behind this embedding (Python
+                // `retained_s`). Set per pooling branch below; drives the gate + weight.
+                var retainedSeconds: Double = 0
 
                 switch config.embedding.titanetPooling {
                 case .cleanWaveform:
@@ -267,6 +270,10 @@ struct TitaNetMaskedExtractor {
                     embedding = try runMaskDecoder(encoded: enc, mask: contiguousMask)
                     metaMask = cleanMask
                     explicitBounds = (selection.firstFrame, selection.lastFrame)
+                    // Pooled clean seconds = sum of the (truncated-to-target) region
+                    // sample lengths / sr — matches Python regions.py `total / sr`.
+                    retainedSeconds =
+                        Double(selection.regions.reduce(0) { $0 + ($1.end - $1.start) }) / Double(sr)
 
                 case .cleanRegion:
                     // Resample the OVERLAP-EXCLUDED mask onto the mel grid, pick the
@@ -292,6 +299,7 @@ struct TitaNetMaskedExtractor {
                     for p in 0..<min(frames.count, Self.melFrames) { contiguousMask[p] = 1 }
                     embedding = try runMaskDecoder(encoded: enc, mask: contiguousMask)
                     metaMask = cleanMask
+                    retainedSeconds = Double(frames.count) * frameDuration
 
                 case .maskedFull:
                     let maskToUse: [Float]
@@ -318,6 +326,7 @@ struct TitaNetMaskedExtractor {
                     }
                     embedding = try runMaskDecoder(encoded: enc, mask: resampledMask)
                     metaMask = maskToUse
+                    retainedSeconds = Double(cleanSum) * frameDuration
                 }
 
                 let firstActive: Int
@@ -340,7 +349,8 @@ struct TitaNetMaskedExtractor {
                         startTime: chunkOffsetSeconds + Double(firstActive) * frameDuration,
                         endTime: chunkOffsetSeconds + Double(lastActive + 1) * frameDuration,
                         embedding256: embedding,
-                        rho128: []
+                        rho128: [],
+                        retainedSeconds: retainedSeconds
                     ))
             }
         }
@@ -508,6 +518,24 @@ struct TitaNetMaskedExtractor {
             throw OfflineDiarizationError.processingFailed("TitaNet maskdec missing embedding output")
         }
         let pointer = embeddingArray.dataPointer.assumingMemoryBound(to: Float.self)
-        return Array(UnsafeBufferPointer(start: pointer, count: embeddingArray.count))
+        var v = Array(UnsafeBufferPointer(start: pointer, count: embeddingArray.count))
+        // L2-normalize to match the Python reference (embeddings.py `l2norm`:
+        // v / (‖v‖₂ + 1e-8)). The offline TitaNet output was previously uploaded
+        // un-normalized (‖v‖ ≈ 0.2–0.5 on healthy hardware); the backend re-normalizes
+        // per-cluster, but per-member cosine + the raw upload need unit vectors.
+        var ss: Float = 0
+        for x in v { ss += x * x }
+        let rawNorm = ss.squareRoot()
+        // Corruption tell: a healthy embedding has ‖v‖ ≈ 0.2–0.5. A norm orders of
+        // magnitude off (≈89 observed on an iPhone-ANE run, k=1 collapse) is a broken
+        // embedder — surface it BEFORE normalization erases the evidence (every
+        // corrupted vector normalizes to ‖1‖ and looks textbook-perfect afterward).
+        if rawNorm > 5.0 || rawNorm < 0.01 {
+            logger.warning(
+                "TitaNet embedding raw ‖v‖=\(rawNorm) outside healthy band (~0.2–0.5) — possible embedder corruption")
+        }
+        let inv = 1 / (rawNorm + 1e-8)
+        for i in v.indices { v[i] *= inv }
+        return v
     }
 }

--- a/Sources/FluidAudio/Diarizer/Offline/Extraction/TitaNetMaskedExtractor.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Extraction/TitaNetMaskedExtractor.swift
@@ -1,0 +1,308 @@
+import Accelerate
+import CoreML
+import Foundation
+
+/// TitaNet-10s masked embedding extractor — selectable alternative to the
+/// WeSpeaker `OfflineEmbeddingExtractor` (`config.embedding.backend == .titanet10s`).
+///
+/// Same inputs (audio source + segmentation chunk stream), same output
+/// (`[TimedEmbedding]`), different mechanics: the TitaNet front + encoder run
+/// ONCE per 10 s window (audio → encoder frames), and the mask-input decoder
+/// runs once per active speaker with that speaker's overlap-excluded mask
+/// (segmentation weights resampled to the 1000 mel frames of the window).
+///
+/// The model ships as THREE CoreML stages (front | encoder | maskdec). The
+/// front and encoder must not be fused into one graph: a fused fp16 graph
+/// collapses (chain parity 0.099 vs the reference); the package boundary
+/// forces fp32 I/O between them and every stage is healthy at fp16.
+///
+/// `embedding256` carries a 192-d vector (field name is historical);
+/// `rho128` is empty — PLDA/VBx are undefined for this space, which is why
+/// the config validator requires `clustering.algorithm == .nmesc`.
+@available(macOS 14.0, iOS 17.0, *)
+struct TitaNetMaskedExtractor {
+    private let frontModel: MLModel
+    private let encoderModel: MLModel
+    private let maskdecModel: MLModel
+    private let config: OfflineDiarizerConfig
+    private let logger = AppLogger(category: "TitaNetExtractor")
+
+    static let embeddingDimension = 192
+    private static let melFrames = 1000
+    private static let windowSamples = 160_000
+    private static let overlapThreshold: Float = 1e-3
+    /// Mirrors OfflineEmbeddingExtractor's minActiveRatio guard.
+    private static let minActiveRatio: Float = 0.2
+
+    private static let frontName = "TitaNet10s_front_fp16"
+    private static let encoderName = "TitaNet10s_encoder_fp16"
+    private static let maskdecName = "TitaNet10s_maskdec_fp16"
+
+    init(
+        directory: URL,
+        config: OfflineDiarizerConfig,
+        computeUnits: MLComputeUnits = .cpuAndNeuralEngine
+    ) async throws {
+        let mlConfiguration = MLModelConfiguration()
+        mlConfiguration.computeUnits = computeUnits
+        frontModel = try await Self.loadModel(
+            named: Self.frontName, in: directory, configuration: mlConfiguration)
+        encoderModel = try await Self.loadModel(
+            named: Self.encoderName, in: directory, configuration: mlConfiguration)
+        maskdecModel = try await Self.loadModel(
+            named: Self.maskdecName, in: directory, configuration: mlConfiguration)
+        self.config = config
+        logger.info("TitaNet 10s masked extractor loaded from \(directory.path)")
+    }
+
+    /// Loads `<name>.mlmodelc` if present, otherwise compiles `<name>.mlpackage`.
+    private static func loadModel(
+        named name: String, in directory: URL, configuration: MLModelConfiguration
+    ) async throws -> MLModel {
+        let compiled = directory.appendingPathComponent("\(name).mlmodelc")
+        if FileManager.default.fileExists(atPath: compiled.path) {
+            return try MLModel(contentsOf: compiled, configuration: configuration)
+        }
+        let package = directory.appendingPathComponent("\(name).mlpackage")
+        guard FileManager.default.fileExists(atPath: package.path) else {
+            throw OfflineDiarizationError.processingFailed(
+                "TitaNet model \(name) not found in \(directory.path)")
+        }
+        let compiledURL = try await MLModel.compileModel(at: package)
+        return try MLModel(contentsOf: compiledURL, configuration: configuration)
+    }
+
+    // MARK: - Entry points (mirror OfflineEmbeddingExtractor)
+
+    func extractEmbeddings(
+        audio: [Float],
+        segmentation: SegmentationOutput
+    ) async throws -> [TimedEmbedding] {
+        try await extractEmbeddings(
+            audioSource: ArrayAudioSampleSource(samples: audio),
+            segmentation: segmentation
+        )
+    }
+
+    func extractEmbeddings(
+        audioSource: AudioSampleSource,
+        segmentation: SegmentationOutput
+    ) async throws -> [TimedEmbedding] {
+        let stream = AsyncThrowingStream<SegmentationChunk, Error> { continuation in
+            for chunkIndex in 0..<segmentation.numChunks {
+                guard segmentation.speakerWeights.indices.contains(chunkIndex) else { continue }
+                let chunkSpeakerWeights = segmentation.speakerWeights[chunkIndex]
+                guard !chunkSpeakerWeights.isEmpty else { continue }
+
+                let chunkOffsetSeconds: Double
+                if segmentation.chunkOffsets.indices.contains(chunkIndex) {
+                    chunkOffsetSeconds = segmentation.chunkOffsets[chunkIndex]
+                } else {
+                    chunkOffsetSeconds = Double(chunkIndex) * config.windowDuration
+                }
+
+                let chunk = SegmentationChunk(
+                    chunkIndex: chunkIndex,
+                    chunkOffsetSeconds: chunkOffsetSeconds,
+                    frameDuration: segmentation.frameDuration,
+                    logProbs: [],
+                    speakerWeights: chunkSpeakerWeights
+                )
+                continuation.yield(chunk)
+            }
+            continuation.finish()
+        }
+
+        return try await extractEmbeddings(
+            audioSource: audioSource,
+            segmentationStream: stream
+        )
+    }
+
+    func extractEmbeddings<S: AsyncSequence>(
+        audioSource: AudioSampleSource,
+        segmentationStream: S
+    ) async throws -> [TimedEmbedding] where S.Element == SegmentationChunk {
+        var embeddings: [TimedEmbedding] = []
+        let totalSamples = audioSource.sampleCount
+        var emptyMaskCount = 0
+        var fallbackMaskCount = 0
+        var windowCount = 0
+
+        for try await chunk in segmentationStream {
+            try Task.checkCancellation()
+
+            let weights = chunk.speakerWeights
+            guard !weights.isEmpty, let speakerCount = weights.first?.count, speakerCount > 0
+            else { continue }
+            let frameCount = weights.count
+
+            let frameDuration: Double
+            if chunk.frameDuration > 0 {
+                frameDuration = chunk.frameDuration
+            } else {
+                frameDuration = config.windowDuration / Double(max(frameCount, 1))
+            }
+            let chunkOffsetSeconds =
+                chunk.chunkOffsetSeconds.isFinite
+                ? chunk.chunkOffsetSeconds
+                : Double(chunk.chunkIndex) * config.windowDuration
+            let minFramesForEmbedding = max(1, Int(ceil(config.minSegmentDuration / frameDuration)))
+
+            // Overlap frames: >1 speaker active (mirror of excludeOverlap).
+            var overlapFrames = [Bool](repeating: false, count: frameCount)
+            if config.embeddingExcludeOverlap {
+                for (frame, row) in weights.enumerated() {
+                    var active = 0
+                    for value in row where value > Self.overlapThreshold {
+                        active += 1
+                        if active > 1 {
+                            overlapFrames[frame] = true
+                            break
+                        }
+                    }
+                }
+            }
+
+            var encoderOutput: MLMultiArray?  // computed lazily, once per window
+
+            for speakerIndex in 0..<speakerCount {
+                var baseMask = [Float](repeating: 0, count: frameCount)
+                for frame in 0..<frameCount { baseMask[frame] = weights[frame][speakerIndex] }
+                let baseSum = VDSPOperations.sum(baseMask)
+                if baseSum <= 0 { continue }
+
+                var cleanMask = baseMask
+                if config.embeddingExcludeOverlap {
+                    for frame in 0..<frameCount where overlapFrames[frame] {
+                        cleanMask[frame] = 0
+                    }
+                }
+                let cleanSum = VDSPOperations.sum(cleanMask)
+                if cleanSum < Float(frameCount) * Self.minActiveRatio {
+                    emptyMaskCount += 1
+                    continue
+                }
+                let maskToUse: [Float]
+                if cleanSum >= Float(minFramesForEmbedding) {
+                    maskToUse = cleanMask
+                } else {
+                    maskToUse = baseMask
+                    fallbackMaskCount += 1
+                }
+
+                let resampledMask = WeightInterpolation.resample(maskToUse, to: Self.melFrames)
+                // Hard guard: the maskdec clamps its pool denominator for fp16
+                // safety, so a near-zero mask returns finite garbage, not NaN.
+                if VDSPOperations.sum(resampledMask) <= 0 {
+                    emptyMaskCount += 1
+                    continue
+                }
+
+                if encoderOutput == nil {
+                    encoderOutput = try encodeWindow(
+                        audioSource: audioSource,
+                        chunkOffsetSeconds: chunkOffsetSeconds,
+                        totalSamples: totalSamples
+                    )
+                    windowCount += 1
+                }
+                guard let encoded = encoderOutput else { break }
+
+                let embedding = try runMaskDecoder(encoded: encoded, mask: resampledMask)
+
+                let firstActive = maskToUse.firstIndex(where: { $0 > Self.overlapThreshold }) ?? 0
+                let lastActive =
+                    maskToUse.lastIndex(where: { $0 > Self.overlapThreshold }) ?? firstActive
+                embeddings.append(
+                    TimedEmbedding(
+                        chunkIndex: chunk.chunkIndex,
+                        speakerIndex: speakerIndex,
+                        startFrame: firstActive,
+                        endFrame: lastActive,
+                        frameWeights: maskToUse,
+                        startTime: chunkOffsetSeconds + Double(firstActive) * frameDuration,
+                        endTime: chunkOffsetSeconds + Double(lastActive + 1) * frameDuration,
+                        embedding256: embedding,
+                        rho128: []
+                    ))
+            }
+        }
+
+        logger.debug(
+            "TitaNet masked extraction: \(embeddings.count) embeddings from \(windowCount) windows (fallbackMasks=\(fallbackMaskCount), emptyMasks=\(emptyMaskCount))"
+        )
+        return embeddings
+    }
+
+    // MARK: - Model stages
+
+    /// audio window → front (mel features) → encoder frames. Runs once per window.
+    private func encodeWindow(
+        audioSource: AudioSampleSource,
+        chunkOffsetSeconds: Double,
+        totalSamples: Int
+    ) throws -> MLMultiArray {
+        let estimatedStartSample = Int((chunkOffsetSeconds * Double(config.sampleRate)).rounded())
+        let startSample = max(0, min(estimatedStartSample, totalSamples))
+        let available = max(0, min(Self.windowSamples, totalSamples - startSample))
+
+        let audioArray = try MLMultiArray(
+            shape: [1, NSNumber(value: Self.windowSamples)], dataType: .float32)
+        let audioPointer = audioArray.dataPointer.assumingMemoryBound(to: Float.self)
+        vDSP_vclr(audioPointer, 1, vDSP_Length(Self.windowSamples))
+        if available > 0 {
+            try audioSource.copySamples(into: audioPointer, offset: startSample, count: available)
+        }
+
+        let options = MLPredictionOptions()
+        audioArray.prefetchToNeuralEngine()
+        let frontOutput = try frontModel.prediction(
+            from: ZeroCopyDiarizerFeatureProvider(features: [
+                "audio": MLFeatureValue(multiArray: audioArray)
+            ]),
+            options: options
+        )
+        guard let features = frontOutput.featureValue(for: "feats")?.multiArrayValue else {
+            throw OfflineDiarizationError.processingFailed("TitaNet front missing feats output")
+        }
+
+        features.prefetchToNeuralEngine()
+        let encoderResult = try encoderModel.prediction(
+            from: ZeroCopyDiarizerFeatureProvider(features: [
+                "feats": MLFeatureValue(multiArray: features)
+            ]),
+            options: options
+        )
+        guard let encoded = encoderResult.featureValue(for: "enc")?.multiArrayValue else {
+            throw OfflineDiarizationError.processingFailed("TitaNet encoder missing enc output")
+        }
+        return encoded
+    }
+
+    /// encoder frames + per-speaker mask → 192-d embedding. Runs once per speaker.
+    private func runMaskDecoder(encoded: MLMultiArray, mask: [Float]) throws -> [Float] {
+        let maskArray = try MLMultiArray(
+            shape: [1, 1, NSNumber(value: Self.melFrames)], dataType: .float32)
+        let maskPointer = maskArray.dataPointer.assumingMemoryBound(to: Float.self)
+        mask.withUnsafeBufferPointer { buffer in
+            maskPointer.update(from: buffer.baseAddress!, count: Self.melFrames)
+        }
+
+        let options = MLPredictionOptions()
+        encoded.prefetchToNeuralEngine()
+        maskArray.prefetchToNeuralEngine()
+        let output = try maskdecModel.prediction(
+            from: ZeroCopyDiarizerFeatureProvider(features: [
+                "enc": MLFeatureValue(multiArray: encoded),
+                "mask": MLFeatureValue(multiArray: maskArray),
+            ]),
+            options: options
+        )
+        guard let embeddingArray = output.featureValue(for: "embedding")?.multiArrayValue else {
+            throw OfflineDiarizationError.processingFailed("TitaNet maskdec missing embedding output")
+        }
+        let pointer = embeddingArray.dataPointer.assumingMemoryBound(to: Float.self)
+        return Array(UnsafeBufferPointer(start: pointer, count: embeddingArray.count))
+    }
+}

--- a/Sources/FluidAudio/Diarizer/Offline/Extraction/TitaNetMaskedExtractor.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Extraction/TitaNetMaskedExtractor.swift
@@ -34,7 +34,11 @@ struct TitaNetMaskedExtractor {
     /// Mirrors OfflineEmbeddingExtractor's minActiveRatio guard.
     private static let minActiveRatio: Float = 0.2
 
-    private static let frontName = "TitaNet10s_front_fp16"
+    // The front MUST stay fp32: at fp16 its power-spectrum/log-mel math
+    // underflows on quiet far-field windows (embedding cosine vs fp32 drops
+    // to 0.21). It is ~570K of DSP, so fp32 costs nothing; only the heavy
+    // encoder benefits from fp16/ANE.
+    private static let frontName = "TitaNet10s_front_fp32"
     private static let encoderName = "TitaNet10s_encoder_fp16"
     private static let maskdecName = "TitaNet10s_maskdec_fp16"
 

--- a/Sources/FluidAudio/Diarizer/Offline/Extraction/TitaNetMaskedExtractor.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Extraction/TitaNetMaskedExtractor.swift
@@ -133,6 +133,11 @@ struct TitaNetMaskedExtractor {
         var fallbackMaskCount = 0
         var windowCount = 0
 
+        // `.cleanWaveform` re-featurizes each clean crop on CPU (vDSP); build the
+        // featurizer (with its FFT setup) once per extraction, only when needed.
+        let waveCropFeaturizer: TitaNetWaveCropFeaturizer? =
+            config.embedding.titanetPooling == .cleanWaveform ? TitaNetWaveCropFeaturizer() : nil
+
         for try await chunk in segmentationStream {
             try Task.checkCancellation()
 
@@ -168,7 +173,31 @@ struct TitaNetMaskedExtractor {
                 }
             }
 
-            var encoderOutput: MLMultiArray?  // computed lazily, once per window
+            var frontFeats: MLMultiArray?  // audio → mel, computed lazily once per window
+            var maskedWindowEnc: MLMultiArray?  // full-window enc, .maskedFull only
+            var windowAudio: [Float]?  // available window samples, .cleanWaveform only
+
+            func ensureFrontFeats() throws -> MLMultiArray {
+                if let feats = frontFeats { return feats }
+                let feats = try runFront(
+                    audioSource: audioSource,
+                    chunkOffsetSeconds: chunkOffsetSeconds,
+                    totalSamples: totalSamples)
+                frontFeats = feats
+                windowCount += 1
+                return feats
+            }
+
+            func ensureWindowAudio() throws -> [Float] {
+                if let audio = windowAudio { return audio }
+                let audio = try readWindowSamples(
+                    audioSource: audioSource,
+                    chunkOffsetSeconds: chunkOffsetSeconds,
+                    totalSamples: totalSamples)
+                windowAudio = audio
+                windowCount += 1
+                return audio
+            }
 
             for speakerIndex in 0..<speakerCount {
                 var baseMask = [Float](repeating: 0, count: frameCount)
@@ -187,44 +216,127 @@ struct TitaNetMaskedExtractor {
                     emptyMaskCount += 1
                     continue
                 }
-                let maskToUse: [Float]
-                if cleanSum >= Float(minFramesForEmbedding) {
-                    maskToUse = cleanMask
+
+                let embedding: [Float]
+                let metaMask: [Float]  // drives frameWeights metadata (+ timing fallback)
+                // Explicit frame bounds for segment timing; only .cleanWaveform sets
+                // it (its clean frames use a 0.5 threshold, not metaMask's soft one).
+                var explicitBounds: (first: Int, last: Int)?
+
+                switch config.embedding.titanetPooling {
+                case .cleanWaveform:
+                    // Reference-faithful path: crop the clean single-speaker
+                    // WAVEFORM, re-featurize each crop on its own (clean-only
+                    // normalization, no cross-talk in any STFT window), drop the
+                    // edge frames, concat in the feature domain, encode once.
+                    guard let featurizer = waveCropFeaturizer else {
+                        emptyMaskCount += 1
+                        continue
+                    }
+                    let sr = config.sampleRate
+                    let audio = try ensureWindowAudio()
+                    guard
+                        let selection = CleanRegionSelector.selectCleanSampleRegions(
+                            weights: weights,
+                            speaker: speakerIndex,
+                            availableSamples: audio.count,
+                            regionMinSamples: Self.sampleCount(ms: config.embedding.regionMinMs, sampleRate: sr),
+                            targetSamples: Self.sampleCount(ms: config.embedding.embedTargetMs, sampleRate: sr),
+                            embedMinSamples: Self.sampleCount(ms: config.embedding.embedMinMs, sampleRate: sr),
+                            threshold: 0.5)
+                    else {
+                        emptyMaskCount += 1
+                        continue
+                    }
+                    var cols: [(feats: [Float], frames: Int)] = []
+                    for region in selection.regions {
+                        let crop = Array(audio[region.start..<region.end])
+                        if let featured = featurizer.featurize(crop: crop) { cols.append(featured) }
+                    }
+                    let packedFlat = CleanRegionSelector.packConcatFeatures(
+                        columns: cols, melBins: TitaNetWaveCropFeaturizer.melBins,
+                        dstFrames: Self.melFrames)
+                    guard packedFlat.usedFrames > 0 else {
+                        emptyMaskCount += 1
+                        continue
+                    }
+                    let packed = try makeFeats(flat: packedFlat.feats)
+                    let enc = try runEncoder(feats: packed)
+                    var contiguousMask = [Float](repeating: 0, count: Self.melFrames)
+                    for p in 0..<min(packedFlat.usedFrames, Self.melFrames) { contiguousMask[p] = 1 }
+                    embedding = try runMaskDecoder(encoded: enc, mask: contiguousMask)
+                    metaMask = cleanMask
+                    explicitBounds = (selection.firstFrame, selection.lastFrame)
+
+                case .cleanRegion:
+                    // Resample the OVERLAP-EXCLUDED mask onto the mel grid, pick the
+                    // clean frames, and pack them contiguously so the encoder never
+                    // convolves over overlap (spec §3.2). Encoder runs per speaker.
+                    let cleanMel = WeightInterpolation.resample(cleanMask, to: Self.melFrames)
+                    guard
+                        let frames = CleanRegionSelector.selectCleanMelFrames(
+                            cleanMaskMel: cleanMel,
+                            collarLead: Self.frameCount(ms: config.embedding.collarLeadMs),
+                            collarTrail: Self.frameCount(ms: config.embedding.collarTrailMs),
+                            regionMin: Self.frameCount(ms: config.embedding.regionMinMs),
+                            embedMin: Self.frameCount(ms: config.embedding.embedMinMs),
+                            embedTarget: Self.frameCount(ms: config.embedding.embedTargetMs))
+                    else {
+                        emptyMaskCount += 1
+                        continue
+                    }
+                    let feats = try ensureFrontFeats()
+                    let packed = try packCleanFeats(feats: feats, frames: frames)
+                    let enc = try runEncoder(feats: packed)
+                    var contiguousMask = [Float](repeating: 0, count: Self.melFrames)
+                    for p in 0..<min(frames.count, Self.melFrames) { contiguousMask[p] = 1 }
+                    embedding = try runMaskDecoder(encoded: enc, mask: contiguousMask)
+                    metaMask = cleanMask
+
+                case .maskedFull:
+                    let maskToUse: [Float]
+                    if cleanSum >= Float(minFramesForEmbedding) {
+                        maskToUse = cleanMask
+                    } else {
+                        maskToUse = baseMask
+                        fallbackMaskCount += 1
+                    }
+                    let resampledMask = WeightInterpolation.resample(maskToUse, to: Self.melFrames)
+                    // Hard guard: the maskdec clamps its pool denominator for fp16
+                    // safety, so a near-zero mask returns finite garbage, not NaN.
+                    if VDSPOperations.sum(resampledMask) <= 0 {
+                        emptyMaskCount += 1
+                        continue
+                    }
+                    let feats = try ensureFrontFeats()
+                    if maskedWindowEnc == nil {
+                        maskedWindowEnc = try runEncoder(feats: feats)
+                    }
+                    guard let enc = maskedWindowEnc else {
+                        emptyMaskCount += 1
+                        continue
+                    }
+                    embedding = try runMaskDecoder(encoded: enc, mask: resampledMask)
+                    metaMask = maskToUse
+                }
+
+                let firstActive: Int
+                let lastActive: Int
+                if let bounds = explicitBounds {
+                    firstActive = bounds.first
+                    lastActive = bounds.last
                 } else {
-                    maskToUse = baseMask
-                    fallbackMaskCount += 1
+                    firstActive = metaMask.firstIndex(where: { $0 > Self.overlapThreshold }) ?? 0
+                    lastActive =
+                        metaMask.lastIndex(where: { $0 > Self.overlapThreshold }) ?? firstActive
                 }
-
-                let resampledMask = WeightInterpolation.resample(maskToUse, to: Self.melFrames)
-                // Hard guard: the maskdec clamps its pool denominator for fp16
-                // safety, so a near-zero mask returns finite garbage, not NaN.
-                if VDSPOperations.sum(resampledMask) <= 0 {
-                    emptyMaskCount += 1
-                    continue
-                }
-
-                if encoderOutput == nil {
-                    encoderOutput = try encodeWindow(
-                        audioSource: audioSource,
-                        chunkOffsetSeconds: chunkOffsetSeconds,
-                        totalSamples: totalSamples
-                    )
-                    windowCount += 1
-                }
-                guard let encoded = encoderOutput else { break }
-
-                let embedding = try runMaskDecoder(encoded: encoded, mask: resampledMask)
-
-                let firstActive = maskToUse.firstIndex(where: { $0 > Self.overlapThreshold }) ?? 0
-                let lastActive =
-                    maskToUse.lastIndex(where: { $0 > Self.overlapThreshold }) ?? firstActive
                 embeddings.append(
                     TimedEmbedding(
                         chunkIndex: chunk.chunkIndex,
                         speakerIndex: speakerIndex,
                         startFrame: firstActive,
                         endFrame: lastActive,
-                        frameWeights: maskToUse,
+                        frameWeights: metaMask,
                         startTime: chunkOffsetSeconds + Double(firstActive) * frameDuration,
                         endTime: chunkOffsetSeconds + Double(lastActive + 1) * frameDuration,
                         embedding256: embedding,
@@ -241,8 +353,8 @@ struct TitaNetMaskedExtractor {
 
     // MARK: - Model stages
 
-    /// audio window → front (mel features) → encoder frames. Runs once per window.
-    private func encodeWindow(
+    /// audio window → front (mel features `[1, mel, melFrames]`). Runs once per window.
+    private func runFront(
         audioSource: AudioSampleSource,
         chunkOffsetSeconds: Double,
         totalSamples: Int
@@ -270,11 +382,17 @@ struct TitaNetMaskedExtractor {
         guard let features = frontOutput.featureValue(for: "feats")?.multiArrayValue else {
             throw OfflineDiarizationError.processingFailed("TitaNet front missing feats output")
         }
+        return features
+    }
 
-        features.prefetchToNeuralEngine()
+    /// mel features `[1, mel, melFrames]` → encoder frames `[1, C, melFrames]`.
+    /// `.maskedFull` runs this once per window; `.cleanRegion` once per (window, speaker).
+    private func runEncoder(feats: MLMultiArray) throws -> MLMultiArray {
+        let options = MLPredictionOptions()
+        feats.prefetchToNeuralEngine()
         let encoderResult = try encoderModel.prediction(
             from: ZeroCopyDiarizerFeatureProvider(features: [
-                "feats": MLFeatureValue(multiArray: features)
+                "feats": MLFeatureValue(multiArray: feats)
             ]),
             options: options
         )
@@ -282,6 +400,89 @@ struct TitaNetMaskedExtractor {
             throw OfflineDiarizationError.processingFailed("TitaNet encoder missing enc output")
         }
         return encoded
+    }
+
+    /// Packs the selected mel frames of `feats` (`[1, mel, melFrames]`) contiguously
+    /// into a fresh zero-padded `[1, mel, melFrames]` buffer, so the encoder's
+    /// convolutions only ever span clean, overlap-free frames (spec §3.2, §5
+    /// `concat_domain = feature`).
+    private func packCleanFeats(feats: MLMultiArray, frames: [Int]) throws -> MLMultiArray {
+        let shape = feats.shape.map { $0.intValue }
+        guard shape.count == 3, shape[2] == Self.melFrames else {
+            throw OfflineDiarizationError.processingFailed(
+                "TitaNet front feats shape \(shape) is not [1, mel, \(Self.melFrames)]")
+        }
+        let melBins = shape[1]
+        let strides = feats.strides.map { $0.intValue }
+        let binStride = strides[1]
+        let frameStride = strides[2]
+
+        // Read feats into a contiguous [melBins, melFrames] buffer (handles any
+        // CoreML output striding once), then pack via the unit-tested core.
+        let src = feats.dataPointer.assumingMemoryBound(to: Float.self)
+        var flat = [Float](repeating: 0, count: melBins * Self.melFrames)
+        for c in 0..<melBins {
+            let srcRow = c * binStride
+            let dstRow = c * Self.melFrames
+            for t in 0..<Self.melFrames { flat[dstRow + t] = src[srcRow + t * frameStride] }
+        }
+        let packedFlat = CleanRegionSelector.packColumns(
+            src: flat, melBins: melBins, srcFrames: Self.melFrames,
+            dstFrames: Self.melFrames, frames: frames)
+
+        let packed = try MLMultiArray(shape: feats.shape, dataType: .float32)
+        let dst = packed.dataPointer.assumingMemoryBound(to: Float.self)
+        packedFlat.withUnsafeBufferPointer { buffer in
+            dst.update(from: buffer.baseAddress!, count: packedFlat.count)
+        }
+        return packed
+    }
+
+    /// Milliseconds → mel-frame count on the 100 fps grid (melFrames over the 10 s window).
+    private static func frameCount(ms: Int) -> Int {
+        let windowSeconds = Double(windowSamples) / 16_000.0
+        return max(0, Int((Double(ms) * Double(melFrames) / (windowSeconds * 1000.0)).rounded()))
+    }
+
+    /// Milliseconds → sample count at the given sample rate (for `.cleanWaveform`
+    /// region thresholds, which operate at sample resolution).
+    private static func sampleCount(ms: Int, sampleRate: Int) -> Int {
+        max(0, ms * sampleRate / 1000)
+    }
+
+    /// Reads the window's available samples (≤ windowSamples, NOT zero-padded) as a
+    /// `[Float]` for `.cleanWaveform` cropping. Runs once per window.
+    private func readWindowSamples(
+        audioSource: AudioSampleSource,
+        chunkOffsetSeconds: Double,
+        totalSamples: Int
+    ) throws -> [Float] {
+        let estimatedStartSample = Int((chunkOffsetSeconds * Double(config.sampleRate)).rounded())
+        let startSample = max(0, min(estimatedStartSample, totalSamples))
+        let available = max(0, min(Self.windowSamples, totalSamples - startSample))
+        guard available > 0 else { return [] }
+        var buffer = [Float](repeating: 0, count: available)
+        try buffer.withUnsafeMutableBufferPointer { pointer in
+            try audioSource.copySamples(
+                into: pointer.baseAddress!, offset: startSample, count: available)
+        }
+        return buffer
+    }
+
+    /// Wraps a mel-major `[melBins * melFrames]` buffer as an encoder `feats`
+    /// `[1, melBins, melFrames]` MLMultiArray (`.cleanWaveform` path).
+    private func makeFeats(flat: [Float]) throws -> MLMultiArray {
+        let arr = try MLMultiArray(
+            shape: [
+                1, NSNumber(value: TitaNetWaveCropFeaturizer.melBins),
+                NSNumber(value: Self.melFrames),
+            ],
+            dataType: .float32)
+        let dst = arr.dataPointer.assumingMemoryBound(to: Float.self)
+        flat.withUnsafeBufferPointer { buffer in
+            dst.update(from: buffer.baseAddress!, count: min(flat.count, arr.count))
+        }
+        return arr
     }
 
     /// encoder frames + per-speaker mask → 192-d embedding. Runs once per speaker.

--- a/Sources/FluidAudio/Diarizer/Offline/Extraction/TitaNetWaveCropFeaturizer.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Extraction/TitaNetWaveCropFeaturizer.swift
@@ -1,0 +1,140 @@
+import Accelerate
+import Foundation
+
+/// Per-crop waveform featurizer for the TitaNet `.cleanWaveform` pooling path.
+///
+/// This is the reference-faithful fix for the `.cleanRegion` over-split. Instead
+/// of cropping full-window MEL columns (which carry the full-window per-bin
+/// mean/std normalization and whose boundary frames were computed by STFT windows
+/// that bled into the overlapping speaker), it re-featurizes each clean *waveform*
+/// crop on its own, so:
+///   • normalization statistics come from clean audio only, and
+///   • no STFT window ever spans cross-talk (each crop is padded from its own
+///     samples, not the window's).
+///
+/// The DSP is delegated to the already-validated `AudioMelSpectrogram` (preemph
+/// off; we apply preemph + reflect padding ourselves so the padding matches
+/// librosa's `center=True, pad_mode="reflect"` exactly). The pipeline mirrors the
+/// Python reference `_infer_features_concat` / the `featurizer.py` prototype:
+///
+///   preemph(0.97) → reflect-pad n_fft/2 → STFT(512/160/400, periodic hann) →
+///   power → Slaney mel(80) → log(+2^-24) → per-mel-bin mean/std norm →
+///   drop `joinFrameDrop` edge frames per crop.
+///
+/// Output is a mel-major `[melBins, T']` flat buffer plus `T'`, ready to be
+/// concatenated across crops in the feature domain.
+@available(macOS 14.0, iOS 17.0, *)
+struct TitaNetWaveCropFeaturizer {
+    static let melBins = 80
+    static let nFFT = 512
+    static let hop = 160
+    static let win = 400
+    static let preemph: Float = 0.97
+    /// Edge mel frames dropped per crop (reflect-pad / co-articulation artifact),
+    /// matching the reference `join_frame_drop = 1`.
+    static let joinFrameDrop = 1
+
+    private let mel: AudioMelSpectrogram
+
+    init() {
+        // preemph: 0 — we apply preemphasis + reflect padding ourselves and feed
+        // the result in `.prePadded` mode, so the model must not pad or preemph
+        // again. windowPeriodic: true matches librosa's default `fftbins=True`
+        // hann. logFloor 2^-24 additive matches the front / featurizer.py.
+        mel = AudioMelSpectrogram(
+            sampleRate: 16_000,
+            nMels: Self.melBins,
+            nFFT: Self.nFFT,
+            hopLength: Self.hop,
+            winLength: Self.win,
+            preemph: 0,
+            padTo: 0,
+            logFloor: powf(2, -24),
+            logFloorMode: .additive,
+            windowPeriodic: true
+        )
+    }
+
+    /// Featurize one clean waveform crop.
+    /// - Returns: mel-major `[melBins * frames]` (per-bin normalized, edge-dropped)
+    ///   and the surviving frame count, or `nil` if the crop is too short.
+    func featurize(crop: [Float]) -> (feats: [Float], frames: Int)? {
+        guard crop.count >= Self.win else { return nil }
+
+        // 1. Preemphasis: pre[0] = crop[0]; pre[i] = crop[i] - 0.97 * crop[i-1].
+        var pre = [Float](repeating: 0, count: crop.count)
+        pre[0] = crop[0]
+        if crop.count > 1 {
+            crop.withUnsafeBufferPointer { src in
+                pre.withUnsafeMutableBufferPointer { dst in
+                    var neg = -Self.preemph
+                    vDSP_vsma(
+                        src.baseAddress!, 1,
+                        &neg,
+                        src.baseAddress! + 1, 1,
+                        dst.baseAddress! + 1, 1,
+                        vDSP_Length(crop.count - 1))
+                }
+            }
+        }
+
+        // 2. Reflect-pad the pre-emphasized signal by n_fft/2 (numpy 'reflect':
+        // mirror around the edge sample without repeating it), matching
+        // librosa.stft(center=True, pad_mode="reflect"). Feeding `.prePadded`
+        // then reproduces librosa's framing exactly.
+        let padded = Self.reflectPad(pre, Self.nFFT / 2)
+
+        // 3. STFT → power → mel → log. Frame-major `[T * melBins]`.
+        let (flatTM, frameCount, _) = mel.computeFlatTransposed(
+            audio: padded, lastAudioSample: 0, paddingMode: .prePadded, expectedFrameCount: nil)
+        let t = frameCount
+        guard t > 0 else { return nil }
+
+        // 4. To mel-major `[melBins, T]` with per-mel-bin mean/std normalization
+        // (over this crop's frames only — the whole point of waveform cropping).
+        var mm = [Float](repeating: 0, count: Self.melBins * t)
+        for m in 0..<Self.melBins {
+            var mean: Float = 0
+            for frame in 0..<t { mean += flatTM[frame * Self.melBins + m] }
+            mean /= Float(t)
+            var variance: Float = 0
+            for frame in 0..<t {
+                let d = flatTM[frame * Self.melBins + m] - mean
+                variance += d * d
+            }
+            let std = (variance / Float(t)).squareRoot()
+            let inv = 1.0 / (std + 1e-5)
+            let row = m * t
+            for frame in 0..<t { mm[row + frame] = (flatTM[frame * Self.melBins + m] - mean) * inv }
+        }
+
+        // 5. Join-frame-drop: drop the first/last `joinFrameDrop` frames (only if
+        // the crop is long enough to keep at least one frame).
+        let d = Self.joinFrameDrop
+        guard t > 2 * d else { return (mm, t) }
+        let t2 = t - 2 * d
+        var out = [Float](repeating: 0, count: Self.melBins * t2)
+        for m in 0..<Self.melBins {
+            let srcRow = m * t + d
+            let dstRow = m * t2
+            for frame in 0..<t2 { out[dstRow + frame] = mm[srcRow + frame] }
+        }
+        return (out, t2)
+    }
+
+    /// numpy 'reflect' padding of width `p` (mirror around the edge sample, no
+    /// edge repeat). Callers only pass crops longer than `p`, so a single
+    /// reflection suffices; the index clamps are defensive.
+    static func reflectPad(_ x: [Float], _ p: Int) -> [Float] {
+        let n = x.count
+        guard n > 1, p > 0 else { return x }
+        var out = [Float]()
+        out.reserveCapacity(n + 2 * p)
+        // left: x[p], x[p-1], …, x[1]
+        for i in stride(from: p, through: 1, by: -1) { out.append(x[min(i, n - 1)]) }
+        out.append(contentsOf: x)
+        // right: x[n-2], x[n-3], …, x[n-1-p]
+        for i in stride(from: n - 2, through: n - 1 - p, by: -1) { out.append(x[max(i, 0)]) }
+        return out
+    }
+}

--- a/Sources/FluidAudio/DownloadUtils.swift
+++ b/Sources/FluidAudio/DownloadUtils.swift
@@ -3,7 +3,6 @@ import Foundation
 
 /// HuggingFace model downloader using URLSession
 public class DownloadUtils {
-
     private static let logger = AppLogger(category: "DownloadUtils")
 
     /// Shared URLSession with registry and proxy configuration
@@ -22,7 +21,7 @@ public class DownloadUtils {
     /// Defaults to `false`. `nonisolated(unsafe)` is acceptable because
     /// the flag is set once at startup before any FluidAudio loaders
     /// are touched and is read-only thereafter.
-    nonisolated(unsafe) public static var enforceOffline: Bool = false
+    public nonisolated(unsafe) static var enforceOffline: Bool = false
 
     /// Errors thrown when `enforceOffline` is on and FluidAudio would
     /// otherwise attempt a network fetch or a cache rebuild that
@@ -41,9 +40,9 @@ public class DownloadUtils {
 
         public var errorDescription: String? {
             switch self {
-            case .networkDisabled(let operation):
+            case let .networkDisabled(operation):
                 return "FluidAudio offline mode: \(operation) blocked"
-            case .modelMissing(let repo, let missing):
+            case let .modelMissing(repo, missing):
                 return
                     "FluidAudio offline mode: required models missing for \(repo): \(missing.joined(separator: ", "))"
             }
@@ -111,13 +110,13 @@ public class DownloadUtils {
             switch self {
             case .invalidResponse:
                 return "Received an invalid response from Hugging Face."
-            case .rateLimited(_, let message):
+            case let .rateLimited(_, message):
                 return "Hugging Face rate limit encountered: \(message)"
-            case .downloadFailed(let path, let underlying):
+            case let .downloadFailed(path, underlying):
                 return "Failed to download \(path): \(underlying.localizedDescription)"
-            case .htmlErrorResponse(let path, let snippet):
+            case let .htmlErrorResponse(path, snippet):
                 return "HuggingFace returned HTML instead of JSON for \(path) (rate limit or server issue): \(snippet)"
-            case .modelNotFound(let path):
+            case let .modelNotFound(path):
                 return "Model file not found: \(path)"
             }
         }
@@ -155,7 +154,7 @@ public class DownloadUtils {
     public struct DownloadConfig: Sendable {
         public let timeout: TimeInterval
 
-        public init(timeout: TimeInterval = 1800) {  // 30 minutes for large models
+        public init(timeout: TimeInterval = 1800) { // 30 minutes for large models
             self.timeout = timeout
         }
 
@@ -175,7 +174,8 @@ public class DownloadUtils {
             return try await loadModelsOnce(
                 repo, modelNames: modelNames,
                 directory: directory, computeUnits: computeUnits, variant: variant,
-                progressHandler: progressHandler)
+                progressHandler: progressHandler
+            )
         } catch {
             // In offline mode never delete cache + re-download. Surface
             // the original load failure so the caller can decide.
@@ -198,7 +198,7 @@ public class DownloadUtils {
                 // If deletion fails (excluding "file not found"), log the error but continue
                 // Robust directory creation will handle any remaining files
                 let nsError = error as NSError
-                if nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileNoSuchFileError {
+                if nsError.domain == NSCocoaErrorDomain, nsError.code == NSFileNoSuchFileError {
                     // File already doesn't exist - this is fine
                 } else {
                     logger.warning("Failed to delete cache: \(error.localizedDescription)")
@@ -209,7 +209,8 @@ public class DownloadUtils {
             return try await loadModelsOnce(
                 repo, modelNames: modelNames,
                 directory: directory, computeUnits: computeUnits, variant: variant,
-                progressHandler: progressHandler)
+                progressHandler: progressHandler
+            )
         }
     }
 
@@ -237,14 +238,14 @@ public class DownloadUtils {
         // Remove the whole `fluidaudio/` root so every backend subdirectory
         // (Models/, voice packs, etc.) is cleared, not just `Models/`.
         #if os(macOS)
-        let home = fm.homeDirectoryForCurrentUser
-        let ttsCache = home.appendingPathComponent(".cache/fluidaudio")
-        try? fm.removeItem(at: ttsCache)
-        #else
-        if let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
-            let ttsCache = appSupport.appendingPathComponent("fluidaudio")
+            let home = fm.homeDirectoryForCurrentUser
+            let ttsCache = home.appendingPathComponent(".cache/fluidaudio")
             try? fm.removeItem(at: ttsCache)
-        }
+        #else
+            if let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+                let ttsCache = appSupport.appendingPathComponent("fluidaudio")
+                try? fm.removeItem(at: ttsCache)
+            }
         #endif
 
         logger.info("All model caches cleared")
@@ -291,11 +292,13 @@ public class DownloadUtils {
             try await downloadRepo(
                 repo, to: directory, variant: variant,
                 additionalModelNames: extraModelNames,
-                progressHandler: progressHandler)
+                progressHandler: progressHandler
+            )
         } else {
             logger.info("Found \(repo.folderName) locally, no download needed")
             progressHandler?(
-                DownloadProgress(fractionCompleted: 0.5, phase: .downloading(completedFiles: 0, totalFiles: 0)))
+                DownloadProgress(fractionCompleted: 0.5, phase: .downloading(completedFiles: 0, totalFiles: 0))
+            )
         }
 
         let config = MLModelConfiguration()
@@ -311,7 +314,8 @@ public class DownloadUtils {
                     userInfo: [
                         NSFilePathErrorKey: modelPath.path,
                         NSLocalizedDescriptionKey: "Model file not found: \(name)",
-                    ])
+                    ]
+                )
             }
 
             var isDirectory: ObjCBool = false
@@ -324,7 +328,8 @@ public class DownloadUtils {
                     userInfo: [
                         NSFilePathErrorKey: modelPath.path,
                         NSLocalizedDescriptionKey: "Model path is not a directory: \(name)",
-                    ])
+                    ]
+                )
             }
 
             let coremlDataPath = modelPath.appendingPathComponent("coremldata.bin")
@@ -335,14 +340,16 @@ public class DownloadUtils {
                     userInfo: [
                         NSFilePathErrorKey: coremlDataPath.path,
                         NSLocalizedDescriptionKey: "Missing coremldata.bin in model: \(name)",
-                    ])
+                    ]
+                )
             }
 
             progressHandler?(
                 DownloadProgress(
                     fractionCompleted: 0.5 + 0.5 * Double(index) / Double(modelNames.count),
                     phase: .compiling(modelName: name)
-                ))
+                )
+            )
 
             let start = Date()
             let model = try MLModel(contentsOf: modelPath, configuration: config)
@@ -374,14 +381,14 @@ public class DownloadUtils {
         progressHandler: ProgressHandler? = nil
     ) async throws {
         try ensureOnlineAllowed("downloadRepo(\(repo.folderName))")
-        logger.info("Downloading \(repo.folderName) from HuggingFace...")
+        logger.info("Downloading \(repo.folderName) from \(ModelRegistry.baseURL)")
 
         let repoPath = directory.appendingPathComponent(repo.folderName)
         try FileManager.default.createDirectory(at: repoPath, withIntermediateDirectories: true)
 
         let requiredModels = ModelNames.getRequiredModelNames(for: repo, variant: variant)
             .union(additionalModelNames)
-        let subPath = repo.subPath  // e.g., "160ms" for parakeetEou160
+        let subPath = repo.subPath // e.g., "160ms" for parakeetEou160
 
         // Build patterns for filtering (relative to subPath if present)
         var patterns: [String] = []
@@ -406,7 +413,8 @@ public class DownloadUtils {
             if let httpResponse = response as? HTTPURLResponse {
                 if httpResponse.statusCode == 429 || httpResponse.statusCode == 503 {
                     throw HuggingFaceDownloadError.rateLimited(
-                        statusCode: httpResponse.statusCode, message: "Rate limited while listing files")
+                        statusCode: httpResponse.statusCode, message: "Rate limited while listing files"
+                    )
                 }
             }
 
@@ -419,7 +427,7 @@ public class DownloadUtils {
 
             for item in items {
                 guard let itemPath = item["path"] as? String,
-                    let itemType = item["type"] as? String
+                      let itemType = item["type"] as? String
                 else { continue }
 
                 if itemType == "directory" {
@@ -428,11 +436,11 @@ public class DownloadUtils {
                     if let sub = subPath {
                         shouldProcess =
                             itemPath == sub || itemPath.hasPrefix("\(sub)/")
-                            || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
+                                || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
                     } else {
                         shouldProcess =
                             patterns.isEmpty
-                            || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
+                                || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
                     }
                     if shouldProcess {
                         try await listDirectory(path: itemPath)
@@ -450,7 +458,7 @@ public class DownloadUtils {
                     } else {
                         shouldInclude =
                             patterns.isEmpty || patterns.contains { itemPath.hasPrefix($0) }
-                            || itemPath.hasSuffix(".json") || itemPath.hasSuffix(".txt")
+                                || itemPath.hasSuffix(".json") || itemPath.hasSuffix(".txt")
                     }
                     if shouldInclude {
                         let fileSize = item["size"] as? Int ?? -1
@@ -460,19 +468,20 @@ public class DownloadUtils {
             }
         }
 
-        // Pull root-level files whose basename is in `names`. Some subPath repos
-        // keep shared auxiliary files at the repo root rather than inside the
-        // precision subdirectory, so a subPath-only traversal misses them.
+        /// Pull root-level files whose basename is in `names`. Some subPath repos
+        /// keep shared auxiliary files at the repo root rather than inside the
+        /// precision subdirectory, so a subPath-only traversal misses them.
         func listRootFiles(matching names: Set<String>) async throws {
             let dirURL = try ModelRegistry.apiModels(repo.remotePath, "tree/main")
             let request = authorizedRequest(url: dirURL)
             let (dirData, response) = try await sharedSession.data(for: request)
 
             if let httpResponse = response as? HTTPURLResponse,
-                httpResponse.statusCode == 429 || httpResponse.statusCode == 503
+               httpResponse.statusCode == 429 || httpResponse.statusCode == 503
             {
                 throw HuggingFaceDownloadError.rateLimited(
-                    statusCode: httpResponse.statusCode, message: "Rate limited while listing root files")
+                    statusCode: httpResponse.statusCode, message: "Rate limited while listing root files"
+                )
             }
 
             try validateJSONResponse(dirData, path: "")
@@ -483,8 +492,8 @@ public class DownloadUtils {
 
             for item in items {
                 guard let itemPath = item["path"] as? String,
-                    item["type"] as? String == "file",
-                    names.contains((itemPath as NSString).lastPathComponent)
+                      item["type"] as? String == "file",
+                      names.contains((itemPath as NSString).lastPathComponent)
                 else { continue }
                 let fileSize = item["size"] as? Int ?? -1
                 filesToDownload.append((path: itemPath, size: fileSize))
@@ -572,7 +581,8 @@ public class DownloadUtils {
                         DownloadProgress(
                             fractionCompleted: min(fraction, 0.5),
                             phase: .downloading(completedFiles: fileIndex, totalFiles: fileCount)
-                        ))
+                        )
+                    )
                 }
             } else {
                 onProgress = nil
@@ -602,7 +612,8 @@ public class DownloadUtils {
                         ? 0.5 * Double(completedBytes) / Double(totalBytes)
                         : 0.5 * Double(index + 1) / Double(filesToDownload.count),
                     phase: .downloading(completedFiles: index + 1, totalFiles: filesToDownload.count)
-                ))
+                )
+            )
         }
 
         // Verify required models are present
@@ -720,14 +731,15 @@ public class DownloadUtils {
     ) async throws -> URL {
         var lastError: Error?
 
-        for attempt in 1...maxAttempts {
+        for attempt in 1 ... maxAttempts {
             do {
                 let tempURL: URL
                 let httpResponse: HTTPURLResponse
 
                 if let onProgress {
                     (tempURL, httpResponse) = try await downloadWithProgress(
-                        request: request, onProgress: onProgress)
+                        request: request, onProgress: onProgress
+                    )
                 } else {
                     let (url, response) = try await sharedSession.download(for: request)
                     guard let resp = response as? HTTPURLResponse else {
@@ -740,10 +752,11 @@ public class DownloadUtils {
                 if httpResponse.statusCode == 429 || httpResponse.statusCode == 503 {
                     throw HuggingFaceDownloadError.rateLimited(
                         statusCode: httpResponse.statusCode,
-                        message: "Rate limited while downloading \(path)")
+                        message: "Rate limited while downloading \(path)"
+                    )
                 }
 
-                guard (200..<300).contains(httpResponse.statusCode) else {
+                guard (200 ..< 300).contains(httpResponse.statusCode) else {
                     throw HuggingFaceDownloadError.downloadFailed(
                         path: path,
                         underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
@@ -775,9 +788,9 @@ public class DownloadUtils {
         if let urlError = error as? URLError {
             switch urlError.code {
             case .timedOut, .cannotConnectToHost, .cannotFindHost,
-                .networkConnectionLost, .notConnectedToInternet,
-                .dnsLookupFailed, .secureConnectionFailed,
-                .resourceUnavailable:
+                 .networkConnectionLost, .notConnectedToInternet,
+                 .dnsLookupFailed, .secureConnectionFailed,
+                 .resourceUnavailable:
                 return true
             default:
                 return false
@@ -787,9 +800,9 @@ public class DownloadUtils {
         switch error {
         case HuggingFaceDownloadError.rateLimited:
             return true
-        case HuggingFaceDownloadError.downloadFailed(_, let underlying):
+        case let HuggingFaceDownloadError.downloadFailed(_, underlying):
             let nsError = underlying as NSError
-            return nsError.domain == "HTTP" && (500...599).contains(nsError.code)
+            return nsError.domain == "HTTP" && (500 ... 599).contains(nsError.code)
         default:
             return false
         }
@@ -825,11 +838,12 @@ public class DownloadUtils {
             let dirURL = try ModelRegistry.apiModels(repo.remotePath, "tree/main/\(path)")
             let (dirData, response) = try await fetchWithAuth(from: dirURL)
             if let httpResponse = response as? HTTPURLResponse,
-                httpResponse.statusCode == 429 || httpResponse.statusCode == 503
+               httpResponse.statusCode == 429 || httpResponse.statusCode == 503
             {
                 throw HuggingFaceDownloadError.rateLimited(
                     statusCode: httpResponse.statusCode,
-                    message: "Rate limited while listing files in \(path)")
+                    message: "Rate limited while listing files in \(path)"
+                )
             }
 
             // Validate that response is JSON, not HTML error page
@@ -840,7 +854,7 @@ public class DownloadUtils {
             }
             for item in items {
                 guard let itemPath = item["path"] as? String,
-                    let itemType = item["type"] as? String
+                      let itemType = item["type"] as? String
                 else { continue }
 
                 if shouldSkip?(itemPath) == true {
@@ -862,7 +876,9 @@ public class DownloadUtils {
         progressHandler?(
             DownloadProgress(
                 fractionCompleted: totalFiles == 0 ? 1.0 : 0.0,
-                phase: .downloading(completedFiles: 0, totalFiles: totalFiles)))
+                phase: .downloading(completedFiles: 0, totalFiles: totalFiles)
+            )
+        )
 
         for (index, file) in filesToDownload.enumerated() {
             let destPath = repoDirectory.appendingPathComponent(file.path)
@@ -872,7 +888,10 @@ public class DownloadUtils {
                     DownloadProgress(
                         fractionCompleted: Double(index + 1) / Double(totalFiles),
                         phase: .downloading(
-                            completedFiles: index + 1, totalFiles: totalFiles)))
+                            completedFiles: index + 1, totalFiles: totalFiles
+                        )
+                    )
+                )
                 continue
             }
 
@@ -887,7 +906,10 @@ public class DownloadUtils {
                     DownloadProgress(
                         fractionCompleted: Double(index + 1) / Double(totalFiles),
                         phase: .downloading(
-                            completedFiles: index + 1, totalFiles: totalFiles)))
+                            completedFiles: index + 1, totalFiles: totalFiles
+                        )
+                    )
+                )
                 if (index + 1) % 5 == 0 || index == totalFiles - 1 {
                     logger.info("Downloaded \(index + 1)/\(totalFiles) \(subdirectory) files")
                 }
@@ -907,10 +929,11 @@ public class DownloadUtils {
             if httpResponse.statusCode == 429 || httpResponse.statusCode == 503 {
                 throw HuggingFaceDownloadError.rateLimited(
                     statusCode: httpResponse.statusCode,
-                    message: "Rate limited while downloading \(file.path)")
+                    message: "Rate limited while downloading \(file.path)"
+                )
             }
 
-            guard (200..<300).contains(httpResponse.statusCode) else {
+            guard (200 ..< 300).contains(httpResponse.statusCode) else {
                 throw HuggingFaceDownloadError.downloadFailed(
                     path: file.path,
                     underlying: NSError(domain: "HTTP", code: httpResponse.statusCode)
@@ -926,7 +949,10 @@ public class DownloadUtils {
                 DownloadProgress(
                     fractionCompleted: Double(index + 1) / Double(totalFiles),
                     phase: .downloading(
-                        completedFiles: index + 1, totalFiles: totalFiles)))
+                        completedFiles: index + 1, totalFiles: totalFiles
+                    )
+                )
+            )
 
             if (index + 1) % 5 == 0 || index == totalFiles - 1 {
                 logger.info("Downloaded \(index + 1)/\(totalFiles) \(subdirectory) files")
@@ -947,7 +973,7 @@ public class DownloadUtils {
         var lastError: Error?
         let request = authorizedRequest(url: url)
 
-        for attempt in 1...maxAttempts {
+        for attempt in 1 ... maxAttempts {
             do {
                 let (data, response) = try await sharedSession.data(for: request)
 
@@ -962,7 +988,7 @@ public class DownloadUtils {
                     )
                 }
 
-                guard (200..<300).contains(httpResponse.statusCode) else {
+                guard (200 ..< 300).contains(httpResponse.statusCode) else {
                     throw HuggingFaceDownloadError.invalidResponse
                 }
 
@@ -995,9 +1021,9 @@ private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelega
     }
 
     func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didWriteData bytesWritten: Int64,
+        _: URLSession,
+        downloadTask _: URLSessionDownloadTask,
+        didWriteData _: Int64,
         totalBytesWritten: Int64,
         totalBytesExpectedToWrite: Int64
     ) {
@@ -1005,9 +1031,9 @@ private final class DownloadProgressDelegate: NSObject, URLSessionDownloadDelega
     }
 
     func urlSession(
-        _ session: URLSession,
-        downloadTask: URLSessionDownloadTask,
-        didFinishDownloadingTo location: URL
+        _: URLSession,
+        downloadTask _: URLSessionDownloadTask,
+        didFinishDownloadingTo _: URL
     ) {
         // Required by protocol — the async download(for:) API handles the file.
     }

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -276,7 +276,6 @@ public enum ParakeetEncoderPrecision: String, Sendable, CaseIterable {
 
 /// Centralized model names for all FluidAudio components
 public enum ModelNames {
-
     /// Diarizer model names
     public enum Diarizer {
         public static let segmentation = "pyannote_segmentation"
@@ -316,6 +315,15 @@ public enum ModelNames {
             pldaRhoPath,
             pldaParameters,
         ]
+
+        /// Files needed when the offline pipeline runs the TitaNet-10s embedder
+        /// with NME-SC clustering — only segmentation. The WeSpeaker embedder,
+        /// FBANK frontend, and PLDA/VBx artifacts are unused on that path (see
+        /// `OfflineDiarizerModels.load(backend:)`), so they are neither
+        /// downloaded nor compiled.
+        public static let titanetRequiredModels: Set<String> = [
+            segmentationPath,
+        ]
     }
 
     /// ASR model names
@@ -326,7 +334,7 @@ public enum ModelNames {
         public static let joint = "JointDecision"
         public static let ctcHead = "CtcHead"
 
-        // Shared vocabulary file across all model versions
+        /// Shared vocabulary file across all model versions
         public static let vocabularyFile = "parakeet_vocab.json"
 
         public static let preprocessorFile = preprocessor + ".mlmodelc"
@@ -367,7 +375,7 @@ public enum ModelNames {
         ]
 
         /// Get vocabulary filename for specific model version
-        public static func vocabulary(for repo: Repo) -> String {
+        public static func vocabulary(for _: Repo) -> String {
             // All Parakeet models use the same vocabulary file (format varies: dict for v2/v3, array for 110m)
             return vocabularyFile
         }
@@ -381,7 +389,7 @@ public enum ModelNames {
         public static let melSpectrogramPath = melSpectrogram + ".mlmodelc"
         public static let audioEncoderPath = audioEncoder + ".mlmodelc"
 
-        // Vocabulary JSON path (shared by Python/Nemo and CoreML exports).
+        /// Vocabulary JSON path (shared by Python/Nemo and CoreML exports).
         public static let vocabularyPath = "vocab.json"
 
         public static let requiredModels: Set<String> = [
@@ -397,9 +405,9 @@ public enum ModelNames {
     /// Plus `vocab.json` (25055 SentencePiece tokens, auto-fetched as a root file).
     public enum SenseVoice {
         public static let preprocessor = "SenseVoicePreprocessor"
-        public static let encoder = "SenseVoiceSmall"  // fp16, runs on ANE (default)
-        public static let encoderInt8 = "SenseVoiceSmall_int8"  // int8 weights, ANE, ~half size
-        public static let encoderFp32 = "SenseVoiceSmall_fp32"  // fp32 fallback (non-ANE)
+        public static let encoder = "SenseVoiceSmall" // fp16, runs on ANE (default)
+        public static let encoderInt8 = "SenseVoiceSmall_int8" // int8 weights, ANE, ~half size
+        public static let encoderFp32 = "SenseVoiceSmall_fp32" // fp32 fallback (non-ANE)
 
         public static let preprocessorFile = preprocessor + ".mlmodelc"
         public static let encoderFile = encoder + ".mlmodelc"
@@ -435,10 +443,10 @@ public enum ModelNames {
     public enum ParaformerZh {
         public static let preprocessor = "ParaformerPreprocessor"
         public static let encoder = "ParaformerEncoder"
-        public static let encoderInt8 = "ParaformerEncoder_int8"  // ~half size, ANE
+        public static let encoderInt8 = "ParaformerEncoder_int8" // ~half size, ANE
         public static let cifAlphas = "ParaformerCifAlphas"
         public static let decoder = "ParaformerDecoder"
-        public static let decoderInt8 = "ParaformerDecoder_int8"  // ~half size, ANE
+        public static let decoderInt8 = "ParaformerDecoder_int8" // ~half size, ANE
 
         public static let preprocessorFile = preprocessor + ".mlmodelc"
         public static let encoderFile = encoder + ".mlmodelc"
@@ -493,7 +501,7 @@ public enum ModelNames {
         public static let sileroVadFile = sileroVad + ".mlmodelc"
 
         public static let requiredModels: Set<String> = [
-            sileroVadFile
+            sileroVadFile,
         ]
     }
 
@@ -534,7 +542,7 @@ public enum ModelNames {
         /// merged inner-loop model (e.g. 2240ms); loaded only if the file exists.
         public static let decoderJointFile = "decoder_joint.mlmodelc"
 
-        // Encoder in subdirectory (int8 quantized only)
+        /// Encoder in subdirectory (int8 quantized only)
         public static let encoderInt8File = "encoder/encoder_int8.mlmodelc"
 
         public static let requiredModels: Set<String> = [
@@ -744,7 +752,9 @@ public enum ModelNames {
                 }
             }
 
-            public var description: String { name }
+            public var description: String {
+                name
+            }
 
             public func name(forStep step: StepSize) -> String {
                 "\(name)_\(step)"
@@ -1061,15 +1071,15 @@ public enum ModelNames {
         public static func requiredFiles(veVariant: String?) -> Set<String> {
             var set = sharedModelFiles.union(companionFiles)
             switch veVariant {
-            case .some(let v) where v.hasPrefix("dyn-"):
+            case let .some(v) where v.hasPrefix("dyn-"):
                 set.insert(vectorEstimatorFile(precisionSuffix: String(v.dropFirst(4)), bucket: nil))
-            case .some(let v) where v.hasPrefix("ane-"):
+            case let .some(v) where v.hasPrefix("ane-"):
                 let q = String(v.dropFirst(4))
                 for b in aneBuckets {
                     set.insert(vectorEstimatorFile(precisionSuffix: q, bucket: b))
                 }
             default:
-                set.insert(vectorEstimatorFile)  // fp16 dynamic
+                set.insert(vectorEstimatorFile) // fp16 dynamic
             }
             return set
         }
@@ -1252,6 +1262,11 @@ public enum ModelNames {
             // Variants: nil/"fp16" (streaming), "offline"/"offline-fp16" (batch).
             return ModelNames.ParakeetUnified.requiredModels(variant: variant)
         case .diarizer:
+            if variant == "offline-titanet" {
+                // TitaNet-10s + NME-SC needs only segmentation on disk; the
+                // download gate must not pull the WeSpeaker/FBANK/PLDA files.
+                return ModelNames.OfflineDiarizer.titanetRequiredModels
+            }
             if variant == "offline" {
                 return ModelNames.OfflineDiarizer.requiredModels
             }

--- a/Sources/FluidAudio/VAD/VadManager.swift
+++ b/Sources/FluidAudio/VAD/VadManager.swift
@@ -159,7 +159,7 @@ public actor VadManager {
         return audioChunk.allSatisfy { abs($0) <= silenceThreshold }
     }
 
-    internal func processChunk(_ audioChunk: [Float], inputState: VadState? = nil) async throws -> VadResult {
+    public func processChunk(_ audioChunk: [Float], inputState: VadState? = nil) async throws -> VadResult {
         guard let loadedModel = vadModel else {
             throw VadError.notInitialized
         }

--- a/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
@@ -152,6 +152,7 @@ enum ProcessCommand {
             if args.useNMESC {
                 offlineConfig.clustering.algorithm = .nmesc
             }
+            offlineConfig.segmentationDumpPath = args.segmentationDumpPath
 
             let modelDir = OfflineDiarizerModels.defaultModelsDirectory()
             let manager = OfflineDiarizerManager(config: offlineConfig)
@@ -249,6 +250,7 @@ enum ProcessCommand {
         var debug = false
         var rttmFile: String?
         var embeddingExportPath: String?
+        var segmentationDumpPath: String?
         var useNMESC = false
 
         // Streaming-mode params
@@ -461,6 +463,11 @@ enum ProcessCommand {
             case "--export-embeddings":
                 if i + 1 < args.count {
                     parsed.embeddingExportPath = args[i + 1]
+                    i += 1
+                }
+            case "--dump-masks":
+                if i + 1 < args.count {
+                    parsed.segmentationDumpPath = args[i + 1]
                     i += 1
                 }
 

--- a/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
@@ -152,6 +152,12 @@ enum ProcessCommand {
             if args.useNMESC {
                 offlineConfig.clustering.algorithm = .nmesc
             }
+            if args.useTitaNet {
+                offlineConfig.embedding.backend = .titanet10s
+                if let dir = args.titanetDir {
+                    offlineConfig.titanetModelDirectory = URL(fileURLWithPath: dir)
+                }
+            }
             offlineConfig.segmentationDumpPath = args.segmentationDumpPath
 
             let modelDir = OfflineDiarizerModels.defaultModelsDirectory()
@@ -252,6 +258,8 @@ enum ProcessCommand {
         var embeddingExportPath: String?
         var segmentationDumpPath: String?
         var useNMESC = false
+        var useTitaNet = false
+        var titanetDir: String?
 
         // Streaming-mode params
         var thresholdS: Float = 0.7045655  // matches pyannote speaker-diarization-3.1 config.yaml
@@ -468,6 +476,16 @@ enum ProcessCommand {
             case "--dump-masks":
                 if i + 1 < args.count {
                     parsed.segmentationDumpPath = args[i + 1]
+                    i += 1
+                }
+            case "--embedder":
+                if i + 1 < args.count {
+                    parsed.useTitaNet = args[i + 1].lowercased() == "titanet10s"
+                    i += 1
+                }
+            case "--titanet-dir":
+                if i + 1 < args.count {
+                    parsed.titanetDir = args[i + 1]
                     i += 1
                 }
 

--- a/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
@@ -157,7 +157,20 @@ enum ProcessCommand {
                 if let dir = args.titanetDir {
                     offlineConfig.titanetModelDirectory = URL(fileURLWithPath: dir)
                 }
+                switch args.titanetPooling {
+                case "maskedfull", "masked", "full":
+                    offlineConfig.embedding.titanetPooling = .maskedFull
+                case "cleanregion", "melcrop":
+                    offlineConfig.embedding.titanetPooling = .cleanRegion
+                default:  // cleanwaveform / wavecrop / waveform (default)
+                    offlineConfig.embedding.titanetPooling = .cleanWaveform
+                }
             }
+            offlineConfig.clustering.mergeEnabled = args.mergeEnabled
+            if let mt = args.mergeThreshold {
+                offlineConfig.clustering.mergeThreshold = mt
+            }
+            offlineConfig.debugDumpEmbeddings = args.dumpEmbeddings
             offlineConfig.segmentationDumpPath = args.segmentationDumpPath
 
             let modelDir = OfflineDiarizerModels.defaultModelsDirectory()
@@ -260,6 +273,10 @@ enum ProcessCommand {
         var useNMESC = false
         var useTitaNet = false
         var titanetDir: String?
+        var titanetPooling: String = "maskedfull"  // maskedfull (default) | cleanregion | cleanwaveform
+        var mergeEnabled = false  // --merge : agglomerative post-merge of over-split clusters
+        var mergeThreshold: Float?  // --merge-threshold <cosine> (default 0.75)
+        var dumpEmbeddings = false  // --dump-embeddings : print raw [[EMB]]/[[MERGE]] to stdout
 
         // Streaming-mode params
         var thresholdS: Float = 0.7045655  // matches pyannote speaker-diarization-3.1 config.yaml
@@ -488,6 +505,20 @@ enum ProcessCommand {
                     parsed.titanetDir = args[i + 1]
                     i += 1
                 }
+            case "--titanet-pooling":
+                if i + 1 < args.count {
+                    parsed.titanetPooling = args[i + 1].lowercased()
+                    i += 1
+                }
+            case "--merge":
+                parsed.mergeEnabled = true
+            case "--merge-threshold":
+                if i + 1 < args.count {
+                    parsed.mergeThreshold = Float(args[i + 1])
+                    i += 1
+                }
+            case "--dump-embeddings":
+                parsed.dumpEmbeddings = true
 
             default:
                 logger.warning("Unknown option: \(args[i])")

--- a/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
@@ -149,6 +149,10 @@ enum ProcessCommand {
                 )
             }
 
+            if args.useNMESC {
+                offlineConfig.clustering.algorithm = .nmesc
+            }
+
             let modelDir = OfflineDiarizerModels.defaultModelsDirectory()
             let manager = OfflineDiarizerManager(config: offlineConfig)
 
@@ -245,6 +249,7 @@ enum ProcessCommand {
         var debug = false
         var rttmFile: String?
         var embeddingExportPath: String?
+        var useNMESC = false
 
         // Streaming-mode params
         var thresholdS: Float = 0.7045655  // matches pyannote speaker-diarization-3.1 config.yaml
@@ -446,6 +451,11 @@ enum ProcessCommand {
             case "--num-speakers":
                 if i + 1 < args.count {
                     parsed.numSpeakers = Int(args[i + 1])
+                    i += 1
+                }
+            case "--clustering":
+                if i + 1 < args.count {
+                    parsed.useNMESC = args[i + 1].lowercased() == "nmesc"
                     i += 1
                 }
             case "--export-embeddings":

--- a/Tests/FluidAudioTests/Diarizer/Extraction/CleanRegionSelectorTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Extraction/CleanRegionSelectorTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Unit tests for the pure clean-region frame selection (TitaNet `.cleanRegion`
+/// pooling). No CoreML — operates on synthetic mel-frame masks.
+final class CleanRegionSelectorTests: XCTestCase {
+
+    /// Length-`n` mel mask with the given [start, end) runs set to 1.0.
+    private func mask(_ n: Int, _ runs: [(Int, Int)]) -> [Float] {
+        var m = [Float](repeating: 0, count: n)
+        for (s, e) in runs { for i in s..<e { m[i] = 1 } }
+        return m
+    }
+
+    /// A single contiguous run ≥ target is embedded in full (not capped).
+    func testSingleLongRunEmbeddedInFull() {
+        let m = mask(1000, [(100, 500)])  // 400 clean frames
+        let f = CleanRegionSelector.selectCleanMelFrames(
+            cleanMaskMel: m, collarLead: 0, collarTrail: 0,
+            regionMin: 50, embedMin: 200, embedTarget: 300)
+        XCTAssertEqual(f?.count, 400)
+        XCTAssertEqual(f?.first, 100)
+        XCTAssertEqual(f?.last, 499)
+    }
+
+    /// Two sub-target runs are concatenated in time order up to the target.
+    func testTwoRunsConcatToTarget() {
+        let m = mask(1000, [(100, 250), (400, 550)])  // two 150-frame runs
+        let f = CleanRegionSelector.selectCleanMelFrames(
+            cleanMaskMel: m, collarLead: 0, collarTrail: 0,
+            regionMin: 50, embedMin: 200, embedTarget: 300)
+        XCTAssertEqual(f?.count, 300)  // 150 + 150 capped at target
+        XCTAssertEqual(Array(f![0..<150]), Array(100..<250))
+        XCTAssertEqual(Array(f![150..<300]), Array(400..<550))
+    }
+
+    /// Total clean below embedMin → skip the speaker.
+    func testBelowEmbedMinSkips() {
+        let m = mask(1000, [(100, 220)])  // 120 clean frames < embedMin 200
+        let f = CleanRegionSelector.selectCleanMelFrames(
+            cleanMaskMel: m, collarLead: 0, collarTrail: 0,
+            regionMin: 50, embedMin: 200, embedTarget: 300)
+        XCTAssertNil(f)
+    }
+
+    /// A run shorter than regionMin is dropped; no runs survive → skip.
+    func testShortRunDroppedByRegionMin() {
+        let m = mask(1000, [(100, 140)])  // 40-frame run < regionMin 50
+        let f = CleanRegionSelector.selectCleanMelFrames(
+            cleanMaskMel: m, collarLead: 0, collarTrail: 0,
+            regionMin: 50, embedMin: 30, embedTarget: 300)
+        XCTAssertNil(f)
+    }
+
+    /// Collar erodes inward from both edges of a run.
+    func testCollarErodesInward() {
+        let m = mask(1000, [(100, 200)])  // 100-frame run
+        let f = CleanRegionSelector.selectCleanMelFrames(
+            cleanMaskMel: m, collarLead: 10, collarTrail: 10,
+            regionMin: 50, embedMin: 50, embedTarget: 300)
+        XCTAssertEqual(f?.count, 80)  // 100 - 10 - 10
+        XCTAssertEqual(f?.first, 110)
+        XCTAssertEqual(f?.last, 189)
+    }
+
+    /// The mel-frame packer selects the requested columns and zero-pads the tail.
+    func testPackColumnsSelectsAndZeroPads() {
+        // 2 mel bins × 4 src frames, row-major.
+        let src: [Float] = [10, 11, 12, 13, 20, 21, 22, 23]
+        let packed = CleanRegionSelector.packColumns(
+            src: src, melBins: 2, srcFrames: 4, dstFrames: 4, frames: [1, 3])
+        XCTAssertEqual(packed, [11, 13, 0, 0, 21, 23, 0, 0])
+    }
+
+    // MARK: - .cleanWaveform sample-region selection
+
+    /// `[[Float]]` weights (frameCount × speakerCount) with the given per-speaker
+    /// [start, end) active runs set to 1.0.
+    private func weights(
+        _ frameCount: Int, _ speakerCount: Int, _ active: [Int: [(Int, Int)]]
+    ) -> [[Float]] {
+        var w = [[Float]](
+            repeating: [Float](repeating: 0, count: speakerCount), count: frameCount)
+        for (spk, runs) in active { for (s, e) in runs { for f in s..<e { w[f][spk] = 1 } } }
+        return w
+    }
+
+    /// A single clean run maps to one sample region; frame bounds are the clean span.
+    func testSampleRegionsSingleRun() {
+        // 100 frames over 16000 samples → spf = 160.
+        let w = weights(100, 2, [0: [(10, 60)]])
+        let out = CleanRegionSelector.selectCleanSampleRegions(
+            weights: w, speaker: 0, availableSamples: 16000,
+            regionMinSamples: 800, targetSamples: 48000, embedMinSamples: 1600, threshold: 0.5)
+        XCTAssertEqual(out?.regions.count, 1)
+        XCTAssertEqual(out?.regions.first?.start, 1600)  // 10 * 160
+        XCTAssertEqual(out?.regions.first?.end, 9600)  // 60 * 160
+        XCTAssertEqual(out?.firstFrame, 10)
+        XCTAssertEqual(out?.lastFrame, 59)
+    }
+
+    /// Frames where a second speaker is active are excluded, splitting the run.
+    func testSampleRegionsExcludesOverlap() {
+        // spk0 active [10,60); spk1 active [30,40) → clean = [10,30) ∪ [40,60).
+        let w = weights(100, 2, [0: [(10, 60)], 1: [(30, 40)]])
+        let out = CleanRegionSelector.selectCleanSampleRegions(
+            weights: w, speaker: 0, availableSamples: 16000,
+            regionMinSamples: 800, targetSamples: 48000, embedMinSamples: 1600, threshold: 0.5)
+        XCTAssertEqual(out?.regions.count, 2)
+        XCTAssertEqual(out?.regions.first?.start, 1600)  // 10 * 160
+        XCTAssertEqual(out?.regions.first?.end, 4800)  // 30 * 160
+        XCTAssertEqual(out?.regions.last?.start, 6400)  // 40 * 160
+        XCTAssertEqual(out?.regions.last?.end, 9600)  // 60 * 160
+        XCTAssertEqual(out?.firstFrame, 10)
+        XCTAssertEqual(out?.lastFrame, 59)
+    }
+
+    /// Total clean samples below embedMin → skip the speaker.
+    func testSampleRegionsBelowEmbedMinSkips() {
+        let w = weights(100, 2, [0: [(10, 20)]])  // 10 frames → 1600 samples
+        let out = CleanRegionSelector.selectCleanSampleRegions(
+            weights: w, speaker: 0, availableSamples: 16000,
+            regionMinSamples: 800, targetSamples: 48000, embedMinSamples: 3200, threshold: 0.5)
+        XCTAssertNil(out)
+    }
+
+    /// A run shorter than regionMin is dropped; nothing survives → skip.
+    func testSampleRegionsShortRunDropped() {
+        let w = weights(100, 2, [0: [(10, 15)]])  // 5 frames → 800 samples
+        let out = CleanRegionSelector.selectCleanSampleRegions(
+            weights: w, speaker: 0, availableSamples: 16000,
+            regionMinSamples: 1600, targetSamples: 48000, embedMinSamples: 1600, threshold: 0.5)
+        XCTAssertNil(out)
+    }
+
+    /// The feature-domain concat packer lays crops end-to-end and zero-pads the tail.
+    func testPackConcatFeatures() {
+        // Two crops, 2 mel bins each. Crop1: bin0=[1,2] bin1=[10,20]; Crop2: bin0=[3,4] bin1=[30,40].
+        let col1: [Float] = [1, 2, 10, 20]  // mel-major [2 bins × 2 frames]
+        let col2: [Float] = [3, 4, 30, 40]
+        let out = CleanRegionSelector.packConcatFeatures(
+            columns: [(col1, 2), (col2, 2)], melBins: 2, dstFrames: 5)
+        XCTAssertEqual(out.usedFrames, 4)
+        XCTAssertEqual(out.feats, [1, 2, 3, 4, 0, /* bin1 */ 10, 20, 30, 40, 0])
+    }
+
+    /// Concat truncates at dstFrames.
+    func testPackConcatFeaturesTruncates() {
+        let col: [Float] = [1, 2, 3, 4, 10, 20, 30, 40]  // [2 bins × 4 frames]
+        let out = CleanRegionSelector.packConcatFeatures(
+            columns: [(col, 4)], melBins: 2, dstFrames: 3)
+        XCTAssertEqual(out.usedFrames, 3)
+        XCTAssertEqual(out.feats, [1, 2, 3, /* bin1 */ 10, 20, 30])
+    }
+
+    /// numpy-'reflect' padding mirrors around the edge sample without repeating it.
+    @available(macOS 14.0, iOS 17.0, *)
+    func testReflectPadMatchesNumpy() {
+        // np.pad([1,2,3,4,5], 2, 'reflect') == [3,2,1,2,3,4,5,4,3]
+        let out = TitaNetWaveCropFeaturizer.reflectPad([1, 2, 3, 4, 5], 2)
+        XCTAssertEqual(out, [3, 2, 1, 2, 3, 4, 5, 4, 3])
+    }
+}

--- a/Tests/FluidAudioTests/Diarizer/NMESCClusteringTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/NMESCClusteringTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+@testable import FluidAudio
+
+final class NMESCClusteringTests: XCTestCase {
+
+    /// Deterministic pseudo-random unit vector near a base direction.
+    private func jitteredVector(base: [Double], seed: Int, jitter: Double) -> [Double] {
+        var v = base
+        var state = UInt64(seed &* 2_654_435_761)
+        for i in 0..<v.count {
+            state = state &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            let r = Double(state >> 11) / Double(UInt64.max >> 11) - 0.5
+            v[i] += r * jitter
+        }
+        let norm = (v.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        return v.map { $0 / norm }
+    }
+
+    // n is chosen to match the production regime (~300-600 window embeddings
+    // per scene). At tiny n the pruning grid degenerates (keep=2 neighbors)
+    // and even clean blobs fragment — a separate known small-n limitation.
+    func testSingleVoiceCollapsesToOneCluster() {
+        var base = [Double](repeating: 0, count: 32)
+        base[0] = 1
+        let points = (0..<150).map { jitteredVector(base: base, seed: $0, jitter: 0.15) }
+        let labels = NMESCClustering().cluster(embeddingFeatures: points)
+        XCTAssertEqual(Set(labels).count, 1, "solo-voice cloud must collapse to k=1")
+    }
+
+    func testTwoSeparatedVoicesStayTwoClusters() {
+        var a = [Double](repeating: 0, count: 32)
+        a[0] = 1
+        var b = [Double](repeating: 0, count: 32)
+        b[1] = 1
+        let points =
+            (0..<150).map { jitteredVector(base: a, seed: $0, jitter: 0.1) }
+            + (0..<150).map { jitteredVector(base: b, seed: 1000 + $0, jitter: 0.1) }
+        let labels = NMESCClustering().cluster(embeddingFeatures: points)
+        XCTAssertEqual(Set(labels).count, 2, "two distinct voices must stay k=2")
+    }
+}

--- a/Tests/FluidAudioTests/Diarizer/Offline/SpeakerClusterMergeTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Offline/SpeakerClusterMergeTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Unit tests for the agglomerative over-split merge. Pure vector math — no models.
+final class SpeakerClusterMergeTests: XCTestCase {
+
+    /// Well-separated (orthogonal) speakers are never folded together.
+    func testKeepsSeparateSpeakers() {
+        let emb: [[Double]] = [[1, 0, 0], [1, 0, 0], [0, 1, 0], [0, 1, 0]]
+        let out = SpeakerClusterMerge.mergedLabels(
+            embeddings: emb, labels: [0, 0, 1, 1], threshold: 0.75)
+        XCTAssertEqual(out, [0, 0, 1, 1])
+    }
+
+    /// A drift chain of near-parallel sub-clusters collapses to one speaker.
+    func testMergesOverSplitChain() {
+        let emb: [[Double]] = [[1, 0, 0], [0.98, 0.2, 0], [0.95, 0.31, 0]]
+        let out = SpeakerClusterMerge.mergedLabels(
+            embeddings: emb, labels: [0, 1, 2], threshold: 0.75)
+        XCTAssertEqual(Set(out).count, 1)
+    }
+
+    /// The threshold gates the merge: a ~0.6-cosine pair splits at 0.75, folds at 0.5.
+    func testThresholdGates() {
+        let emb: [[Double]] = [[1, 0, 0], [0.6, 0.8, 0]]  // centroid cosine = 0.6
+        XCTAssertEqual(
+            Set(SpeakerClusterMerge.mergedLabels(embeddings: emb, labels: [0, 1], threshold: 0.75))
+                .count, 2)
+        XCTAssertEqual(
+            Set(SpeakerClusterMerge.mergedLabels(embeddings: emb, labels: [0, 1], threshold: 0.5))
+                .count, 1)
+    }
+
+    /// Non-contiguous input labels are renumbered to 0..<k (no merge when orthogonal).
+    func testRenumbersNonContiguous() {
+        let emb: [[Double]] = [[1, 0, 0], [0, 1, 0]]
+        let out = SpeakerClusterMerge.mergedLabels(
+            embeddings: emb, labels: [5, 3], threshold: 0.99)
+        XCTAssertEqual(out, [0, 1])
+    }
+
+    /// Zero-energy embeddings (garbage masks) are ignored without crashing.
+    func testIgnoresZeroVectors() {
+        let emb: [[Double]] = [[0, 0, 0], [1, 0, 0], [1, 0, 0]]
+        let out = SpeakerClusterMerge.mergedLabels(
+            embeddings: emb, labels: [0, 1, 1], threshold: 0.75)
+        XCTAssertEqual(out.count, 3)
+    }
+}


### PR DESCRIPTION
Align on-device TitaNet-10s diarizer with the Python reference

Brings the FluidAudio offline diarizer in line with the audria-diarid reference (scenes_diarize.py, --cluster-gate 3.5).

Changes
- Clean-region truncation — CleanRegionSelector caps the final pooled region at embedTargetMs exactly (was overshooting), mirroring regions.py.
- L2-normalized embeddings — runMaskDecoder normalizes output (v/(‖v‖+1e-8)) like embeddings.py, and warns when the raw norm leaves the healthy 0.2–0.5 band (the ~89-norm ANE-corruption tell).
- retained_s + pristine gate — TimedEmbedding/ChunkEmbedding now carry clean-solo-speech seconds; new Clustering.minRetainedSeconds lets only ≥gate-second embeddings shape clusters, while shorter ones still assign to the nearest centroid.
- Average-linkage merge — SpeakerClusterMerge switches from centroid- to average-linkage over member pairs (matches merge_oversplit).

Verification — on b22ed10d: retained_s min/max/mean 2.53/6.00/5.74 (reference 2.53/6.00/5.77), 104 embeddings (ref 103), k=2 preserved.

Notes — Additive and back-compatible; no behavior change until a consumer sets the new config. Average-linkage threshold ≠ centroid (reference ~0.80, pending labelled A/B). App config (embedTargetMs=6000, stepRatio=0.3, minRetainedSeconds=3.5, threshold 0.80) lands with the pin bump.