### PR TITLE
fix(asr/eou): debounce on wall-clock silence, not consecutive EOU emissions

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/EOU/StreamingEouAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/EOU/StreamingEouAsrManager.swift
@@ -207,7 +207,9 @@ public actor StreamingEouAsrManager {
     private var partialCallback: PartialCallback?
 
     // EOU Debouncing - requires sustained silence before triggering
-    /// Minimum duration of silence (in ms) before EOU is confirmed
+    /// Wall-clock silence (in ms) after the EOU head first fires before EOU is confirmed.
+    /// Measured from the first EOU signal; only newly decoded words reset it, so a silent
+    /// chunk that does not re-emit the EOU token does not restart the timer.
     public var eouDebounceMs: Int = 1280
     /// Timestamp when EOU was first detected (for debouncing)
     private var eouFirstDetectedAt: Int?  // in processed samples
@@ -277,6 +279,50 @@ public actor StreamingEouAsrManager {
         frameDurationMs: Int
     ) -> [Int] {
         tokenFrames.map { (baseFrame + $0) * frameDurationMs }
+    }
+
+    /// Outcome of the per-chunk EOU debounce evaluation.
+    struct EouDebounceDecision: Equatable {
+        /// Updated debounce anchor (in processed samples), or nil if the timer is not running.
+        let anchorSamples: Int?
+        /// Whether EOU should be confirmed on this chunk.
+        let confirmed: Bool
+    }
+
+    /// Pure debounce rule for confirming End-of-Utterance.
+    ///
+    /// `debounceMs` measures wall-clock silence — the elapsed time since the EOU head first
+    /// fired during which no new words are decoded. The anchor starts on the first chunk that
+    /// signals EOU with no new tokens, and only a chunk that decodes new words (ongoing speech)
+    /// resets it. A silent chunk that fails to re-emit the EOU token neither starts nor resets
+    /// the timer, so the value behaves as the duration its name implies rather than requiring
+    /// consecutive EOU emissions. See issue #827.
+    static func evaluateEouDebounce(
+        hasNewTokens: Bool,
+        eouSignal: Bool,
+        totalSamplesProcessed: Int,
+        anchorSamples: Int?,
+        alreadyConfirmed: Bool,
+        debounceMs: Int,
+        sampleRate: Int = 16000
+    ) -> EouDebounceDecision {
+        // Newly decoded words mean speech is ongoing - reset the timer.
+        if hasNewTokens {
+            return EouDebounceDecision(anchorSamples: nil, confirmed: false)
+        }
+
+        // Start the timer on the first EOU signal; otherwise carry the existing anchor forward.
+        var anchor = anchorSamples
+        if anchor == nil, eouSignal {
+            anchor = totalSamplesProcessed
+        }
+
+        guard let firstDetected = anchor, !alreadyConfirmed else {
+            return EouDebounceDecision(anchorSamples: anchor, confirmed: false)
+        }
+
+        let elapsedMs = ((totalSamplesProcessed - firstDetected) * 1000) / sampleRate
+        return EouDebounceDecision(anchorSamples: anchor, confirmed: elapsedMs >= debounceMs)
     }
 
     /// Load models from a specific directory
@@ -611,39 +657,28 @@ public actor StreamingEouAsrManager {
         // Track total samples for timing
         totalSamplesProcessed += shiftSamples
 
-        // Handle EOU detection with debouncing
-        // EOU requires sustained silence for eouDebounceMs before triggering
-        if decodeResult.eouDetected {
-            // If new tokens were produced, speech is ongoing - reset debounce timer
-            if !decodeResult.tokenIds.isEmpty {
-                eouFirstDetectedAt = nil
-            } else if eouFirstDetectedAt == nil {
-                // First EOU detection - start debounce timer
-                eouFirstDetectedAt = totalSamplesProcessed
-                logger.debug("EOU candidate at chunk \(processedChunks), starting debounce timer")
+        // Handle EOU detection with debouncing (see evaluateEouDebounce for the rule).
+        let decision = Self.evaluateEouDebounce(
+            hasNewTokens: !decodeResult.tokenIds.isEmpty,
+            eouSignal: decodeResult.eouDetected,
+            totalSamplesProcessed: totalSamplesProcessed,
+            anchorSamples: eouFirstDetectedAt,
+            alreadyConfirmed: eouDetected,
+            debounceMs: eouDebounceMs
+        )
+        eouFirstDetectedAt = decision.anchorSamples
+
+        if decision.confirmed {
+            eouDetected = true
+            let eouTimestampMs = (totalSamplesProcessed * 1000) / 16000
+            logger.info("EOU confirmed at chunk \(processedChunks) (\(eouTimestampMs)ms)")
+            accumulatedEouTimestampsMs.append(eouTimestampMs)
+
+            // Invoke callback with current transcript
+            if let callback = eouCallback, let tokenizer = tokenizer {
+                let transcript = tokenizer.decode(ids: accumulatedTokenIds)
+                callback(transcript)
             }
-
-            // Check if debounce period has elapsed
-            if let firstDetected = eouFirstDetectedAt {
-                let elapsedSamples = totalSamplesProcessed - firstDetected
-                let elapsedMs = (elapsedSamples * 1000) / 16000  // Convert samples to ms at 16kHz
-
-                if elapsedMs >= eouDebounceMs && !eouDetected {
-                    eouDetected = true
-                    logger.info("EOU confirmed at chunk \(processedChunks) after \(elapsedMs)ms silence")
-                    let eouTimestampMs = (totalSamplesProcessed * 1000) / 16000
-                    accumulatedEouTimestampsMs.append(eouTimestampMs)
-
-                    // Invoke callback with current transcript
-                    if let callback = eouCallback, let tokenizer = tokenizer {
-                        let transcript = tokenizer.decode(ids: accumulatedTokenIds)
-                        callback(transcript)
-                    }
-                }
-            }
-        } else {
-            // Model did not predict EOU - speech is ongoing, reset debounce timer
-            eouFirstDetectedAt = nil
         }
 
         processedChunks += 1

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/StreamingEouAsrManagerTimestampTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/StreamingEouAsrManagerTimestampTests.swift
@@ -26,4 +26,96 @@ final class StreamingEouAsrManagerTimestampTests: XCTestCase {
 
         XCTAssertTrue(timestamps.isEmpty)
     }
+
+    // MARK: - EOU Debounce (issue #827)
+
+    private let sampleRate = 16000
+    private let chunkSamples = 16000 / 1000 * 320  // 320ms chunk shift
+
+    /// Runs a sequence of chunks through the pure debounce rule and returns the
+    /// chunk index (0-based) at which EOU is confirmed, or nil if never.
+    /// Each element is (hasNewTokens, eouSignal).
+    private func confirmChunk(
+        _ chunks: [(Bool, Bool)],
+        debounceMs: Int
+    ) -> Int? {
+        var anchor: Int?
+        var confirmed = false
+        var total = 0
+        for (i, chunk) in chunks.enumerated() {
+            total += chunkSamples
+            let decision = StreamingEouAsrManager.evaluateEouDebounce(
+                hasNewTokens: chunk.0,
+                eouSignal: chunk.1,
+                totalSamplesProcessed: total,
+                anchorSamples: anchor,
+                alreadyConfirmed: confirmed,
+                debounceMs: debounceMs,
+                sampleRate: sampleRate
+            )
+            anchor = decision.anchorSamples
+            if decision.confirmed {
+                confirmed = true
+                return i
+            }
+        }
+        return nil
+    }
+
+    /// A single EOU signal followed by silent, non-EOU chunks still confirms once
+    /// enough wall-clock time elapses — no consecutive EOU emissions required.
+    func testDebounceFiresOnSilenceAfterSingleEouSignal() {
+        // 1280ms debounce at 320ms chunks: anchor at t=320ms, confirm at t=1600ms.
+        let chunks: [(Bool, Bool)] = [
+            (false, true),  // t=320ms: EOU signal starts the timer
+            (false, false),  // t=640ms: silent, no EOU token
+            (false, false),  // t=960ms
+            (false, false),  // t=1280ms: elapsed 960ms since anchor
+            (false, false),  // t=1600ms: elapsed 1280ms -> confirm
+        ]
+        XCTAssertEqual(confirmChunk(chunks, debounceMs: 1280), 4)
+    }
+
+    /// The old behavior required every chunk to re-emit EOU; verify a lone blank
+    /// chunk in the middle no longer resets the timer.
+    func testDebounceSurvivesBlankChunk() {
+        let chunks: [(Bool, Bool)] = [
+            (false, true),  // start
+            (false, false),  // blank - would have reset under old logic
+            (false, true),
+            (false, false),
+            (false, false),  // t=1600ms, elapsed 1280ms -> confirm
+        ]
+        XCTAssertEqual(confirmChunk(chunks, debounceMs: 1280), 4)
+    }
+
+    /// Newly decoded words reset the timer (real speech is ongoing).
+    func testDebounceResetOnNewTokens() {
+        let chunks: [(Bool, Bool)] = [
+            (false, true),  // start timer
+            (false, false),
+            (true, false),  // decoded a word -> reset
+            (false, true),  // restart timer here (t=1280ms)
+            (false, false),  // t=1600ms, elapsed 320ms
+            (false, false),  // t=1920ms, elapsed 640ms
+            (false, false),  // t=2240ms, elapsed 960ms
+            (false, false),  // t=2560ms, elapsed 1280ms -> confirm
+        ]
+        XCTAssertEqual(confirmChunk(chunks, debounceMs: 1280), 7)
+    }
+
+    /// A larger value produces a proportionally longer pause (the reporter's 4s case).
+    func testDebounceScalesWithValue() {
+        // 4000ms at 320ms chunks: anchor at chunk 0 (t=320ms); confirm when
+        // total - 320 >= 4000, i.e. total >= 4320ms -> chunk index 13 (t=4480ms).
+        var chunks: [(Bool, Bool)] = [(false, true)]
+        chunks.append(contentsOf: Array(repeating: (false, false), count: 20))
+        XCTAssertEqual(confirmChunk(chunks, debounceMs: 4000), 13)
+    }
+
+    /// No EOU signal ever means no confirmation, regardless of silence length.
+    func testDebounceNeverFiresWithoutEouSignal() {
+        let chunks: [(Bool, Bool)] = Array(repeating: (false, false), count: 30)
+        XCTAssertNil(confirmChunk(chunks, debounceMs: 1280))
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #827. `StreamingEouAsrManager.eouDebounceMs` was documented as "minimum duration of silence (in ms) before EOU is confirmed," but the timer reset on **any** chunk that didn't emit the EOU token — so it actually required that many *consecutive* EOU emissions. A single blank chunk anywhere in the silence restarted the count, and large values (e.g. 4000ms) could stop firing altogether.

The reporter (@ankitsejwal) diagnosed this precisely: at `.ms320`, the 1280ms default needed 4 consecutive EOU-emitting chunks and 4000ms needed ~13, so raising the value didn't lengthen the pause proportionally.

## The fix

Reset the debounce anchor only when a chunk decodes **new words** (genuine ongoing speech). A silent chunk that fails to re-emit the EOU token no longer restarts the timer:

- Anchor starts on the first chunk that signals EOU with no new tokens.
- Only newly decoded tokens reset it.
- Elapsed wall-clock silence accrues regardless of whether later chunks re-emit the EOU token.

`eouDebounceMs` now behaves as the duration its name implies — setting `4000` gives a real ~4s pause.

The rule is extracted into a pure `static func evaluateEouDebounce(...)` (mirroring the existing `computeTokenTimestampsMs`) so it can be unit-tested without loading models.

## Tests

Five new cases in `StreamingEouAsrManagerTimestampTests`:
- fires on silence after a single EOU signal,
- survives a lone blank chunk (the core regression),
- resets on newly decoded words,
- scales proportionally (the 4000ms case),
- never fires without any EOU signal.

## Verification

- `swift build` succeeds (pre-existing warnings only).
- `swift format lint` clean on both files.
- Tests run in CI (local toolchain has no XCTest module).