### PR TITLE
fix(download): include CoreML bundle internals for subPath repos (StyleTTS2 corruptedModel)

### DIFF
--- a/Sources/FluidAudio/Shared/Download/ModelHub.swift
+++ b/Sources/FluidAudio/Shared/Download/ModelHub.swift
@@ -274,30 +274,7 @@ public enum ModelHub {
             }
         }
 
-        // File selection rules for repo downloads (subPath scoping, required-
-        // model patterns, metadata-extension allowances).
-        let include: (String, Bool) -> Bool = { itemPath, isDirectory in
-            if isDirectory {
-                // For subPath repos, only process paths within the subPath
-                if let sub = subPath {
-                    return itemPath == sub || itemPath.hasPrefix("\(sub)/")
-                        || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
-                }
-                return patterns.isEmpty
-                    || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
-            }
-            // For subPath repos, only include files within the subPath
-            if let sub = subPath {
-                let isInSubPath = itemPath.hasPrefix("\(sub)/")
-                let matchesPattern =
-                    patterns.isEmpty || patterns.contains { itemPath.hasPrefix($0) }
-                let isMetadata =
-                    itemPath.hasSuffix(".json") || itemPath.hasSuffix(".model") || itemPath.hasSuffix(".bin")
-                return isInSubPath && (matchesPattern || isMetadata)
-            }
-            return patterns.isEmpty || patterns.contains { itemPath.hasPrefix($0) }
-                || itemPath.hasSuffix(".json") || itemPath.hasSuffix(".txt")
-        }
+        let include = Self.repoIncludeRule(subPath: subPath, patterns: patterns)
 
         // Repo loads: download occupies 0-0.5, CoreML compile 0.5-1.0.
         let reporter = ProgressReporter(handler: progressHandler, downloadPhaseWeight: 0.5)
@@ -520,5 +497,45 @@ public enum ModelHub {
             from: url, description: description,
             maxAttempts: maxAttempts, minBackoff: minBackoff,
             configuration: configuration)
+    }
+
+    /// File/directory selection rule for repo downloads: subPath scoping,
+    /// required-model patterns, metadata-extension allowances, and CoreML
+    /// bundle completeness.
+    ///
+    /// Files inside a `.mlmodelc`/`.mlpackage` under the subPath are always
+    /// included: the metadata allowance alone sweeps in a non-required
+    /// bundle's `.json`/`.bin` (including its weights) but drops `model.mil`,
+    /// leaving a bundle that passes the `coremldata.bin` existence check yet
+    /// fails MIL load ("Error in reading the MIL network") — seen with
+    /// StyleTTS2's t64/t128/t256 buckets, which the default variant does not
+    /// declare as required.
+    static func repoIncludeRule(
+        subPath: String?, patterns: [String]
+    ) -> (String, Bool) -> Bool {
+        { itemPath, isDirectory in
+            if isDirectory {
+                // For subPath repos, only process paths within the subPath
+                if let sub = subPath {
+                    return itemPath == sub || itemPath.hasPrefix("\(sub)/")
+                        || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
+                }
+                return patterns.isEmpty
+                    || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
+            }
+            // For subPath repos, only include files within the subPath
+            if let sub = subPath {
+                let isInSubPath = itemPath.hasPrefix("\(sub)/")
+                let matchesPattern =
+                    patterns.isEmpty || patterns.contains { itemPath.hasPrefix($0) }
+                let isMetadata =
+                    itemPath.hasSuffix(".json") || itemPath.hasSuffix(".model") || itemPath.hasSuffix(".bin")
+                let isBundleInternal =
+                    itemPath.contains(".mlmodelc/") || itemPath.contains(".mlpackage/")
+                return isInSubPath && (matchesPattern || isMetadata || isBundleInternal)
+            }
+            return patterns.isEmpty || patterns.contains { itemPath.hasPrefix($0) }
+                || itemPath.hasSuffix(".json") || itemPath.hasSuffix(".txt")
+        }
     }
 }

