### PR TITLE
fix(tts): repair legacy Kokoro ANE caches on OS 27

### DIFF
--- a/Documentation/TTS/KokoroAne.md
+++ b/Documentation/TTS/KokoroAne.md
@@ -231,8 +231,22 @@ phrases that pull the per-corpus aggregate down to ~5.2× — see
 
 ## Known OS issues
 
-Two distinct Apple runtime bugs affect the 7-stage chain. Neither is
-input-, model-, or FluidAudio-version-gated.
+The following OS/runtime constraints affect the 7-stage chain:
+
+- **OS 27 background inference:** iOS and iPadOS 27 require the host app to
+  include the
+  [`com.apple.developer.background-tasks.continued-processing.inference`](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.developer.background-tasks.continued-processing.inference)
+  entitlement before Core ML can use the Neural Engine while the app is in the
+  background. A Swift package cannot add application entitlements; enable it
+  on the consuming app target. Foreground inference does not require it.
+- **Legacy Kokoro ANE caches on OS 27:** older compiled bundles without MIL
+  `FlexibleShapeInformation` can return invalid dynamic-shape output (including
+  NaN durations) under the E5 runtime (#738). FluidAudio now detects those
+  bundles during initialization and transactionally replaces only the affected
+  cache entries. No manual cache deletion is required; a failed download rolls
+  back to the previous bundle.
+- The two execution bugs below are handled by OS updates or FluidAudio's
+  default per-stage compute routing.
 
 | Bug | Signature | Affected OS | Status |
 |-----|-----------|-------------|--------|

--- a/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneModelCacheMigration.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneModelCacheMigration.swift
@@ -1,0 +1,169 @@
+import Foundation
+
+/// Validates and transactionally repairs legacy Kokoro ANE model caches.
+///
+/// Early copies of the seven-stage bundles could contain dynamic MIL inputs
+/// without the `FlexibleShapeInformation` function attribute. OS 26 tolerated
+/// those bundles, but the OS 27 E5 runtime can execute them with unknown shapes
+/// and return invalid values (issue #738). The current Hugging Face bundles
+/// contain the attribute; this migrator makes sure existence-only caching does
+/// not keep the older artifacts forever.
+enum KokoroAneModelCompatibility {
+    private static let flexibleShapeAttribute = Data("[FlexibleShapeInformation =".utf8)
+    private static let backupSuffix = ".pre-flexible-shape-migration"
+
+    static func milProgramHasFlexibleShapeInformation(_ data: Data) -> Bool {
+        data.range(of: flexibleShapeAttribute) != nil
+    }
+
+    static func bundleHasFlexibleShapeInformation(at bundleURL: URL) -> Bool {
+        let milURL = bundleURL.appendingPathComponent("model.mil")
+        guard let mil = try? Data(contentsOf: milURL, options: .mappedIfSafe) else {
+            return false
+        }
+        return milProgramHasFlexibleShapeInformation(mil)
+    }
+
+    static func existingBundlesRequiringMigration(
+        in repoDirectory: URL,
+        modelNames: Set<String>,
+        fileManager: FileManager = .default
+    ) -> [String] {
+        modelNames.filter { name in
+            let bundleURL = repoDirectory.appendingPathComponent(name)
+            return fileManager.fileExists(atPath: bundleURL.path)
+                && !bundleHasFlexibleShapeInformation(at: bundleURL)
+        }.sorted()
+    }
+
+    static func backupURL(for modelName: String, in repoDirectory: URL) -> URL {
+        repoDirectory.appendingPathComponent(modelName + backupSuffix)
+    }
+}
+
+/// Serializes cache migration within the process. Multiple managers may be
+/// initialized concurrently, but only one may move or replace a bundle.
+actor KokoroAneModelCacheMigrationCoordinator {
+    static let shared = KokoroAneModelCacheMigrationCoordinator()
+
+    private let logger = AppLogger(category: "KokoroAneModelCacheMigration")
+
+    func repairIfNeeded(
+        repo: Repo,
+        modelsDirectory: URL,
+        repoDirectory: URL,
+        progressHandler: ProgressHandler?
+    ) async throws {
+        let modelNames = ModelNames.KokoroAne.requiredCoreMLModels
+        try recoverInterruptedMigration(
+            in: repoDirectory, modelNames: modelNames)
+
+        let incompatible = KokoroAneModelCompatibility.existingBundlesRequiringMigration(
+            in: repoDirectory, modelNames: modelNames)
+        guard !incompatible.isEmpty else { return }
+
+        logger.warning(
+            "Replacing legacy Kokoro ANE bundles without OS 27 flexible-shape metadata: "
+                + incompatible.joined(separator: ", "))
+
+        var backedUp: [String] = []
+        do {
+            for name in incompatible {
+                let currentURL = repoDirectory.appendingPathComponent(name)
+                let backupURL = KokoroAneModelCompatibility.backupURL(
+                    for: name, in: repoDirectory)
+                try FileManager.default.moveItem(at: currentURL, to: backupURL)
+                backedUp.append(name)
+            }
+
+            try await ModelHub.download(
+                repo,
+                to: modelsDirectory,
+                progressHandler: progressHandler
+            )
+
+            let invalidReplacements = backedUp.filter { name in
+                let bundleURL = repoDirectory.appendingPathComponent(name)
+                return !KokoroAneModelCompatibility.bundleHasFlexibleShapeInformation(
+                    at: bundleURL)
+            }
+            guard invalidReplacements.isEmpty else {
+                throw KokoroAneError.downloadFailed(
+                    "Replacement bundles still lack FlexibleShapeInformation: "
+                        + invalidReplacements.joined(separator: ", "))
+            }
+
+            for name in backedUp {
+                let backupURL = KokoroAneModelCompatibility.backupURL(
+                    for: name, in: repoDirectory)
+                do {
+                    try FileManager.default.removeItem(at: backupURL)
+                } catch {
+                    logger.warning(
+                        "Could not remove Kokoro ANE migration backup at \(backupURL.path): "
+                            + error.localizedDescription)
+                }
+            }
+            logger.info("Kokoro ANE flexible-shape cache migration completed")
+        } catch {
+            rollback(backedUp, in: repoDirectory)
+            throw error
+        }
+    }
+
+    /// Restore a backup left by process termination during migration. A valid
+    /// replacement wins; otherwise the previous bundle is restored before a
+    /// fresh transactional attempt starts.
+    private func recoverInterruptedMigration(
+        in repoDirectory: URL,
+        modelNames: Set<String>
+    ) throws {
+        for name in modelNames.sorted() {
+            let currentURL = repoDirectory.appendingPathComponent(name)
+            let backupURL = KokoroAneModelCompatibility.backupURL(
+                for: name, in: repoDirectory)
+            guard FileManager.default.fileExists(atPath: backupURL.path) else {
+                continue
+            }
+
+            if KokoroAneModelCompatibility.bundleHasFlexibleShapeInformation(
+                at: currentURL)
+            {
+                do {
+                    try FileManager.default.removeItem(at: backupURL)
+                } catch {
+                    logger.warning(
+                        "Could not remove stale Kokoro ANE migration backup at \(backupURL.path): "
+                            + error.localizedDescription)
+                }
+                continue
+            }
+
+            if FileManager.default.fileExists(atPath: currentURL.path) {
+                try FileManager.default.removeItem(at: currentURL)
+            }
+            try FileManager.default.moveItem(at: backupURL, to: currentURL)
+            logger.info("Recovered interrupted Kokoro ANE cache migration for \(name)")
+        }
+    }
+
+    private func rollback(_ modelNames: [String], in repoDirectory: URL) {
+        for name in modelNames.reversed() {
+            let currentURL = repoDirectory.appendingPathComponent(name)
+            let backupURL = KokoroAneModelCompatibility.backupURL(
+                for: name, in: repoDirectory)
+            do {
+                if FileManager.default.fileExists(atPath: currentURL.path) {
+                    try FileManager.default.removeItem(at: currentURL)
+                }
+                if FileManager.default.fileExists(atPath: backupURL.path) {
+                    try FileManager.default.moveItem(at: backupURL, to: currentURL)
+                }
+            } catch {
+                logger.error(
+                    "Failed to roll back Kokoro ANE cache migration for \(name): "
+                        + error.localizedDescription)
+            }
+        }
+    }
+}

--- a/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
@@ -32,6 +32,18 @@ public enum KokoroAneResourceDownloader {
         case .japanese:
             required = ModelNames.KokoroAne.requiredModelsJa
         }
+
+        // ModelHub deliberately skips existing files. Repair legacy compiled
+        // bundles before the existence-only fast path so caches created before
+        // the flexible-shape models were published do not remain broken on the
+        // OS 27 E5 runtime forever (#738).
+        try await KokoroAneModelCacheMigrationCoordinator.shared.repairIfNeeded(
+            repo: repo,
+            modelsDirectory: modelsDirectory,
+            repoDirectory: repoDir,
+            progressHandler: progressHandler
+        )
+
         let allPresent = required.allSatisfy { name in
             FileManager.default.fileExists(atPath: repoDir.appendingPathComponent(name).path)
         }

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneModelCompatibilityTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneModelCompatibilityTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+final class KokoroAneModelCompatibilityTests: XCTestCase {
+
+    func testRecognizesFlexibleShapeInformationOnDynamicMilFunction() {
+        // Exact structure emitted by the current Core ML compiler for the
+        // published KokoroPostAlbert bundle, reduced to the function header.
+        let mil = Data(
+            """
+            program(1.0) {
+                func main<ios17>(tensor<int32, [1, ?]> input_ids)
+                    [FlexibleShapeInformation = tuple<tuple<tensor<string, []>>>()] {
+                }
+            }
+            """.utf8)
+
+        XCTAssertTrue(
+            KokoroAneModelCompatibility.milProgramHasFlexibleShapeInformation(mil))
+    }
+
+    func testRejectsLegacyDynamicMilFunctionWithoutFlexibleShapeInformation() {
+        // This is the model shape that produces the E5 warning in #738: the
+        // external input is dynamic, but the function has no shape attribute.
+        let legacyMil = Data(
+            """
+            program(1.0) {
+                func main<ios17>(tensor<int32, [1, ?]> input_ids) {
+                }
+            }
+            """.utf8)
+
+        XCTAssertFalse(
+            KokoroAneModelCompatibility.milProgramHasFlexibleShapeInformation(
+                legacyMil))
+    }
+
+    func testRejectsEmptyMilProgram() {
+        XCTAssertFalse(
+            KokoroAneModelCompatibility.milProgramHasFlexibleShapeInformation(Data()))
+    }
+}

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneSynthesizerTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneSynthesizerTests.swift
@@ -69,6 +69,23 @@ final class KokoroAneSynthesizerTests: XCTestCase {
         ProcessInfo.processInfo.environment["FLUIDAUDIO_RUN_KOKOROANE_E2E"] == "1"
     }
 
+    func testPublishedBundlesContainFlexibleShapeInformation() async throws {
+        try XCTSkipUnless(
+            shouldRunHeavy,
+            "Set FLUIDAUDIO_RUN_KOKOROANE_E2E=1 to validate the real Kokoro-ANE models."
+        )
+
+        let repoDirectory = try await KokoroAneResourceDownloader.ensureModels()
+        let incompatible = KokoroAneModelCompatibility.existingBundlesRequiringMigration(
+            in: repoDirectory,
+            modelNames: ModelNames.KokoroAne.requiredCoreMLModels)
+
+        XCTAssertEqual(
+            incompatible,
+            [],
+            "Published Kokoro ANE bundles must expose FlexibleShapeInformation to OS 27")
+    }
+
     func testSynthesizeShortPhrase() async throws {
         try XCTSkipUnless(
             shouldRunHeavy,


### PR DESCRIPTION
## Summary

- validate the seven cached Kokoro ANE `model.mil` programs before the existence-only download fast path
- transactionally replace only legacy bundles missing `FlexibleShapeInformation`, with rollback and interrupted-migration recovery
- add marker-level unit coverage plus an opt-in check against the real published bundles
- document the OS 27 background-inference entitlement that must be set by the host app

## Root cause

OS 27's E5 Core ML runtime no longer accepts dynamic external inputs when the compiled MIL function lacks flexible-shape metadata. The current Hugging Face bundles contain that metadata, but `ModelHub` correctly preserves existing files, so a legacy same-named cache can survive upgrades indefinitely and return invalid output such as NaN durations.

## Validation

- `swift format lint --configuration .swift-format ...`
- `swift build --sdk /Library/Developer/CommandLineTools/SDKs/MacOSX15.4.sdk`
- real-model smoke test: all seven published bundles loaded and synthesized a 2.925 s, 24 kHz mono WAV
- verified every current required bundle contains the `FlexibleShapeInformation` function attribute

The XCTest target could not run on this machine because only Command Line Tools are installed and its SDK does not provide an importable `XCTest` module. CI should exercise the added unit tests. OS 27 device validation is still requested before marking this ready.

Fixes #738