### PR TITLE
fix(tts/kokoro-ane): throw instead of trapping on non-finite PostAlbert durations

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneError.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneError.swift
@@ -13,6 +13,7 @@ public enum KokoroAneError: Error, LocalizedError {
     case acousticFramesExceedCap(have: Int, cap: Int)
     case predictionFailed(stage: String, underlying: Error)
     case unexpectedOutputShape(stage: String, expected: String, got: String)
+    case nonFiniteModelOutput(stage: String, output: String)
     case audioConversionFailed(String)
 
     public var errorDescription: String? {
@@ -39,6 +40,11 @@ public enum KokoroAneError: Error, LocalizedError {
             return "KokoroAne stage '\(stage)' failed: \(err.localizedDescription)"
         case .unexpectedOutputShape(let stage, let expected, let got):
             return "KokoroAne stage '\(stage)' returned unexpected shape (expected \(expected), got \(got))."
+        case .nonFiniteModelOutput(let stage, let output):
+            return
+                "KokoroAne stage '\(stage)' returned non-finite values in '\(output)'. "
+                + "The CoreML runtime mis-executed the model on this OS (seen on iOS 27 betas, "
+                + "see FluidAudio issue #738)."
         case .audioConversionFailed(let detail):
             return "KokoroAne audio conversion failed: \(detail)"
         }

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer.swift
@@ -70,10 +70,7 @@ public struct KokoroAneSynthesizer {
         // duration → pred_dur (int32, rounded, clamped ≥ 1)
         let duration = try outputArray(postOut, key: "duration", stage: .postAlbert)
         let durFloats = KokoroAneArrays.readFloats(duration)
-        let predDur = durFloats.map { d -> Int32 in
-            let r = Int32(Float(d).rounded())
-            return max(r, 1)
-        }
+        let predDur = try predictedDurations(from: durFloats)
         let tA = predDur.reduce(0) { $0 + Int($1) }
         if tA > KokoroAneConstants.maxAcousticFrames {
             throw KokoroAneError.acousticFramesExceedCap(
@@ -163,6 +160,22 @@ public struct KokoroAneSynthesizer {
     }
 
     // MARK: - Helpers
+
+    /// Round PostAlbert `duration` floats to per-token frame counts, clamped
+    /// to [1, maxAcousticFrames]. Throws instead of trapping when the model
+    /// emits NaN/±inf — broken CoreML runtimes can return non-finite outputs
+    /// (iOS 27 betas mis-execute the dynamic-shape stages, issue #738), and
+    /// `Int32(Float)` on those values is a fatal error in the host app.
+    static func predictedDurations(from durFloats: [Float]) throws -> [Int32] {
+        guard durFloats.allSatisfy({ $0.isFinite }) else {
+            throw KokoroAneError.nonFiniteModelOutput(
+                stage: KokoroAneStage.postAlbert.rawValue, output: "duration")
+        }
+        let cap = Float(KokoroAneConstants.maxAcousticFrames)
+        return durFloats.map { d in
+            Int32(min(max(d.rounded(), 1), cap))
+        }
+    }
 
     private static func predict(
         stage: KokoroAneStage,

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneSynthesizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneSynthesizerTests.swift
@@ -3,6 +3,51 @@ import XCTest
 
 @testable import FluidAudio
 
+/// Lightweight tests for the pure duration-rounding helper (no models needed).
+final class KokoroAnePredictedDurationTests: XCTestCase {
+
+    func testRoundsAndClampsToMinimumOne() throws {
+        let out = try KokoroAneSynthesizer.predictedDurations(
+            from: [0.2, 0.5, 1.4, 2.5, 7.9, -3.0])
+        // .rounded() is half-away-from-zero: 2.5 → 3.
+        XCTAssertEqual(out, [1, 1, 1, 3, 8, 1])
+    }
+
+    func testNaNThrowsInsteadOfTrapping() {
+        // iOS 27 betas mis-execute the dynamic-shape PostAlbert stage and
+        // return NaN durations (#738); Int32(NaN) would crash the host app.
+        XCTAssertThrowsError(
+            try KokoroAneSynthesizer.predictedDurations(from: [1.0, .nan, 2.0])
+        ) { error in
+            guard case KokoroAneError.nonFiniteModelOutput(let stage, let output) = error else {
+                return XCTFail("Expected nonFiniteModelOutput, got \(error)")
+            }
+            XCTAssertEqual(stage, KokoroAneStage.postAlbert.rawValue)
+            XCTAssertEqual(output, "duration")
+        }
+    }
+
+    func testInfinityThrows() {
+        XCTAssertThrowsError(
+            try KokoroAneSynthesizer.predictedDurations(from: [.infinity]))
+        XCTAssertThrowsError(
+            try KokoroAneSynthesizer.predictedDurations(from: [-.infinity]))
+    }
+
+    func testHugeFiniteValueClampsWithoutTrapping() throws {
+        // Garbage runtimes can also return huge finite values; Int32(1e30)
+        // would trap. Clamped to the frame cap, the downstream T_a check
+        // then throws acousticFramesExceedCap.
+        let out = try KokoroAneSynthesizer.predictedDurations(from: [1e30, 3.0])
+        XCTAssertEqual(out[0], Int32(KokoroAneConstants.maxAcousticFrames))
+        XCTAssertEqual(out[1], 3)
+    }
+
+    func testEmptyInput() throws {
+        XCTAssertEqual(try KokoroAneSynthesizer.predictedDurations(from: []), [])
+    }
+}
+
 /// Heavy E2E tests gated by env var (require all 7 mlmodelc + voice + vocab
 /// in cache). Skipped on CI by default.
 final class KokoroAneSynthesizerTests: XCTestCase {


### PR DESCRIPTION
## Summary

Fixes the hard crash reported in #738 ([comment](https://github.com/FluidInference/FluidAudio/issues/738#issuecomment-5063569059)): on iOS 27 public beta, Kokoro synthesis kills the host app with

```
Fatal error: Float value cannot be converted to Int32 because it is either infinite or NaN
```

at `KokoroAneSynthesizer.swift:74` (`d=NaN`).

## Root cause

iOS 27's new E5 CoreML runtime flags the dynamic-shape Kokoro stages at load time (`MIL program has non-constant (dynamic) shapes for external input but FlexibleShapeInformation attribute is missing`) and then mis-executes them — PostAlbert returns NaN for its `duration` output. The `pred_dur` conversion did `Int32(Float(d).rounded())`, which is a Swift runtime trap on NaN, so the whole host app crashed instead of receiving an error. Same class of on-device dynamic-shape misbehavior as #739 (there the symptom was zeros; here NaNs).

## Change

- Extract the rounding into `KokoroAneSynthesizer.predictedDurations(from:)`:
  - throws new `KokoroAneError.nonFiniteModelOutput(stage:output:)` on NaN/±inf, with a message pointing at the iOS 27 runtime and #738
  - clamps finite values to `[1, maxAcousticFrames]` so huge garbage values can't trap `Int32()` either; absurd totals still surface through the existing `acousticFramesExceedCap` check
- Output for well-formed durations is byte-identical (small positive floats, far below the cap).
- Unit tests for rounding/clamping/NaN/inf paths — pure function, no models needed.

This makes the failure catchable; it does **not** make Kokoro work on iOS 27 betas. The model-side fix (attaching flexible-shape info so E5 compiles the dynamic stages correctly) is separate follow-up work. Affected users can try `KokoroAneComputeUnits.cpuAndGpu` as a possible workaround.

## Testing

- `swift build` clean, `swift format lint` clean
- New `KokoroAnePredictedDurationTests` (run on CI; no model downloads required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)