### PR TITLE
fix(tts/kokoro-ane): keep BNNS crash advisory active on iOS 26.6+

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -68,10 +68,11 @@ public actor KokoroAneManager {
     public func initialize(preloadVoices: Set<String>? = nil) async throws {
         if Self.isBnnsCrashProneOS(ProcessInfo.processInfo.operatingSystemVersion) {
             logger.warning(
-                "This OS build (26.4–26.5.x line) has a known Apple BNNS bug that can "
+                "This OS build has a known Apple BNNS bug that can "
                     + "intermittently crash Kokoro synthesis (EXC_BAD_ACCESS in libBNNS) "
-                    + "regardless of compute-unit routing. Fixed in the 26.6 OS line. "
-                    + "See https://github.com/FluidInference/FluidAudio/issues/817")
+                    + "regardless of compute-unit routing. macOS 26.6 fixes it; on iOS "
+                    + "the 26.6 line still crashes. "
+                    + "See https://github.com/FluidInference/FluidAudio/issues/844")
         }
         try await store.loadIfNeeded()
         // English G2P CoreML assets live in the kokoro repo and are loaded
@@ -107,11 +108,22 @@ public actor KokoroAneManager {
         }
     }
 
-    /// OS builds in the 26.4–26.5.x line carry an Apple BNNS bug that can
-    /// intermittently crash synthesis in libBNNS on any compute-unit routing
-    /// (#328/#587/#667/#817); the 26.6 line fixes it.
-    static func isBnnsCrashProneOS(_ version: OperatingSystemVersion) -> Bool {
-        version.majorVersion == 26 && (4...5).contains(version.minorVersion)
+    #if os(macOS)
+    private static let runningOnMacOS = true
+    #else
+    private static let runningOnMacOS = false
+    #endif
+
+    /// The 26.4+ OS line carries an Apple BNNS bug that can intermittently
+    /// crash synthesis in libBNNS on any compute-unit routing
+    /// (#328/#587/#667/#817). macOS 26.6 fixes it (verified, #817); iOS 26.6
+    /// still crashes with the identical signature (#844), so on non-macOS the
+    /// whole 26.4+ line stays flagged until a fixed build is confirmed.
+    static func isBnnsCrashProneOS(
+        _ version: OperatingSystemVersion, onMacOS: Bool = runningOnMacOS
+    ) -> Bool {
+        guard version.majorVersion == 26, version.minorVersion >= 4 else { return false }
+        return onMacOS ? version.minorVersion <= 5 : true
     }
 
     /// `true` once the 7 mlmodelcs + vocab are resident.

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneOsAdvisoryTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneOsAdvisoryTests.swift
@@ -8,18 +8,34 @@ final class KokoroAneOsAdvisoryTests: XCTestCase {
         OperatingSystemVersion(majorVersion: major, minorVersion: minor, patchVersion: patch)
     }
 
-    func testAffectedLineIsFlagged() {
-        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 4)))
-        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 4, 2)))
-        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 5)))
-        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 5, 2)))
+    func testAffectedLineIsFlaggedOnAllPlatforms() {
+        for onMacOS in [true, false] {
+            XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 4), onMacOS: onMacOS))
+            XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 4, 2), onMacOS: onMacOS))
+            XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 5), onMacOS: onMacOS))
+            XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 5, 2), onMacOS: onMacOS))
+        }
     }
 
-    func testFixedAndUnaffectedLinesAreNotFlagged() {
-        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(26, 3, 1)))
-        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(26, 6)))
-        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(26, 7)))
-        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(27, 0)))
-        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(25, 5)))
+    func testMacOSFixedAndUnaffectedLinesAreNotFlagged() {
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(26, 3, 1), onMacOS: true))
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(26, 6), onMacOS: true))
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(26, 7), onMacOS: true))
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(27, 0), onMacOS: true))
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(25, 5), onMacOS: true))
+    }
+
+    // #844: iOS 26.6 still reproduces the libBNNS SIGSEGV that macOS 26.6
+    // fixed, so on non-macOS the whole 26.4+ line stays flagged.
+    func testIOSStaysFlaggedThrough26Line() {
+        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 6), onMacOS: false))
+        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 6, 1), onMacOS: false))
+        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(26, 7), onMacOS: false))
+    }
+
+    func testIOSUnaffectedLinesAreNotFlagged() {
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(26, 3, 1), onMacOS: false))
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(27, 0), onMacOS: false))
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(25, 5), onMacOS: false))
     }
 }


### PR DESCRIPTION
Fixes #844.

## Problem

`isBnnsCrashProneOS` flagged 26.4–26.5 on every platform, because the libBNNS fix was verified on **macOS** 26.6 when closing #817. **iOS** 26.6 still reproduces the identical `BnnsCpuInferenceOperation` SIGSEGV (iPhone 17 Pro Max / A19 Pro, main @ 00a9aa7), so iOS users on 26.6 got no advisory while still being exposed to the crash.

## Fix

Platform-split the gate:

- macOS: 26.4–26.5 flagged, clears at 26.6 (unchanged, verified in #817).
- non-macOS: the whole 26.4+ line stays flagged until a fixed build is confirmed. OS 27 is not flagged (the #843 reporter runs the BNNS CPU path on 27 without incident).

The platform arrives via an `onMacOS` parameter defaulting to a compile-time constant, so both branches are unit-testable on macOS CI. Warning text and doc comment updated to state the split.

This is the advisory gate only — the underlying crash is Apple's bug (no radar besides ours exists per #817), so accurate warning coverage is the available mitigation.

## Testing

- `KokoroAneOsAdvisoryTests` reworked: affected line flagged on both platforms, macOS clears at 26.6, iOS stays flagged through 26.x, unaffected lines clear on both.
- `swift build --target FluidAudio` clean, `swift format lint` clean.