### PR TITLE
feat(cli/process): add --compute-units flag for offline diarization

### DIFF
--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerModels.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerModels.swift
@@ -71,10 +71,6 @@ public struct OfflineDiarizerModels: Sendable {
         MLModelConfigurationUtils.defaultModelsDirectory()
     }
 
-    private static func defaultConfiguration() -> MLModelConfiguration {
-        MLModelConfigurationUtils.defaultConfiguration(computeUnits: .all)
-    }
-
     public static func load(
         from directory: URL? = nil,
         configuration: MLModelConfiguration? = nil,
@@ -85,6 +81,9 @@ public struct OfflineDiarizerModels: Sendable {
         logger.info("Loading offline diarization models from \(modelsDirectory.path)")
 
         let loadStart = Date()
+        // Honor the caller's requested compute units for the segmentation/embedding/PLDA
+        // models; default to `.all` when no configuration is supplied. The fbank model
+        // stays `.cpuOnly` regardless (below) since it runs faster on CPU.
         let inferenceComputeUnits: MLComputeUnits = configuration?.computeUnits ?? .all
 
         let segmentationAndEmbeddingNames: [String] = [

--- a/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ProcessCommand.swift
@@ -1,5 +1,6 @@
 #if os(macOS)
 import AVFoundation
+import CoreML
 import FluidAudio
 import Foundation
 
@@ -152,7 +153,10 @@ enum ProcessCommand {
             let modelDir = OfflineDiarizerModels.defaultModelsDirectory()
             let manager = OfflineDiarizerManager(config: offlineConfig)
 
-            let models = try await OfflineDiarizerModels.load(from: modelDir)
+            let configuration = MLModelConfigurationUtils.defaultConfiguration(
+                computeUnits: args.computeUnits)
+            let models = try await OfflineDiarizerModels.load(
+                from: modelDir, configuration: configuration)
             manager.initialize(models: models)
 
             logger.info("Offline manager initialized")
@@ -278,6 +282,7 @@ enum ProcessCommand {
         var minSpeakers: Int?
         var maxSpeakers: Int?
         var numSpeakers: Int?
+        var computeUnits: MLComputeUnits = .all
     }
 
     private static func parseArguments(_ args: [String]) -> ParsedArgs {
@@ -453,6 +458,17 @@ enum ProcessCommand {
                     parsed.embeddingExportPath = args[i + 1]
                     i += 1
                 }
+            case "--compute-units":
+                if i + 1 < args.count {
+                    switch args[i + 1].lowercased() {
+                    case "all": parsed.computeUnits = .all
+                    case "cpu-only": parsed.computeUnits = .cpuOnly
+                    case "ane": parsed.computeUnits = .cpuAndNeuralEngine
+                    default:
+                        logger.warning("Invalid --compute-units value '\(args[i + 1])', using 'all'")
+                    }
+                    i += 1
+                }
 
             default:
                 logger.warning("Unknown option: \(args[i])")
@@ -510,6 +526,8 @@ enum ProcessCommand {
                 --max-speakers <n>              Maximum number of speakers
                 --num-speakers <n>              Exact speaker count (overrides min/max)
                 --export-embeddings <file>      Export embeddings to JSON for debugging
+                --compute-units <all|cpu-only|ane>  ML compute units for inference; use cpu-only/ane
+                                                to guarantee off-GPU (default: all)
 
             Examples:
                 # Streaming mode (default)


### PR DESCRIPTION
## Summary

Fixes #808. The offline diarization `process` command had no `--compute-units` flag, so it always ran with CoreML `computeUnits = .all` — with no way to constrain it from the CLI, unlike sibling commands (`vad-benchmark`, `vad-analyze`, `sortformer`). `.all` leaves the GPU-vs-ANE choice to CoreML, which is a real contention risk when a resident GPU consumer (e.g. an MLX model) is coordinated on the same machine.

## Changes

- **`ProcessCommand.swift`**: parse `--compute-units <all|cpu-only|ane>`, store it on `ParsedArgs`, build an `MLModelConfiguration` via `MLModelConfigurationUtils.defaultConfiguration(computeUnits:)`, and thread it through to `OfflineDiarizerModels.load(from:configuration:)`. Added usage docs.
- **`OfflineDiarizerModels.swift`**: dropped the now-unused private `defaultConfiguration()` and documented that the fbank model deliberately stays `.cpuOnly` while segmentation/embedding/PLDA follow the requested units. (`load()` already honored `configuration?.computeUnits` on `main`.)

## Mapping

`all → .all`, `cpu-only → .cpuOnly`, `ane → .cpuAndNeuralEngine`. Default remains `.all` (no behavior change). Choosing `cpu-only` or `ane` gives a hard off-GPU guarantee.

Note: unlike `VadAnalyzeCommand` (which maps `all → .cpuAndNeuralEngine`), this maps `all → .all` so the flag is truthful about GPU eligibility.

## Verification

- `swift build` succeeds
- swift-format lint passes
- `process --mode offline --help` now lists `--compute-units`