### PR TITLE
Exclude Parakeet benchmark documentation from target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
                 "NemoTextProcessing",
             ],
             path: "Sources/FluidAudio",
+            exclude: ["ASR/Parakeet/Unified/benchmark.md"],
             resources: [
                 // Keep .process: .copy of a Resources-named directory breaks Apple code signing on iOS.
                 .process("TTS/LuxTts/G2p/Resources")


### PR DESCRIPTION
## Summary

- exclude the generated Parakeet Unified benchmark report from the `FluidAudio` target
- prevent SwiftPM consumers from reporting `benchmark.md` as an unhandled file

## Validation

- `swift package dump-package`
- `swift build --target FluidAudio`
- confirmed the build output no longer identifies `ASR/Parakeet/Unified/benchmark.md` as unhandled

This changes only package-manifest source discovery; the benchmark document remains in the repository and is not bundled as a resource.
