### PR TITLE
feat(tts/kokoro-ane): expose predicted token durations

### DIFF
--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer+Types.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer+Types.swift
@@ -40,6 +40,16 @@ public struct KokoroAneSynthesisResult: Sendable {
     public let encoderTokens: Int
     /// `T_a` — acoustic frames produced by PostAlbert / Alignment.
     public let acousticFrames: Int
+    /// Token ids passed to the Kokoro chain, including BOS/EOS.
+    ///
+    /// Indices align one-to-one with ``predictedDurations``.
+    public let inputIds: [Int32]
+    /// PostAlbert `pred_dur`: acoustic-frame counts for each input token.
+    ///
+    /// Kokoro uses these exact durations to build the alignment consumed by
+    /// the downstream prosody/vocoder stages. Exposing them lets callers
+    /// derive token/word timestamps without re-aligning the synthesized audio.
+    public let predictedDurations: [Int32]
     /// Per-stage timings.
     public let timings: KokoroAneStageTimings
 
@@ -53,12 +63,16 @@ public struct KokoroAneSynthesisResult: Sendable {
         sampleRate: Int,
         encoderTokens: Int,
         acousticFrames: Int,
-        timings: KokoroAneStageTimings
+        timings: KokoroAneStageTimings,
+        inputIds: [Int32] = [],
+        predictedDurations: [Int32] = []
     ) {
         self.samples = samples
         self.sampleRate = sampleRate
         self.encoderTokens = encoderTokens
         self.acousticFrames = acousticFrames
+        self.inputIds = inputIds
+        self.predictedDurations = predictedDurations
         self.timings = timings
     }
 }

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer.swift
@@ -155,7 +155,9 @@ public struct KokoroAneSynthesizer {
             sampleRate: KokoroAneConstants.sampleRate,
             encoderTokens: tEnc,
             acousticFrames: tA,
-            timings: timings
+            timings: timings,
+            inputIds: inputIds,
+            predictedDurations: predDur
         )
     }
 

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneSynthesizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneSynthesizerTests.swift
@@ -46,6 +46,19 @@ final class KokoroAnePredictedDurationTests: XCTestCase {
     func testEmptyInput() throws {
         XCTAssertEqual(try KokoroAneSynthesizer.predictedDurations(from: []), [])
     }
+
+    func testSynthesisResultTimingMetadataDefaultsForSourceCompatibility() {
+        let result = KokoroAneSynthesisResult(
+            samples: [0],
+            sampleRate: KokoroAneConstants.sampleRate,
+            encoderTokens: 1,
+            acousticFrames: 1,
+            timings: KokoroAneStageTimings()
+        )
+
+        XCTAssertTrue(result.inputIds.isEmpty)
+        XCTAssertTrue(result.predictedDurations.isEmpty)
+    }
 }
 
 /// Heavy E2E tests gated by env var (require all 7 mlmodelc + voice + vocab
@@ -78,6 +91,15 @@ final class KokoroAneSynthesizerTests: XCTestCase {
         XCTAssertGreaterThan(result.acousticFrames, 0)
         XCTAssertLessThanOrEqual(
             result.acousticFrames, KokoroAneConstants.maxAcousticFrames)
+
+        // Duration metadata should describe exactly the token sequence and
+        // acoustic-frame count that were used by the alignment stage.
+        XCTAssertEqual(result.inputIds.count, result.encoderTokens)
+        XCTAssertEqual(result.predictedDurations.count, result.inputIds.count)
+        XCTAssertEqual(
+            result.predictedDurations.reduce(0) { $0 + Int($1) },
+            result.acousticFrames)
+        XCTAssertTrue(result.predictedDurations.allSatisfy { $0 >= 1 })
 
         // Per-stage timings should all be > 0.
         XCTAssertGreaterThan(result.timings.totalMs, 0)


### PR DESCRIPTION
## Summary

Expose KokoroAne's existing per-token PostAlbert duration predictions from `KokoroAneSynthesisResult`.

`KokoroAneSynthesizer` already computes `pred_dur`, converts it to integer acoustic-frame counts, and feeds those exact values into the Alignment stage. Today that information is discarded after synthesis, leaving callers that need synchronized text/audio to estimate timings or re-align generated speech.

This PR adds two fields to the detailed result:

- `inputIds: [Int32]` — the exact token ids passed to the chain, including BOS/EOS
- `predictedDurations: [Int32]` — the corresponding PostAlbert `pred_dur` acoustic-frame counts

The arrays align one-to-one, so callers can derive token/word timestamps using the same duration signal Kokoro itself uses for alignment.

## Why

Useful for text highlighting, karaoke-style display, accessibility readers, RSVP/speed-reading UIs, and other applications that need text to remain synchronized with synthesized audio.

This follows Kokoro's reference approach: its Python pipeline derives token/word timestamps from `pred_dur` rather than running a separate forced aligner.

## Compatibility

- No model or synthesis-path changes.
- Existing `KokoroAneSynthesisResult` initializers remain source-compatible via defaulted values for the two new fields.
- Existing audio-only APIs are unchanged.

## Tests

- Added a lightweight source-compatibility/default-metadata test.
- Extended the gated KokoroAne E2E test to assert:
  - `inputIds.count == encoderTokens`
  - `predictedDurations.count == inputIds.count`
  - `sum(predictedDurations) == acousticFrames`
  - every exposed duration is at least one frame

I could not run the macOS/CoreML test suite from the current execution environment, so the heavy E2E assertions are intentionally added to the existing `FLUIDAUDIO_RUN_KOKOROANE_E2E=1` path for CI/local Apple-hardware validation.