--- a/Tests/FluidAudioTests/Shared/ModelHubIncludeRuleTests.swift
+++ b/Tests/FluidAudioTests/Shared/ModelHubIncludeRuleTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Unit tests for `ModelHub.repoIncludeRule` — the file/directory selection
+/// rule behind repo downloads. The regression case: for subPath repos, files
+/// inside a CoreML bundle that is not in the required-model patterns must be
+/// taken all-or-nothing. The `.json`/`.bin` metadata allowance used to sweep
+/// in such a bundle's weights and coremldata while dropping `model.mil`,
+/// producing bundles that fail MIL load (StyleTTS2 t64/t128/t256 buckets).
+final class ModelHubIncludeRuleTests: XCTestCase {
+
+    private let sub = "iteration_3/compiled"
+    private var patterns: [String] {
+        // Default styletts2 variant declares the unsized bundles only.
+        ["iteration_3/compiled/bert_fp16.mlmodelc/", "iteration_3/compiled/ref_encoder_fp16.mlmodelc/"]
+    }
+
+    private func include(_ path: String, isDirectory: Bool = false) -> Bool {
+        ModelHub.repoIncludeRule(subPath: sub, patterns: patterns)(path, isDirectory)
+    }
+
+    // MARK: - CoreML bundle completeness (regression)
+
+    func testNonRequiredBundleModelMilIsIncluded() {
+        // Previously excluded (not .json/.model/.bin, bundle not in patterns).
+        XCTAssertTrue(include("iteration_3/compiled/bert_fp16_t128.mlmodelc/model.mil"))
+    }
+
+    func testNonRequiredBundleWeightsAndMetadataStayIncluded() {
+        XCTAssertTrue(include("iteration_3/compiled/bert_fp16_t128.mlmodelc/weights/weight.bin"))
+        XCTAssertTrue(include("iteration_3/compiled/bert_fp16_t128.mlmodelc/coremldata.bin"))
+        XCTAssertTrue(include("iteration_3/compiled/bert_fp16_t128.mlmodelc/metadata.json"))
+    }
+
+    func testMlpackageInternalFilesAreIncluded() {
+        XCTAssertTrue(
+            include("iteration_3/compiled/foo.mlpackage/Data/com.apple.CoreML/model.mlmodel"))
+    }
+
+    // MARK: - Existing behavior unchanged
+
+    func testRequiredBundleFilesIncluded() {
+        XCTAssertTrue(include("iteration_3/compiled/bert_fp16.mlmodelc/model.mil"))
+    }
+
+    func testStrayNonBundleFileOutsideAllowancesExcluded() {
+        XCTAssertFalse(include("iteration_3/compiled/notes.txt"))
+    }
+
+    func testFileOutsideSubPathExcluded() {
+        XCTAssertFalse(include("iteration_1/compiled/bert_fp16.mlmodelc/model.mil"))
+        XCTAssertFalse(include("README.md"))
+    }
+
+    func testSubPathDirectoryTraversal() {
+        XCTAssertTrue(include("iteration_3/compiled", isDirectory: true))
+        XCTAssertTrue(include("iteration_3/compiled/bert_fp16.mlmodelc", isDirectory: true))
+        XCTAssertFalse(include("iteration_1", isDirectory: true))
+    }
+
+    func testNoSubPathRepoBehaviorUnchanged() {
+        let rule = ModelHub.repoIncludeRule(subPath: nil, patterns: ["Melspectrogram.mlmodelc/"])
+        XCTAssertTrue(rule("Melspectrogram.mlmodelc/model.mil", false))
+        XCTAssertTrue(rule("config.json", false))
+        XCTAssertTrue(rule("vocab.txt", false))
+        XCTAssertFalse(rule("Other.mlmodelc/model.mil", false))
+    }
+}


### PR DESCRIPTION
## Bug

For subPath repos, the repo-download include rule admits files via the `.json`/`.model`/`.bin` metadata allowance even when their parent `.mlmodelc` bundle is not in the required-model patterns. A non-required bundle therefore gets materialized ~completely — its **weights are `.bin`** — while **`model.mil` is dropped**. The resulting bundle passes the `coremldata.bin` existence check but fails CoreML load with `Error in reading the MIL network`, and corrupt-model auto-recovery re-downloads the exact same hole.

## Field case

StyleTTS2 (`FluidInference/StyleTTS-2-coreml/iteration_3/compiled`): the default variant declares only the 8 unsized bundles, so `bert_fp16_t{64,128,256}.mlmodelc` and the sized `fused_diffusion_sampler_fp16_t*` buckets leaked in without `model.mil`. Any text long enough to route to a sized bucket failed with `corruptedModel("bert_fp16_t128.mlmodelc", …)`. Reproduced with two fresh downloads; verified the hosted HF files are complete (`iteration_3/compiled/*/model.mil` all present) — curling the six missing `model.mil` files into the cache immediately fixed synthesis at all text lengths (benchmarked 11–18× RTFx after repair).

## Fix

Treat CoreML bundles as all-or-nothing: include any file under a `.mlmodelc/` or `.mlpackage/` within the subPath. This only *adds* small files for bundles that were already being ~fully downloaded via the metadata allowance.

Extracted the inline include closure to `ModelHub.repoIncludeRule(subPath:patterns:)` and added unit tests (`ModelHubIncludeRuleTests`): the model.mil regression case, unchanged metadata/pattern/traversal behavior, and the no-subPath path.

`swift build` + `swift format lint` clean locally; relying on CI for the test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)