### PR TITLE
feat(tts/kokoro-ane): Japanese variant + MiniMax benchmark support (--phonemes)

### DIFF
--- a/Documentation/TTS/Benchmarks.md
+++ b/Documentation/TTS/Benchmarks.md
@@ -1,6 +1,7 @@
 # TTS Benchmarks
 
-> **Setup:** Apple M5 Pro, 24 GB, macOS 26.5 (25F71), on AC.
+> **Setup:** Apple M5 Pro, 24 GB, on AC — Kokoro ANE rows on macOS
+> 26.6, PocketTTS / Supertonic-3 rows on macOS 26.5 (25F71).
 > Kokoro ANE now runs on M5 out of the box — the **default** compute
 > routing is the M5-safe placement (tail iSTFT on GPU, RNN stages on
 > ANE; see the ᴷ footnote). Only the StyleTTS2 row is carried from the
@@ -10,10 +11,10 @@
 > phrases / language, CC-BY-SA-4.0) — the same public corpus used
 > by [MiniMax-Speech][mms], seed-tts-eval, and Gradium, so numbers
 > here are directly paper-comparable.
-> **Status:** Kokoro ANE (English + Mandarin), PocketTTS (English),
-> and Supertonic-3 (English) all complete the full
-> 100-phrase MiniMax run on **M5 Pro** (Kokoro on its default M5-safe
-> routing). Only **StyleTTS2** is **M2-only** here — its bucketed BERT
+> **Status:** Kokoro ANE (English + Mandarin + Japanese via
+> `--phonemes`), PocketTTS (English), and Supertonic-3 (English) all
+> complete the full 100-phrase MiniMax run on **M5 Pro** (Kokoro on
+> its default M5-safe routing). Only **StyleTTS2** is **M2-only** here — its bucketed BERT
 > assets ship without `model.mil`; that row carries its M2 numbers.
 >
 > [minimax]: https://huggingface.co/datasets/MiniMaxAI/TTS-Multilingual-Test-Set
@@ -59,7 +60,7 @@ Reference each language as `--corpus minimax-<lang>`:
 
 | Backend     | Default corpus     | Other supported MiniMax languages              |
 |-------------|--------------------|------------------------------------------------|
-| Kokoro ANE  | `minimax-english` | `english` (`af_heart`); Kokoro ANE also ships `chinese` (`--variant mandarin`, voice `zf_001`) |
+| Kokoro ANE  | `minimax-english` | `english` (`af_heart`); Kokoro ANE also ships `chinese` (`--variant mandarin`, voice `zf_001`) and `japanese` (`--variant japanese`, voice `jf_alpha` — no in-process G2P, so pass a pre-phonemized `ipa_phonemes\|reference_text` corpus via `--corpus-path … --phonemes`; see footnote ᴶ) |
 | PocketTTS   | `minimax-english`  | 6L packs: `english`, `german`, `italian`, `portuguese`, `spanish`. 24L packs: `french_24l`, `german_24l`, `italian_24l`, `portuguese_24l`, `spanish_24l` |
 | StyleTTS2   | `minimax-english`  | `english` only (LibriTTS iteration_3, zero-shot from `--reference` audio) |
 | Supertonic-3 | `minimax-english` | 31 ISO codes minus `zh`: `english`, `korean`, `japanese`, `arabic`, `bulgarian`, `czech`, `danish`, `german`, `greek`, `spanish`, `estonian`, `finnish`, `french`, `hindi`, `croatian`, `hungarian`, `indonesian`, `italian`, `lithuanian`, `latvian`, `dutch`, `polish`, `portuguese`, `romanian`, `russian`, `slovak`, `slovenian`, `swedish`, `turkish`, `ukrainian`, `vietnamese`. Voice styling via `--voice-style <preset.json>` |
@@ -163,9 +164,9 @@ Mandarin (or any of the 14 Cohere languages) against
 
 ### Per-backend top-line
 
