### PR TITLE
feat(download): stall watchdog + DownloadConfig plumbing (#810)

### DIFF
--- a/Sources/FluidAudio/Shared/Download/DownloadTypes.swift
+++ b/Sources/FluidAudio/Shared/Download/DownloadTypes.swift
@@ -13,6 +13,12 @@ public enum DownloadError: LocalizedError {
     case htmlErrorResponse(path: String, snippet: String)
     case invalidArtifact(path: String, reason: String)
 
+    /// The byte stream stalled: fewer than `DownloadConfig.minStallBytes`
+    /// arrived within `window` seconds, so the transfer was cancelled early
+    /// for retry — byte-range resume continues from the bytes already on disk
+    /// — instead of hanging on the multi-minute idle `timeout`. Retryable.
+    case stalled(path: String, window: TimeInterval)
+
     /// A code path that would have hit the network was blocked by
     /// `ModelHub.offlineMode`. `operation` is the short tag of the blocked
     /// entry point (e.g. `"download(parakeet-tdt-0.6b-v3-coreml)"`).
@@ -37,6 +43,9 @@ public enum DownloadError: LocalizedError {
             return "Model file not found: \(path)"
         case .invalidArtifact(let path, let reason):
             return "Downloaded artifact for \(path) is invalid (\(reason)); refusing to cache it."
+        case .stalled(let path, let window):
+            return
+                "Download of \(path) stalled (no meaningful progress for \(Int(window))s); cancelled for retry."
         case .networkDisabled(let operation):
             return "FluidAudio offline mode: \(operation) blocked"
         case .modelMissing(let repo, let missing):
@@ -48,13 +57,41 @@ public enum DownloadError: LocalizedError {
 
 /// Download configuration shared by the download stack.
 public struct DownloadConfig: Sendable {
+    /// Per-request idle timeout (`URLRequest.timeoutInterval`). This timer
+    /// resets whenever *any* byte arrives, so on its own it only fires after a
+    /// full `timeout` seconds of complete silence — it will not catch a
+    /// connection that trickles a few bytes. The stall watchdog below is what
+    /// detects a frozen transfer quickly; `timeout` remains the outer bound.
     public let timeout: TimeInterval
 
-    public init(timeout: TimeInterval = 1800) {  // 30 minutes for large models
+    /// Stall watchdog threshold: the minimum number of bytes that must arrive
+    /// within each `stallWindow` interval for the transfer to be considered
+    /// alive. If fewer arrive, the transfer is cancelled and retried (byte-range
+    /// resume continues from the bytes already on disk), surfacing a frozen CDN
+    /// connection in seconds instead of waiting out `timeout`. Set to `0` to
+    /// disable the watchdog. Defaults to 1 MiB.
+    public let minStallBytes: Int64
+
+    /// Length of each stall-watchdog observation window, in seconds. The
+    /// watchdog wakes every `stallWindow` seconds and fails the transfer when
+    /// fewer than `minStallBytes` arrived since the previous wake. Defaults to
+    /// 120 s.
+    public let stallWindow: TimeInterval
+
+    public init(
+        timeout: TimeInterval = 1800,  // 30 minutes for large models
+        minStallBytes: Int64 = 1 << 20,  // 1 MiB
+        stallWindow: TimeInterval = 120
+    ) {
         self.timeout = timeout
+        self.minStallBytes = minStallBytes
+        self.stallWindow = stallWindow
     }
 
     public static let `default` = DownloadConfig()
+
+    /// `true` when the stall watchdog is active (positive threshold and window).
+    var stallWatchdogEnabled: Bool { minStallBytes > 0 && stallWindow > 0 }
 }
 
 /// Phase of a model download operation.

--- a/Sources/FluidAudio/Shared/Download/FileDownloader.swift
+++ b/Sources/FluidAudio/Shared/Download/FileDownloader.swift
@@ -38,6 +38,7 @@ enum FileDownloader {
         from repoRemotePath: String,
         at destination: URL,
         recoveringBlockedPaths: Bool,
+        config: DownloadConfig = .default,
         configuration: URLSessionConfiguration? = nil,
         onBytes: (@Sendable (Int64, Int64) -> Void)? = nil
     ) async throws -> Outcome {
@@ -63,7 +64,7 @@ enum FileDownloader {
         let encodedPath =
             file.path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? file.path
         let fileURL = try ModelRegistry.resolveModel(repoRemotePath, encodedPath)
-        let request = HFClient.authorizedRequest(url: fileURL)
+        let request = HFClient.authorizedRequest(url: fileURL, timeout: config.timeout)
 
         let tempURL = try await download(
             request: request,
@@ -71,6 +72,7 @@ enum FileDownloader {
             expectedSize: file.size,
             partialFileURL: destination.appendingPathExtension("partial"),
             onProgress: onBytes,
+            config: config,
             configuration: configuration
         )
 
@@ -206,6 +208,9 @@ enum FileDownloader {
         request: URLRequest,
         to destination: URL,
         resumeOffset: Int64 = 0,
+        path: String = "",
+        minStallBytes: Int64 = 0,
+        stallWindow: TimeInterval = 0,
         configuration: URLSessionConfiguration? = nil,
         onProgress: (@Sendable (Int64, Int64) -> Void)? = nil,
         onResponse: (@Sendable (HTTPURLResponse) -> Void)? = nil
@@ -213,6 +218,9 @@ enum FileDownloader {
         let delegate = StreamingDownloadDelegate(
             destination: destination,
             resumeOffset: resumeOffset,
+            path: path,
+            minStallBytes: minStallBytes,
+            stallWindow: stallWindow,
             onProgress: onProgress,
             onResponse: onResponse
         )
@@ -290,6 +298,7 @@ enum FileDownloader {
         onProgress: (@Sendable (Int64, Int64) -> Void)?,
         maxAttempts: Int = 4,
         minBackoff: TimeInterval = 1.0,
+        config: DownloadConfig = .default,
         configuration: URLSessionConfiguration? = nil
     ) async throws -> URL {
         let defaultPartialURL = FileManager.default.temporaryDirectory
@@ -341,6 +350,9 @@ enum FileDownloader {
                 request: attemptRequest,
                 to: partialURL,
                 resumeOffset: resumeOffset,
+                path: path,
+                minStallBytes: config.minStallBytes,
+                stallWindow: config.stallWindow,
                 configuration: configuration,
                 onProgress: onProgress,
                 onResponse: { response in
@@ -406,10 +418,25 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
         var expectedTotal: Int64 = -1
         var writeError: Error?
         var finished = false
+        // Stall watchdog: `bytesAtWindowStart` snapshots `bytesWritten` at the
+        // top of each observation window; `stalled` records that the watchdog
+        // (not the caller) cancelled the task so completion surfaces a typed,
+        // retryable `.stalled` error instead of a bare cancellation.
+        var watchdog: DispatchSourceTimer?
+        var bytesAtWindowStart: Int64 = 0
+        var stalled = false
     }
+
+    /// Serial queue that fires every download's stall-watchdog timer; shared so
+    /// concurrent per-file downloads don't each spin up a thread.
+    private static let watchdogQueue = DispatchQueue(label: "com.fluidaudio.download.stall-watchdog")
+    private static let logger = AppLogger(category: "DownloadUtils")
 
     private let destination: URL
     private let resumeOffset: Int64
+    private let path: String
+    private let minStallBytes: Int64
+    private let stallWindow: TimeInterval
     private let onProgress: (@Sendable (Int64, Int64) -> Void)?
     private let onResponse: (@Sendable (HTTPURLResponse) -> Void)?
     // Holds the non-Sendable continuation and file handle; the lock (not
@@ -419,28 +446,66 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
     init(
         destination: URL,
         resumeOffset: Int64,
+        path: String,
+        minStallBytes: Int64,
+        stallWindow: TimeInterval,
         onProgress: (@Sendable (Int64, Int64) -> Void)?,
         onResponse: (@Sendable (HTTPURLResponse) -> Void)?
     ) {
         self.destination = destination
         self.resumeOffset = resumeOffset
+        self.path = path
+        self.minStallBytes = minStallBytes
+        self.stallWindow = stallWindow
         self.onProgress = onProgress
         self.onResponse = onResponse
     }
 
-    /// Register the continuation and task before the task starts.
+    /// Register the continuation and task before the task starts, and arm the
+    /// stall watchdog (when enabled). The timer wakes every `stallWindow` and
+    /// cancels the task if fewer than `minStallBytes` arrived since the last
+    /// wake — catching a frozen CDN connection in seconds rather than waiting
+    /// out the request's idle `timeout`.
     func attach(
         continuation: CheckedContinuation<HTTPURLResponse, Error>,
         task: URLSessionDataTask
     ) {
+        let timer: DispatchSourceTimer? =
+            (minStallBytes > 0 && stallWindow > 0)
+            ? DispatchSource.makeTimerSource(queue: Self.watchdogQueue) : nil
         state.withLockUnchecked {
             $0.continuation = continuation
             $0.task = task
+            $0.watchdog = timer
+        }
+        if let timer {
+            timer.schedule(deadline: .now() + stallWindow, repeating: stallWindow)
+            timer.setEventHandler { [weak self] in self?.checkStall() }
+            timer.resume()
         }
     }
 
     func cancel() {
         state.withLockUnchecked { $0.task }?.cancel()
+    }
+
+    /// One watchdog tick: cancel the task if the byte count advanced by less
+    /// than `minStallBytes` over the last window. `stalled` is set under the
+    /// lock before cancelling so `didCompleteWithError` reports `.stalled`.
+    private func checkStall() {
+        let stalledTask = state.withLockUnchecked { st -> URLSessionTask? in
+            guard !st.finished, !st.stalled, let task = st.task else { return nil }
+            let delta = st.bytesWritten - st.bytesAtWindowStart
+            st.bytesAtWindowStart = st.bytesWritten
+            guard delta < minStallBytes else { return nil }
+            st.stalled = true
+            return task
+        }
+        guard let stalledTask else { return }
+        Self.logger.warning(
+            "Download of \(path) stalled (<\(minStallBytes) bytes in \(Int(stallWindow))s); cancelling for retry."
+        )
+        stalledTask.cancel()
     }
 
     func urlSession(
@@ -522,8 +587,12 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
         didCompleteWithError error: Error?
     ) {
         let response = task.response as? HTTPURLResponse
+        let path = self.path
+        let stallWindow = self.stallWindow
         // Extract the resume action under the lock, run it after releasing.
         let resume = state.withLockUnchecked { st -> (() -> Void)? in
+            st.watchdog?.cancel()
+            st.watchdog = nil
             guard !st.finished, let continuation = st.continuation else { return nil }
             st.finished = true
             st.continuation = nil
@@ -531,8 +600,15 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
             try? st.handle?.close()
             st.handle = nil
             let writeError = st.writeError
+            let stalled = st.stalled
             return {
-                if let writeError {
+                if stalled {
+                    // The watchdog cancelled a frozen transfer: surface a typed,
+                    // retryable error rather than the bare cancellation URLError
+                    // (which the retry layer treats as a caller abort).
+                    continuation.resume(
+                        throwing: DownloadError.stalled(path: path, window: stallWindow))
+                } else if let writeError {
                     continuation.resume(throwing: writeError)
                 } else if let error {
                     continuation.resume(throwing: error)

--- a/Sources/FluidAudio/Shared/Download/ModelHub.swift
+++ b/Sources/FluidAudio/Shared/Download/ModelHub.swift
@@ -88,6 +88,7 @@ public enum ModelHub {
         directory: URL,
         computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
         variant: String? = nil,
+        config: DownloadConfig = .default,
         progressHandler: ProgressHandler? = nil
     ) async throws -> [String: MLModel] {
         await SystemInfo.logOnce(using: logger)
@@ -95,7 +96,7 @@ public enum ModelHub {
             return try await loadModelsOnce(
                 repo, modelNames: modelNames,
                 directory: directory, computeUnits: computeUnits, variant: variant,
-                progressHandler: progressHandler)
+                config: config, progressHandler: progressHandler)
         } catch {
             // In offline mode never delete cache + re-download. Surface
             // the original load failure so the caller can decide.
@@ -138,7 +139,7 @@ public enum ModelHub {
             return try await loadModelsOnce(
                 repo, modelNames: modelNames,
                 directory: directory, computeUnits: computeUnits, variant: variant,
-                progressHandler: progressHandler)
+                config: config, progressHandler: progressHandler)
         }
     }
     private static func loadModelsOnce(
@@ -147,6 +148,7 @@ public enum ModelHub {
         directory: URL,
         computeUnits: MLComputeUnits = .cpuAndNeuralEngine,
         variant: String? = nil,
+        config: DownloadConfig = .default,
         progressHandler: ProgressHandler? = nil
     ) async throws -> [String: MLModel] {
         await SystemInfo.logOnce(using: logger)
@@ -177,15 +179,16 @@ public enum ModelHub {
             try await download(
                 repo, to: directory, variant: variant,
                 additionalModelNames: extraModelNames,
+                config: config,
                 progressHandler: progressHandler)
         } else {
             logger.info("Found \(repo.folderName) locally, no download needed")
             reporter.cachedModelsAvailable()
         }
 
-        let config = MLModelConfiguration()
-        config.computeUnits = computeUnits
-        config.allowLowPrecisionAccumulationOnGPU = true
+        let mlConfig = MLModelConfiguration()
+        mlConfig.computeUnits = computeUnits
+        mlConfig.allowLowPrecisionAccumulationOnGPU = true
 
         var models: [String: MLModel] = [:]
         for (index, name) in modelNames.enumerated() {
@@ -195,7 +198,7 @@ public enum ModelHub {
             reporter.compiling(name: name, index: index, count: modelNames.count)
 
             let start = Date()
-            let model = try MLModel(contentsOf: modelPath, configuration: config)
+            let model = try MLModel(contentsOf: modelPath, configuration: mlConfig)
             let elapsed = Date().timeIntervalSince(start)
 
             models[name] = model
@@ -221,11 +224,13 @@ public enum ModelHub {
         to directory: URL,
         variant: String? = nil,
         additionalModelNames: Set<String> = [],
+        config: DownloadConfig = .default,
         progressHandler: ProgressHandler? = nil
     ) async throws {
         try await download(
             repo, to: directory, variant: variant,
             additionalModelNames: additionalModelNames,
+            config: config,
             progressHandler: progressHandler,
             configuration: nil)
     }
@@ -240,6 +245,7 @@ public enum ModelHub {
         to directory: URL,
         variant: String? = nil,
         additionalModelNames: Set<String> = [],
+        config: DownloadConfig = .default,
         progressHandler: ProgressHandler? = nil,
         configuration: URLSessionConfiguration?
     ) async throws {
@@ -367,6 +373,7 @@ public enum ModelHub {
                 from: repo.remotePath,
                 at: destPath,
                 recoveringBlockedPaths: true,
+                config: config,
                 configuration: configuration,
                 onBytes: onBytes
             )
@@ -413,6 +420,7 @@ public enum ModelHub {
         _ repo: Repo,
         subdirectory: String,
         to repoDirectory: URL,
+        config: DownloadConfig = .default,
         progressHandler: ProgressHandler? = nil,
         shouldSkip: (@Sendable (String) -> Bool)? = nil
     ) async throws {
@@ -464,6 +472,7 @@ public enum ModelHub {
                 from: repo.remotePath,
                 at: destPath,
                 recoveringBlockedPaths: false,
+                config: config,
                 onBytes: onBytes
             )
             completedBytes += Int64(max(0, file.size))

--- a/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
+++ b/Sources/FluidAudio/Shared/Download/RetryPolicy.swift
@@ -94,6 +94,10 @@ enum RetryPolicy {
         case DownloadError.invalidArtifact:
             // Usually a transient unhealthy network path (proxy, mirror 5xx) — retry.
             return true
+        case DownloadError.stalled:
+            // A frozen CDN connection cancelled by the stall watchdog — retry
+            // (byte-range resume continues from the bytes already on disk).
+            return true
         case DownloadError.downloadFailed(_, let underlying):
             let nsError = underlying as NSError
             return nsError.domain == "HTTP" && (500...599).contains(nsError.code)

--- a/Tests/FluidAudioTests/Shared/DownloadResumeTests.swift
+++ b/Tests/FluidAudioTests/Shared/DownloadResumeTests.swift
@@ -211,6 +211,71 @@ final class DownloadResumeTests: XCTestCase {
             "a complete, valid partial must be reused without hitting the network")
     }
 
+    // MARK: - Stall watchdog (#810)
+
+    /// A frozen mid-transfer connection is cancelled by the watchdog and the
+    /// retry resumes to completion — instead of hanging on the idle `timeout`.
+    func testStalledTransferIsCancelledAndRetried() async throws {
+        // Attempt 1: 200 + ETag, delivers a small head, then freezes. The head
+        // is far below the 1 MiB threshold so the watchdog trips on its first
+        // (sub-second) window.
+        ResumeStubURLProtocol.enqueue(
+            .init(
+                status: 200,
+                headers: ["ETag": "\"v1\"", "Content-Length": String(Self.fullBody.count)],
+                chunks: [Data(Self.fullBody.prefix(10))],
+                stall: true))
+        // Attempt 2: a range-capable server completes the file.
+        ResumeStubURLProtocol.enqueue(
+            .init(status: 200, headers: ["ETag": "\"v1\""], chunks: [], rangeAwareBody: Self.fullBody))
+
+        let fastWatchdog = DownloadConfig(minStallBytes: 1 << 20, stallWindow: 0.2)
+        let url = try await FileDownloader.download(
+            request: request,
+            path: "model.bin",
+            expectedSize: Self.fullBody.count,
+            partialFileURL: partialURL(),
+            onProgress: nil,
+            maxAttempts: 3,
+            minBackoff: 0.01,
+            config: fastWatchdog,
+            configuration: stubConfiguration
+        )
+
+        XCTAssertEqual(try Data(contentsOf: url), Self.fullBody)
+        XCTAssertEqual(
+            ResumeStubURLProtocol.recordedRequests().count, 2,
+            "the stalled attempt must be cancelled and retried")
+    }
+
+    /// A disabled watchdog (`minStallBytes == 0`) must not cancel a healthy,
+    /// progressing download.
+    func testDisabledWatchdogDoesNotCancelHealthyDownload() async throws {
+        ResumeStubURLProtocol.enqueue(
+            .init(status: 200, headers: ["ETag": "\"v1\""], chunks: [Self.fullBody]))
+
+        let noWatchdog = DownloadConfig(minStallBytes: 0, stallWindow: 0)
+        let url = try await FileDownloader.download(
+            request: request,
+            path: "model.bin",
+            expectedSize: Self.fullBody.count,
+            partialFileURL: partialURL(),
+            onProgress: nil,
+            maxAttempts: 1,
+            minBackoff: 0.01,
+            config: noWatchdog,
+            configuration: stubConfiguration
+        )
+
+        XCTAssertEqual(try Data(contentsOf: url), Self.fullBody)
+        XCTAssertEqual(ResumeStubURLProtocol.recordedRequests().count, 1)
+    }
+
+    func testStalledErrorIsClassifiedRetryable() {
+        XCTAssertTrue(RetryPolicy.isRetryable(DownloadError.stalled(path: "model.bin", window: 120)))
+        XCTAssertFalse(RetryPolicy.isCancellation(DownloadError.stalled(path: "model.bin", window: 120)))
+    }
+
     func testProgressIncludesResumedOffsetSoItNeverDips() async throws {
         let splitAt = 10
         try seedPartial(Data(Self.fullBody.prefix(splitAt)), validator: "\"v1\"")
@@ -256,6 +321,9 @@ final class ResumeStubURLProtocol: URLProtocol {
         let chunks: [Data]
         /// Deliver this many chunks, then fail with `.networkConnectionLost`.
         var failAfterChunks: Int? = nil
+        /// Deliver the chunks, then go silent forever — never finish, never
+        /// fail. Simulates a frozen CDN connection so the stall watchdog fires.
+        var stall: Bool = false
         /// When set, respond like a real range-capable server instead of using
         /// `status`/`chunks`: 206 + the slice from the request's `Range` offset
         /// when the header is present, else 200 + the full body. Lets tests
@@ -330,6 +398,9 @@ final class ResumeStubURLProtocol: URLProtocol {
             }
             client?.urlProtocol(self, didLoad: chunk)
         }
+        // Frozen connection: bytes stop flowing but the request stays open, so
+        // only the stall watchdog (not the idle timeout) can end it.
+        if script.stall { return }
         if let failAfter = script.failAfterChunks, failAfter >= script.chunks.count {
             failAfterFlush()
             return


### PR DESCRIPTION
Closes #810.

## Problem
When an HF model download stalls mid-transfer (bytes stop flowing but the connection stays open), the download hangs for up to the 30-minute request idle timeout before failing. `URLRequest.timeoutInterval` resets on every received byte, so it only fires after *complete* silence — a transfer frozen at 80% still hangs the provisioning flow for half an hour. `DownloadConfig` carried the timeout but was not reachable from the public download API, so integrators could not tune it.

Byte-range resume (#757) already landed on `main`; this PR adds the two remaining fixes the issue asked for.

## Changes
- **Stall watchdog** (`StreamingDownloadDelegate`): a `DispatchSourceTimer` wakes every `DownloadConfig.stallWindow` (default 120 s) and cancels the task when fewer than `DownloadConfig.minStallBytes` (default 1 MiB) arrived since the last wake. The cancellation surfaces as the retryable `DownloadError.stalled`, and byte-range resume continues from the bytes already on disk — so the retry does not restart from zero. Set `minStallBytes = 0` to disable.
- **`DownloadConfig` plumbing**: threaded a `config: DownloadConfig = .default` parameter through `ModelHub.loadModels` / `download` / `download(subdirectory:)` down to `FileDownloader`, wiring `config.timeout` into the request and the watchdog thresholds into the transport. The default enables the watchdog for all callers; integrators can now override.
- `DownloadConfig` gains `minStallBytes` / `stallWindow` (defaults 1 MiB / 120 s, matching the reporter's validated workaround).

## Tests
- `testStalledTransferIsCancelledAndRetried` — a frozen connection is cancelled sub-second and the retry resumes to a complete, unspliced file.
- `testDisabledWatchdogDoesNotCancelHealthyDownload` — `minStallBytes == 0` leaves a healthy download untouched.
- `testStalledErrorIsClassifiedRetryable` — `.stalled` is retryable and not classified as a cancellation.

All new public parameters are defaulted, so existing call sites are source-compatible. `swift build` and format lint pass locally; XCTest runs in CI (unavailable locally).