### PR TITLE
fix(download): stop downloading never-loaded sibling bundles in subPath repos (#826)

### DIFF
--- a/Sources/FluidAudio/Shared/Download/ModelHub.swift
+++ b/Sources/FluidAudio/Shared/Download/ModelHub.swift
@@ -667,23 +667,39 @@ public enum ModelHub {
     }
 
     /// File/directory selection rule for repo downloads: subPath scoping,
-    /// required-model patterns, metadata-extension allowances, and CoreML
-    /// bundle completeness.
+    /// required-model patterns, metadata-extension allowances, and
+    /// all-or-nothing CoreML bundle matching.
     ///
-    /// Files inside a `.mlmodelc`/`.mlpackage` under the subPath are always
-    /// included: the metadata allowance alone sweeps in a non-required
-    /// bundle's `.json`/`.bin` (including its weights) but drops `model.mil`,
-    /// leaving a bundle that passes the `coremldata.bin` existence check yet
-    /// fails MIL load ("Error in reading the MIL network") — seen with
-    /// StyleTTS2's t64/t128/t256 buckets, which the default variant does not
-    /// declare as required.
+    /// For subPath repos, paths that are (or are inside) a
+    /// `.mlmodelc`/`.mlpackage` are decided at bundle granularity against the
+    /// required-model patterns:
+    ///
+    /// - A required bundle is taken whole. The metadata allowance alone
+    ///   sweeps in a bundle's `.json`/`.bin` but drops `model.mil`, leaving a
+    ///   bundle that passes the `coremldata.bin` existence check yet fails
+    ///   MIL load ("Error in reading the MIL network") — StyleTTS2's
+    ///   t64/t128/t256 buckets (#821).
+    /// - A non-required bundle is skipped whole. These repos publish the
+    ///   uncompiled `.mlpackage` next to each compiled `.mlmodelc`, and the
+    ///   `.bin` allowance was pulling every `weight.bin` inside them —
+    ///   roughly half of a first-run parakeetEou/kokoroAne download was never
+    ///   loaded (#826). Skipping applies to directory traversal too, so the
+    ///   tree lister does not recurse into excluded bundles.
     static func repoIncludeRule(
         subPath: String?, patterns: [String]
     ) -> (String, Bool) -> Bool {
         { itemPath, isDirectory in
+            let isBundlePath =
+                itemPath.hasSuffix(".mlmodelc") || itemPath.hasSuffix(".mlpackage")
+                || itemPath.contains(".mlmodelc/") || itemPath.contains(".mlpackage/")
             if isDirectory {
                 // For subPath repos, only process paths within the subPath
                 if let sub = subPath {
+                    if isBundlePath, !patterns.isEmpty {
+                        return patterns.contains {
+                            (itemPath + "/").hasPrefix($0) || $0.hasPrefix(itemPath + "/")
+                        }
+                    }
                     return itemPath == sub || itemPath.hasPrefix("\(sub)/")
                         || patterns.contains { itemPath.hasPrefix($0) || $0.hasPrefix(itemPath + "/") }
                 }
@@ -695,11 +711,12 @@ public enum ModelHub {
                 let isInSubPath = itemPath.hasPrefix("\(sub)/")
                 let matchesPattern =
                     patterns.isEmpty || patterns.contains { itemPath.hasPrefix($0) }
+                if isBundlePath {
+                    return isInSubPath && matchesPattern
+                }
                 let isMetadata =
                     itemPath.hasSuffix(".json") || itemPath.hasSuffix(".model") || itemPath.hasSuffix(".bin")
-                let isBundleInternal =
-                    itemPath.contains(".mlmodelc/") || itemPath.contains(".mlpackage/")
-                return isInSubPath && (matchesPattern || isMetadata || isBundleInternal)
+                return isInSubPath && (matchesPattern || isMetadata)
             }
             return patterns.isEmpty || patterns.contains { itemPath.hasPrefix($0) }
                 || itemPath.hasSuffix(".json") || itemPath.hasSuffix(".txt")

--- a/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2ResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/StyleTTS2/Assets/StyleTTS2ResourceDownloader.swift
@@ -130,17 +130,21 @@ public enum StyleTTS2ResourceDownloader {
         }
 
         logger.info("Fetching StyleTTS2 bucket T=\(t) (\(missing.count) bundles)")
-        for fileName in missing {
-            do {
-                try await ModelHub.download(
-                    .styletts2,
-                    subdirectory: fileName,
-                    to: repoDir
-                )
-            } catch {
-                throw StyleTTS2Error.downloadFailed(
-                    "bucket T=\(t) bundle \(fileName) — \(error)")
-            }
+        // The "t<T>" sentinel variant scopes the repo download to the two
+        // bucket bundles; the repo download handles subPath stripping, so the
+        // bundles land directly under `repoDir` where the model store loads
+        // them. (The previous `download(subdirectory:)` call listed the
+        // bundle name at the repo *root* — the buckets live under the
+        // `iteration_3/compiled` subPath, so it fetched nothing; it went
+        // unnoticed because the bulk download used to sweep the buckets in.)
+        var modelsRoot = repoDir
+        for _ in Repo.styletts2.folderName.split(separator: "/") {
+            modelsRoot.deleteLastPathComponent()
+        }
+        do {
+            try await ModelHub.download(.styletts2, to: modelsRoot, variant: "t\(t)")
+        } catch {
+            throw StyleTTS2Error.downloadFailed("bucket T=\(t) — \(error)")
         }
     }
 

--- a/Tests/FluidAudioTests/Shared/ModelHubIncludeRuleTests.swift
+++ b/Tests/FluidAudioTests/Shared/ModelHubIncludeRuleTests.swift
@@ -3,60 +3,127 @@ import XCTest
 @testable import FluidAudio
 
 /// Unit tests for `ModelHub.repoIncludeRule` — the file/directory selection
-/// rule behind repo downloads. The regression case: for subPath repos, files
-/// inside a CoreML bundle that is not in the required-model patterns must be
-/// taken all-or-nothing. The `.json`/`.bin` metadata allowance used to sweep
-/// in such a bundle's weights and coremldata while dropping `model.mil`,
-/// producing bundles that fail MIL load (StyleTTS2 t64/t128/t256 buckets).
+/// rule behind repo downloads. For subPath repos, CoreML bundles are matched
+/// all-or-nothing against the required-model patterns:
+///
+/// - Required bundles are taken whole: the `.json`/`.bin` metadata allowance
+///   alone used to sweep in a bundle's weights and coremldata while dropping
+///   `model.mil`, producing bundles that fail MIL load (#821, StyleTTS2
+///   t64/t128/t256 buckets).
+/// - Non-required bundles are skipped whole: the `.bin` allowance used to
+///   pull every `weight.bin` inside the uncompiled `.mlpackage` published
+///   next to each compiled `.mlmodelc`, so ~half of a first-run download was
+///   never loaded (#826, parakeetEou/kokoroAne).
 final class ModelHubIncludeRuleTests: XCTestCase {
 
-    private let sub = "iteration_3/compiled"
-    private var patterns: [String] {
+    // MARK: - StyleTTS2-shaped repo (#821)
+
+    private let styleSub = "iteration_3/compiled"
+    private var stylePatterns: [String] {
         // Default styletts2 variant declares the unsized bundles only.
         ["iteration_3/compiled/bert_fp16.mlmodelc/", "iteration_3/compiled/ref_encoder_fp16.mlmodelc/"]
     }
 
-    private func include(_ path: String, isDirectory: Bool = false) -> Bool {
-        ModelHub.repoIncludeRule(subPath: sub, patterns: patterns)(path, isDirectory)
+    private func styleInclude(_ path: String, isDirectory: Bool = false) -> Bool {
+        ModelHub.repoIncludeRule(subPath: styleSub, patterns: stylePatterns)(path, isDirectory)
     }
 
-    // MARK: - CoreML bundle completeness (regression)
-
-    func testNonRequiredBundleModelMilIsIncluded() {
-        // Previously excluded (not .json/.model/.bin, bundle not in patterns).
-        XCTAssertTrue(include("iteration_3/compiled/bert_fp16_t128.mlmodelc/model.mil"))
+    func testRequiredBundleTakenWhole() {
+        XCTAssertTrue(styleInclude("iteration_3/compiled/bert_fp16.mlmodelc/model.mil"))
+        XCTAssertTrue(styleInclude("iteration_3/compiled/bert_fp16.mlmodelc/weights/weight.bin"))
+        XCTAssertTrue(styleInclude("iteration_3/compiled/bert_fp16.mlmodelc/coremldata.bin"))
+        XCTAssertTrue(styleInclude("iteration_3/compiled/bert_fp16.mlmodelc/metadata.json"))
     }
 
-    func testNonRequiredBundleWeightsAndMetadataStayIncluded() {
-        XCTAssertTrue(include("iteration_3/compiled/bert_fp16_t128.mlmodelc/weights/weight.bin"))
-        XCTAssertTrue(include("iteration_3/compiled/bert_fp16_t128.mlmodelc/coremldata.bin"))
-        XCTAssertTrue(include("iteration_3/compiled/bert_fp16_t128.mlmodelc/metadata.json"))
+    func testNonRequiredBundleSkippedWhole() {
+        // No partial bundle: the metadata allowance must not admit a
+        // non-required bundle's .json/.bin while dropping model.mil.
+        XCTAssertFalse(styleInclude("iteration_3/compiled/bert_fp16_t128.mlmodelc/model.mil"))
+        XCTAssertFalse(styleInclude("iteration_3/compiled/bert_fp16_t128.mlmodelc/weights/weight.bin"))
+        XCTAssertFalse(styleInclude("iteration_3/compiled/bert_fp16_t128.mlmodelc/coremldata.bin"))
+        XCTAssertFalse(styleInclude("iteration_3/compiled/bert_fp16_t128.mlmodelc/metadata.json"))
     }
 
-    func testMlpackageInternalFilesAreIncluded() {
-        XCTAssertTrue(
-            include("iteration_3/compiled/foo.mlpackage/Data/com.apple.CoreML/model.mlmodel"))
+    // MARK: - parakeetEou-shaped repo (#826)
+
+    private let eouSub = "320ms"
+    private var eouPatterns: [String] {
+        [
+            "320ms/streaming_encoder.mlmodelc/", "320ms/decoder.mlmodelc/",
+            "320ms/joint_decision.mlmodelc/", "320ms/vocab.json/",
+        ]
     }
 
-    // MARK: - Existing behavior unchanged
+    private func eouInclude(_ path: String, isDirectory: Bool = false) -> Bool {
+        ModelHub.repoIncludeRule(subPath: eouSub, patterns: eouPatterns)(path, isDirectory)
+    }
+
+    func testUncompiledMlpackageSiblingExcluded() {
+        // The .mlpackage copy beside each required .mlmodelc is never loaded;
+        // its weight.bin must not ride in on the .bin metadata allowance.
+        XCTAssertFalse(
+            eouInclude("320ms/streaming_encoder.mlpackage/Data/com.apple.CoreML/weights/weight.bin"))
+        XCTAssertFalse(
+            eouInclude("320ms/streaming_encoder.mlpackage/Data/com.apple.CoreML/model.mlmodel"))
+        XCTAssertFalse(eouInclude("320ms/streaming_encoder.mlpackage/Manifest.json"))
+    }
+
+    func testMlpackageDirectoryPruned() {
+        // Directory traversal skips excluded bundles instead of recursing.
+        XCTAssertFalse(eouInclude("320ms/streaming_encoder.mlpackage", isDirectory: true))
+        XCTAssertFalse(
+            eouInclude("320ms/streaming_encoder.mlpackage/Data", isDirectory: true))
+    }
+
+    func testRequiredBundleDirectoriesTraversed() {
+        XCTAssertTrue(eouInclude("320ms", isDirectory: true))
+        XCTAssertTrue(eouInclude("320ms/streaming_encoder.mlmodelc", isDirectory: true))
+        XCTAssertTrue(eouInclude("320ms/streaming_encoder.mlmodelc/weights", isDirectory: true))
+    }
 
     func testRequiredBundleFilesIncluded() {
-        XCTAssertTrue(include("iteration_3/compiled/bert_fp16.mlmodelc/model.mil"))
+        XCTAssertTrue(eouInclude("320ms/streaming_encoder.mlmodelc/model.mil"))
+        XCTAssertTrue(eouInclude("320ms/streaming_encoder.mlmodelc/weights/weight.bin"))
+    }
+
+    func testLooseMetadataAllowanceUnchanged() {
+        // Aux files outside any bundle still ride the metadata allowance
+        // (vocab.json is in patterns but with a trailing slash, so only the
+        // allowance admits it; voice packs are loose .bin files).
+        XCTAssertTrue(eouInclude("320ms/vocab.json"))
+        XCTAssertTrue(eouInclude("320ms/streaming_encoder_metadata.json"))
+        XCTAssertTrue(eouInclude("320ms/af_heart.bin"))
     }
 
     func testStrayNonBundleFileOutsideAllowancesExcluded() {
-        XCTAssertFalse(include("iteration_3/compiled/notes.txt"))
+        XCTAssertFalse(eouInclude("320ms/convert_parakeet_eou.py"))
+        XCTAssertFalse(eouInclude("320ms/.DS_Store"))
     }
 
     func testFileOutsideSubPathExcluded() {
-        XCTAssertFalse(include("iteration_1/compiled/bert_fp16.mlmodelc/model.mil"))
-        XCTAssertFalse(include("README.md"))
+        XCTAssertFalse(eouInclude("160ms/streaming_encoder.mlmodelc/model.mil"))
+        XCTAssertFalse(eouInclude("README.md"))
+        XCTAssertFalse(eouInclude("160ms", isDirectory: true))
     }
 
-    func testSubPathDirectoryTraversal() {
-        XCTAssertTrue(include("iteration_3/compiled", isDirectory: true))
-        XCTAssertTrue(include("iteration_3/compiled/bert_fp16.mlmodelc", isDirectory: true))
-        XCTAssertFalse(include("iteration_1", isDirectory: true))
+    func testNestedRequiredBundlePatternStillMatches() {
+        // Nemotron declares a nested bundle path (encoder/encoder_int8.mlmodelc).
+        let rule = ModelHub.repoIncludeRule(
+            subPath: "nemotron_coreml_2240ms",
+            patterns: ["nemotron_coreml_2240ms/encoder/encoder_int8.mlmodelc/"])
+        XCTAssertTrue(rule("nemotron_coreml_2240ms/encoder", true))
+        XCTAssertTrue(rule("nemotron_coreml_2240ms/encoder/encoder_int8.mlmodelc", true))
+        XCTAssertTrue(rule("nemotron_coreml_2240ms/encoder/encoder_int8.mlmodelc/model.mil", false))
+        XCTAssertTrue(
+            rule("nemotron_coreml_2240ms/encoder/encoder_int8.mlmodelc/weights/weight.bin", false))
+    }
+
+    func testEmptyPatternsDownloadEverythingUnderSubPath() {
+        let rule = ModelHub.repoIncludeRule(subPath: "320ms", patterns: [])
+        XCTAssertTrue(rule("320ms/streaming_encoder.mlpackage", true))
+        XCTAssertTrue(
+            rule("320ms/streaming_encoder.mlpackage/Data/com.apple.CoreML/weights/weight.bin", false))
+        XCTAssertTrue(rule("320ms/streaming_encoder.mlmodelc/model.mil", false))
     }
 
     func testNoSubPathRepoBehaviorUnchanged() {


### PR DESCRIPTION
Fixes #826.

## Problem

For every subPath repo, `ModelHub.download` pulled the uncompiled `.mlpackage` bundles published beside the compiled `.mlmodelc` ones. The `.bin`/`.json` metadata allowance admitted their weight files, and the #821 bundle-completeness fix (`isBundleInternal`) then swept in entire non-required bundles unconditionally. Nothing ever loads them, so roughly half of a first-run download was dead on arrival.

Measured against the live HuggingFace trees with the new rule:

| repo | before | after | saved |
| --- | --- | --- | --- |
| parakeet-realtime-eou-120m `320ms/` | 448 MB | 224 MB | 50% |
| kokoro-82m `ANE/` | 174 MB | 83 MB | 53% |
| cohere-transcribe `q8/` | 4.99 GB | 2.19 GB | 56% |
| StyleTTS-2 `iteration_3/compiled/` | 473 MB | 287 MB | 39% |

## Changes

**`ModelHub.repoIncludeRule`** — for subPath repos, CoreML bundle paths are now decided all-or-nothing at bundle granularity against the required-model patterns:

- Required bundles are taken whole, so the #821 partial-bundle failure ("Error in reading the MIL network" from a bundle missing `model.mil`) stays fixed.
- Non-required bundles are skipped whole — including directory traversal, so the tree lister no longer recurses into excluded bundles (fewer listing API calls).
- The loose-file metadata allowance (`vocab.json`, voice `.bin` packs, tokenizer blobs), the non-subPath branch, and `download(subdirectory:)` are unchanged.

**StyleTTS2 `ensureBucket`** — a required companion fix, not a drive-by: with the buckets no longer swept in by the bulk download, the lazy bucket fetch becomes the live path for long prompts, and it was silently broken. It listed the bundle name at the repo *root* (`tree/main/bert_fp16_t64.mlmodelc`), but the buckets live under the `iteration_3/compiled` subPath — and had the listing succeeded, files would have landed at the wrong local path anyway. It went unnoticed because the bulk download used to sweep the buckets in. It now uses the existing `"t64"`/`"t128"`/`"t256"` sentinel variants through the normal repo download, which handles subPath stripping and the post-download verify pass.

**Tests** — `ModelHubIncludeRuleTests` rewritten to pin both regressions: required-bundle completeness (#821), `.mlpackage` sibling exclusion and directory pruning (#826), the Nemotron nested-bundle pattern (`encoder/encoder_int8.mlmodelc`), empty-pattern (download-everything) behavior, loose-metadata allowance, and the untouched non-subPath branch.

## Checked for fallout

- Cohere's legacy v1 decoder (`cohere_decoder_cache_external.mlmodelc`, now excluded by default) is explicit opt-in via caller-provided dirs (`requiredModelsLegacy` / CLI `--decoder v1`); the default set has always declared v2 only.
- Old `KokoroNoise.mlmodelc` (v1) has no references; `KokoroNoise_v2` is the required one.
- LS-EEND fetches per-bundle via `download(subdirectory:)` with the full remote path — unaffected.
- Cohere's root-level `vocab.json` still arrives via the existing root-aux fallback (#649 path), which is independent of the include rule.
- Warm caches containing the old `.mlpackage` junk stay valid — cache validity is judged on required files only, so no forced re-downloads.

Sizes validated by simulating the exact include-rule logic over the recursive HF tree listings; every required bundle retains its `model.mil`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)