### PR TITLE
fix(asr): preserve merge token order at chunk seams (#825)

### DIFF
--- a/Documentation/ASR/LongTranscription.md
+++ b/Documentation/ASR/LongTranscription.md
@@ -47,6 +47,11 @@ When reviewing long-form ASR output, check the transcript for:
 - glued words (two words joined without a space) or hybrid words stitched
   from both windows' segmentation of the same seam word — `"worksks"`,
   `"automoti"`, mid-word punctuation like `"ye,ah"` (issue #683)
+- subword or word order scrambled *across* a seam — subwords of two
+  adjacent words interleaved (`"im Frühjahr"` → `"imüh Frjahr"`), two words
+  swapped (`"Für die"` → `"die Für"`), or a word's own pieces rearranged
+  (`"Punkt"` → `"Pktun"`). Fixed in PR #830 — see "Token Order Is
+  Authoritative" (issue #825)
 - missing clauses or full sentences after a boundary
 - wrong-language insertions in otherwise single-language audio
 - wrong-script bursts on multilingual v3 audio
@@ -248,6 +253,32 @@ cannot collapse two different words that happen to share a substring, and it
 is robust to small per-chunk timestamp jitter. The contiguous-match path
 preserves order strictly; LCS is only entered when adjacent chunks disagree
 enough that a contiguous run would be dishonest.
+
+### Token Order Is Authoritative
+
+Each merge step produces tokens in linear text order (left prefix, spliced
+seam, right suffix), and `convertTokensToText` builds the transcript by
+joining tokens in that array order. The merged order — not the frame
+timestamps — is the source of truth for the text.
+
+Frame timestamps are therefore **clamped monotonic, never sorted**
+(`enforceMonotonicTimestamps`). A timestamp sort is unsafe as a final pass
+because the key is both coarse and non-monotonic across a seam:
+
+- TDT emits several tokens per 80 ms encoder frame, so many tokens share a
+  timestamp; sorting on ties can reorder same-frame subwords.
+- The two overlapping windows number frames from different global offsets
+  (plus mel-context / warmup adjustments), so a token that linearly *follows*
+  another can carry a numerically *smaller* timestamp. Sorting then pulls it
+  ahead, interleaving subwords from the two windows.
+
+Re-sorting the merged stream by timestamp produced the seam scrambles in
+issue #825 (`"im Frühjahr"` → `"imüh Frjahr"`, `"Für die"` → `"die Für"`,
+`"Punkt"` → `"Pktun"`) — it discarded the order the splice logic below had
+carefully constructed. The clamp instead only raises any backward-stepping
+timestamp to the running maximum, leaving token order untouched while keeping
+the sequence non-decreasing for word timing, `collapseSeamWordDuplicates`,
+and the post-merge repair pass (PR #830).
 
 ### Case-Folded Matching and Seam Word Duplicates
 
@@ -469,7 +500,12 @@ RMS exceeds `0.008 / 0.3 ≈ 0.027`.
 - Probes are extra window decodes: ~25–30 on a 30-minute applause-heavy
   conference file (~20% over baseline), near zero on clean audio.
 - Seam **garbles** ("language in" → "languag ines") leave no token gap and
-  are invisible to the pass — they need a fix in the merger itself.
+  are invisible to the pass — they need a fix in the merger itself. The
+  *order-inversion* subclass of this (subwords/words reordered across a seam,
+  issue #825) is fixed in the merger by keeping token order authoritative
+  instead of re-sorting by timestamp (PR #830, see "Token Order Is
+  Authoritative"). Garbles from the two windows tokenizing the same audio
+  *differently* at the splice are a separate, still-open case.
 - Edge re-hearings with different tokenization can occasionally duplicate a
   boundary word (~1 per 15–20 min of dense conference speech) — the same
   artifact class and rate the merger already produces. Deliberately not
@@ -612,6 +648,7 @@ authoritative record; the milestones:
 | 2026-07 (#758 → #761) | Seam-gap repair pass | multi-second speech spans dropped at low-SNR seams — unfixable at the merge layer because the tokens never existed. |
 | 2026-07 (#759) | Bound-safe fallbacks in merge repairs | three residual paths that dropped content when no splice-safe token existed. |
 | 2026-07 (#747) | End-aligned final window + adaptive speech gate | final-window blank-out on quiet audio — a short last chunk zero-padded to the model window is a degenerate input; fixed structurally by backfilling with real audio. The adaptive gate replaced an absolute energy gate that was structurally dead on the quiet-audio class. |
+| 2026-07 (#825 → #830) | Merge order authoritative; clamp timestamps instead of re-sorting | subwords/words reordered across a seam ("im Frühjahr" → "imüh Frjahr", "Für die" → "die Für") — a final global timestamp sort scrambled the order the splice logic had built, because frame timestamps are coarse and don't co-register across a seam. |
 
 Two recurring lessons in that table:
 

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessor.swift
@@ -671,12 +671,22 @@ struct ChunkProcessor {
                     caseVariantIds: caseVariantIds
                 )
             }
-            if mergedTokens.count > 1 {
-                mergedTokens.sort { $0.timestamp < $1.timestamp }
-            }
+            // The pairwise merges above already yield tokens in linear (text)
+            // order. Do NOT re-sort by timestamp: frame timestamps are coarse
+            // (TDT emits several tokens per 80 ms frame, so many are equal) and
+            // the two overlapping windows' frame indices don't co-register
+            // across a seam, so a timestamp sort reorders same-frame subwords
+            // and interleaves subwords from the two windows — the token-order
+            // inversion in issue #825 ("Für die" -> "die Für", "im Frühjahr"
+            // -> "imüh Frjahr", "Punkt" -> "Pktun"). Preserve the merge order
+            // and only clamp timestamps to be non-decreasing so downstream word
+            // timing and the seam-gap repair pass stay monotonic.
+            mergedTokens = Self.enforceMonotonicTimestamps(mergedTokens)
             mergedTokens = collapseSeamWordDuplicates(mergedTokens, vocabulary: vocabulary)
-        } else if mergedTokens.count > 1 {
-            mergedTokens.sort { $0.timestamp < $1.timestamp }
+        } else {
+            // Single window: tokens are already emitted in time order; clamp is
+            // a no-op but keeps the invariant explicit.
+            mergedTokens = Self.enforceMonotonicTimestamps(mergedTokens)
         }
 
         // Post-merge repair pass re-decodes seam gaps the merger dropped
@@ -822,6 +832,28 @@ struct ChunkProcessor {
     /// left by a false sentence start, at word granularity (issue #706) — see
     /// "Case-Folded Matching" in Documentation/ASR/LongTranscription.md for
     /// the collapse conditions and what is deliberately left alone.
+    /// Make token timestamps non-decreasing *without reordering* the stream.
+    /// The merged token order is the source of truth for the transcript text
+    /// (`convertTokensToText` joins tokens in array order); frame timestamps
+    /// are metadata that can be locally out of order across a chunk seam.
+    /// Each token that would step backwards in time is clamped up to the
+    /// running maximum, so word timing and the seam-gap repair pass see a
+    /// monotonic sequence while the text order the merger produced is kept
+    /// intact (issue #825).
+    static func enforceMonotonicTimestamps(_ tokens: [TokenWindow]) -> [TokenWindow] {
+        guard tokens.count > 1 else { return tokens }
+        var result = tokens
+        var lastTimestamp = result[0].timestamp
+        for index in 1..<result.count {
+            if result[index].timestamp < lastTimestamp {
+                result[index].timestamp = lastTimestamp
+            } else {
+                lastTimestamp = result[index].timestamp
+            }
+        }
+        return result
+    }
+
     func collapseSeamWordDuplicates(
         _ tokens: [TokenWindow],
         vocabulary: [Int: String]

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/ChunkSeamTokenOrderTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/ChunkSeamTokenOrderTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Regression tests for issue #825: the post-merge global timestamp sort
+/// reordered tokens the merger had placed in correct linear (text) order,
+/// interleaving subwords across a chunk seam and inverting word order. The
+/// fix replaces the sort with `enforceMonotonicTimestamps`, which clamps
+/// timestamps upward without reordering.
+final class ChunkSeamTokenOrderTests: XCTestCase {
+
+    private typealias TokenWindow = (token: Int, timestamp: Int, confidence: Float, duration: Int)
+
+    private func tok(_ id: Int, _ ts: Int) -> TokenWindow {
+        (token: id, timestamp: ts, confidence: 0.9, duration: 1)
+    }
+
+    /// "im Frühjahr": the right window's "Früh" carries a frame index one
+    /// lower than the left window's "im" at the seam. A timestamp sort would
+    /// interleave them into "Früh im jahr" ("imüh Frjahr"); the clamp keeps
+    /// the merged order.
+    func testCrossWindowSubwordOrderPreserved() {
+        let im = 11
+        let fruh = 12
+        let jahr = 13
+        let merged = [tok(im, 160), tok(fruh, 159), tok(jahr, 161)]
+
+        let result = ChunkProcessor.enforceMonotonicTimestamps(merged)
+
+        XCTAssertEqual(result.map { $0.token }, [im, fruh, jahr], "token order must be preserved")
+        XCTAssertEqual(result.map { $0.timestamp }, [160, 160, 161], "timestamps clamped monotonic")
+        // A timestamp sort would have produced the corrupted order.
+        XCTAssertEqual(merged.sorted { $0.timestamp < $1.timestamp }.map { $0.token }, [fruh, im, jahr])
+    }
+
+    /// "Für die Regale": the merger produced [Für, die, Regale] but "die"
+    /// carries an earlier frame than "Für". A sort inverts to "die Für";
+    /// the clamp keeps "Für die Regale".
+    func testWordOrderInversionPrevented() {
+        let fur = 21
+        let die = 22
+        let regale = 23
+        let merged = [tok(fur, 160), tok(die, 158), tok(regale, 162)]
+
+        let result = ChunkProcessor.enforceMonotonicTimestamps(merged)
+
+        XCTAssertEqual(result.map { $0.token }, [fur, die, regale])
+        XCTAssertEqual(result.map { $0.timestamp }, [160, 160, 162])
+    }
+
+    func testAlreadyMonotonicIsUnchanged() {
+        let merged = [tok(1, 10), tok(2, 12), tok(3, 12), tok(4, 20)]
+        let result = ChunkProcessor.enforceMonotonicTimestamps(merged)
+        XCTAssertEqual(result.map { $0.token }, [1, 2, 3, 4])
+        XCTAssertEqual(result.map { $0.timestamp }, [10, 12, 12, 20])
+    }
+
+    func testEqualTimestampsKeepEmissionOrder() {
+        // Same-frame subwords ("P","un","kt" of "Punkt") must not be shuffled.
+        let merged = [tok(100, 40), tok(101, 40), tok(102, 40)]
+        let result = ChunkProcessor.enforceMonotonicTimestamps(merged)
+        XCTAssertEqual(result.map { $0.token }, [100, 101, 102])
+        XCTAssertEqual(result.map { $0.timestamp }, [40, 40, 40])
+    }
+
+    func testSingleAndEmptyAreNoOps() {
+        XCTAssertEqual(ChunkProcessor.enforceMonotonicTimestamps([]).count, 0)
+        let one = [tok(7, 5)]
+        XCTAssertEqual(ChunkProcessor.enforceMonotonicTimestamps(one).map { $0.timestamp }, [5])
+    }
+
+    func testConfidenceAndDurationArePreserved() {
+        let merged = [
+            (token: 1, timestamp: 30, confidence: Float(0.8), duration: 3),
+            (token: 2, timestamp: 28, confidence: Float(0.6), duration: 2),
+        ]
+        let result = ChunkProcessor.enforceMonotonicTimestamps(merged)
+        XCTAssertEqual(result[1].timestamp, 30)
+        XCTAssertEqual(result[1].confidence, 0.6)
+        XCTAssertEqual(result[1].duration, 2)
+    }
+}


### PR DESCRIPTION
Fixes #825.

## Root cause

The `AsrManager` batch long-form path merges overlapping windows with order-aware, word-boundary-aware splicing (`mergeChunks`), which yields tokens in correct **linear (text) order**. It then globally re-sorted that stream by frame timestamp before building the transcript:

```swift
mergedTokens.sort { $0.timestamp < $1.timestamp }   // ChunkProcessor.swift
```

`convertTokensToText` joins tokens in **array order**, so that sort determines the transcript. But frame timestamps are a bad sort key here:

- TDT emits several tokens per 80 ms frame, so many timestamps are **equal**.
- The two overlapping windows' frame indices don't **co-register** across a seam (different global offsets + mel-context/warmup frame adjustments), so a token that linearly *follows* another can carry a numerically *smaller* timestamp.

Re-sorting by that coarse, locally non-monotonic key reorders same-frame subwords and interleaves subwords from the two windows — exactly the reporter's German seam:

| expected | produced |
|---|---|
| `im Frühjahr` | `imüh Frjahr` (subwords interleaved) |
| `Für die Regale` | `die Für Regale` (word order inverted) |
| `Punkt` | `Pktun` (same-frame subwords shuffled) |

This is the token-order-inversion class #761 flagged as needing "a fix in the merger itself."

## Fix

The pairwise merges already produce correct order, so the global sort is not just unnecessary — it's the corruption. Replace it with `enforceMonotonicTimestamps`, which clamps each backward-stepping timestamp up to the running maximum **without reordering**. Text order (the merger's output) is preserved; word timing and the opt-in seam-gap repair pass still see a non-decreasing timestamp sequence. `collapseSeamWordDuplicates` and `repairSeamGaps` are unaffected — both depend on token order + monotonic time, which the clamp keeps (and both previously ran on the *scrambled* stream).

## Scope

Targets the merge-seam reordering (the issue's title class). The first-chunk mel-context degradation the report also notes (all-lowercase, spoken-punctuation not converted) is the separate #594 family and is out of scope here.

## Tests

Adds `ChunkSeamTokenOrderTests` — token-level regression covering the cross-window subword interleave, the word-order inversion, same-frame ties, and the already-monotonic no-op, each asserting order is preserved while timestamps become non-decreasing. (Local XCTest is unavailable in my env; validated the clamp logic + golden values with a standalone harness, and the FluidAudio library target builds clean.)