### PR TITLE
Expose token timings from the Unified offline batch path

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
@@ -182,7 +182,8 @@ public actor UnifiedAsrManager {
     /// 15 s windows.
     public func transcribe(_ samples: [Float]) async throws -> String {
         guard let tokenizer = tokenizer else { throw ASRError.notInitialized }
-        return tokenizer.decode(ids: try await decodedTokens(samples).map(\.token))
+        let merged = try await decodedTokens(samples, tokenizer: tokenizer)
+        return tokenizer.decode(ids: merged.map(\.token))
     }
 
     /// Transcribe as `transcribe(_:)` does, additionally reporting the encoder
@@ -197,30 +198,39 @@ public actor UnifiedAsrManager {
     /// word→speaker attribution).
     ///
     /// As in the streaming manager, RNNT tokens are emitted *at* a frame and
-    /// have no intrinsic duration, so each token's `endTime` is the next
-    /// token's start; the last token gets a provisional one-frame end. These
-    /// are emission times rather than forced-alignment boundaries: the decoder
-    /// emits once it has heard enough context, so a token's start can sit
-    /// slightly after the word's true onset.
+    /// have no intrinsic duration, so every token gets a provisional one-frame
+    /// end that is clamped back only when it would overrun its successor. The
+    /// spans are therefore not contiguous: a real pause stays visible as a gap
+    /// between one token's end and the next one's start. The last token keeps
+    /// its provisional end, clamped to the end of the clip. These are emission
+    /// times rather than forced-alignment boundaries: the decoder emits once it
+    /// has heard enough context, so a token's start can sit slightly after the
+    /// word's true onset.
     public func transcribeWithTimings(_ samples: [Float]) async throws -> TranscriptionWithTimings {
         guard let tokenizer = tokenizer else { throw ASRError.notInitialized }
-        let merged = try await decodedTokens(samples)
+        let merged = try await decodedTokens(samples, tokenizer: tokenizer)
         return TranscriptionWithTimings(
             text: tokenizer.decode(ids: merged.map(\.token)),
             tokenTimings: Self.tokenTimings(
                 from: merged,
                 secondsPerFrame: Double(config.frameSamples) / Double(config.sampleRate),
-                vocabulary: tokenizer.vocabulary
+                vocabulary: tokenizer.vocabulary,
+                clipDuration: Double(samples.count) / Double(config.sampleRate)
             )
         )
     }
 
     /// Emission frames → seconds. Pure, so the back-fill rule can be tested
     /// without loading a 600M parameter model.
+    ///
+    /// `clipDuration` bounds the last token's provisional end, which the batch
+    /// path can do because it knows the sample count up front and the streaming
+    /// one cannot. Pass `nil` to leave it unbounded.
     static func tokenTimings(
         from emissions: [ChunkProcessor.TokenWindow],
         secondsPerFrame: Double,
-        vocabulary: [Int: String]
+        vocabulary: [Int: String],
+        clipDuration: Double? = nil
     ) -> [TokenTiming] {
         var timings: [TokenTiming] = []
         timings.reserveCapacity(emissions.count)
@@ -248,15 +258,25 @@ public actor UnifiedAsrManager {
                 )
             )
         }
+        // The frontier token's one-frame end is a guess; offline knows where the
+        // audio actually stops, so don't hand callers a seek target past EOF.
+        if let clipDuration, let last = timings.indices.last, timings[last].endTime > clipDuration {
+            let previous = timings[last]
+            timings[last] = TokenTiming(
+                token: previous.token, tokenId: previous.tokenId,
+                startTime: previous.startTime, endTime: max(previous.startTime, clipDuration),
+                confidence: previous.confidence
+            )
+        }
         return timings
     }
 
     /// The merged, seam-collapsed token stream for the whole recording, in
     /// emission order. Shared by both batch entry points so the text they
     /// return cannot drift apart.
