### PR TITLE
fix(audio): tolerate the phantom tail of packetized formats in resampleAudioFile

### DIFF
--- a/Sources/FluidAudio/Shared/AudioConverter.swift
+++ b/Sources/FluidAudio/Shared/AudioConverter.swift
@@ -101,7 +101,23 @@ final public class AudioConverter: Sendable {
             guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: framesToRead) else {
                 throw AudioConverterError.failedToCreateBuffer
             }
-            try audioFile.read(into: buffer)
+            do {
+                try audioFile.read(into: buffer)
+            } catch {
+                // AVAudioFile.length is an ESTIMATE for packetized formats
+                // (MP3/AAC): encoder delay/padding accounting can overshoot the
+                // decodable stream by a few hundred frames, and reading the
+                // phantom tail throws a contract-breaking nilError
+                // (Foundation._GenericObjCError 0) instead of returning an
+                // empty buffer. Everything decodable is already in hand —
+                // treat a failed read after real audio as EOF rather than
+                // failing the whole file. A throw on the FIRST read is a
+                // genuinely unreadable file and still propagates.
+                if monoSamples.isEmpty {
+                    throw error
+                }
+                break
+            }
             if buffer.frameLength == 0 {
                 break
             }


### PR DESCRIPTION
AVAudioFile.length is an estimate for packetized formats (MP3/AAC): encoder delay/padding accounting can overshoot the decodable stream by a few hundred frames, and reading the phantom tail throws a contract-breaking `nilError` (`Foundation._GenericObjCError` code 0) instead of returning an empty buffer — so `resampleAudioFile` rejects a fully-decodable file over milliseconds that never existed.

**Real-world case**: a LAME 3.100 mono CBR 160 kbps MP3 declaring 2,829,064 frames whose stream ends at 2,828,736. The final chunked read throws, and the whole 64-second file fails with the meaningless `error 0`. (Web Audio decoders play the same file happily — they take the everything-decodable stance.)

**Fix**: a read failure after real audio has been decoded is treated as EOF; a throw on the *first* read still propagates, so genuinely unreadable files keep failing loudly. Verified against the reproducing file: full 64.14 s decoded, phantom 328-frame tail skipped.