### PR TITLE
fix(package): exclude ASR/Parakeet/Unified/benchmark.md from the FluidAudio target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
                 "NemoTextProcessing",
             ],
             path: "Sources/FluidAudio",
+            exclude: ["ASR/Parakeet/Unified/benchmark.md"],
             resources: [
                 // Keep .process: .copy of a Resources-named directory breaks Apple code signing on iOS.
                 .process("TTS/LuxTts/G2p/Resources")


### PR DESCRIPTION
Every consumer build of FluidAudio currently prints:

```
warning: 'fluidaudio': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    Sources/FluidAudio/ASR/Parakeet/Unified/benchmark.md
```

This adds the file to the FluidAudio target's `exclude` list, the same way the CLI target already excludes its `README.md`. Verified with a clean `swift build` on macOS (Swift 6.3.3): the warning is gone and the build completes.