-    private func decodedTokens(_ samples: [Float]) async throws -> [ChunkProcessor.TokenWindow] {
-        guard let tokenizer = tokenizer else { throw ASRError.notInitialized }
-
+    private func decodedTokens(
+        _ samples: [Float], tokenizer: Tokenizer
+    ) async throws -> [ChunkProcessor.TokenWindow] {
         var merged: [ChunkProcessor.TokenWindow] = []
         // Reuse the TDT overlap merger to dedupe adjacent windows.
         let merger = ChunkProcessor(audioSamples: samples)

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
@@ -167,9 +167,94 @@ public actor UnifiedAsrManager {
 
     // MARK: - Batch API
 
+    /// A transcript and the per-token timings behind it.
+    public struct TranscriptionWithTimings: Sendable {
+        public let text: String
+        public let tokenTimings: [TokenTiming]
+
+        public init(text: String, tokenTimings: [TokenTiming]) {
+            self.text = text
+            self.tokenTimings = tokenTimings
+        }
+    }
+
     /// Transcribe 16 kHz mono samples of arbitrary length using overlapping
     /// 15 s windows.
     public func transcribe(_ samples: [Float]) async throws -> String {
+        guard let tokenizer = tokenizer else { throw ASRError.notInitialized }
+        return tokenizer.decode(ids: try await decodedTokens(samples).map(\.token))
+    }
+
+    /// Transcribe as `transcribe(_:)` does, additionally reporting the encoder
+    /// frame each token was emitted at, converted to seconds.
+    ///
+    /// The offline path already carries these frames — the greedy RNNT decoder
+    /// records one per emission and the overlap merge preserves them — so this
+    /// costs nothing beyond the conversion. It is the batch counterpart to
+    /// `StreamingUnifiedAsrManager.consumeTokenTimings()`, and its output feeds
+    /// `buildWordTimings(from:)` the same way, for callers that need to align
+    /// the transcript back to the audio (seeking, playback highlighting,
+    /// word→speaker attribution).
+    ///
+    /// As in the streaming manager, RNNT tokens are emitted *at* a frame and
+    /// have no intrinsic duration, so each token's `endTime` is the next
+    /// token's start; the last token gets a provisional one-frame end. These
+    /// are emission times rather than forced-alignment boundaries: the decoder
+    /// emits once it has heard enough context, so a token's start can sit
+    /// slightly after the word's true onset.
+    public func transcribeWithTimings(_ samples: [Float]) async throws -> TranscriptionWithTimings {
+        guard let tokenizer = tokenizer else { throw ASRError.notInitialized }
+        let merged = try await decodedTokens(samples)
+        return TranscriptionWithTimings(
+            text: tokenizer.decode(ids: merged.map(\.token)),
+            tokenTimings: Self.tokenTimings(
+                from: merged,
+                secondsPerFrame: Double(config.frameSamples) / Double(config.sampleRate),
+                vocabulary: tokenizer.vocabulary
+            )
+        )
+    }
+
+    /// Emission frames → seconds. Pure, so the back-fill rule can be tested
+    /// without loading a 600M parameter model.
+    static func tokenTimings(
+        from emissions: [ChunkProcessor.TokenWindow],
+        secondsPerFrame: Double,
+        vocabulary: [Int: String]
+    ) -> [TokenTiming] {
+        var timings: [TokenTiming] = []
+        timings.reserveCapacity(emissions.count)
+        for emission in emissions {
+            guard let piece = vocabulary[emission.token] else { continue }
+            let start = Double(emission.timestamp) * secondsPerFrame
+            // RNNT tokens have no intrinsic duration — back-fill the previous
+            // token's end to this token's start so durations reflect real gaps.
+            if let last = timings.indices.last, timings[last].endTime > start {
+                let previous = timings[last]
+                timings[last] = TokenTiming(
+                    token: previous.token, tokenId: previous.tokenId,
+                    startTime: previous.startTime, endTime: max(previous.startTime, start),
+                    confidence: previous.confidence
+                )
+            }
+            // Frontier token: provisional one-frame end, as in the streaming manager.
+            timings.append(
+                TokenTiming(
+                    token: piece.replacingOccurrences(of: "\u{2581}", with: " "),
+                    tokenId: emission.token,
+                    startTime: start,
+                    endTime: start + secondsPerFrame,
+                    confidence: emission.confidence
+                )
+            )
+        }
+        return timings
+    }
+
+    /// The merged, seam-collapsed token stream for the whole recording, in
+    /// emission order. Shared by both batch entry points so the text they
+    /// return cannot drift apart.
+    private func decodedTokens(_ samples: [Float]) async throws -> [ChunkProcessor.TokenWindow] {
         guard let tokenizer = tokenizer else { throw ASRError.notInitialized }
 
         var merged: [ChunkProcessor.TokenWindow] = []
@@ -199,8 +284,7 @@ public actor UnifiedAsrManager {
         }
 
         merged.sort { $0.timestamp < $1.timestamp }
-        merged = merger.collapseSeamWordDuplicates(merged, vocabulary: tokenizer.vocabulary)
-        return tokenizer.decode(ids: merged.map(\.token))
+        return merger.collapseSeamWordDuplicates(merged, vocabulary: tokenizer.vocabulary)
     }
 
     /// Transcribe an audio buffer (any format; resampled to 16 kHz mono).

--- a/Tests/FluidAudioTests/ASR/Parakeet/UnifiedTokenTimingTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/UnifiedTokenTimingTests.swift
@@ -14,9 +14,9 @@ struct UnifiedTokenTimingTests {
         10: "\u{2581}play", 11: "back", 12: "\u{2581}the", 13: "\u{2581}note",
     ]
 
-    private func emission(_ token: Int, frame: Int, confidence: Float = 0.9)
-        -> ChunkProcessor.TokenWindow
-    {
+    private func emission(
+        _ token: Int, frame: Int, confidence: Float = 0.9
+    ) -> ChunkProcessor.TokenWindow {
         (token: token, timestamp: frame, confidence: confidence, duration: 0)
     }
 
@@ -66,6 +66,29 @@ struct UnifiedTokenTimingTests {
         let timings = UnifiedAsrManager.tokenTimings(
             from: [emission(10, frame: 37)],
             secondsPerFrame: secondsPerFrame, vocabulary: vocabulary)
+        #expect(abs((timings[0].endTime - timings[0].startTime) - secondsPerFrame) < 0.0001)
+    }
+
+    /// That provisional frame must not run past the end of the audio, or a
+    /// caller seeking to the last token's end lands past EOF. Offline knows the
+    /// sample count, so it can bound what streaming has to leave open.
+    @Test
+    func theLastTokenIsClampedToTheEndOfTheClip() {
+        let timings = UnifiedAsrManager.tokenTimings(
+            from: [emission(10, frame: 37)],
+            secondsPerFrame: secondsPerFrame, vocabulary: vocabulary,
+            clipDuration: 3.0)
+        #expect(abs(timings[0].endTime - 3.0) < 0.0001)
+        #expect(timings[0].endTime >= timings[0].startTime)
+    }
+
+    /// A clip longer than the last emission leaves the one-frame end alone.
+    @Test
+    func aLongerClipLeavesTheProvisionalEndAlone() {
+        let timings = UnifiedAsrManager.tokenTimings(
+            from: [emission(10, frame: 37)],
+            secondsPerFrame: secondsPerFrame, vocabulary: vocabulary,
+            clipDuration: 60.0)
         #expect(abs((timings[0].endTime - timings[0].startTime) - secondsPerFrame) < 0.0001)
     }
 

--- a/Tests/FluidAudioTests/ASR/Parakeet/UnifiedTokenTimingTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/UnifiedTokenTimingTests.swift
@@ -1,0 +1,107 @@
+import Testing
+
+@testable import FluidAudio
+
+/// Tests for the offline batch path's emission-frame → seconds conversion
+/// (`UnifiedAsrManager.transcribeWithTimings`). The conversion is pure, so
+/// none of this needs the 600M parameter model loaded.
+struct UnifiedTokenTimingTests {
+
+    private let secondsPerFrame = 1280.0 / 16000.0  // 80 ms
+
+    /// id → SentencePiece piece, with `▁` marking a word boundary.
+    private let vocabulary: [Int: String] = [
+        10: "\u{2581}play", 11: "back", 12: "\u{2581}the", 13: "\u{2581}note",
+    ]
+
+    private func emission(_ token: Int, frame: Int, confidence: Float = 0.9)
+        -> ChunkProcessor.TokenWindow
+    {
+        (token: token, timestamp: frame, confidence: confidence, duration: 0)
+    }
+
+    @Test
+    func framesConvertAtEightyMilliseconds() {
+        let timings = UnifiedAsrManager.tokenTimings(
+            from: [emission(10, frame: 37)],
+            secondsPerFrame: secondsPerFrame, vocabulary: vocabulary)
+        #expect(timings.count == 1)
+        #expect(abs(timings[0].startTime - 2.96) < 0.0001)
+        #expect(timings[0].tokenId == 10)
+    }
+
+    /// RNNT emits a token AT a frame with no duration, so a token's end is
+    /// provisional and only clamped back when it would overrun its successor.
+    /// A real pause is therefore preserved as a gap between one token's end
+    /// and the next one's start, which is what pause-based segmentation reads.
+    @Test
+    func silenceSurvivesAsAGapBetweenTokens() {
+        let timings = UnifiedAsrManager.tokenTimings(
+            from: [emission(10, frame: 37), emission(11, frame: 38), emission(12, frame: 44)],
+            secondsPerFrame: secondsPerFrame, vocabulary: vocabulary)
+        #expect(timings.count == 3)
+        // Consecutive frames: no gap, and no overlap either.
+        #expect(abs(timings[0].endTime - timings[1].startTime) < 0.0001)
+        // Six frames of silence between "back" and "the" stay visible as 0.4 s.
+        #expect(abs((timings[2].startTime - timings[1].endTime) - 0.4) < 0.0001)
+    }
+
+    /// No token may extend past the one that follows it, or spans overlap and
+    /// a pause can read as negative.
+    @Test
+    func noTokenOverrunsItsSuccessor() {
+        let timings = UnifiedAsrManager.tokenTimings(
+            from: [emission(10, frame: 37), emission(11, frame: 38), emission(12, frame: 44)],
+            secondsPerFrame: secondsPerFrame, vocabulary: vocabulary)
+        for (earlier, later) in zip(timings, timings.dropFirst()) {
+            #expect(earlier.endTime <= later.startTime + 0.0001)
+            #expect(earlier.endTime >= earlier.startTime)
+        }
+    }
+
+    /// The frontier token has no successor, so it gets one frame rather than
+    /// a zero-length span.
+    @Test
+    func theLastTokenGetsAProvisionalOneFrameEnd() {
+        let timings = UnifiedAsrManager.tokenTimings(
+            from: [emission(10, frame: 37)],
+            secondsPerFrame: secondsPerFrame, vocabulary: vocabulary)
+        #expect(abs((timings[0].endTime - timings[0].startTime) - secondsPerFrame) < 0.0001)
+    }
+
+    /// Two tokens emitted on the same frame must not produce a negative span.
+    @Test
+    func tokensSharingAFrameKeepNonNegativeSpans() {
+        let timings = UnifiedAsrManager.tokenTimings(
+            from: [emission(10, frame: 37), emission(11, frame: 37)],
+            secondsPerFrame: secondsPerFrame, vocabulary: vocabulary)
+        #expect(timings[0].endTime >= timings[0].startTime)
+        #expect(abs(timings[0].endTime - timings[0].startTime) < 0.0001)
+    }
+
+    /// The whole point of the conversion: the result feeds `buildWordTimings`,
+    /// which regroups sub-word pieces into words on the `▁` marker.
+    @Test
+    func outputGroupsIntoWordsWithTheSharedHelper() {
+        let timings = UnifiedAsrManager.tokenTimings(
+            from: [
+                emission(10, frame: 37), emission(11, frame: 38),
+                emission(12, frame: 44), emission(13, frame: 47),
+            ],
+            secondsPerFrame: secondsPerFrame, vocabulary: vocabulary)
+        let words = buildWordTimings(from: timings)
+        #expect(words.map(\.word) == ["playback", "the", "note"])
+        #expect(abs(words[0].startTime - 2.96) < 0.0001)
+        #expect(abs(words[1].startTime - 3.52) < 0.0001)
+    }
+
+    /// An id the vocabulary doesn't cover is skipped rather than emitted as an
+    /// empty token that would swallow the next word's boundary marker.
+    @Test
+    func unknownTokenIdsAreSkipped() {
+        let timings = UnifiedAsrManager.tokenTimings(
+            from: [emission(10, frame: 37), emission(999, frame: 40), emission(12, frame: 44)],
+            secondsPerFrame: secondsPerFrame, vocabulary: vocabulary)
+        #expect(timings.map(\.tokenId) == [10, 12])
+    }
+}


### PR DESCRIPTION
### Problem

`UnifiedAsrManager.transcribe(_:)` returns only a `String`, so there is no way to align a batch transcript back to its audio. The information is already there and is thrown away one line before the return:

```swift
merged.sort { $0.timestamp < $1.timestamp }
merged = merger.collapseSeamWordDuplicates(merged, vocabulary: tokenizer.vocabulary)
return tokenizer.decode(ids: merged.map(\.token))   // timestamps dropped here
```

`ChunkProcessor.TokenWindow.timestamp` is the global encoder frame the greedy RNNT decoder records per emission (`transcribeWindow` passes `globalFrameOffset: chunkStart / config.frameSamples`), and the overlap merge preserves it.

The streaming sibling already publishes exactly this, via `StreamingUnifiedAsrManager.consumeTokenTimings()` — `buildWordTimings(from:)` even cites it in its doc comment. So the offline path is the odd one out. Applications that want Unified's WER and punctuation for batch transcription currently have to fall back to a TDT checkpoint purely to keep seek and playback highlighting, which means shipping a second English model.

### Change

Adds `UnifiedAsrManager.transcribeWithTimings(_:) -> TranscriptionWithTimings`, returning the text plus `[TokenTiming]`, so it drops straight into `buildWordTimings(from:)`.

The conversion mirrors `StreamingUnifiedAsrManager` rather than inventing anything: `frame x frameSamples / sampleRate` (80 ms), `▁` normalized to a leading space, and each token's `endTime` clamped back only when it would overrun its successor, so genuine pauses survive as gaps between spans.

Both batch entry points now go through one `decodedTokens` helper, so the text from `transcribe` and `transcribeWithTimings` cannot drift apart. `transcribe(_:)`'s behavior and signature are unchanged.

### Tests

The conversion is factored out as a pure function, so `UnifiedTokenTimingTests` covers it without loading the model: frame→seconds, pause preservation, no span overrunning its successor, tokens sharing a frame, the frontier token's provisional one-frame end, unknown ids, and end-to-end regrouping through `buildWordTimings`. 7 tests, and `swift build` / the existing suite are unaffected.

### Caveat

These are emission times, not forced-alignment boundaries: RNNT emits once the decoder has heard enough context, so a token's start can sit slightly after the word's true onset. That is already true of `consumeTokenTimings()` and is documented on the new method.