### PR TITLE
Add ModelRegistry.repoOverrides so mirrored repos can be resolved

### DIFF
--- a/Sources/FluidAudio/ModelRegistry.swift
+++ b/Sources/FluidAudio/ModelRegistry.swift
@@ -41,11 +41,49 @@ public enum ModelRegistry {
         }
     }
 
+    // MARK: - Repository Overrides
+
+    // Mutable static for runtime configuration, matching the `_customBaseURL` pattern above.
+    nonisolated(unsafe) private static var _repoOverrides: [String: String] = [:]
+
+    /// Maps upstream repository paths to alternates, e.g. a mirror under a different owner.
+    ///
+    /// `baseURL` only repoints the *host*, but repository paths come from the hardcoded `Repo`
+    /// enum, so a mirror hosted under a different owner on the same registry is unreachable
+    /// without this. Matching is longest-prefix, so mapping a repo also maps its subpaths
+    /// (e.g. `…/parakeet-realtime-eou-120m-coreml/160ms`).
+    ///
+    /// Repositories with no mapping resolve upstream unchanged, so a partial mirror is safe.
+    ///
+    ///     ModelRegistry.repoOverrides = [
+    ///         "FluidInference/parakeet-tdt-0.6b-v3-coreml": "DictionLabs/parakeet-tdt-0.6b-v3-coreml"
+    ///     ]
+    public static var repoOverrides: [String: String] {
+        get { _repoOverrides }
+        set { _repoOverrides = newValue }
+    }
+
+    /// Applies `repoOverrides` to a repository path. Longest key wins, so a more specific
+    /// mapping always beats a broader one regardless of dictionary ordering.
+    static func mapRepoPath(_ repoPath: String) -> String {
+        guard !_repoOverrides.isEmpty else { return repoPath }
+        for from in _repoOverrides.keys.sorted(by: { $0.count > $1.count }) {
+            guard let to = _repoOverrides[from] else { continue }
+            if repoPath == from {
+                return to
+            }
+            if repoPath.hasPrefix(from + "/") {
+                return to + repoPath.dropFirst(from.count)
+            }
+        }
+        return repoPath
+    }
+
     // MARK: - URL Construction
 
     /// Construct API URL for listing model repository contents
     public static func apiModels(_ repoPath: String, _ apiPath: String) throws -> URL {
-        let urlString = "\(baseURL)/api/models/\(repoPath)/\(apiPath)"
+        let urlString = "\(baseURL)/api/models/\(mapRepoPath(repoPath))/\(apiPath)"
         guard let url = URL(string: urlString) else {
             throw Error.invalidURL(urlString)
         }
@@ -54,7 +92,7 @@ public enum ModelRegistry {
 
     /// Construct download URL for a model file
     public static func resolveModel(_ repoPath: String, _ filePath: String) throws -> URL {
-        let urlString = "\(baseURL)/\(repoPath)/resolve/main/\(filePath)"
+        let urlString = "\(baseURL)/\(mapRepoPath(repoPath))/resolve/main/\(filePath)"
         guard let url = URL(string: urlString) else {
             throw Error.invalidURL(urlString)
         }

--- a/Tests/FluidAudioTests/Shared/ModelRegistryTests.swift
+++ b/Tests/FluidAudioTests/Shared/ModelRegistryTests.swift
@@ -11,6 +11,7 @@ final class ModelRegistryTests: XCTestCase {
         super.tearDown()
         // Reset the custom base URL after each test
         ModelRegistry.baseURL = "https://huggingface.co"
+        ModelRegistry.repoOverrides = [:]
     }
 
     // MARK: - Registry URL Configuration Priority Tests
@@ -266,4 +267,84 @@ final class ModelRegistryTests: XCTestCase {
                 "URL should contain file path for registry: \(registry)")
         }
     }
+
+    // MARK: - Repository Override Tests
+
+    func testNoOverridesLeavesRepoPathUnchanged() throws {
+        let url = try ModelRegistry.resolveModel("FluidInference/parakeet-tdt-0.6b-v3-coreml", "config.json")
+        XCTAssertEqual(
+            url.absoluteString,
+            "https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml/resolve/main/config.json",
+            "An empty override map must not alter the upstream path")
+    }
+
+    func testOverrideRedirectsResolveModel() throws {
+        ModelRegistry.repoOverrides = [
+            "FluidInference/parakeet-tdt-0.6b-v3-coreml": "DictionLabs/parakeet-tdt-0.6b-v3-coreml"
+        ]
+
+        let url = try ModelRegistry.resolveModel("FluidInference/parakeet-tdt-0.6b-v3-coreml", "Encoder.mlmodelc/model.mil")
+        XCTAssertEqual(
+            url.absoluteString,
+            "https://huggingface.co/DictionLabs/parakeet-tdt-0.6b-v3-coreml/resolve/main/Encoder.mlmodelc/model.mil")
+    }
+
+    /// apiModels and resolveModel must map identically, or the library would list files from
+    /// one repository and download them from another.
+    func testOverrideAppliesToApiModelsToo() throws {
+        ModelRegistry.repoOverrides = [
+            "FluidInference/silero-vad-coreml": "DictionLabs/silero-vad-coreml"
+        ]
+
+        let url = try ModelRegistry.apiModels("FluidInference/silero-vad-coreml", "tree/main")
+        XCTAssertEqual(
+            url.absoluteString,
+            "https://huggingface.co/api/models/DictionLabs/silero-vad-coreml/tree/main")
+    }
+
+    func testUnmappedRepoFallsThroughToUpstream() throws {
+        ModelRegistry.repoOverrides = [
+            "FluidInference/silero-vad-coreml": "DictionLabs/silero-vad-coreml"
+        ]
+
+        let url = try ModelRegistry.resolveModel("FluidInference/parakeet-tdt-0.6b-v2-coreml", "config.json")
+        XCTAssertEqual(
+            url.absoluteString,
+            "https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v2-coreml/resolve/main/config.json",
+            "A partial mirror must leave unmapped repos pointing upstream")
+    }
+
+    /// Several Repo cases carry a subpath, e.g. `.../parakeet-realtime-eou-120m-coreml/160ms`.
+    func testOverrideMapsSubpaths() throws {
+        ModelRegistry.repoOverrides = [
+            "FluidInference/parakeet-realtime-eou-120m-coreml": "DictionLabs/parakeet-realtime-eou-120m-coreml"
+        ]
+
+        let url = try ModelRegistry.resolveModel("FluidInference/parakeet-realtime-eou-120m-coreml/160ms", "config.json")
+        XCTAssertEqual(
+            url.absoluteString,
+            "https://huggingface.co/DictionLabs/parakeet-realtime-eou-120m-coreml/160ms/resolve/main/config.json")
+    }
+
+    /// Longest key wins, so ordering of the dictionary cannot change the result.
+    func testLongestPrefixWins() throws {
+        ModelRegistry.repoOverrides = [
+            "FluidInference/parakeet-realtime-eou-120m-coreml": "DictionLabs/broad",
+            "FluidInference/parakeet-realtime-eou-120m-coreml/160ms": "DictionLabs/specific",
+        ]
+
+        let url = try ModelRegistry.resolveModel("FluidInference/parakeet-realtime-eou-120m-coreml/160ms", "c.json")
+        XCTAssertEqual(url.absoluteString, "https://huggingface.co/DictionLabs/specific/resolve/main/c.json")
+    }
+
+    func testOverrideComposesWithCustomBaseURL() throws {
+        ModelRegistry.baseURL = "https://models.diction.one"
+        ModelRegistry.repoOverrides = ["FluidInference/silero-vad-coreml": "DictionLabs/silero-vad-coreml"]
+
+        let url = try ModelRegistry.resolveModel("FluidInference/silero-vad-coreml", "config.json")
+        XCTAssertEqual(
+            url.absoluteString,
+            "https://models.diction.one/DictionLabs/silero-vad-coreml/resolve/main/config.json")
+    }
+
 }