-Reference machine: **Apple M5 Pro, 24 GB unified memory, macOS 26.5
-(`25F71`), on AC** for the Kokoro ANE, PocketTTS, and
-Supertonic-3 rows. Only the **StyleTTS2** row is carried from the
+Reference machine: **Apple M5 Pro, 24 GB unified memory, on AC** —
+Kokoro ANE rows re-measured on **macOS 26.6** (post-[#700][i700]),
+PocketTTS and Supertonic-3 rows on macOS 26.5 (`25F71`). Only the **StyleTTS2** row is carried from the
 prior **MacBook Air, Apple M2 (2022), 8-core CPU / 8-core GPU /
 16-core Neural Engine, 16 GB, macOS 26** (`Mac14,2`) reference — it
 does not run on the M5 host (missing `model.mil` in the shipped
@@ -184,8 +185,9 @@ peak RSS, WER, CER) so there is a single source of truth.
 
 | Backend    | License    | Language (voice)          | Footprint                  | Sample rate | Max chunk per pass                                               | Streaming | TTFT p50 / p95\*  | Synth p50 / p95   | Agg RTFx  | Peak RSS | WER    | CER    |
 |------------|------------|---------------------------|----------------------------|-------------|------------------------------------------------------------------|-----------|-------------------|-------------------|-----------|----------|--------|--------|
-| Kokoro ANEᴷ | Apache-2.0 | en (`af_heart`)           | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **277 / 346 ms** | 277 / 346 ms     | **28.7×**ᴷ | 788 MB   | 10.38% | 3.72%  |
-| Kokoro ANEᴷ | Apache-2.0 | zh (`zf_001`)             | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **201 / 286 ms** | 201 / 286 ms     | 20.1×ᴷ     | 761 MB   | n/a‡   | 3.81%‡ |
+| Kokoro ANEᴷ | Apache-2.0 | en (`af_heart`)           | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **241 / 305 ms** | 241 / 305 ms     | **31.0×**ᴷ | 881 MB   | 0.68%ᴷ | 0.15%ᴷ |
+| Kokoro ANEᴷ | Apache-2.0 | zh (`zf_001`)             | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **176 / 231 ms** | 176 / 231 ms     | 37.4×ᴷ     | 737 MB   | n/a‡   | 1.90%‡ |
+| Kokoro ANEᴷ | Apache-2.0 | ja (`jf_alpha`)ᴶ          | ~0.33 GB                   | 24 kHz      | 510 phonemes / pass (≈25–30 s of audio)                          | No        | **210 / 320 ms** | 210 / 320 ms     | 41.6×ᴷ     | 953 MB   | n/aᴶ   | 1.51%ᴶ |
 | PocketTTS (v2.1) | research   | en (`alba`, 6L pack)      | fp16 ~330 MB | 24 kHz      | 80 ms Mimi frame, streams until EOS (no fixed cap)               | Yes       | **26 / 27 ms** | 933 / 1233 ms    | **6.51×** | 761 MB   | 0.51%  | 0.08%  |
 | StyleTTS2 (M2)ˢ | research   | en (LibriTTS iteration_3) | ~0.67 GB¶                  | 24 kHz      | 256 tokens / pass (≈30 s of audio max)                           | No        | 1574 / 3088 ms    | 1574 / 3088 ms    | 4.59×     | 522 MB   | 9.4%   | 4.1%   |
 | Supertonic-3 (int4) | Apache-2.0 | en (`M1`, 31-lang)        | int4 ~0.10 GB                   | 44.1 kHz    | 128 codepoints / pass (chunker splits ≥70 char Latin / 57 CJK)   | No        | **81 / 120 ms** | 81 / 120 ms     | **94×** | 197 MB   | 1.02%ᶜ | 0.31%ᶜ |
@@ -199,15 +201,20 @@ supported'` on the prosody RNN on the GPU), and `all-ane`/`cpu-only`
 crash in `libBNNS` (SIGSEGV) on the tail iSTFT. Keeping the RNN off the
 GPU and the iSTFT off BNNS dodges both (the tail was always meant to run
 fp32 on CPU/GPU — ANE rejects the exp/sin/iSTFT — so this is faithful,
-not a hack). Quality matches the prior M2 baseline (en WER ~10.3% vs
-10.8%; zh CER 3.81% vs 4.01%). The en row was re-measured after the
-Noise→GPU routing fix (Noise is all-fp32, so `.cpuAndNeuralEngine`
-degenerated to plain CPU; it has no RNN ops, so the #667 GPU ban never
-applied): TTFT p50 317→277 ms, agg RTFx 25.1→28.7 (+14%), WER
-unchanged. The zh row predates the fix; expect a similar improvement. The old `.all` default ran fine on M2 but
+not a hack). The old `.all` default ran fine on M2 but
 its M2 perf under the new default is not re-verified here. The underlying
 Apple bug is tracked in [#667][i667]; this routing is
 `TtsComputeUnitPreset.default` / `.aneTailGpu`.
+
+All three Kokoro ANE rows were **re-measured on macOS 26.6 after the
+KokoroNoise v2 fix** ([#700][i700] — atan2 phase reconstruction,
+removing the high-frequency sharpness of the v1 noise stage). The fix
+is a step-change in ASR-measured quality: en WER 10.38% → **0.68%**
+and CER 3.72% → **0.15%** (same Parakeet TDT roundtrip), zh CER
+3.81% → **1.90%** (same whisper-large-v3-turbo methodology, see ‡).
+Speed also improved across the board (en agg RTFx 28.7 → 31.0; the zh
+row additionally picks up the Noise→GPU routing fix it predated:
+TTFT p50 201 → 176 ms, agg RTFx 20.1 → 37.4).
 
 ᶜ **Supertonic-3 (int4)** is measured on **M5 Pro / macOS 26.5** with
 the default **int4 L-bucketed (ANE) VectorEstimator**. The int4-ANE
@@ -232,12 +239,31 @@ rows `ttft_ms == synth_ms == time-to-complete-wav`.
 ‡ Kokoro ANE Mandarin CER measured on the **full 100-phrase**
 `minimax-chinese` corpus via `mlx-community/whisper-large-v3-turbo`
 against the WAVs rendered by `tts-benchmark --backend kokoro-ane
---variant mandarin --voice zf_001 --corpus minimax-chinese
---compute-units ane-tail-gpu --skip-asr`: **macro CER 3.81% (M5 Pro /
-macOS 26.5)**, in line with the prior M2 baseline (4.01%). WER is
-omitted because Mandarin has no word boundaries and `WERCalculator`
-splits on whitespace — word-level WER reads near 100% and is
-meaningless.
+--variant mandarin --voice zf_001 --corpus minimax-chinese --skip-asr
+--audio-dir …`: **macro CER 1.90% (M5 Pro / macOS 26.6, post-#700)**,
+down from 3.81% pre-fix. Hypothesis and reference are NFKC-folded,
+punctuation/whitespace-stripped, and **converted traditional →
+simplified (`zhconv`) before scoring** — whisper freely emits
+traditional script, which is an orthography difference, not a TTS
+error (unnormalized it reads 6.19%). WER is omitted because Mandarin
+has no word boundaries and `WERCalculator` splits on whitespace —
+word-level WER reads near 100% and is meaningless.
+
+ᴶ **Kokoro ANE Japanese** (`jf_alpha`, ANE-ja bundle) ships **no
+in-process text→phoneme frontend** — `synthesize(text:)` throws (see
+[#698][i698]). It is benchmarked through the `--phonemes` G2P bypass:
+the 100-phrase `minimax-japanese` corpus is phonemized offline with
+[`misaki[ja]`](https://github.com/hexgrad/misaki) (the same G2P
+upstream Kokoro uses for `jf_*`/`jm_*` voices) into
+`ipa_phonemes|reference_text` lines, synthesis feeds the IPA, and
+quality scores against the reference text. CER via
+`whisper-large-v3-turbo` on **kana readings** (both sides converted
+with `pykakasi` after NFKC + punctuation strip): **macro CER 1.51%**.
+Raw character CER reads 4.24%, but the gap is orthographic variance
+(whisper writing 頑張って where the corpus has がんばって, 私 vs
+わたくし), not pronunciation error — the reading-level number is the
+faithful one, mirroring the trad→simp normalization for zh. WER n/a
+for the same no-word-boundary reason as zh.
 
 ¶ StyleTTS2 footprint is the sum of the shipped iteration_3 mlpackages
 (text encoder + bert + ref_encoder + post_albert + alignment + prosody
@@ -345,3 +371,5 @@ raw paper numbers.
 [i667]: https://github.com/FluidInference/FluidAudio/issues/667
 [i668]: https://github.com/FluidInference/FluidAudio/issues/668
 [i669]: https://github.com/FluidInference/FluidAudio/issues/669
+[i698]: https://github.com/FluidInference/FluidAudio/issues/698
+[i700]: https://github.com/FluidInference/FluidAudio/pull/700

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -44,6 +44,7 @@ public enum Repo: String, CaseIterable, Sendable {
     case kokoro = "FluidInference/kokoro-82m-coreml"
     case kokoroAne = "FluidInference/kokoro-82m-coreml/ANE"
     case kokoroAneZh = "FluidInference/kokoro-82m-coreml/ANE-zh"
+    case kokoroAneJa = "FluidInference/kokoro-82m-coreml/ANE-ja"
     case sortformer = "FluidInference/diar-streaming-sortformer-coreml"
     case lseendAmi = "FluidInference/ls-eend-coreml/optimized/ami"
     case lseendCallHome = "FluidInference/ls-eend-coreml/optimized/ch"
@@ -108,6 +109,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "kokoro-82m-coreml/ANE"
         case .kokoroAneZh:
             return "kokoro-82m-coreml/ANE-zh"
+        case .kokoroAneJa:
+            return "kokoro-82m-coreml/ANE-ja"
         case .sortformer:
             return "diar-streaming-sortformer-coreml"
         case .lseendAmi:
@@ -142,7 +145,7 @@ public enum Repo: String, CaseIterable, Sendable {
             return "FluidInference/parakeet-ctc-0.6b-coreml"
         case .parakeetEou160, .parakeetEou320, .parakeetEou1280:
             return "FluidInference/parakeet-realtime-eou-120m-coreml"
-        case .kokoroAne, .kokoroAneZh:
+        case .kokoroAne, .kokoroAneZh, .kokoroAneJa:
             return "FluidInference/kokoro-82m-coreml"
         case .nemotronStreaming2240, .nemotronStreaming1120, .nemotronStreaming560:
             return "FluidInference/nemotron-speech-streaming-en-0.6b-coreml"
@@ -170,6 +173,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "ANE"
         case .kokoroAneZh:
             return "ANE-zh"
+        case .kokoroAneJa:
+            return "ANE-ja"
         case .parakeetEou160:
             return "160ms"
         case .parakeetEou320:
@@ -208,6 +213,8 @@ public enum Repo: String, CaseIterable, Sendable {
             return "kokoro-82m-coreml/ANE"
         case .kokoroAneZh:
             return "kokoro-82m-coreml/ANE-zh"
+        case .kokoroAneJa:
+            return "kokoro-82m-coreml/ANE-ja"
         case .parakeetEou160:
             return "parakeet-eou-streaming/160ms"
         case .parakeetEou320:
@@ -1141,6 +1148,12 @@ public enum ModelNames {
         /// `<repoDir>/voices/zf_001.bin`.
         public static let defaultVoiceFileZh = "voices/zf_001.bin"
 
+        /// Japanese (`ANE-ja/`) default voice. Mirrors the Mandarin layout —
+        /// voice packs live under a `voices/` subdirectory, so the path is
+        /// kept in the constant for the "all-required-files-present" check to
+        /// resolve against `<repoDir>/voices/jf_alpha.bin`.
+        public static let defaultVoiceFileJa = "voices/jf_alpha.bin"
+
         /// Mandarin g2pW polyphone-disambiguator CoreML bundle. Lives under
         /// `<repoDir>/g2pw/` — included in `requiredModelsZh` so the bulk
         /// `ensureModels(.mandarin)` grab pulls it without an extra round
@@ -1168,6 +1181,14 @@ public enum ModelNames {
             requiredCoreMLModels.union([
                 vocab, defaultVoiceFileZh, g2pwModelZh,
             ])
+        }
+
+        /// CoreML bundles + the vocab JSON + the Japanese default voice .bin
+        /// (under `voices/`). No G2P assets — the Japanese variant ships no
+        /// in-process text frontend; callers feed pre-computed IPA via
+        /// `synthesizeFromPhonemes(_:voice:)`.
+        public static var requiredModelsJa: Set<String> {
+            requiredCoreMLModels.union([vocab, defaultVoiceFileJa])
         }
     }
 
@@ -1226,6 +1247,8 @@ public enum ModelNames {
             return ModelNames.KokoroAne.requiredModels
         case .kokoroAneZh:
             return ModelNames.KokoroAne.requiredModelsZh
+        case .kokoroAneJa:
+            return ModelNames.KokoroAne.requiredModelsJa
         case .sortformer:
             if let variant = variant {
                 return [variant]

--- a/Sources/FluidAudio/Shared/AudioConverter.swift
+++ b/Sources/FluidAudio/Shared/AudioConverter.swift
@@ -457,10 +457,18 @@ final public class AudioConverter: Sendable {
 // MARK: - WAV Utilities (shared by TTS/ASR)
 public enum AudioWAV {
     /// Convert float samples to 16-bit PCM mono WAV at the given sample rate.
-    public static func data(from samples: [Float], sampleRate: Double) throws -> Data {
-        // Normalize to [-1, 1]
+    ///
+    /// - Parameter normalize: when `true` (default) the samples are peak-scaled
+    ///   to ±1.0 before quantization (consistent loudness). Pass `false` to
+    ///   write the samples at their native level — used by backends whose
+    ///   model output is already correctly leveled (e.g. KokoroAne, which
+    ///   matches the PyTorch reference level) so the output isn't slammed to
+    ///   0 dBFS. Out-of-range samples are still clamped to [-1, 1].
+    public static func data(
+        from samples: [Float], sampleRate: Double, normalize: Bool = true
+    ) throws -> Data {
         let maxVal = samples.map { abs($0) }.max() ?? 1.0
-        let norm = maxVal > 0 ? samples.map { $0 / maxVal } : samples
+        let norm = (normalize && maxVal > 0) ? samples.map { $0 / maxVal } : samples
 
         // Convert to 16-bit PCM
         var pcm = Data()

--- a/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
@@ -29,6 +29,8 @@ public enum KokoroAneResourceDownloader {
             required = ModelNames.KokoroAne.requiredModels
         case .mandarin:
             required = ModelNames.KokoroAne.requiredModelsZh
+        case .japanese:
+            required = ModelNames.KokoroAne.requiredModelsJa
         }
         let allPresent = required.allSatisfy { name in
             FileManager.default.fileExists(atPath: repoDir.appendingPathComponent(name).path)

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
@@ -13,6 +13,9 @@ public enum KokoroAneConstants {
     /// Default voice id for the Mandarin (`ANE-zh/`) variant.
     public static let defaultVoiceMandarin = "zf_001"
 
+    /// Default voice id for the Japanese (`ANE-ja/`) variant.
+    public static let defaultVoiceJapanese = "jf_alpha"
+
     /// Output sample rate of the iSTFT in `KokoroTail.mlpackage`.
     public static let sampleRate = 24_000
 
@@ -115,28 +118,37 @@ public enum KokoroAneConstants {
 /// the embedding vocab, HF subdirectory, voice-file layout, and the default
 /// voice id differ.
 ///
-/// | Variant      | HF subdir | Vocab | Default voice | Voice layout       |
-/// |--------------|-----------|-------|---------------|--------------------|
-/// | `.english`   | `ANE/`    | 177   | `af_heart`    | flat (`<voice>.bin`)            |
-/// | `.mandarin`  | `ANE-zh/` | 171   | `zf_001`      | nested (`voices/<voice>.bin`)   |
+/// | Variant      | HF subdir  | Default voice | Voice layout                  | Text frontend                |
+/// |--------------|------------|---------------|-------------------------------|------------------------------|
+/// | `.english`   | `ANE/`     | `af_heart`    | flat (`<voice>.bin`)          | `KokoroAneEnglishPhonemizer` |
+/// | `.mandarin`  | `ANE-zh/`  | `zf_001`      | nested (`voices/<voice>.bin`) | `MandarinG2P`                |
+/// | `.japanese`  | `ANE-ja/`  | `jf_alpha`    | nested (`voices/<voice>.bin`) | none — phoneme bypass only   |
+///
+/// The Japanese variant ships **no in-process text → phoneme frontend**.
+/// `synthesize(text:)` / `phonemes(for:)` throw for `.japanese`; callers feed
+/// pre-computed IPA through ``KokoroAneManager/synthesizeFromPhonemes(_:voice:speed:)``
+/// (the bypass path the 7-stage chain already supports). See issue #698.
 public enum KokoroAneVariant: String, CaseIterable, Sendable {
     case english
     case mandarin
+    case japanese
 
     /// Default voice id shipped with the variant's HF bundle.
     public var defaultVoice: String {
         switch self {
         case .english: return KokoroAneConstants.defaultVoice
         case .mandarin: return KokoroAneConstants.defaultVoiceMandarin
+        case .japanese: return KokoroAneConstants.defaultVoiceJapanese
         }
     }
 
-    /// True if voice packs live under a `voices/` subdirectory inside the
-    /// repo bundle (Mandarin); false if they sit at the bundle root (English).
+    /// True if voice packs live under a `voices/` subdirectory inside the repo
+    /// bundle (Mandarin / Japanese); false if they sit at the bundle root
+    /// (English).
     public var useVoicesSubdir: Bool {
         switch self {
         case .english: return false
-        case .mandarin: return true
+        case .mandarin, .japanese: return true
         }
     }
 
@@ -145,6 +157,7 @@ public enum KokoroAneVariant: String, CaseIterable, Sendable {
         switch self {
         case .english: return .kokoroAne
         case .mandarin: return .kokoroAneZh
+        case .japanese: return .kokoroAneJa
         }
     }
 }

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -324,9 +324,14 @@ public actor KokoroAneManager {
 
     private func wavData(from result: KokoroAneSynthesisResult) throws -> Data {
         do {
+            // Japanese writes at the model's native level (no peak-normalization)
+            // so the output matches the PyTorch reference instead of being
+            // slammed to 0 dBFS. English/Mandarin keep peak-normalization until
+            // their tails get the same COLA-corrected iSTFT (#698 follow-up).
             return try AudioWAV.data(
                 from: result.samples,
-                sampleRate: Double(result.sampleRate))
+                sampleRate: Double(result.sampleRate),
+                normalize: variant != .japanese)
         } catch {
             throw KokoroAneError.audioConversionFailed(error.localizedDescription)
         }

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -185,7 +185,9 @@ public actor KokoroAneManager {
     ///
     /// English: Misaki-lexicon-first with BART G2P fallback. Mandarin:
     /// the ``MandarinG2P`` pipeline for Hanzi input, pass-through for
-    /// strings that already look like phonemes.
+    /// strings that already look like phonemes. Japanese: no text frontend
+    /// — throws (use ``synthesizeFromPhonemes(_:voice:speed:)`` with
+    /// pre-computed IPA, issue #698).
     public func phonemes(for text: String) async throws -> String {
         switch variant {
         case .english:
@@ -201,6 +203,14 @@ public actor KokoroAneManager {
                 // still override pronunciation manually.
                 return text
             }
+        case .japanese:
+            // The Japanese variant ships no in-process kana/kanji → IPA
+            // frontend. Text synthesis isn't supported; callers feed
+            // pre-computed IPA via synthesizeFromPhonemes(_:voice:speed:),
+            // which bypasses phonemes(for:) entirely.
+            throw KokoroAneError.inputProcessingFailed(
+                "Japanese variant has no text G2P frontend; call "
+                    + "synthesizeFromPhonemes(_:voice:speed:) with pre-computed IPA (see #698).")
         }
     }
 

--- a/Sources/FluidAudioCLI/Commands/TTSAsrVerifyCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSAsrVerifyCommand.swift
@@ -1,4 +1,5 @@
 #if os(macOS)
+import AVFoundation
 import FluidAudio
 import Foundation
 
@@ -24,6 +25,7 @@ public enum TTSAsrVerifyCommand {
         var voice: String = TtsConstants.recommendedVoice
         var outputJson: String?
         var audioDir: String?
+        var scoreOnly = false
 
         var i = 0
         while i < arguments.count {
@@ -54,6 +56,8 @@ public enum TTSAsrVerifyCommand {
                     audioDir = arguments[i + 1]
                     i += 1
                 }
+            case "--score-only":
+                scoreOnly = true
             case "--help", "-h":
                 printUsage()
                 return
@@ -81,6 +85,18 @@ public enum TTSAsrVerifyCommand {
             exit(1)
         }
         logger.info("Loaded \(phrases.count) phrase(s) from \(textsFile)")
+
+        if scoreOnly {
+            guard let audioDir else {
+                logger.error("--score-only requires --audio-dir with phrase_%03d.wav files")
+                exit(1)
+            }
+            await runScoreOnly(
+                phrases: phrases,
+                audioDir: resolveURL(audioDir, isDirectory: true),
+                outputJson: outputJson)
+            return
+        }
 
         let backend = parseBackend(backendName)
         guard backend == .kokoroAne else {
@@ -250,6 +266,100 @@ public enum TTSAsrVerifyCommand {
             }
         } catch {
             logger.error("tts-asr-verify failed: \(error)")
+            exit(1)
+        }
+    }
+
+    // MARK: - Score-only mode
+
+    /// Transcribe pre-rendered `phrase_%03d.wav` files (e.g. from an external
+    /// TTS engine) and score them against the texts file with the same
+    /// Parakeet + TextNormalizer path the synthesis mode uses.
+    private static func runScoreOnly(
+        phrases: [String], audioDir: URL, outputJson: String?
+    ) async {
+        do {
+            let asrModels = try await AsrModels.downloadAndLoad()
+            let asr = AsrManager()
+            try await asr.loadModels(asrModels)
+            let decoderLayers = await asr.decoderLayerCount
+
+            var perPhrase: [[String: Any]] = []
+            var werValues: [Double] = []
+            var cerValues: [Double] = []
+            var totalAudioS = 0.0
+            var totalAsrS = 0.0
+
+            for (idx, phrase) in phrases.enumerated() {
+                let wavURL = audioDir.appendingPathComponent(
+                    String(format: "phrase_%03d.wav", idx + 1))
+                guard FileManager.default.fileExists(atPath: wavURL.path) else {
+                    logger.error("Missing \(wavURL.path)")
+                    exit(1)
+                }
+                let audioFile = try AVAudioFile(forReading: wavURL)
+                let audioS = Double(audioFile.length) / audioFile.processingFormat.sampleRate
+
+                let asr0 = Date()
+                var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
+                let transcription = try await asr.transcribe(wavURL, decoderState: &decoderState)
+                let asrS = Date().timeIntervalSince(asr0)
+
+                let m = WERCalculator.calculateWERAndCER(
+                    hypothesis: transcription.text, reference: phrase)
+                werValues.append(m.wer)
+                cerValues.append(m.cer)
+                totalAudioS += audioS
+                totalAsrS += asrS
+
+                logger.info(
+                    String(
+                        format: "[%03d/%03d] wer=%.1f%% cer=%.1f%% audio=%.2fs",
+                        idx + 1, phrases.count, m.wer * 100, m.cer * 100, audioS))
+                perPhrase.append([
+                    "index": idx + 1,
+                    "reference": phrase,
+                    "hypothesis": transcription.text,
+                    "wer": m.wer,
+                    "cer": m.cer,
+                    "audio_s": audioS,
+                    "asr_s": asrS,
+                    "wav_path": wavURL.path,
+                ])
+            }
+            await asr.cleanup()
+
+            let macroWer = werValues.isEmpty ? 0.0 : werValues.reduce(0, +) / Double(werValues.count)
+            let macroCer = cerValues.isEmpty ? 0.0 : cerValues.reduce(0, +) / Double(cerValues.count)
+            logger.info("--- Summary (score-only) ---")
+            logger.info("  phrases: \(phrases.count)")
+            logger.info(String(format: "  macro WER: %.2f%%", macroWer * 100))
+            logger.info(String(format: "  macro CER: %.2f%%", macroCer * 100))
+            logger.info(String(format: "  total audio: %.2fs  total asr: %.2fs", totalAudioS, totalAsrS))
+
+            if let outputJson {
+                let report: [String: Any] = [
+                    "summary": [
+                        "mode": "score-only",
+                        "audio_dir": audioDir.path,
+                        "phrase_count": phrases.count,
+                        "macro_wer": macroWer,
+                        "macro_cer": macroCer,
+                        "total_audio_s": totalAudioS,
+                        "total_asr_s": totalAsrS,
+                    ],
+                    "phrases": perPhrase,
+                ]
+                let url = resolveURL(outputJson, isDirectory: false)
+                try FileManager.default.createDirectory(
+                    at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+                let data = try JSONSerialization.data(
+                    withJSONObject: report, options: [.prettyPrinted, .sortedKeys])
+                try data.write(to: url)
+                logger.info("Report written: \(url.path)")
+            }
+        } catch {
+            logger.error("tts-asr-verify --score-only failed: \(error)")
             exit(1)
         }
     }

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -64,6 +64,11 @@ public struct TTS {
         var kokoroAneVariant: KokoroAneVariant = .english
         var lexiconPath: String? = nil
         var text: String? = nil
+        // KokoroAne: treat the positional/`--text` value as a pre-computed
+        // phoneme string (IPA for en/ja, Bopomofo+tone for zh) and bypass
+        // G2P via synthesizeFromPhonemes. Required for `.japanese`, which
+        // ships no text frontend (issue #698).
+        var treatAsPhonemes = false
         var deEss = true
         var backend: TtsBackend = .kokoroAne
         var cloneVoicePath: String? = nil
@@ -113,6 +118,8 @@ public struct TTS {
                     metricsPath = arguments[i + 1]
                     i += 1
                 }
+            case "--phonemes":
+                treatAsPhonemes = true
             case "--variant", "--model-variant":
                 if i + 1 < arguments.count {
                     let value = arguments[i + 1].lowercased()
@@ -291,7 +298,8 @@ public struct TTS {
         case .kokoroAne:
             await runKokoroAne(
                 text: text, output: output, voice: voice, metricsPath: metricsPath,
-                variant: kokoroAneVariant, lexiconPath: lexiconPath)
+                variant: kokoroAneVariant, lexiconPath: lexiconPath,
+                treatAsPhonemes: treatAsPhonemes)
         case .styletts2:
             await runStyleTTS2(
                 text: text, ipa: styletts2Ipa,
@@ -514,7 +522,7 @@ public struct TTS {
 
     private static func runKokoroAne(
         text: String, output: String, voice: String, metricsPath: String?,
-        variant: KokoroAneVariant, lexiconPath: String?
+        variant: KokoroAneVariant, lexiconPath: String?, treatAsPhonemes: Bool
     ) async {
         do {
             let tStart = Date()
@@ -548,11 +556,18 @@ public struct TTS {
             let tLoad1 = Date()
 
             let tSynth0 = Date()
-            // synthesizeDetailed handles both variants: English routes
-            // through G2PModel, Mandarin routes Hanzi through MandarinG2P
-            // (and passes through pre-computed Bopomofo verbatim).
-            let detailed = try await manager.synthesizeDetailed(
-                text: text, voice: resolvedVoice, speed: 1.0)
+            // synthesizeDetailed handles English (G2PModel) and Mandarin
+            // (MandarinG2P, with pass-through for pre-computed Bopomofo).
+            // With --phonemes, or for Japanese (no text frontend), bypass
+            // G2P and feed the input as a pre-computed phoneme string.
+            let detailed: KokoroAneSynthesisResult
+            if treatAsPhonemes || variant == .japanese {
+                detailed = try await manager.synthesizeFromPhonemesDetailed(
+                    text, voice: resolvedVoice, speed: 1.0)
+            } else {
+                detailed = try await manager.synthesizeDetailed(
+                    text: text, voice: resolvedVoice, speed: 1.0)
+            }
             let wav = try AudioWAV.data(
                 from: detailed.samples,
                 sampleRate: Double(detailed.sampleRate))

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -121,6 +121,8 @@ public struct TTS {
                         kokoroAneVariant = .english
                     case "zh", "mandarin", "zh-cn", "zh_cn":
                         kokoroAneVariant = .mandarin
+                    case "ja", "japanese", "jp":
+                        kokoroAneVariant = .japanese
                     default:
                         logger.warning("Unknown variant preference '\(arguments[i + 1])'; ignoring")
                     }
@@ -534,10 +536,10 @@ public struct TTS {
                     if let lex = try loadMandarinLexicon(from: lexiconPath) {
                         await manager.setMandarinCustomLexicon(lex)
                     }
-                case .english:
+                case .english, .japanese:
                     logger.warning(
-                        "--lexicon ignored: KokoroAne English variant has "
-                            + "no custom lexicon support yet (only Mandarin does).")
+                        "--lexicon ignored: only the KokoroAne Mandarin variant "
+                            + "supports a custom lexicon.")
                 }
             }
 

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -570,7 +570,8 @@ public struct TTS {
             }
             let wav = try AudioWAV.data(
                 from: detailed.samples,
-                sampleRate: Double(detailed.sampleRate))
+                sampleRate: Double(detailed.sampleRate),
+                normalize: variant != .japanese)
             let tSynth1 = Date()
 
             let outURL = resolveInputURL(output)

--- a/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
@@ -106,6 +106,7 @@ public enum TtsBenchmarkCommand {
         var cohereComputeUnitsArg: String?
         var referencePath: String?
         var variantArg: String?
+        var phonemesMode = false
         var voiceStylePath: String?
         var totalStepsArg: Int?
         var speedArg: Float?
@@ -156,6 +157,8 @@ public enum TtsBenchmarkCommand {
                 }
             case "--skip-asr":
                 skipAsr = true
+            case "--phonemes":
+                phonemesMode = true
             case "--asr-backend":
                 if i + 1 < arguments.count {
                     asrBackendName = arguments[i + 1]
@@ -213,7 +216,7 @@ public enum TtsBenchmarkCommand {
         let backend = parseBackend(backendName)
 
         // Resolve corpus.
-        let phrases: [(category: String, text: String)]
+        var phrases: [(category: String, text: String)]
         let corpusLabel: String
         do {
             if let corpusPath {
@@ -233,6 +236,35 @@ public enum TtsBenchmarkCommand {
         guard !phrases.isEmpty else {
             logger.error("Corpus is empty after parsing")
             exit(1)
+        }
+
+        // --phonemes: each corpus line is `ipa_phonemes|reference_text`.
+        // Synthesis feeds the phonemes (G2P bypass); WER/CER scores against
+        // the reference text. Kokoro ANE only — the Japanese variant has no
+        // in-process G2P, so this is the only way to benchmark it.
+        var phonemesByReference: [String: String] = [:]
+        if phonemesMode {
+            guard backend == .kokoroAne else {
+                logger.error("--phonemes is only supported for --backend kokoro-ane")
+                exit(1)
+            }
+            var split: [(category: String, text: String)] = []
+            for item in phrases {
+                guard let pipe = item.text.firstIndex(of: "|") else {
+                    logger.error("--phonemes corpus line has no `phonemes|reference` pipe: \(item.text)")
+                    exit(1)
+                }
+                let phonemes = String(item.text[..<pipe]).trimmingCharacters(in: .whitespaces)
+                let reference = String(item.text[item.text.index(after: pipe)...])
+                    .trimmingCharacters(in: .whitespaces)
+                guard !phonemes.isEmpty, !reference.isEmpty else {
+                    logger.error("--phonemes corpus line has empty phonemes or reference: \(item.text)")
+                    exit(1)
+                }
+                phonemesByReference[reference] = phonemes
+                split.append((category: item.category, text: reference))
+            }
+            phrases = split
         }
         logger.info("Loaded \(phrases.count) phrase(s) from corpus '\(corpusLabel)'")
 
@@ -268,10 +300,17 @@ public enum TtsBenchmarkCommand {
             switch backend {
             case .kokoroAne:
                 let kaVariant = parseKokoroAneVariant(variantArg)
+                if kaVariant == .japanese && !phonemesMode {
+                    logger.error(
+                        "The japanese variant has no text G2P; pass --phonemes with a "
+                            + "`ipa_phonemes|reference_text` corpus (see #698).")
+                    exit(1)
+                }
                 try await runKokoroAne(
                     phrases: phrases, corpusLabel: corpusLabel,
                     variant: kaVariant,
                     voice: voice ?? kaVariant.defaultVoice,
+                    phonemesByReference: phonemesMode ? phonemesByReference : nil,
                     preset: preset, outputJson: outputJson, audioDir: audioDir,
                     asrChoice: asrChoice)
             case .pocketTts:
@@ -311,6 +350,7 @@ public enum TtsBenchmarkCommand {
         corpusLabel: String,
         variant: KokoroAneVariant,
         voice: String,
+        phonemesByReference: [String: String]?,
         preset: TtsComputeUnitPreset,
         outputJson: String?,
         audioDir: String?,
@@ -325,8 +365,15 @@ public enum TtsBenchmarkCommand {
         logger.info(String(format: "Cold start (initialize): %.2fs", coldStartS))
 
         let firstStart = Date()
-        _ = try await manager.synthesizeDetailed(
-            text: "Initialization warm-up.", voice: voice, speed: 1.0)
+        if let phonemesByReference {
+            // Text warm-up would throw on G2P-less variants (japanese);
+            // warm up through the same bypass the loop uses.
+            let warmUp = phrases.first.flatMap { phonemesByReference[$0.text] } ?? "aɾʲiɡatoː"
+            _ = try await manager.synthesizeFromPhonemesDetailed(warmUp, voice: voice, speed: 1.0)
+        } else {
+            _ = try await manager.synthesizeDetailed(
+                text: "Initialization warm-up.", voice: voice, speed: 1.0)
+        }
         let firstSynthMs = Date().timeIntervalSince(firstStart) * 1000
         logger.info(String(format: "First synth: %.0f ms", firstSynthMs))
 
@@ -344,8 +391,18 @@ public enum TtsBenchmarkCommand {
             extraSummary: ["voice": voice]
         ) { text in
             let t0 = Date()
-            let result = try await manager.synthesizeDetailed(
-                text: text, voice: voice, speed: 1.0)
+            let result: KokoroAneSynthesisResult
+            if let phonemesByReference {
+                guard let phonemes = phonemesByReference[text] else {
+                    throw KokoroAneError.inputProcessingFailed(
+                        "No phonemes mapped for reference: \(text)")
+                }
+                result = try await manager.synthesizeFromPhonemesDetailed(
+                    phonemes, voice: voice, speed: 1.0)
+            } else {
+                result = try await manager.synthesizeDetailed(
+                    text: text, voice: voice, speed: 1.0)
+            }
             let synthMs = Date().timeIntervalSince(t0) * 1000
             return BackendPhraseSample(
                 synthMs: synthMs,
@@ -979,6 +1036,8 @@ public enum TtsBenchmarkCommand {
         switch name?.lowercased() {
         case "mandarin", "zh", "chinese", "zh-cn":
             return .mandarin
+        case "japanese", "ja", "jp":
+            return .japanese
         case "english", "en", "en-us", nil, "":
             return .english
         default:
@@ -1281,8 +1340,14 @@ public enum TtsBenchmarkCommand {
                                         (required for --backend styletts2;
                                         any sample rate / channel layout —
                                         resampled to 24 kHz mono internally)
-              --variant <name>          Kokoro ANE variant: english (default) or
-                                        mandarin (aliases: zh, chinese)
+              --variant <name>          Kokoro ANE variant: english (default),
+                                        mandarin (aliases: zh, chinese), or
+                                        japanese (aliases: ja, jp; requires
+                                        --phonemes)
+              --phonemes                Kokoro ANE G2P bypass: corpus lines are
+                                        `ipa_phonemes|reference_text`; synthesis
+                                        feeds the phonemes, WER/CER scores
+                                        against the reference text
               --voice-style <path>      Supertonic-3 voice style JSON
                                         (required for --backend supertonic3;
                                         e.g. M1.json shipped under

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneJapaneseVariantTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneJapaneseVariantTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Config tests for the `.japanese` KokoroAne variant (issue #698).
+///
+/// The Japanese variant reuses the language-agnostic 7-stage chain and the
+/// `synthesizeFromPhonemes` bypass; it ships no text frontend. These tests
+/// pin the wiring (HF paths, default voice, required-file set, routing) so a
+/// regression surfaces without needing the (separately uploaded) `ANE-ja/`
+/// CoreML weights.
+final class KokoroAneJapaneseVariantTests: XCTestCase {
+
+    func testVariantIsEnumerated() {
+        XCTAssertTrue(KokoroAneVariant.allCases.contains(.japanese))
+    }
+
+    func testVariantConfig() {
+        XCTAssertEqual(KokoroAneVariant.japanese.defaultVoice, "jf_alpha")
+        XCTAssertEqual(KokoroAneVariant.japanese.repo, .kokoroAneJa)
+        // Voice packs nest under `voices/` (mirrors Mandarin).
+        XCTAssertTrue(KokoroAneVariant.japanese.useVoicesSubdir)
+    }
+
+    func testRepoPaths() {
+        let repo = Repo.kokoroAneJa
+        XCTAssertEqual(repo.subPath, "ANE-ja")
+        XCTAssertEqual(repo.folderName, "kokoro-82m-coreml/ANE-ja")
+        XCTAssertEqual(repo.remotePath, "FluidInference/kokoro-82m-coreml")
+        XCTAssertEqual(repo.name, "kokoro-82m-coreml/ANE-ja")
+    }
+
+    func testRequiredModels() {
+        let required = ModelNames.KokoroAne.requiredModelsJa
+        // 7 CoreML bundles + vocab + the nested default voice = 9 files.
+        XCTAssertTrue(required.isSuperset(of: ModelNames.KokoroAne.requiredCoreMLModels))
+        XCTAssertTrue(required.contains(ModelNames.KokoroAne.vocab))
+        XCTAssertTrue(required.contains(ModelNames.KokoroAne.defaultVoiceFileJa))
+        XCTAssertEqual(ModelNames.KokoroAne.defaultVoiceFileJa, "voices/jf_alpha.bin")
+        // No Mandarin g2pW bundle — Japanese has no in-process G2P.
+        XCTAssertFalse(required.contains(ModelNames.KokoroAne.g2pwModelZh))
+        XCTAssertEqual(required.count, 9)
+    }
+
+    func testRequiredModelNamesRoutesToJa() {
+        XCTAssertEqual(
+            ModelNames.getRequiredModelNames(for: .kokoroAneJa, variant: nil),
+            ModelNames.KokoroAne.requiredModelsJa)
+    }
+
+    /// The Japanese variant has no text→phoneme frontend; `phonemes(for:)`
+    /// must throw rather than silently mis-synthesize. (Phoneme bypass via
+    /// `synthesizeFromPhonemes` does not route through this method.)
+    func testTextFrontendThrows() async {
+        let manager = KokoroAneManager(variant: .japanese)
+        do {
+            _ = try await manager.phonemes(for: "ありがとう")
+            XCTFail("expected phonemes(for:) to throw on the Japanese variant")
+        } catch let error as KokoroAneError {
+            guard case .inputProcessingFailed = error else {
+                return XCTFail("expected inputProcessingFailed, got \(error)")
+            }
+        } catch {
+            XCTFail("expected KokoroAneError.inputProcessingFailed, got \(error)")
+        }
+    }
+}

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVariantTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVariantTests.swift
@@ -35,9 +35,10 @@ final class KokoroAneVariantTests: XCTestCase {
     }
 
     func testVariantAllCases() {
-        XCTAssertEqual(KokoroAneVariant.allCases.count, 2)
+        XCTAssertEqual(KokoroAneVariant.allCases.count, 3)
         XCTAssertTrue(KokoroAneVariant.allCases.contains(.english))
         XCTAssertTrue(KokoroAneVariant.allCases.contains(.mandarin))
+        XCTAssertTrue(KokoroAneVariant.allCases.contains(.japanese))
     }
 
     // MARK: - Repo wiring


### PR DESCRIPTION
## Summary

Adds the Kokoro ANE **Japanese variant** (#698) plus the benchmark plumbing to measure it, and re-baselines the Kokoro MiniMax rows post KokoroNoise v2.

### Japanese variant
- `KokoroAneVariant.japanese` → `FluidInference/kokoro-82m-coreml/ANE-ja`, default voice `jf_alpha`, reusing the language-agnostic 7-stage chain via the `synthesizeFromPhonemes` bypass (no in-process JA G2P; `synthesize(text:)` throws with guidance).
- PyTorch output-level match (no peak-normalize for JA), CLI `tts --phonemes` bypass.

### Benchmark support
- `tts-benchmark --phonemes`: corpus lines are `ipa_phonemes|reference_text` — synthesis feeds the IPA, WER/CER scores against the reference. `--variant japanese` wired.
- `tts-asr-verify --score-only`: scores pre-rendered `phrase_NNN.wav` against a texts file through the same Parakeet + TextNormalizer path (used to compare external engines on the benchmark axis).

### Results (M5 Pro, macOS 26.6, MiniMax 100 phrases/lang)
| variant | TTFT p50/p95 | RTFx | quality |
|---|---|---|---|
| en `af_heart` | 241/305 ms | 31.0× | WER 0.68% / CER 0.15% (Parakeet) |
| zh `zf_001` | 176/231 ms | 37.4× | CER 1.90% (whisper-v3-turbo, trad→simp normalized) |
| ja `jf_alpha` (new) | 210/320 ms | 41.6× | CER 1.51% (whisper, kana-reading normalized) |

en WER 10.38% → 0.68% vs the previous baseline — the documented rows predated the KokoroNoise v2 atan2 phase fix (#700). Benchmarks.md re-baselined with methodology footnotes (ja corpus phonemized with misaki[ja]; raw-vs-normalized CER documented).

Closes #698