### PR TITLE
fix(asr/streaming): re-decode final window from frame 0 — stops #855 trailing-word loss

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -52,6 +52,34 @@ extension AsrManager {
         return result
     }
 
+    /// Cross-window emission jitter allowance for the final-window re-decode: a
+    /// re-decoded token can land a few frames from its original emission, so the
+    /// suppression cutoff backs off this much and dedup strips what remains.
+    internal static let redecodeEmissionJitterFrames = 5
+
+    /// Decoder-entry plan for the final streaming window (issue #855).
+    ///
+    /// Returns `initialTimeIndexOverride: 0` so the decoder re-decodes the window
+    /// from frame 0 with its carried state (a mid-window entry into a short flush
+    /// window can blank out the trailing speech), plus an emission cutoff in
+    /// window-local frames: tokens for audio the previous windows already emitted
+    /// are suppressed at the source, leaving dedup only the jitter margin.
+    /// Non-final windows and callers without accumulated timestamps get `(nil, nil)`
+    /// — the legacy navigation.
+    nonisolated internal static func lastChunkRedecodePlan(
+        isLastChunk: Bool,
+        previousTokens: [Int],
+        previousTokenTimestamps: [Int]?,
+        globalFrameOffset: Int
+    ) -> (initialTimeIndexOverride: Int?, emitTokensAfterFrame: Int?) {
+        guard isLastChunk, let previousTimestamps = previousTokenTimestamps, !previousTokens.isEmpty else {
+            return (nil, nil)
+        }
+        let lastEmittedGlobalFrame = previousTimestamps.max() ?? 0
+        let cutoff = max(0, lastEmittedGlobalFrame - globalFrameOffset - redecodeEmissionJitterFrames)
+        return (0, cutoff)
+    }
+
     /// Chunk transcription that preserves decoder state between calls.
     /// Used by SlidingWindowAsrManager for overlapping-window processing with token deduplication.
     func transcribeChunk(
@@ -70,9 +98,16 @@ extension AsrManager {
         // Jumping mid-window into a short flush window can blank out the trailing
         // speech entirely (issue #855: the joint emits a boundary punctuation, then
         // blanks to the end, dropping the final words). Re-decoding the overlap with
-        // the carried state is robust, and the temporally-gated dedup below strips
-        // the re-decoded tokens (they land within a few frames of the originals).
-        let redecodeFromWindowStart = isLastChunk && previousTokenTimestamps != nil && !previousTokens.isEmpty
+        // the carried state is robust; emissions for audio the previous windows
+        // already covered are suppressed at the source (the decoder still updates
+        // its LSTM state through them), so dedup only sees the few-frame jitter
+        // margin — a token-dense overlap cannot outgrow dedup's bounded search.
+        let redecodePlan = Self.lastChunkRedecodePlan(
+            isLastChunk: isLastChunk,
+            previousTokens: previousTokens,
+            previousTokenTimestamps: previousTokenTimestamps,
+            globalFrameOffset: globalFrameOffset
+        )
         let (hypothesis, encLen) = try await executeMLInferenceWithTimings(
             padded,
             originalLength: frameAlignedLength,
@@ -81,7 +116,8 @@ extension AsrManager {
             contextFrameAdjustment: 0,  // Non-streaming chunks don't use adaptive context
             isLastChunk: isLastChunk,
             language: language,
-            initialTimeIndexOverride: redecodeFromWindowStart ? 0 : nil
+            emitTokensAfterGlobalFrame: redecodePlan.emitTokensAfterFrame,
+            initialTimeIndexOverride: redecodePlan.initialTimeIndexOverride
         )
 
         // Apply token deduplication if previous tokens are provided

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -66,6 +66,13 @@ extension AsrManager {
         let (alignedSamples, frameAlignedLength) = frameAlignedAudio(
             chunkSamples, allowAlignment: previousTokens.isEmpty)
         let padded = padAudioIfNeeded(alignedSamples, targetLength: ASRConstants.maxModelSamples)
+        // Last streaming window: decode from frame 0 instead of skipping the overlap.
+        // Jumping mid-window into a short flush window can blank out the trailing
+        // speech entirely (issue #855: the joint emits a boundary punctuation, then
+        // blanks to the end, dropping the final words). Re-decoding the overlap with
+        // the carried state is robust, and the temporally-gated dedup below strips
+        // the re-decoded tokens (they land within a few frames of the originals).
+        let redecodeFromWindowStart = isLastChunk && previousTokenTimestamps != nil && !previousTokens.isEmpty
         let (hypothesis, encLen) = try await executeMLInferenceWithTimings(
             padded,
             originalLength: frameAlignedLength,
@@ -73,7 +80,8 @@ extension AsrManager {
             decoderState: &decoderState,
             contextFrameAdjustment: 0,  // Non-streaming chunks don't use adaptive context
             isLastChunk: isLastChunk,
-            language: language
+            language: language,
+            initialTimeIndexOverride: redecodeFromWindowStart ? 0 : nil
         )
 
         // Apply token deduplication if previous tokens are provided

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
@@ -300,7 +300,9 @@ public actor AsrManager {
                 decoderState: &decoderState,
                 contextFrameAdjustment: contextFrameAdjustment,
                 isLastChunk: isLastChunk,
-                globalFrameOffset: globalFrameOffset
+                globalFrameOffset: globalFrameOffset,
+                emitTokensAfterGlobalFrame: emitTokensAfterGlobalFrame,
+                initialTimeIndexOverride: initialTimeIndexOverride
             )
         case .v3:
             // Pass `vocabulary` unconditionally. `TdtDecoderV3.tokenLanguageFilter`

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV2.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV2.swift
@@ -18,7 +18,9 @@ internal struct TdtDecoderV2 {
         decoderState: inout TdtDecoderState,
         contextFrameAdjustment: Int = 0,
         isLastChunk: Bool = false,
-        globalFrameOffset: Int = 0
+        globalFrameOffset: Int = 0,
+        emitTokensAfterGlobalFrame: Int? = nil,
+        initialTimeIndexOverride: Int? = nil
     ) async throws -> TdtHypothesis {
         let decoder = TdtDecoderV3(config: config)
         return try await decoder.decodeWithTimings(
@@ -30,7 +32,9 @@ internal struct TdtDecoderV2 {
             decoderState: &decoderState,
             contextFrameAdjustment: contextFrameAdjustment,
             isLastChunk: isLastChunk,
-            globalFrameOffset: globalFrameOffset
+            globalFrameOffset: globalFrameOffset,
+            emitTokensAfterGlobalFrame: emitTokensAfterGlobalFrame,
+            initialTimeIndexOverride: initialTimeIndexOverride
         )
     }
 

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -373,4 +373,54 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - Issue #855: last-window overlap re-decode must be stripped
+
+    /// Captured from the issue #855 repro (repetitive speech, final flush window
+    /// re-decoded from frame 0): the previous tail ends "...would go for where we
+    /// would." and the re-decode repeats that run 1-3 frames later before the new
+    /// words (" remove filler words."). The temporally-gated dedup must strip the
+    /// re-decoded overlap (including the partial leading token) and keep the new
+    /// trailing words.
+    func testDedup_855_LastWindowRedecodeStripped() {
+        let asrManager = AsrManager()
+        let previous = [
+            4223, 6882, 317, 910, 3463, 6314, 1316, 7950, 283, 7877, 1974, 4223, 1455, 509, 6843, 750, 4223, 7883,
+        ]
+        let previousTs = [100, 103, 105, 106, 108, 111, 113, 115, 117, 120, 122, 124, 126, 128, 130, 131, 134, 137]
+        // 5831 is a partial word at the window edge; 4223...4223 re-decodes the
+        // previous tail; 4942... are the genuinely new trailing words.
+        let current = [5831, 4223, 1455, 509, 6843, 750, 4223, 4942, 1337, 309, 6312, 4128, 7870, 7883]
+        let currentTs = [122, 125, 127, 130, 133, 135, 137, 139, 141, 144, 146, 150, 152, 154]
+
+        let (deduped, removed) = asrManager.removeDuplicateTokenSequence(
+            previous: previous,
+            current: current,
+            previousTimestamps: previousTs,
+            currentTimestamps: currentTs
+        )
+        XCTAssertEqual(
+            deduped, [4942, 1337, 309, 6312, 4128, 7870, 7883],
+            "Re-decoded overlap must be stripped; trailing words must survive")
+        XCTAssertEqual(removed, 7)
+    }
+
+    /// Same trace with the timestamps 10s apart: the identical token runs are then
+    /// genuine repetition, not a seam duplicate, and must be kept (gate holds).
+    func testDedup_855_FarApartRepetitionKept() {
+        let asrManager = AsrManager()
+        let previous = [1974, 4223, 1455, 509, 6843, 750, 4223]
+        let previousTs = [10, 12, 14, 16, 18, 20, 22]
+        let current = [1974, 4223, 1455, 509, 6843, 750, 4223, 4942]
+        let currentTs = [145, 147, 149, 151, 153, 155, 157, 159]
+
+        let (deduped, removed) = asrManager.removeDuplicateTokenSequence(
+            previous: previous,
+            current: current,
+            previousTimestamps: previousTs,
+            currentTimestamps: currentTs
+        )
+        XCTAssertEqual(deduped, current, "Repetition ~10s later is not a seam duplicate")
+        XCTAssertEqual(removed, 0)
+    }
 }

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -423,4 +423,61 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertEqual(deduped, current, "Repetition ~10s later is not a seam duplicate")
         XCTAssertEqual(removed, 0)
     }
+
+    // MARK: - Issue #855: final-window re-decode plan (decoder-entry behavior)
+
+    /// The plan drives the production decoder entry: frame-0 re-decode plus an
+    /// emission cutoff. Removing the production change removes this helper, so
+    /// these tests are coupled to the fix itself, not just to dedup.
+    func testRedecodePlan_LastStreamingChunk() {
+        let plan = AsrManager.lastChunkRedecodePlan(
+            isLastChunk: true,
+            previousTokens: [1, 2, 3],
+            previousTokenTimestamps: [130, 134, 137],
+            globalFrameOffset: 112
+        )
+        XCTAssertEqual(plan.initialTimeIndexOverride, 0, "Final window must re-decode from frame 0")
+        XCTAssertEqual(
+            plan.emitTokensAfterFrame,
+            137 - 112 - AsrManager.redecodeEmissionJitterFrames,
+            "Cutoff = last emitted frame in window-local space minus the jitter margin")
+    }
+
+    func testRedecodePlan_CutoffClampedToZero() {
+        let plan = AsrManager.lastChunkRedecodePlan(
+            isLastChunk: true,
+            previousTokens: [1],
+            previousTokenTimestamps: [3],
+            globalFrameOffset: 112
+        )
+        XCTAssertEqual(plan.initialTimeIndexOverride, 0)
+        XCTAssertEqual(plan.emitTokensAfterFrame, 0, "Cutoff before the window start suppresses nothing")
+    }
+
+    func testRedecodePlan_InactiveOutsideFinalStreamingWindow() {
+        let interior = AsrManager.lastChunkRedecodePlan(
+            isLastChunk: false,
+            previousTokens: [1, 2],
+            previousTokenTimestamps: [10, 20],
+            globalFrameOffset: 0
+        )
+        XCTAssertNil(interior.initialTimeIndexOverride)
+        XCTAssertNil(interior.emitTokensAfterFrame)
+
+        let noTimestamps = AsrManager.lastChunkRedecodePlan(
+            isLastChunk: true,
+            previousTokens: [1, 2],
+            previousTokenTimestamps: nil,
+            globalFrameOffset: 0
+        )
+        XCTAssertNil(noTimestamps.initialTimeIndexOverride, "Batch callers (no timestamps) keep legacy navigation")
+
+        let firstWindow = AsrManager.lastChunkRedecodePlan(
+            isLastChunk: true,
+            previousTokens: [],
+            previousTokenTimestamps: [],
+            globalFrameOffset: 0
+        )
+        XCTAssertNil(firstWindow.initialTimeIndexOverride, "Single-window streams have nothing to re-decode")
+    }
 }


### PR DESCRIPTION
Addresses the trailing-word loss from #855 (repro 1).

## Root cause

Repro 1 was reproduced locally from the issue text with macOS TTS. Streaming deterministically dropped `"remove filler words."` while batch transcription retained it.

Tracing showed that the temporal deduplication gate was not the direct cause: the final window's hypothesis reached deduplication nearly empty. The failure occurs when entering the decoder for the short final flush window:

- The window contains left context plus the remaining audio (about 44 encoder frames in the repro).
- When `timeJump == 0`, the normal continuation path skips the standard two-second overlap and starts at frame 25.
- Entering that short window mid-stream with the carried LSTM state emits boundary punctuation and then blanks through the remaining frames, dropping clear trailing speech.
- Decoding the same window from frame 0 produces the missing lexical tokens.

## Exact WAV reproduction

No API key or external TTS service is required. This command uses macOS TTS and writes 16-bit little-endian PCM at 16 kHz; the `.wav` extension selects the WAVE container:

```bash
say -o /tmp/repro855.wav --data-format=LEI16@16000 "This would go for self correction, this would go for building lists, this would go for places where we would want paragraphs. This would go for where we would make grammatical fixes. This would go for where we would remove filler words."
```

The generated file was verified with `afinfo /tmp/repro855.wav`:

```text
File type ID:   WAVE
Data format:    1 ch, 16000 Hz, Int16
Duration:       12.485250 s
```

For the verification run documented below, the artifact was 403,624 bytes with SHA-256:

```text
b0ec1e67653b6432bce96eaea0362676cd6cc5cf4f09210e70e680745ec73fb6
```

The command does not specify `-v`, so it uses the configured default macOS voice. The container and PCM properties are fixed, but duration and bytes can vary with the installed/default voice and OS version.

Using the same WAV for every run:

```bash
swift run -c release fluidaudiocli transcribe /tmp/repro855.wav --streaming --model-version v3
swift run -c release fluidaudiocli transcribe /tmp/repro855.wav --model-version v3
```

Observed transcript tails:

| Revision/mode | Result |
|---|---|
| Unfixed PR base `df1417ce`, streaming | `…this would go for where we would.` — dropped `remove filler words.` |
| Fixed head `2a522d9b`, streaming | `…this would go for where we would. remove filler words.` — lexical tail restored |
| Fixed head `2a522d9b`, batch reference | `…this would go for where we would remove filler words.` |

The extra sentence-final period in the fixed streaming result is the known cosmetic boundary behavior described below.

## Fix

For the final streaming window with accumulated tokens and timestamps, `lastChunkRedecodePlan` now:

1. Sets `initialTimeIndexOverride: 0` so decoding starts at the beginning of the window.
2. Derives a window-local emission cutoff from the latest accumulated token timestamp.
3. Backs the cutoff up by five frames to allow for cross-window emission jitter.

The decoder still processes the suppressed overlap and updates its LSTM state, but it does not append tokens for audio already covered by previous windows. Temporally gated deduplication therefore handles only the small jitter margin plus genuinely new trailing content, rather than the entire re-decoded overlap. This also prevents token-dense overlaps from exceeding the deduplicator's bounded search window.

The override and emission cutoff are forwarded through all supported decoder routes, including Parakeet v2 and TDT-CTC 110m as well as v3 and tdtJa.

Batch `ChunkProcessor`, interior streaming windows, and single-window streams without accumulated history keep their existing navigation.

## Verification

Verified on an M5 Pro using a release build:

| Clip | Before | After |
|---|---|---|
| #855 macOS TTS WAV | Trailing `"remove filler words"` dropped | Restored, 3/3 stable |
| 26-second multi-window clip | — | All content present |
| FLEURS `en_us_0000` | — | Batch and streaming byte-identical |
| Two voice variants | One clean; one split-word artifact | Clean / content-complete |

The manual audio verification used Parakeet TDT v3. The v2/110m forwarding is covered by the shared decoder route in this change.

## Tests

- Captured #855 trace: strips the re-decoded overlap, including its partial leading token, while retaining the trailing words.
- Timestamp inverse: keeps an identical token run when the occurrences are about ten seconds apart.
- Final-window decoder-entry plan: verifies the frame-0 override and emission-cutoff arithmetic.
- Cutoff clamping and inactive cases: verifies legacy navigation for interior windows, callers without timestamps, and first/single windows.

## Known remaining behavior

- Repro 2 from #855 (a phantom phrase at an interior seam) is not directly addressed because the reporter's private clip is required for verification.
- A truncated window can still emit sentence-final punctuation at its boundary, producing cosmetic output such as `"…we would. remove filler words."`. This pre-existing behavior is intentionally not trimmed heuristically because timestamp-based trimming can remove real words.
