### PR TITLE
fix(tts/kokoro-ane): warn on BNNS-crash-prone OS builds (26.4–26.5.x) + document both Apple bug classes

### DIFF
--- a/Documentation/TTS/KokoroAne.md
+++ b/Documentation/TTS/KokoroAne.md
@@ -229,6 +229,25 @@ MiniMax-English 100-phrase suite — including the longer paragraph
 phrases that pull the per-corpus aggregate down to ~5.2× — see
 [Benchmarks.md](Benchmarks.md).
 
+## Known OS issues
+
+Two distinct Apple runtime bugs affect the 7-stage chain. Neither is
+input-, model-, or FluidAudio-version-gated.
+
+| Bug | Signature | Affected OS | Status |
+|-----|-----------|-------------|--------|
+| BNNS CPU segfault | `EXC_BAD_ACCESS` in `libBNNS.dylib` (`BNNSGraphContextExecute_v2` → `BnnsCpuInferenceOperation::ExecuteSync`, queue `com.apple.e5rt.concurrentExecutionQueue`) | iOS/macOS **26.4 – 26.5.x** | **Fixed in the 26.6 line.** Verified on M5/macOS 26.6: the #667 repro (repeated synthesis) passes under `cpuOnly` and `allAne`, both of which segfaulted every time on 26.5. |
+| GPU RNN JIT assert | `GPURNNOps.mm: failed assertion 'JIT not supported'` (SIGABRT) | macOS 26.5+, incl. **26.6** (M5-class) | **Still live.** Avoided by the default routing (#671/#677), which keeps RNN-bearing stages off the GPU. Do not route Prosody/Vocoder to `.cpuAndGPU`. |
+
+The BNNS segfault cannot be avoided by compute-unit routing — CoreML places
+segments on the BNNS CPU path even under `.cpuOnly` (#587), and on affected
+OS builds the same binary can flip between all-pass and all-crash across a
+day (#817). `KokoroAneManager.initialize()` logs a warning on affected OS
+builds. The only reliable remedy is updating to the 26.6 OS line.
+
+History: #328 (26.4 beta), #587 (iOS 26.4.2), #661 (cross-manager E5RT),
+#667 (M5/macOS 26.5), #817 (time/environment-gated evidence).
+
 ## Source
 
 - HuggingFace (English): [`FluidInference/kokoro-82m-coreml/ANE/`](https://huggingface.co/FluidInference/kokoro-82m-coreml/tree/main/ANE)

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -66,6 +66,13 @@ public actor KokoroAneManager {
     /// Download (if missing), load all 7 mlmodelcs + vocab + default voice
     /// pack. Optionally pre-warm additional voice packs.
     public func initialize(preloadVoices: Set<String>? = nil) async throws {
+        if Self.isBnnsCrashProneOS(ProcessInfo.processInfo.operatingSystemVersion) {
+            logger.warning(
+                "This OS build (26.4–26.5.x line) has a known Apple BNNS bug that can "
+                    + "intermittently crash Kokoro synthesis (EXC_BAD_ACCESS in libBNNS) "
+                    + "regardless of compute-unit routing. Fixed in the 26.6 OS line. "
+                    + "See https://github.com/FluidInference/FluidAudio/issues/817")
+        }
         try await store.loadIfNeeded()
         // English G2P CoreML assets live in the kokoro repo and are loaded
         // from ~/.cache/fluidaudio/Models/kokoro/. The Mandarin variant
@@ -98,6 +105,13 @@ public actor KokoroAneManager {
                 _ = try await store.voicePack(voice)
             }
         }
+    }
+
+    /// OS builds in the 26.4–26.5.x line carry an Apple BNNS bug that can
+    /// intermittently crash synthesis in libBNNS on any compute-unit routing
+    /// (#328/#587/#667/#817); the 26.6 line fixes it.
+    static func isBnnsCrashProneOS(_ version: OperatingSystemVersion) -> Bool {
+        version.majorVersion == 26 && (4...5).contains(version.minorVersion)
     }
 
     /// `true` once the 7 mlmodelcs + vocab are resident.

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneOsAdvisoryTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneOsAdvisoryTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+@testable import FluidAudio
+
+final class KokoroAneOsAdvisoryTests: XCTestCase {
+
+    private func version(_ major: Int, _ minor: Int, _ patch: Int = 0) -> OperatingSystemVersion {
+        OperatingSystemVersion(majorVersion: major, minorVersion: minor, patchVersion: patch)
+    }
+
+    func testAffectedLineIsFlagged() {
+        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 4)))
+        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 4, 2)))
+        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 5)))
+        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 5, 2)))
+    }
+
+    func testFixedAndUnaffectedLinesAreNotFlagged() {
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(26, 3, 1)))
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(26, 6)))
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(26, 7)))
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(27, 0)))
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(25, 5)))
+    }
+}


### PR DESCRIPTION
Addresses the library-side portion of #817 (follow-up to #328/#587/#667).

## Context

The Kokoro ANE `libBNNS` `EXC_BAD_ACCESS` (`BNNSGraphContextExecute_v2` → `BnnsCpuInferenceOperation::ExecuteSync`) is an **Apple bug in the 26.4–26.5.x OS line**:

- Strikes on **any** compute-unit routing — even `cpuOnly` (#587), so no placement change can avoid it.
- Time/environment-gated: the same binary flips 40/40 PASS → 0/15 CRASH within a day (#817's controlled evidence).
- **Verified fixed in the 26.6 line** — on M5 Pro / macOS 26.6 (25G70), the #667 repro (same phrase ×5, one process) passes 5/5 under `cpu-only` and `all-ane`, both of which segfaulted deterministically on macOS 26.5:

| Config | macOS 26.5 (#667) | macOS 26.6 |
|---|---|---|
| `default` (aneTailGpu) | pass | pass 5/5 |
| `cpu-only` | SIGSEGV libBNNS | **pass 5/5** |
| `all-ane` | SIGSEGV libBNNS | **pass 5/5** |
| `cpu-and-gpu` | GPURNNOps abort | still aborts (`JIT not supported`) |

## Changes

Since no library-side mitigation exists, the honest fix is diagnosis:

- **`KokoroAneManager.initialize()`** logs a warning on affected OS builds (26.4–26.5.x) pointing at #817, so users hitting the segfault learn it's OS-gated instead of chasing inputs, models, or FluidAudio versions. Predicate extracted as `isBnnsCrashProneOS(_:)` for testability.
- **`KokoroAneOsAdvisoryTests`** — boundary coverage (26.3.1 ✗ / 26.4 ✓ / 26.5.2 ✓ / 26.6 ✗ / 27.0 ✗).
- **`Documentation/TTS/KokoroAne.md`** — new "Known OS issues" section separating the two distinct Apple bugs: the BNNS segfault (fixed in 26.6) and the still-live GPU RNN `JIT not supported` assert, which the #671/#677 default routing avoids (do not route RNN stages to GPU, including on 26.6).

## Verification

- `swift build` green, `swift format lint` clean.
- Repro matrix above run with `tts-benchmark --corpus-path` on M5 Pro / macOS 26.6.

Closes nothing on its own — #817 stays open pending the reporter's iOS 26.6 re-test and their Apple Feedback number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)