### PR DESCRIPTION
`baseURL` already lets you point FluidAudio at a different registry host. What it does not let you do is point at a different *owner*, because the repository paths come from the `Repo` enum and those are baked in as `FluidInference/...`.

That gap shows up as soon as you mirror the models. We ship FluidAudio in an iOS app, and we want the model downloads our users trigger to come from a namespace we control, so we can read the release notes and test a new build before it reaches anyone. Setting `baseURL` to our own Hugging Face org does not get us there, since the path still says `FluidInference/`. Editing the enum does, but it has 82 cases and you add to it regularly, so we would be rebasing on every release.

A map felt like the smaller change:

```swift
ModelRegistry.repoOverrides = [
    "FluidInference/parakeet-tdt-0.6b-v3-coreml": "DictionLabs/parakeet-tdt-0.6b-v3-coreml"
]
```

Applied in both places that build a repo URL, `apiModels` and `resolveModel`, so listing and downloading can never point at different repos. Matching is longest-prefix, which picks up the cases carrying a subpath like `parakeet-realtime-eou-120m-coreml/160ms`. Anything unmapped resolves upstream unchanged, so a partial mirror is safe and new models you add keep working with nobody touching their config.

The default is an empty dictionary, so behavior is byte-identical unless someone sets it. It follows the same `nonisolated(unsafe)` static pattern as `_customBaseURL` directly above it.

Tests cover the no-op case, redirect through both call sites, fall-through for unmapped repos, subpath mapping, longest-prefix precedence, and composition with a custom `baseURL`.

Happy to rename it or change the matching rule if you would rather it behaved differently. We are running this in a fork either way, so there is no pressure on your side.

Disclosure: the code and this description were written in cooperation with AI coding agents.