### PR TITLE
fix(asr/tdt): scope applyEnglishBlocklist to French only

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV3.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV3.swift
@@ -290,7 +290,7 @@ internal struct TdtDecoderV3: Sendable {
                 vocabulary: vocabulary,
                 blankId: blankId
             )
-            if let lang = language, lang.script == .latin, lang != .english,
+            if Self.englishBlocklistApplies(to: language),
                 let ids = decision.topKIds, let logits = decision.topKLogits, let vocab = vocabulary
             {
                 Self.applyEnglishBlocklist(
@@ -377,7 +377,7 @@ internal struct TdtDecoderV3: Sendable {
                     vocabulary: vocabulary,
                     blankId: blankId
                 )
-                if let lang = language, lang.script == .latin, lang != .english,
+                if Self.englishBlocklistApplies(to: language),
                     let ids = innerDecision.topKIds, let logits = innerDecision.topKLogits,
                     let vocab = vocabulary
                 {
@@ -616,9 +616,17 @@ internal struct TdtDecoderV3: Sendable {
 
     // MARK: - Private Helper Methods
 
-    /// When the target language is a non-English Latin-script language and the
-    /// winning token is in the English-exclusive blocklist, replace it with the
-    /// highest-logit top-K token that is not in the blocklist.
+    /// The blocklist is French-only: its token list was tuned against French
+    /// prose (#630), and the same ids are core vocabulary elsewhere — Dutch
+    /// ' we'/' was', German ' so', Italian ' so' — so running it for every
+    /// non-English Latin language corrupts clean speech (#840).
+    static func englishBlocklistApplies(to language: Language?) -> Bool {
+        language == .french
+    }
+
+    /// When the target language is French and the winning token is in the
+    /// English-exclusive blocklist, replace it with the highest-logit top-K
+    /// token that is not in the blocklist.
     ///
     /// This runs AFTER `tokenLanguageFilter` (which only distinguishes
     /// Latin from Cyrillic and leaves English/French ambiguous). It targets

--- a/Tests/FluidAudioTests/ASR/Parakeet/EnglishBlocklistTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/EnglishBlocklistTests.swift
@@ -102,6 +102,22 @@ final class EnglishBlocklistTests: XCTestCase {
         XCTAssertEqual(score, expected, accuracy: 1e-5)
     }
 
+    func testBlocklistAppliesOnlyToFrench() {
+        XCTAssertTrue(TdtDecoderV3.englishBlocklistApplies(to: .french))
+
+        // #840: the French-tuned blocklist corrupts other Latin-script
+        // languages whose core vocabulary overlaps the blocked ids.
+        XCTAssertFalse(TdtDecoderV3.englishBlocklistApplies(to: .german))
+        XCTAssertFalse(TdtDecoderV3.englishBlocklistApplies(to: .dutch))
+        XCTAssertFalse(TdtDecoderV3.englishBlocklistApplies(to: .italian))
+        XCTAssertFalse(TdtDecoderV3.englishBlocklistApplies(to: .polish))
+        XCTAssertFalse(TdtDecoderV3.englishBlocklistApplies(to: .spanish))
+
+        XCTAssertFalse(TdtDecoderV3.englishBlocklistApplies(to: .english))
+        XCTAssertFalse(TdtDecoderV3.englishBlocklistApplies(to: .russian))
+        XCTAssertFalse(TdtDecoderV3.englishBlocklistApplies(to: nil))
+    }
+
     func testBlocklistContainsExpectedTokens() {
         XCTAssertTrue(TdtDecoderV3.englishBlocklistIds.contains(506))  // ' the'
         XCTAssertTrue(TdtDecoderV3.englishBlocklistIds.contains(575))  // ' and'


### PR DESCRIPTION
Fixes #840.

## Problem

`applyEnglishBlocklist` (added in #630 to reduce English drift on **French** recordings) ran for every non-English Latin-script language (`lang.script == .latin, lang != .english`). Its ~50 "English-exclusive" token ids are core vocabulary in several of those languages — Dutch ` we`/` was`, German ` so`/` her`, Italian ` so` — so passing `language:` for German, Dutch, Italian, or Polish corrupted clean speech and degraded German/English code-switching (measured across ~1,700 A/B transcriptions in the issue report).

## Fix

- Scope the blocklist to `language == .french`, the language it was tuned against.
- Extract the gate into `TdtDecoderV3.englishBlocklistApplies(to:)` so both decode-loop call sites share one testable condition.

## Testing

- New `testBlocklistAppliesOnlyToFrench` covering French (true), the languages damaged in the issue report (false), plus English/Cyrillic/nil (false).
- `swift build --target FluidAudio` clean, `swift format lint` clean.