### PR TITLE
fix: prevent integer overflow in AudioSourceFactory frame count calculation

### DIFF
--- a/Sources/FluidAudio/Shared/AudioSourceFactory.swift
+++ b/Sources/FluidAudio/Shared/AudioSourceFactory.swift
@@ -135,7 +135,9 @@ public struct AudioSourceFactory {
             }
 
             do {
-                let remainingFrames = AVAudioFrameCount(audioFile.length - audioFile.framePosition)
+                // Clamp to AVAudioFrameCount.max to prevent overflow when casting from Int64
+                let remainingFramesInt64 = audioFile.length - audioFile.framePosition
+                let remainingFrames = AVAudioFrameCount(min(remainingFramesInt64, Int64(AVAudioFrameCount.max)))
                 let framesToRead = min(inputCapacity, remainingFrames)
                 if framesToRead > 0 {
                     try audioFile.read(into: capturedInputBuffer, frameCount: framesToRead)


### PR DESCRIPTION
## Summary
Fixes a crash when processing audio files where `(audioFile.length - audioFile.framePosition)` exceeds `AVAudioFrameCount.max` (UInt32.max = ~4.29 billion frames).

## Problem
The bug caused a Swift runtime failure: **"Not enough bits to represent the passed value"** when casting `Int64` to `UInt32` without bounds checking in `AudioSourceFactory.swift:138`.

This occurred during initialization in macOS apps using FluidAudio for diarization, particularly when Speech API capability checks triggered audio processing with test/probe audio files.

## Solution
Clamp the remaining frames to `AVAudioFrameCount.max` before casting:

```swift
// Before:
let remainingFrames = AVAudioFrameCount(audioFile.length - audioFile.framePosition)

// After:
let remainingFramesInt64 = audioFile.length - audioFile.framePosition
let remainingFrames = AVAudioFrameCount(min(remainingFramesInt64, Int64(AVAudioFrameCount.max)))
```

This prevents overflow while maintaining correct behavior for normal-sized audio files.

## Testing
- ✅ Builds successfully with `swift build`
- ✅ Fixed crash in production macOS application during Speech API initialization
- ✅ No impact on normal audio file processing

## Backport Request
This fix should be backported to the 0.14.x maintenance branch as well, as it affects apps using FluidAudio 0.14.5-0.14.8.