### PR TITLE
fix(asr): post-#804 cleanup — format CI, pointer lifetimes, shared argmax, timestamp tail

### DIFF
--- a/Sources/FluidAudio/ASR/Paraformer/ParaformerManager.swift
+++ b/Sources/FluidAudio/ASR/Paraformer/ParaformerManager.swift
@@ -135,20 +135,22 @@ public actor ParaformerManager {
         logits: MLMultiArray, tokenCount: Int, alphas: [Float], audio: [Float]
     ) -> [TimestampedSegment] {
         let upsampleRate = 3
-        let timeRate = 10.0 * 6.0 / 1000.0 / Double(upsampleRate) // 0.02 s
+        let timeRate = 10.0 * 6.0 / 1000.0 / Double(upsampleRate)  // 0.02 s
         let cifThreshold: Float = 1.0 - 1e-4
 
         // 1) Greedy decode every decoder position; ids stay 1:1 with the acoustic
-        //    fire frames. Uses Accelerate (vDSP_maxvi) + stride-correct pointer read,
-        //    matching `decode` and the SenseVoice CTC optimization.
-        let tokenIds = greedyArgmax(logits: logits, tokenCount: tokenCount)
+        //    fire frames.
+        let tokenIds = LogitsArgmax.argmaxPerFrame(logits: logits, frames: tokenCount)
 
         // 2) char_list: drop <blank>/<s>/</s> (keep ▁ if present).
         var charList: [String] = []
         for id in tokenIds {
             if id == ParaformerConfig.blankId
                 || id == ParaformerConfig.sosId
-                || id == ParaformerConfig.eosId { continue }
+                || id == ParaformerConfig.eosId
+            {
+                continue
+            }
             guard let tok = models.vocabulary[id], !tok.isEmpty else { continue }
             charList.append(tok)
         }
@@ -192,19 +194,27 @@ public actor ParaformerManager {
         let env = Self.smooth(rawEnv, window: 3)
         let floor = env.isEmpty ? 0 : Self.percentile(env, q: 0.1)
         let energyThreshold = max(floor * 2.5, 1e-4)
-        let minRun = 3 // frames (~30 ms) — reject single-frame noise spikes
+        let minRun = 3  // frames (~30 ms) — reject single-frame noise spikes
         let n = min(charList.count, centroids.count - 1)
+        // Typical inter-token spacing; bounds the final token so trailing silence
+        // (audioEnd - centroid) can't inflate its span to the end of the file.
+        let spacings = (1..<max(n, 1)).map { Float(centroids[$0] - centroids[$0 - 1]) }
+        let typicalDur = Double(spacings.isEmpty ? 0.3 : Self.percentile(spacings, q: 0.5))
         var raw: [(text: String, start: Double, end: Double)] = []
         var cursor: Double = 0.0
         for i in 0..<n {
-            let dur = (i < n - 1) ? (centroids[i + 1] - centroids[i]) : (audioEnd - centroids[i])
+            let dur =
+                (i < n - 1)
+                ? (centroids[i + 1] - centroids[i])
+                : min(audioEnd - centroids[i], max(typicalDur * 2, 0.4))
             let searchEnd = min(audioEnd, centroids[i] + dur * 1.5 + 0.15)
             let span = Self.energySpan(
                 from: cursor, to: searchEnd, centroid: centroids[i],
                 env: env, hopSec: 0.01, threshold: energyThreshold, minRun: minRun)
             let (s, e): (Double, Double)
             if let span {
-                s = span.0; e = span.1
+                s = span.0
+                e = span.1
             } else {
                 // No energy run found (very quiet token): advance by the expected
                 // duration so we don't get stuck, and keep a plausible span.
@@ -227,7 +237,8 @@ public actor ParaformerManager {
                 text = String(text.dropLast(2))
                 i += 1
                 if i < raw.count {
-                    let piece = raw[i].text.hasPrefix(ASRConstants.sentencePieceWordBoundary)
+                    let piece =
+                        raw[i].text.hasPrefix(ASRConstants.sentencePieceWordBoundary)
                         ? String(raw[i].text.dropFirst()) : raw[i].text
                     text += piece
                     end = raw[i].end
@@ -271,7 +282,10 @@ public actor ParaformerManager {
         var idx = 0
         while idx + hop <= audio.count {
             var sum: Float = 0
-            for j in 0..<hop { let s = audio[idx + j]; sum += s * s }
+            for j in 0..<hop {
+                let s = audio[idx + j]
+                sum += s * s
+            }
             env.append(sqrt(sum / Float(hop)))
             idx += hop
         }
@@ -335,7 +349,10 @@ public actor ParaformerManager {
         var bestD = abs((runs[0].0 + runs[0].1) - 2 * ci)
         for r in runs[1...] {
             let d = abs((r.0 + r.1) - 2 * ci)
-            if d < bestD { bestD = d; best = r }
+            if d < bestD {
+                bestD = d
+                best = r
+            }
         }
         return (Double(best.0) * hopSec, Double(best.1) * hopSec)
     }
@@ -430,53 +447,8 @@ public actor ParaformerManager {
         return logits
     }
 
-    /// Greedy argmax over the decoder logits `[1, L, V]` for the first `tokenCount`
-    /// positions. Returns the raw token ids (before special-token filtering).
-    ///
-    /// This mirrors the SenseVoice CTC-decode optimization: a naive Swift loop over
-    /// `tokenCount × vocab` (~1M for Paraformer) of `MLMultiArray` `NSNumber` reads is
-    /// several hundred milliseconds; `vDSP_maxvi` (SIMD) collapses it to sub-ms. The
-    /// real row `stride` is used (CoreML pads rows for ANE alignment, e.g. 8404→8408),
-    /// so it is correct for both float16 (converted via `vImage` first) and float32.
-    private func greedyArgmax(logits: MLMultiArray, tokenCount: Int) -> [Int] {
-        let vocab = logits.shape[2].intValue
-        // The frame stride may exceed `vocab` (CoreML pads rows for ANE alignment).
-        // Use the real stride and only scan `vocab` elements per row.
-        let frameStride = logits.strides[1].intValue
-        var ids: [Int] = []
-        ids.reserveCapacity(tokenCount)
-
-        func runLoop(_ p: UnsafePointer<Float>) {
-            for t in 0..<tokenCount {
-                let base = t * frameStride
-                var bestVal: Float = 0
-                var bestIdx = vDSP_Length(0)
-                vDSP_maxvi(p + base, 1, &bestVal, &bestIdx, vDSP_Length(vocab))
-                ids.append(Int(bestIdx))
-            }
-        }
-
-        if logits.dataType == .float32 {
-            runLoop(logits.dataPointer.assumingMemoryBound(to: Float32.self))
-        } else {
-            let count = tokenCount * frameStride
-            var buf = [Float](repeating: 0, count: count)
-            let src = logits.dataPointer.assumingMemoryBound(to: Float16.self)
-            var srcBuf = vImage_Buffer(
-                data: UnsafeMutableRawPointer(mutating: src),
-                height: 1, width: vImagePixelCount(count),
-                rowBytes: count * MemoryLayout<Float16>.size)
-            var dstBuf = vImage_Buffer(
-                data: &buf, height: 1, width: vImagePixelCount(count),
-                rowBytes: count * MemoryLayout<Float>.size)
-            vImageConvert_Planar16FtoPlanarF(&srcBuf, &dstBuf, 0)  // float16 → float32
-            buf.withUnsafeBufferPointer { runLoop($0.baseAddress!) }
-        }
-        return ids
-    }
-
     private func decode(logits: MLMultiArray, tokenCount: Int) -> String {
-        let ids = greedyArgmax(logits: logits, tokenCount: tokenCount)
+        let ids = LogitsArgmax.argmaxPerFrame(logits: logits, frames: tokenCount)
         var pieces: [String] = []
         for best in ids {
             if best == ParaformerConfig.blankId || best == ParaformerConfig.sosId || best == ParaformerConfig.eosId {

--- a/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceManager.swift
+++ b/Sources/FluidAudio/ASR/SenseVoice/SenseVoiceManager.swift
@@ -112,50 +112,16 @@ public actor SenseVoiceManager {
     /// Greedy CTC over the first `validFrames` (drop blank 0, collapse repeats),
     /// detokenize, then strip the `<|...|>` meta tags.
     private func decode(logits: MLMultiArray, validFrames: Int) -> String {
-        let vocab = logits.shape[2].intValue
         let frames = min(validFrames, logits.shape[1].intValue)
-        // The frame stride may exceed `vocab` (CoreML pads rows for ANE alignment,
-        // e.g. stride 25056 for a 25055-wide vocab). Use the real stride and only
-        // scan `vocab` elements per row so we never read the padding slot.
-        let frameStride = logits.strides[1].intValue
+        // Per-frame argmax via the shared vDSP helper (~0.5s -> sub-ms for the
+        // frames×vocab ~6.4M element scan), then CTC collapse (drop blank 0,
+        // collapse repeats).
         var ids: [Int] = []
         ids.reserveCapacity(frames)
         var prev = -1
-
-        // Greedy argmax per frame via Accelerate (vDSP_maxvi, SIMD). A naive Swift
-        // loop over frames×vocab (~6.4M) elements takes ~0.5s; vDSP does it in
-        // well under a millisecond, matching the model card's ~274x RTFx claim.
-        // fp16 logits are converted to float32 in a single vImage pass first.
-        func runLoop(_ p: UnsafePointer<Float>) {
-            for t in 0..<frames {
-                let base = t * frameStride
-                var bestVal: Float = 0
-                var bestIdx = vDSP_Length(0)
-                vDSP_maxvi(p + base, 1, &bestVal, &bestIdx, vDSP_Length(vocab))
-                let best = Int(bestIdx)
-                if best != SenseVoiceConfig.blankId && best != prev { ids.append(best) }
-                prev = best
-            }
-        }
-
-        if logits.dataType == .float32 {
-            runLoop(logits.dataPointer.assumingMemoryBound(to: Float32.self))
-        } else {
-            let count = frames * frameStride
-            var buf = [Float](repeating: 0, count: count)
-            let src = logits.dataPointer.assumingMemoryBound(to: Float16.self)
-            var srcBuf = vImage_Buffer(
-                data: UnsafeMutableRawPointer(mutating: src),
-                height: 1,
-                width: vImagePixelCount(count),
-                rowBytes: count * MemoryLayout<Float16>.size)
-            var dstBuf = vImage_Buffer(
-                data: &buf,
-                height: 1,
-                width: vImagePixelCount(count),
-                rowBytes: count * MemoryLayout<Float>.size)
-            vImageConvert_Planar16FtoPlanarF(&srcBuf, &dstBuf, 0)
-            buf.withUnsafeBufferPointer { runLoop($0.baseAddress!) }
+        for best in LogitsArgmax.argmaxPerFrame(logits: logits, frames: frames) {
+            if best != SenseVoiceConfig.blankId && best != prev { ids.append(best) }
+            prev = best
         }
 
         let raw = decodeCtcTokenIds(ids, vocabulary: models.vocabulary)

--- a/Sources/FluidAudio/ASR/Shared/LogitsArgmax.swift
+++ b/Sources/FluidAudio/ASR/Shared/LogitsArgmax.swift
@@ -1,0 +1,56 @@
+import Accelerate
+@preconcurrency import CoreML
+
+/// Greedy per-frame argmax over `[1, frames, vocab]` logits, shared by the
+/// SenseVoice CTC and Paraformer decoders.
+///
+/// Uses `vDSP_maxvi` (SIMD) instead of per-element `MLMultiArray` subscript
+/// reads — the boxed `NSNumber` path is several hundred ms for ~1M elements.
+/// Reads use the tensor's real row stride (CoreML pads rows for ANE alignment,
+/// e.g. 8404 -> 8408) and scan only `vocab` elements per row, so the padding
+/// slots are never consulted. fp16 logits are widened to fp32 in a single
+/// vImage pass first.
+enum LogitsArgmax {
+
+    /// Returns the argmax token id for each of the first `frames` rows.
+    static func argmaxPerFrame(logits: MLMultiArray, frames: Int) -> [Int] {
+        let vocab = logits.shape[2].intValue
+        let frameStride = logits.strides[1].intValue
+        var ids: [Int] = []
+        ids.reserveCapacity(frames)
+
+        func run(_ p: UnsafePointer<Float>) {
+            for t in 0..<frames {
+                var bestVal: Float = 0
+                var bestIdx = vDSP_Length(0)
+                vDSP_maxvi(p + t * frameStride, 1, &bestVal, &bestIdx, vDSP_Length(vocab))
+                ids.append(Int(bestIdx))
+            }
+        }
+
+        if logits.dataType == .float32 {
+            run(logits.dataPointer.assumingMemoryBound(to: Float32.self))
+        } else {
+            let count = frames * frameStride
+            let src = logits.dataPointer.assumingMemoryBound(to: Float16.self)
+            var buf = [Float](repeating: 0, count: count)
+            // The vImage buffers must not outlive the pointers they wrap, so the
+            // convert + argmax both run inside the withUnsafe scope.
+            buf.withUnsafeMutableBufferPointer { dst in
+                var srcBuf = vImage_Buffer(
+                    data: UnsafeMutableRawPointer(mutating: src),
+                    height: 1,
+                    width: vImagePixelCount(count),
+                    rowBytes: count * MemoryLayout<Float16>.size)
+                var dstBuf = vImage_Buffer(
+                    data: dst.baseAddress!,
+                    height: 1,
+                    width: vImagePixelCount(count),
+                    rowBytes: count * MemoryLayout<Float>.size)
+                vImageConvert_Planar16FtoPlanarF(&srcBuf, &dstBuf, 0)
+                run(dst.baseAddress!)
+            }
+        }
+        return ids
+    }
+}

--- a/Sources/FluidAudioCLI/Commands/ASR/ParaformerTranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/ParaformerTranscribeCommand.swift
@@ -3,21 +3,23 @@ import AVFoundation
 import FluidAudio
 import Foundation
 
-/// `paraformer-transcribe <audio> [--verbose]`
+/// `paraformer-transcribe <audio> [--int8] [--timestamps] [--verbose]`
 enum ParaformerTranscribeCommand {
     private static let logger = AppLogger(category: "ParaformerTranscribe")
 
     static func run(arguments: [String]) async {
         var audioPath: String?
         var verbose = false
+        var timestamps = false
         var precision: ParaformerPrecision = .fp16
         var i = 0
         while i < arguments.count {
             switch arguments[i] {
             case "--int8": precision = .int8
+            case "--timestamps", "-t": timestamps = true
             case "--verbose", "-v": verbose = true
             case "--help", "-h":
-                print("Usage: fluidaudio paraformer-transcribe <audio-file> [--int8] [--verbose]")
+                print("Usage: fluidaudio paraformer-transcribe <audio-file> [--int8] [--timestamps] [--verbose]")
                 return
             default: if audioPath == nil { audioPath = arguments[i] }
             }
@@ -36,9 +38,21 @@ enum ParaformerTranscribeCommand {
             logger.info("Loading Paraformer-large (zh) models (\(precision.rawValue))...")
             let manager = try await ParaformerManager.load(precision: precision)
             let start = Date()
-            let text = try await manager.transcribe(audioURL: url)
-            if verbose { logger.info("Transcribed in \(String(format: "%.2f", Date().timeIntervalSince(start)))s") }
-            print(text)
+            if timestamps {
+                let segments = try await manager.transcribeWithTimestamps(audioURL: url)
+                if verbose {
+                    logger.info("Transcribed in \(String(format: "%.2f", Date().timeIntervalSince(start)))s")
+                }
+                for s in segments {
+                    print(String(format: "[%7.2f - %7.2f] %@", s.startTime, s.endTime, s.text))
+                }
+            } else {
+                let text = try await manager.transcribe(audioURL: url)
+                if verbose {
+                    logger.info("Transcribed in \(String(format: "%.2f", Date().timeIntervalSince(start)))s")
+                }
+                print(text)
+            }
         } catch {
             logger.error("Transcription failed: \(error)")
         }

--- a/Tests/FluidAudioTests/ASR/LogitsArgmaxTests.swift
+++ b/Tests/FluidAudioTests/ASR/LogitsArgmaxTests.swift
@@ -1,0 +1,85 @@
+import CoreML
+import XCTest
+
+@testable import FluidAudio
+
+final class LogitsArgmaxTests: XCTestCase {
+
+    /// Contiguous fp32 logits: argmax per frame matches a scalar reference.
+    func testFloat32Contiguous() throws {
+        let frames = 3
+        let vocab = 5
+        let logits = try MLMultiArray(shape: [1, frames as NSNumber, vocab as NSNumber], dataType: .float32)
+        let values: [[Float]] = [
+            [0.1, 0.9, -0.3, 0.2, 0.0],
+            [-2.0, -1.0, -0.5, -3.0, -4.0],
+            [7.0, 7.0, 8.0, 8.0, 1.0],  // tie on the max: first index wins
+        ]
+        for t in 0..<frames {
+            for v in 0..<vocab { logits[[0, t as NSNumber, v as NSNumber]] = NSNumber(value: values[t][v]) }
+        }
+        XCTAssertEqual(LogitsArgmax.argmaxPerFrame(logits: logits, frames: frames), [1, 2, 2])
+    }
+
+    /// fp16 logits go through the vImage widening path.
+    func testFloat16Conversion() throws {
+        let frames = 2
+        let vocab = 4
+        let logits = try MLMultiArray(shape: [1, frames as NSNumber, vocab as NSNumber], dataType: .float16)
+        let values: [[Float]] = [
+            [0.25, -0.5, 3.0, 1.5],
+            [-1.0, -0.25, -0.75, -0.125],
+        ]
+        for t in 0..<frames {
+            for v in 0..<vocab { logits[[0, t as NSNumber, v as NSNumber]] = NSNumber(value: values[t][v]) }
+        }
+        XCTAssertEqual(LogitsArgmax.argmaxPerFrame(logits: logits, frames: frames), [2, 3])
+    }
+
+    /// Padded row stride (CoreML pads rows for ANE alignment, e.g. 8404 -> 8408):
+    /// the padding slot holds a huge value that must never be selected.
+    func testPaddedStrideIgnoresPadding() throws {
+        let frames = 3
+        let vocab = 3
+        let stride = 4  // one padding slot per row
+        var storage = [Float](repeating: 0, count: frames * stride)
+        let rows: [[Float]] = [
+            [0.5, 0.1, 0.2],
+            [-1.0, -0.2, -0.6],
+            [2.0, 9.0, 3.0],
+        ]
+        for t in 0..<frames {
+            for v in 0..<vocab { storage[t * stride + v] = rows[t][v] }
+            storage[t * stride + vocab] = 1e9  // poison the padding slot
+        }
+        let expected = [0, 1, 1]
+        try storage.withUnsafeMutableBytes { buf in
+            let logits = try MLMultiArray(
+                dataPointer: buf.baseAddress!,
+                shape: [1, frames as NSNumber, vocab as NSNumber],
+                dataType: .float32,
+                strides: [NSNumber(value: frames * stride), NSNumber(value: stride), 1])
+            XCTAssertEqual(LogitsArgmax.argmaxPerFrame(logits: logits, frames: frames), expected)
+        }
+    }
+
+    /// `frames` smaller than the tensor's frame dimension only scans that prefix.
+    func testFramePrefix() throws {
+        let logits = try MLMultiArray(shape: [1, 4, 2], dataType: .float32)
+        for t in 0..<4 {
+            logits[[0, t as NSNumber, 0]] = NSNumber(value: Float(t))
+            logits[[0, t as NSNumber, 1]] = NSNumber(value: -Float(t))
+        }
+        XCTAssertEqual(LogitsArgmax.argmaxPerFrame(logits: logits, frames: 2).count, 2)
+    }
+
+    /// All-negative logits: `vDSP_maxvi` must still pick the true maximum
+    /// (regression guard for an accumulator seeded with 0).
+    func testAllNegativeLogits() throws {
+        let logits = try MLMultiArray(shape: [1, 1, 3], dataType: .float32)
+        logits[[0, 0, 0]] = -5.0
+        logits[[0, 0, 1]] = -2.0
+        logits[[0, 0, 2]] = -9.0
+        XCTAssertEqual(LogitsArgmax.argmaxPerFrame(logits: logits, frames: 1), [1])
+    }
+}


### PR DESCRIPTION
Follow-up to #804, which merged with swift-format CI failing and a few loose ends from review.

## Changes

- **swift-format**: `ParaformerManager` had semicolons (`DoNotUseSemicolons` at 207/274/338) and over-long lines that made the repo-wide format check fail on main. Auto-formatted; `swift format --in-place` over `Sources/ Tests/` is now a no-op.
- **Shared argmax helper**: #804 added near-identical vDSP argmax code to both `SenseVoiceManager` and `ParaformerManager`. Extracted into `ASR/Shared/LogitsArgmax.argmaxPerFrame` — same `vDSP_maxvi` + single-pass fp16→fp32 vImage widening, stride-correct for CoreML's ANE row padding.
- **Pointer-lifetime fix**: both fp16 paths built a `vImage_Buffer(data: &buf, ...)` and used the stored pointer after the initializer returned (an escaped in-out pointer — works today, but UB). The convert + argmax now run inside `withUnsafeMutableBufferPointer`.
- **Timestamp tail clamp**: the final token's expected duration was `audioEnd - centroid`, so trailing silence inflated the last segment to the file end. On FLEURS `cmn_hans_cn_0366` (25.74 s, speech ends ~22.9 s) the last token spanned `23.40–25.74`; it is now bounded by 2× the median inter-centroid spacing (min 0.4 s) and emits `23.40–23.80`.
- **CLI**: `paraformer-transcribe --timestamps` prints the per-token segments, so the new API from #804 is reachable and verifiable without writing code.
- **Tests**: `LogitsArgmaxTests` covers fp32/fp16, a poisoned padded-stride tensor (the padding slot holds `1e9` and must never win), frame-prefix scanning, and all-negative logits.

## Verification

On FLEURS `cmn_hans_cn_0366` (25.74 s, M5 Pro, release):
- Transcripts byte-identical to #804 for both SenseVoice and Paraformer.
- Warm whole-process wall times unchanged: sensevoice 0.20 s, paraformer 0.26 s (vs 3.1 s / 0.50 s before #804).
- Timestamps remain monotonic and in-bounds; first-token onset (3.57 s) still matches the measured energy onset (3.67 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
