### PR TITLE
feat(asr/unified): vocabulary boosting on the unified Parakeet path

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyBoostingSession.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyBoostingSession.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// Vocabulary-boosting pipeline shared by the ASR engines: CTC keyword
+/// spotting over the audio plus constrained rescoring of the transcript.
+///
+/// The CTC pass runs a separate CTC model (e.g. parakeet-ctc-110m) on the raw
+/// audio, so the session is independent of which primary model produced the
+/// transcript — any engine that can supply its transcript, token timings, and
+/// the audio behind them can use it (SlidingWindow TDT, Unified batch,
+/// Unified streaming).
+public struct VocabularyBoostingSession: Sendable {
+    private let logger = AppLogger(category: "VocabBoosting")
+
+    public let vocabulary: CustomVocabularyContext
+    let spotter: CtcKeywordSpotter
+    let rescorer: VocabularyRescorer
+    let vocabSizeConfig: ContextBiasingConstants.VocabSizeConfig
+
+    /// Recommended rescorer config for engines whose output text is
+    /// inverse-text-normalized (parakeet-unified writes "11.4 billion" and
+    /// "35.3%"). ITN packs a multi-second spoken number into one or two
+    /// written words, so short word spans cover long acoustic stretches and
+    /// become eligible for the spotter-anchored rescue pass at garbage
+    /// spotter scores ('yen, down by 35.3%' → term at sim 0.20). The #702
+    /// similarity floors close exactly that hole; spelled-out engines
+    /// (SlidingWindow TDT) keep `.default`, where the rescue recovers brand
+    /// names the model mangles past the similarity gate.
+    public static let itnDefaultConfig = VocabularyRescorer.Config(
+        spotterRescueMinSimilarity: 0.30,
+        spotterRescueMultiWordMinSimilarity: 0.50
+    )
+
+    /// Create a session from a tokenized vocabulary and pre-loaded CTC models.
+    ///
+    /// - Parameters:
+    ///   - vocabulary: Custom vocabulary context with terms to detect. Terms
+    ///     must carry `ctcTokenIds` (e.g. via
+    ///     `CustomVocabularyContext.loadWithCtcTokens(from:ctcVariant:)`).
+    ///   - ctcModels: Pre-loaded CTC models for keyword spotting
+    ///   - config: Optional rescorer configuration (default: `.default`)
+    /// - Throws: Error if rescorer initialization fails
+    public init(
+        vocabulary: CustomVocabularyContext,
+        ctcModels: CtcModels,
+        config: VocabularyRescorer.Config? = nil
+    ) async throws {
+        self.vocabulary = vocabulary
+
+        let blankId = ctcModels.vocabulary.count
+        let spotter = CtcKeywordSpotter(models: ctcModels, blankId: blankId)
+        self.spotter = spotter
+
+        self.vocabSizeConfig = ContextBiasingConstants.rescorerConfig(
+            forVocabSize: vocabulary.terms.count)
+
+        let ctcModelDir = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
+        self.rescorer = try await VocabularyRescorer.create(
+            spotter: spotter,
+            vocabulary: vocabulary,
+            config: config ?? .default,
+            ctcModelDirectory: ctcModelDir
+        )
+    }
+
+    /// Rescore a transcript against CTC acoustic evidence from its audio.
+    ///
+    /// `tokenTimings` must be on the same clock as `audioSamples`: time zero
+    /// is the first sample. Callers rescoring a window or segment out of a
+    /// longer stream pass segment-local timings with the segment's audio.
+    ///
+    /// - Returns: The rescore output if any replacement was applied,
+    ///   nil otherwise (including on CTC inference failure, which is logged
+    ///   and absorbed — boosting must never break transcription).
+    public func rescore(
+        text: String,
+        tokenTimings: [TokenTiming],
+        audioSamples: [Float]
+    ) async -> VocabularyRescorer.RescoreOutput? {
+        guard !tokenTimings.isEmpty, !audioSamples.isEmpty else { return nil }
+
+        do {
+            let spotResult = try await spotter.spotKeywordsWithLogProbs(
+                audioSamples: audioSamples,
+                customVocabulary: vocabulary,
+                minScore: nil
+            )
+
+            let logProbs = spotResult.logProbs
+            guard !logProbs.isEmpty else {
+                logger.debug("Vocabulary rescoring skipped: no log probs from CTC")
+                return nil
+            }
+
+            // Vocabulary-size-aware thresholds, respecting the caller-specified
+            // threshold when stricter.
+            let minSimilarity = max(vocabSizeConfig.minSimilarity, vocabulary.minSimilarity)
+
+            let rescoreOutput = rescorer.ctcTokenRescore(
+                transcript: text,
+                tokenTimings: tokenTimings,
+                logProbs: logProbs,
+                frameDuration: spotResult.frameDuration,
+                cbw: vocabSizeConfig.cbw,
+                marginSeconds: 0.5,
+                minSimilarity: minSimilarity
+            )
+
+            guard rescoreOutput.wasModified else { return nil }
+
+            logger.info(
+                "Vocabulary rescoring applied \(rescoreOutput.replacements.count) replacement(s)"
+            )
+            for replacement in rescoreOutput.replacements where replacement.shouldReplace {
+                logger.debug(
+                    "  '\(replacement.originalWord)' → '\(replacement.replacementWord ?? "")'"
+                )
+            }
+            return rescoreOutput
+        } catch {
+            logger.warning("Vocabulary rescoring failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -60,12 +60,9 @@ public actor SlidingWindowAsrManager {
     private var lastWindowError: SlidingWindowAsrError?
 
     // Vocabulary boosting
-    // These are initialized via configureVocabularyBoosting() before start()
-    private var customVocabulary: CustomVocabularyContext?
-    private var ctcSpotter: CtcKeywordSpotter?
-    private var vocabularyRescorer: VocabularyRescorer?
-    private var vocabSizeConfig: ContextBiasingConstants.VocabSizeConfig?
-    private var vocabBoostingEnabled: Bool { customVocabulary != nil && vocabularyRescorer != nil }
+    // Initialized via configureVocabularyBoosting() before start()
+    private var vocabularyBoosting: VocabularyBoostingSession?
+    private var vocabBoostingEnabled: Bool { vocabularyBoosting != nil }
 
     /// Initialize the sliding-window ASR manager
     /// - Parameter config: Configuration for streaming behavior
@@ -97,27 +94,11 @@ public actor SlidingWindowAsrManager {
         ctcModels: CtcModels,
         config: VocabularyRescorer.Config? = nil
     ) async throws {
-        self.customVocabulary = vocabulary
-
-        // Create CTC spotter
-        let blankId = ctcModels.vocabulary.count
-        self.ctcSpotter = CtcKeywordSpotter(models: ctcModels, blankId: blankId)
-
-        // Use vocabulary-size-aware config (matching batch mode behavior)
-        let vocabSize = vocabulary.terms.count
-        let vocabConfig = ContextBiasingConstants.rescorerConfig(forVocabSize: vocabSize)
-        self.vocabSizeConfig = vocabConfig
-        let effectiveConfig = config ?? .default
-
-        // Create rescorer
-        let ctcModelDir = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
-        self.vocabularyRescorer = try await VocabularyRescorer.create(
-            spotter: ctcSpotter!,
-            vocabulary: vocabulary,
-            config: effectiveConfig,
-            ctcModelDirectory: ctcModelDir
+        self.vocabularyBoosting = try await VocabularyBoostingSession(
+            vocabulary: vocabulary, ctcModels: ctcModels, config: config
         )
 
+        let vocabSize = vocabulary.terms.count
         let isLargeVocab = vocabSize > ContextBiasingConstants.largeVocabThreshold
         logger.info(
             "Vocabulary boosting configured with \(vocabSize) terms (isLargeVocab: \(isLargeVocab))"
@@ -611,62 +592,10 @@ public actor SlidingWindowAsrManager {
         tokenTimings: [TokenTiming],
         windowSamples: [Float]
     ) async -> VocabularyRescorer.RescoreOutput? {
-        guard let spotter = ctcSpotter,
-            let rescorer = vocabularyRescorer,
-            let vocab = customVocabulary,
-            !tokenTimings.isEmpty
-        else {
-            return nil
-        }
-
-        do {
-            // Run CTC inference on the chunk audio to get log probabilities
-            let spotResult = try await spotter.spotKeywordsWithLogProbs(
-                audioSamples: windowSamples,
-                customVocabulary: vocab,
-                minScore: nil
-            )
-
-            let logProbs = spotResult.logProbs
-            guard !logProbs.isEmpty else {
-                logger.debug("Vocabulary rescoring skipped: no log probs from CTC")
-                return nil
-            }
-
-            // Determine rescoring parameters based on vocabulary size,
-            // but respect the caller-specified threshold when stricter.
-            let vocabConfig = vocabSizeConfig ?? ContextBiasingConstants.rescorerConfig(forVocabSize: 0)
-            let minSimilarity = max(vocabConfig.minSimilarity, vocab.minSimilarity)
-            let cbw = vocabConfig.cbw
-
-            // Apply constrained CTC rescoring
-            let rescoreOutput = rescorer.ctcTokenRescore(
-                transcript: text,
-                tokenTimings: tokenTimings,
-                logProbs: logProbs,
-                frameDuration: spotResult.frameDuration,
-                cbw: cbw,
-                marginSeconds: 0.5,
-                minSimilarity: minSimilarity
-            )
-
-            if rescoreOutput.wasModified {
-                logger.info(
-                    "Vocabulary rescoring applied \(rescoreOutput.replacements.count) replacement(s) in streaming chunk"
-                )
-                for replacement in rescoreOutput.replacements where replacement.shouldReplace {
-                    logger.debug(
-                        "  '\(replacement.originalWord)' → '\(replacement.replacementWord ?? "")'"
-                    )
-                }
-                return rescoreOutput
-            }
-
-            return nil
-        } catch {
-            logger.warning("Vocabulary rescoring failed: \(error.localizedDescription)")
-            return nil
-        }
+        guard let boosting = vocabularyBoosting else { return nil }
+        return await boosting.rescore(
+            text: text, tokenTimings: tokenTimings, audioSamples: windowSamples
+        )
     }
 
     /// Apply encoder-frame offset derived from the absolute window start sample.

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/StreamingUnifiedAsrManager.swift
@@ -62,6 +62,29 @@ public actor StreamingUnifiedAsrManager {
     private var partialCallback: (@Sendable (String) -> Void)?
     private var processedChunks: Int = 0
 
+    // Vocabulary boosting (issue #851). The CTC spotter needs the segment's
+    // raw audio and the rescorer segment-local token timings, so while
+    // boosting is enabled the manager retains audio and timings for the
+    // not-yet-rescored tail of the stream and rescores it one word-aligned
+    // segment at a time (~15 s, matching the sliding-window batch cadence)
+    // instead of per 1 s chunk — CTC keyword spans would straddle chunk
+    // seams and a per-chunk CTC pass would dominate the step budget.
+    private var vocabularyBoosting: VocabularyBoostingSession?
+    // Transcript already rescored (immutable prefix). The un-rescored tail
+    // is the concatenation of `vocabTimings` token texts.
+    private var rescoredTranscript: String = ""
+    // Token timings (global clock) for the un-rescored tail.
+    private var vocabTimings: [TokenTiming] = []
+    // Audio backing the un-rescored tail; `vocabAudio[0]` is global sample
+    // `vocabAudioGlobalStart`.
+    private var vocabAudio: [Float] = []
+    private var vocabAudioGlobalStart: Int = 0
+    /// Un-rescored audio needed before a segment rescore is attempted.
+    private let vocabSegmentSeconds: Double = 15.0
+    /// Audio kept before the first pending token when a segment is released,
+    /// so the next CTC pass sees the word's onset.
+    private let vocabPreRollSeconds: Double = 1.0
+
     public private(set) var mlConfiguration: MLModelConfiguration
 
     public init(
@@ -178,22 +201,65 @@ public actor StreamingUnifiedAsrManager {
         }
     }
 
+    // MARK: - Vocabulary Boosting
+
+    /// Configure vocabulary boosting for streaming transcription.
+    ///
+    /// When configured, the transcript is rescored against CTC acoustic
+    /// evidence in word-aligned segments of roughly `vocabSegmentSeconds`:
+    /// corrections surface retroactively through `getPartialTranscript()` /
+    /// the partial callback, and the tail is always rescored by `finish()`.
+    /// Call before streaming starts. Same pipeline as
+    /// `SlidingWindowAsrManager.configureVocabularyBoosting`.
+    ///
+    /// - Parameters:
+    ///   - vocabulary: Custom vocabulary context with terms to detect
+    ///     (tokenize via `CustomVocabularyContext.loadWithCtcTokens`)
+    ///   - ctcModels: Pre-loaded CTC models for keyword spotting
+    ///   - config: Optional rescorer configuration (default:
+    ///     `VocabularyBoostingSession.itnDefaultConfig` — this engine's ITN
+    ///     output needs the #702 spotter-rescue similarity floors)
+    /// - Throws: Error if rescorer initialization fails
+    public func configureVocabularyBoosting(
+        vocabulary: CustomVocabularyContext,
+        ctcModels: CtcModels,
+        config: VocabularyRescorer.Config? = nil
+    ) async throws {
+        self.vocabularyBoosting = try await VocabularyBoostingSession(
+            vocabulary: vocabulary, ctcModels: ctcModels,
+            config: config ?? VocabularyBoostingSession.itnDefaultConfig
+        )
+        // Anchor the retained-audio clock at the current stream position and
+        // freeze any text decoded before boosting was enabled: audio for it
+        // was not retained, so it can never be rescored.
+        vocabAudio.removeAll()
+        vocabAudioGlobalStart = samplesGlobalStart + samples.count
+        rescoredTranscript += transcriptCache
+        transcriptCache = ""
+        logger.info("Vocabulary boosting configured with \(vocabulary.terms.count) terms")
+    }
+
     // MARK: - Streaming API
 
     public func appendAudio(_ buffer: AVAudioPCMBuffer) throws {
         let converted = try audioConverter.resampleBuffer(buffer)
         samples.append(contentsOf: converted)
+        if vocabularyBoosting != nil {
+            vocabAudio.append(contentsOf: converted)
+        }
     }
 
     /// Process as many complete chunks as the buffered audio allows.
     public func processBufferedAudio() async throws {
         try await processAvailableWindows(isFinal: false)
+        await maybeRescoreSegment(force: false)
     }
 
     /// Flush remaining audio and return the final transcript.
     public func finish() async throws -> String {
         guard tokenizer != nil else { throw ASRError.notInitialized }
         try await processAvailableWindows(isFinal: true)
+        await maybeRescoreSegment(force: true)
         return currentTranscript()
     }
 
@@ -230,6 +296,10 @@ public actor StreamingUnifiedAsrManager {
         transcriptCache = ""
         pendingTokenTimings.removeAll()
         processedChunks = 0
+        rescoredTranscript = ""
+        vocabTimings.removeAll()
+        vocabAudio.removeAll()
+        vocabAudioGlobalStart = 0
         try rnntDecoder?.reset()
     }
 
@@ -308,7 +378,6 @@ public actor StreamingUnifiedAsrManager {
             for emission in emissions {
                 guard let piece = tokenizer.piece(forId: emission.token) else { continue }
                 let text = piece.replacingOccurrences(of: "\u{2581}", with: " ")
-                transcriptCache += text
                 let start = Double(emission.frame) * secondsPerFrame
                 // RNNT tokens have no intrinsic duration — back-fill the previous
                 // token's end to this token's start so durations reflect real gaps.
@@ -321,15 +390,29 @@ public actor StreamingUnifiedAsrManager {
                     )
                 }
                 // Frontier token: provisional one-frame end until the next emission.
-                pendingTokenTimings.append(
-                    TokenTiming(
-                        token: text,
-                        tokenId: emission.token,
-                        startTime: start,
-                        endTime: start + secondsPerFrame,
-                        confidence: emission.prob
-                    )
+                let timing = TokenTiming(
+                    token: text,
+                    tokenId: emission.token,
+                    startTime: start,
+                    endTime: start + secondsPerFrame,
+                    confidence: emission.prob
                 )
+                pendingTokenTimings.append(timing)
+                if vocabularyBoosting != nil {
+                    // The un-rescored tail lives in `vocabTimings` (its token
+                    // texts ARE the tail transcript); same frontier back-fill.
+                    if let last = vocabTimings.indices.last, vocabTimings[last].endTime > start {
+                        let prev = vocabTimings[last]
+                        vocabTimings[last] = TokenTiming(
+                            token: prev.token, tokenId: prev.tokenId,
+                            startTime: prev.startTime, endTime: max(prev.startTime, start),
+                            confidence: prev.confidence
+                        )
+                    }
+                    vocabTimings.append(timing)
+                } else {
+                    transcriptCache += text
+                }
             }
         }
         processedChunks += 1
@@ -340,7 +423,118 @@ public actor StreamingUnifiedAsrManager {
     }
 
     private func currentTranscript() -> String {
-        transcriptCache.trimmingCharacters(in: .whitespaces)
+        guard vocabularyBoosting != nil else {
+            return transcriptCache.trimmingCharacters(in: .whitespaces)
+        }
+        return (rescoredTranscript + vocabTimings.map(\.token).joined())
+            .trimmingCharacters(in: .whitespaces)
+    }
+
+    // MARK: - Segment Rescoring
+
+    /// Rescore the un-rescored tail of the stream against CTC evidence.
+    ///
+    /// Non-final calls wait until `vocabSegmentSeconds` of audio has
+    /// accumulated, then rescore up to the last word boundary, holding the
+    /// frontier word back (it may still be growing). `force` (at `finish()`)
+    /// rescores everything pending.
+    private func maybeRescoreSegment(force: Bool) async {
+        guard let boosting = vocabularyBoosting else { return }
+
+        let sampleRate = Double(config.sampleRate)
+        let segmentStartSeconds = Double(vocabAudioGlobalStart) / sampleRate
+
+        // Silence guard: no pending tokens, so there is nothing to rescore —
+        // cap the retained audio at one encoder window (future emissions can
+        // only come from frames the windower has not consumed yet).
+        if vocabTimings.isEmpty {
+            let keep = config.windowSamples
+            if vocabAudio.count > keep {
+                dropVocabAudio(count: vocabAudio.count - keep)
+            }
+            return
+        }
+
+        if !force && vocabAudio.count < Int(vocabSegmentSeconds * sampleRate) { return }
+
+        guard let cut = Self.vocabSegmentCut(timings: vocabTimings, force: force) else { return }
+
+        let segmentTimings = Self.segmentLocalTimings(
+            Array(vocabTimings[..<cut]), segmentStartSeconds: segmentStartSeconds
+        )
+        let segmentText = vocabTimings[..<cut].map(\.token).joined()
+
+        var releasedText = segmentText
+        // The rescorer reconstructs its output text from the word timings, so
+        // every token of the segment must be represented: if any were dropped
+        // for lacking retained audio (configure-mid-stream straddle), release
+        // this one segment unscored rather than lose those words.
+        if segmentTimings.count == cut,
+            let rescored = await boosting.rescore(
+                text: segmentText, tokenTimings: segmentTimings, audioSamples: vocabAudio
+            )
+        {
+            // The rescorer rebuilds its text as words joined by single spaces,
+            // dropping the segment's leading separator — restore it so the
+            // released text still butts cleanly against the rescored prefix.
+            releasedText = (segmentText.hasPrefix(" ") ? " " : "") + rescored.text
+        }
+        rescoredTranscript += releasedText
+        vocabTimings.removeFirst(cut)
+
+        // Release segment audio, keeping a pre-roll before the first held
+        // token so the next CTC pass sees its word onset.
+        if let firstKept = vocabTimings.first {
+            let newStart = Int((firstKept.startTime - vocabPreRollSeconds) * sampleRate)
+            if newStart > vocabAudioGlobalStart {
+                dropVocabAudio(count: min(newStart - vocabAudioGlobalStart, vocabAudio.count))
+            }
+        } else {
+            dropVocabAudio(count: vocabAudio.count)
+        }
+
+        if releasedText != segmentText, let callback = partialCallback {
+            callback(currentTranscript())
+        }
+    }
+
+    private func dropVocabAudio(count: Int) {
+        guard count > 0 else { return }
+        vocabAudio.removeFirst(count)
+        vocabAudioGlobalStart += count
+    }
+
+    /// Word-boundary cut for a segment release: rescore `[0..<cut]`, hold
+    /// `[cut...]`. Cutting only where a token starts a new word (leading
+    /// space after `▁` substitution) guarantees a sub-word split across the
+    /// segment edge can never be half-replaced. Non-final calls hold the
+    /// frontier word back (it may still be growing), so a single pending
+    /// word yields no cut. Pure, for testability.
+    static func vocabSegmentCut(timings: [TokenTiming], force: Bool) -> Int? {
+        guard !timings.isEmpty else { return nil }
+        if force { return timings.count }
+        guard let lastWordStart = timings.lastIndex(where: { $0.token.hasPrefix(" ") }),
+            lastWordStart > 0
+        else { return nil }
+        return lastWordStart
+    }
+
+    /// Rebase global-clock timings onto the retained segment audio (t=0 at
+    /// `segmentStartSeconds`). Tokens decoded before that point have no
+    /// retained audio behind them and are dropped — they pass through
+    /// unscored. Pure, for testability.
+    static func segmentLocalTimings(
+        _ timings: [TokenTiming], segmentStartSeconds: Double
+    ) -> [TokenTiming] {
+        timings.compactMap { timing in
+            guard timing.startTime >= segmentStartSeconds else { return nil }
+            return TokenTiming(
+                token: timing.token, tokenId: timing.tokenId,
+                startTime: timing.startTime - segmentStartSeconds,
+                endTime: max(0, timing.endTime - segmentStartSeconds),
+                confidence: timing.confidence
+            )
+        }
     }
 
     /// Drop audio that can no longer appear in any future window.

--- a/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Unified/UnifiedAsrManager.swift
@@ -69,6 +69,10 @@ public actor UnifiedAsrManager {
     private var lastTranscript: String = ""
     private var partialCallback: (@Sendable (String) -> Void)?
 
+    // Vocabulary boosting (issue #851): configured via
+    // configureVocabularyBoosting() before transcription.
+    private var vocabularyBoosting: VocabularyBoostingSession?
+
     public private(set) var mlConfiguration: MLModelConfiguration
 
     public init(
@@ -180,6 +184,36 @@ public actor UnifiedAsrManager {
         }
     }
 
+    // MARK: - Vocabulary Boosting
+
+    /// Configure vocabulary boosting for batch transcription.
+    ///
+    /// When configured, the final merged transcript of each `transcribe` call
+    /// is rescored against CTC acoustic evidence: a separate CTC model runs
+    /// over the same audio and vocabulary terms replace misrecognized words
+    /// where the acoustics support it. Same pipeline as
+    /// `SlidingWindowAsrManager.configureVocabularyBoosting`.
+    ///
+    /// - Parameters:
+    ///   - vocabulary: Custom vocabulary context with terms to detect
+    ///     (tokenize via `CustomVocabularyContext.loadWithCtcTokens`)
+    ///   - ctcModels: Pre-loaded CTC models for keyword spotting
+    ///   - config: Optional rescorer configuration (default:
+    ///     `VocabularyBoostingSession.itnDefaultConfig` — this engine's ITN
+    ///     output needs the #702 spotter-rescue similarity floors)
+    /// - Throws: Error if rescorer initialization fails
+    public func configureVocabularyBoosting(
+        vocabulary: CustomVocabularyContext,
+        ctcModels: CtcModels,
+        config: VocabularyRescorer.Config? = nil
+    ) async throws {
+        self.vocabularyBoosting = try await VocabularyBoostingSession(
+            vocabulary: vocabulary, ctcModels: ctcModels,
+            config: config ?? VocabularyBoostingSession.itnDefaultConfig
+        )
+        logger.info("Vocabulary boosting configured with \(vocabulary.terms.count) terms")
+    }
+
     // MARK: - Batch API
 
     /// A transcript and the per-token timings behind it.
@@ -198,7 +232,8 @@ public actor UnifiedAsrManager {
     public func transcribe(_ samples: [Float]) async throws -> String {
         guard let tokenizer = tokenizer else { throw ASRError.notInitialized }
         let merged = try await decodedTokens(samples, tokenizer: tokenizer)
-        return tokenizer.decode(ids: merged.map(\.token))
+        let text = tokenizer.decode(ids: merged.map(\.token))
+        return await rescoreIfConfigured(text: text, merged: merged, samples: samples)
     }
 
     /// Transcribe as `transcribe(_:)` does, additionally reporting the encoder
@@ -224,15 +259,38 @@ public actor UnifiedAsrManager {
     public func transcribeWithTimings(_ samples: [Float]) async throws -> TranscriptionWithTimings {
         guard let tokenizer = tokenizer else { throw ASRError.notInitialized }
         let merged = try await decodedTokens(samples, tokenizer: tokenizer)
-        return TranscriptionWithTimings(
-            text: tokenizer.decode(ids: merged.map(\.token)),
-            tokenTimings: Self.tokenTimings(
-                from: merged,
-                secondsPerFrame: Double(config.frameSamples) / Double(config.sampleRate),
-                vocabulary: tokenizer.vocabulary,
-                clipDuration: Double(samples.count) / Double(config.sampleRate)
-            )
+        let timings = Self.tokenTimings(
+            from: merged,
+            secondsPerFrame: Double(config.frameSamples) / Double(config.sampleRate),
+            vocabulary: tokenizer.vocabulary,
+            clipDuration: Double(samples.count) / Double(config.sampleRate)
         )
+        var text = tokenizer.decode(ids: merged.map(\.token))
+        // Rescored text can replace words, so token timings no longer decode
+        // to the text verbatim; they remain the raw emissions, which is what
+        // timing consumers (seek, attribution) want.
+        if let boosting = vocabularyBoosting,
+            let rescored = await boosting.rescore(text: text, tokenTimings: timings, audioSamples: samples)
+        {
+            text = rescored.text
+        }
+        return TranscriptionWithTimings(text: text, tokenTimings: timings)
+    }
+
+    /// Apply vocabulary rescoring to a finished transcript when boosting is
+    /// configured; otherwise return the transcript unchanged.
+    private func rescoreIfConfigured(
+        text: String, merged: [ChunkProcessor.TokenWindow], samples: [Float]
+    ) async -> String {
+        guard let boosting = vocabularyBoosting, let tokenizer = tokenizer else { return text }
+        let timings = Self.tokenTimings(
+            from: merged,
+            secondsPerFrame: Double(config.frameSamples) / Double(config.sampleRate),
+            vocabulary: tokenizer.vocabulary,
+            clipDuration: Double(samples.count) / Double(config.sampleRate)
+        )
+        let rescored = await boosting.rescore(text: text, tokenTimings: timings, audioSamples: samples)
+        return rescored?.text ?? text
     }
 
     /// Emission frames → seconds. Pure, so the back-fill rule can be tested

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/CtcEarningsBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/CtcEarningsBenchmark.swift
@@ -16,6 +16,13 @@ public enum CtcEarningsBenchmark {
         case file = "file"
     }
 
+    /// Primary transcription engine (the CTC spotting/rescoring side is
+    /// engine-independent — issue #851)
+    public enum BenchmarkEngine: String {
+        case tdt = "tdt"
+        case unified = "unified"
+    }
+
     /// Default CTC model directory for a given variant
     private static func defaultCtcModelPath(for variant: CtcModelVariant) -> String? {
         let appSupport = FileManager.default.urls(
@@ -59,6 +66,7 @@ public enum CtcEarningsBenchmark {
         var ctcVariant: CtcModelVariant = .ctc110m
         // Constrained CTC rescoring is enabled by default
         var useConstrainedCTC = true
+        var engine: BenchmarkEngine = .tdt
 
         var i = 0
         while i < arguments.count {
@@ -127,6 +135,15 @@ public enum CtcEarningsBenchmark {
                 }
             case "--no-constrained-ctc":
                 useConstrainedCTC = false
+            case "--engine":
+                if i + 1 < arguments.count {
+                    if let parsed = BenchmarkEngine(rawValue: arguments[i + 1].lowercased()) {
+                        engine = parsed
+                    } else {
+                        print("WARNING: Invalid engine '\(arguments[i + 1])'. Using 'tdt'.")
+                    }
+                    i += 1
+                }
             default:
                 break
             }
@@ -148,9 +165,10 @@ public enum CtcEarningsBenchmark {
             dataDir = defaultDataDir()
         }
 
-        print("Earnings Benchmark (TDT transcription + CTC keyword spotting)")
+        print("Earnings Benchmark (\(engine == .unified ? "Unified" : "TDT") transcription + CTC keyword spotting)")
         print("  Data directory: \(dataDir ?? "not found")")
         print("  Output file: \(outputFile)")
+        print("  Engine: \(engine.rawValue)")
         print("  TDT version: \(tdtVersion == .v2 ? "v2" : tdtVersion == .tdtCtc110m ? "110m" : "v3")")
         print("  CTC variant: \(ctcVariant.displayName)")
         print("  CTC model: \(ctcModelPath ?? "not found")")
@@ -177,14 +195,26 @@ public enum CtcEarningsBenchmark {
         let dataDirResolved = finalDataDir
 
         do {
-            // Load TDT models for transcription
-            print(
-                "Loading TDT models (\(tdtVersion == .v2 ? "v2" : tdtVersion == .tdtCtc110m ? "110m" : "v3")) for transcription..."
-            )
-            let tdtModels = try await AsrModels.downloadAndLoad(version: tdtVersion)
-            let asrManager = AsrManager(config: .default)
-            try await asrManager.loadModels(tdtModels)
-            print("TDT models loaded successfully")
+            // Load the primary transcription engine
+            var asrManager: AsrManager? = nil
+            var unifiedManager: UnifiedAsrManager? = nil
+            switch engine {
+            case .tdt:
+                print(
+                    "Loading TDT models (\(tdtVersion == .v2 ? "v2" : tdtVersion == .tdtCtc110m ? "110m" : "v3")) for transcription..."
+                )
+                let tdtModels = try await AsrModels.downloadAndLoad(version: tdtVersion)
+                let manager = AsrManager(config: .default)
+                try await manager.loadModels(tdtModels)
+                asrManager = manager
+                print("TDT models loaded successfully")
+            case .unified:
+                print("Loading parakeet-unified offline models for transcription...")
+                let manager = UnifiedAsrManager()
+                try await manager.loadModels()
+                unifiedManager = manager
+                print("Unified models loaded successfully")
+            }
 
             // Load CTC models for keyword spotting
             print("Loading CTC models from: \(modelPath)")
@@ -247,6 +277,7 @@ public enum CtcEarningsBenchmark {
                     fileId: fileId,
                     dataDir: dataDirURL,
                     asrManager: asrManager,
+                    unifiedManager: unifiedManager,
                     ctcModels: ctcModels,
                     spotter: spotter,
                     keywordsMode: keywordsMode,
@@ -370,7 +401,8 @@ public enum CtcEarningsBenchmark {
     private static func processFile(
         fileId: String,
         dataDir: URL,
-        asrManager: AsrManager,
+        asrManager: AsrManager?,
+        unifiedManager: UnifiedAsrManager?,
         ctcModels: CtcModels,
         spotter: CtcKeywordSpotter,
         keywordsMode: KeywordsMode,
@@ -453,19 +485,33 @@ public enum CtcEarningsBenchmark {
 
         let startTime = Date()
 
-        // 1. TDT transcription for low WER
-        var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
-        let tdtResult = try await asrManager.transcribe(wavFile, decoderState: &decoderState)
+        // 1. Primary transcription for low WER
+        let asrText: String
+        let asrTimings: [TokenTiming]?
+        if let unifiedManager {
+            let unifiedResult = try await unifiedManager.transcribeWithTimings(samples)
+            asrText = unifiedResult.text
+            asrTimings = unifiedResult.tokenTimings
+        } else if let asrManager {
+            var decoderState = TdtDecoderState.make(decoderLayers: await asrManager.decoderLayerCount)
+            let tdtResult = try await asrManager.transcribe(wavFile, decoderState: &decoderState)
+            asrText = tdtResult.text
+            asrTimings = tdtResult.tokenTimings
+        } else {
+            throw NSError(
+                domain: "CtcEarningsBenchmark", code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "No transcription engine loaded"])
+        }
 
-        // Skip files where TDT returns empty (some audio files cause model issues)
-        if tdtResult.text.isEmpty {
-            print("  SKIPPED: TDT returned empty transcription")
+        // Skip files where the engine returns empty (some audio files cause model issues)
+        if asrText.isEmpty {
+            print("  SKIPPED: engine returned empty transcription")
             return nil
         }
 
-        // Debug: Show TDT word timings if available
+        // Debug: Show engine word timings if available
         let debugTimings = ProcessInfo.processInfo.environment["DEBUG_TIMINGS"] == "1"
-        if debugTimings, let tokenTimings = tdtResult.tokenTimings, !tokenTimings.isEmpty {
+        if debugTimings, let tokenTimings = asrTimings, !tokenTimings.isEmpty {
             print("  TDT Token Count: \(tokenTimings.count)")
             // Show raw tokens around 8.0-12.0s (where "Bose" should be - reference says "Bose, just, all I said")
             print("  TDT Tokens 7.0-13.0s:")
@@ -527,7 +573,13 @@ public enum CtcEarningsBenchmark {
             let vocabSize = vocabularyWords.count
             let vocabConfig = ContextBiasingConstants.rescorerConfig(forVocabSize: vocabSize)
 
-            let rescorerConfig = VocabularyRescorer.Config.default
+            // Match production defaults per engine: the unified engine's ITN
+            // output needs the #702 spotter-rescue similarity floors (see
+            // VocabularyBoostingSession.itnDefaultConfig).
+            let rescorerConfig =
+                unifiedManager != nil
+                ? VocabularyBoostingSession.itnDefaultConfig
+                : VocabularyRescorer.Config.default
 
             let ctcModelDir = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
             let rescorer = try await VocabularyRescorer.create(
@@ -562,10 +614,10 @@ public enum CtcEarningsBenchmark {
                 ProcessInfo.processInfo.environment["MARGIN_SECONDS"]
                 .flatMap { Double($0) } ?? ContextBiasingConstants.defaultMarginSeconds
 
-            if useConstrainedCTC, let tokenTimings = tdtResult.tokenTimings, !tokenTimings.isEmpty {
+            if useConstrainedCTC, let tokenTimings = asrTimings, !tokenTimings.isEmpty {
                 // Use constrained CTC rescoring (string similarity first, then constrained DP)
                 let rescoreResult = rescorer.ctcTokenRescore(
-                    transcript: tdtResult.text,
+                    transcript: asrText,
                     tokenTimings: tokenTimings,
                     logProbs: logProbs,
                     frameDuration: frameDuration,
@@ -575,10 +627,10 @@ public enum CtcEarningsBenchmark {
                 )
                 hypothesis = rescoreResult.text
             } else {
-                hypothesis = tdtResult.text  // No rescoring (missing token timings or --no-constrained-ctc)
+                hypothesis = asrText  // No rescoring (missing token timings or --no-constrained-ctc)
             }
         } else {
-            hypothesis = tdtResult.text  // Baseline: no CTC corrections
+            hypothesis = asrText  // Baseline: no CTC corrections
         }
 
         let processingTime = Date().timeIntervalSince(startTime)
@@ -1124,6 +1176,7 @@ public enum CtcEarningsBenchmark {
                                       - 110m: Parakeet CTC 110M (hybrid TDT+CTC, blank-dominant)
                                       - 06b: Parakeet CTC 0.6B (pure CTC, better for greedy decoding)
                 --no-constrained-ctc  Disable constrained CTC rescoring (enabled by default)
+                --engine <engine>     Transcription engine: 'tdt' (default) or 'unified' (parakeet-unified offline batch)
                 --file-id <id>        Run benchmark on a single file (e.g., "4468654_chunk39")
                 --max-files <n>       Maximum number of files to process
                 --output, -o <path>   Output JSON file (default: ctc_earnings_benchmark.json)

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -932,6 +932,19 @@ enum TranscribeCommand {
             let loadTime = Date().timeIntervalSince(loadStart)
             logger.info("Models loaded in \(String(format: "%.2f", loadTime))s")
 
+            if let vocabPath = args.customVocabPath {
+                let (customVocab, ctcModels) = try await CustomVocabularyContext.loadWithCtcTokens(from: vocabPath)
+                if let unified = engine as? StreamingUnifiedAsrManager {
+                    try await unified.configureVocabularyBoosting(vocabulary: customVocab, ctcModels: ctcModels)
+                    logger.info("Vocabulary boosting enabled (\(customVocab.terms.count) terms)")
+                } else if let unifiedBatch = engine as? UnifiedAsrManager {
+                    try await unifiedBatch.configureVocabularyBoosting(vocabulary: customVocab, ctcModels: ctcModels)
+                    logger.info("Vocabulary boosting enabled (\(customVocab.terms.count) terms)")
+                } else {
+                    logger.warning("--custom-vocab is not supported for \(variant.displayName); ignoring")
+                }
+            }
+
             let audioFileURL = URL(fileURLWithPath: audioFile)
             let audioFileHandle = try AVAudioFile(forReading: audioFileURL)
             let format = audioFileHandle.processingFormat

--- a/Tests/FluidAudioTests/ASR/Parakeet/UnifiedVocabularySegmentTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/UnifiedVocabularySegmentTests.swift
@@ -1,0 +1,124 @@
+import Testing
+
+@testable import FluidAudio
+
+/// Tests for the streaming unified vocabulary-boosting segmentation rules
+/// (`StreamingUnifiedAsrManager.vocabSegmentCut` / `segmentLocalTimings`).
+/// Both are pure, so none of this needs models loaded.
+struct UnifiedVocabularySegmentTests {
+
+    private func timing(
+        _ token: String, start: Double, end: Double? = nil, id: Int = 0
+    ) -> TokenTiming {
+        TokenTiming(
+            token: token, tokenId: id, startTime: start,
+            endTime: end ?? start + 0.08, confidence: 0.9
+        )
+    }
+
+    // MARK: - vocabSegmentCut
+
+    @Test
+    func emptyTimingsYieldNoCut() {
+        #expect(StreamingUnifiedAsrManager.vocabSegmentCut(timings: [], force: false) == nil)
+        #expect(StreamingUnifiedAsrManager.vocabSegmentCut(timings: [], force: true) == nil)
+    }
+
+    @Test
+    func forceCutsEverything() {
+        let timings = [timing(" hel", start: 0.0), timing("lo", start: 0.1)]
+        #expect(StreamingUnifiedAsrManager.vocabSegmentCut(timings: timings, force: true) == 2)
+    }
+
+    @Test
+    func nonFinalCutHoldsFrontierWordBack() {
+        // " play" "back" | " the" — frontier word " the" must stay pending.
+        let timings = [
+            timing(" play", start: 0.0),
+            timing("back", start: 0.1),
+            timing(" the", start: 0.3),
+        ]
+        #expect(StreamingUnifiedAsrManager.vocabSegmentCut(timings: timings, force: false) == 2)
+    }
+
+    @Test
+    func cutNeverSplitsAWord() {
+        // Frontier word spans two sub-word tokens; the cut lands before its
+        // first token, not between them.
+        let timings = [
+            timing(" romvim", start: 0.0),
+            timing(" za", start: 0.4, id: 1),  // separate word
+            timing("wa", start: 0.5, id: 2),  // continuation of " za"
+        ]
+        let cut = StreamingUnifiedAsrManager.vocabSegmentCut(timings: timings, force: false)
+        #expect(cut == 1)
+    }
+
+    @Test
+    func singlePendingWordYieldsNoCut() {
+        // All tokens belong to one word — nothing can be released yet.
+        let timings = [timing(" hel", start: 0.0), timing("lo", start: 0.1)]
+        #expect(StreamingUnifiedAsrManager.vocabSegmentCut(timings: timings, force: false) == nil)
+    }
+
+    @Test
+    func noWordBoundaryYieldsNoCut() {
+        // Degenerate stream of continuation tokens only.
+        let timings = [timing("lo", start: 0.0), timing("re", start: 0.1)]
+        #expect(StreamingUnifiedAsrManager.vocabSegmentCut(timings: timings, force: false) == nil)
+    }
+
+    // MARK: - segmentLocalTimings
+
+    @Test
+    func rebasesOntoSegmentClock() {
+        let rebased = StreamingUnifiedAsrManager.segmentLocalTimings(
+            [timing(" the", start: 20.0, end: 20.08)], segmentStartSeconds: 18.5
+        )
+        #expect(rebased.count == 1)
+        #expect(abs(rebased[0].startTime - 1.5) < 0.0001)
+        #expect(abs(rebased[0].endTime - 1.58) < 0.0001)
+        #expect(rebased[0].token == " the")
+    }
+
+    @Test
+    func dropsTokensBeforeRetainedAudio() {
+        // Tokens decoded before boosting was configured have no retained
+        // audio behind them and must not reach the rescorer.
+        let rebased = StreamingUnifiedAsrManager.segmentLocalTimings(
+            [
+                timing(" old", start: 3.0),
+                timing(" new", start: 10.0),
+            ],
+            segmentStartSeconds: 5.0
+        )
+        #expect(rebased.count == 1)
+        #expect(rebased[0].token == " new")
+        #expect(abs(rebased[0].startTime - 5.0) < 0.0001)
+    }
+
+    // MARK: - itnDefaultConfig
+
+    @Test
+    func itnDefaultConfigSetsRescueSimilarityFloors() {
+        // ITN engines need the #702 floors; without them the spotter-anchored
+        // rescue replaces digit spans at garbage similarity (see session docs).
+        let config = VocabularyBoostingSession.itnDefaultConfig
+        #expect(config.spotterRescueMinSimilarity == 0.30)
+        #expect(config.spotterRescueMultiWordMinSimilarity == 0.50)
+        #expect(config.spotterRescueEnabled)
+    }
+
+    @Test
+    func preservesTokenIdentityAndConfidence() {
+        let original = TokenTiming(
+            token: " word", tokenId: 42, startTime: 7.0, endTime: 7.2, confidence: 0.75
+        )
+        let rebased = StreamingUnifiedAsrManager.segmentLocalTimings(
+            [original], segmentStartSeconds: 7.0
+        )
+        #expect(rebased[0].tokenId == 42)
+        #expect(rebased[0].confidence == 0.75)
+        #expect(abs(rebased[0].startTime) < 0.0001)
+    }
+}


### PR DESCRIPTION
Closes #851

## Summary

Brings `configureVocabularyBoosting(vocabulary:ctcModels:)` — previously exclusive to `SlidingWindowAsrManager` — to both unified Parakeet managers, with the same API shape. The CTC spotting pipeline runs a separate CTC model (parakeet-ctc-110m) over raw audio and rescores at the word/time level, so it is independent of which primary model produced the transcript; wiring it to the unified path is plumbing, not new modeling.

Note on #435 for context: the "unified Preprocessor" doc comments on `CtcKeywordSpotter` refer to that closed proposal (exporting the auxiliary CTC head from hybrid TDT-CTC-110M). `parakeet-unified-en-0.6b` is RNNT-only — there is no CTC head to export — so the two-model approach here is the viable one.

## Design

- **`VocabularyBoostingSession`** (new): the CTC-spotting + constrained-rescoring pipeline extracted from `SlidingWindowAsrManager`, which now delegates to it. Its public API and behavior are unchanged.
- **`UnifiedAsrManager` (offline 15s batch)**: the final merged transcript is rescored once over the full audio (the spotter's chunked long-audio path handles arbitrary length). The batch-on-finish `StreamingAsrManager` conformance inherits boosting via `transcribe()`.
- **`StreamingUnifiedAsrManager`**: segment-level rescoring — ~15 s word-aligned segments with the frontier word held back so a sub-word split can never be half-replaced. Corrections surface retroactively through partials; `finish()` always rescores the tail. Audio/timings for the un-rescored tail are retained and released per segment (silence-capped at one encoder window). Cut/rebase decisions are pure statics with unit tests.
- **`itnDefaultConfig`**: the unified model's inverse-text-normalized output ("35.3%") packs multi-second phrases into one or two written words, which made the spotter-anchored rescue pass replace digit spans at similarity 0.20 ('yen, down by 35.3%' → vocab term). The unified managers default to the documented #702 similarity floors (0.30 / 0.50 multi-word); SlidingWindow keeps `.default`.
- **CLI**: `--custom-vocab` now applies to `--parakeet-variant` runs; `ctc-earnings-benchmark` gains `--engine unified`.

Two correctness details handled explicitly: `RescoreOutput.text` is rebuilt from word timings (words joined by single spaces), so the streaming release restores the segment's leading separator, and a segment whose tokens predate the retained audio (configure-mid-stream) is released unscored rather than losing words.

## Benchmarks

`ctc-earnings-benchmark`, full earnings22-kws set (772 files, chunk-level dictionaries), release build, M-series. Baseline = `NO_CTC_RESCORING=1`.

| Engine | Config | WER | Vocab Recall | Vocab Precision | Vocab F-score |
|---|---|---|---|---|---|
| Unified offline 15s | baseline | 15.72% | 51.0% | 99.7% | 67.5% |
| Unified offline 15s | **boosted** | **13.99%** | **89.1%** | 99.5% | **94.0%** |
| TDT v2 (reference) | baseline | 15.70% | 49.3% | 99.7% | 66.0% |
| TDT v2 (reference) | boosted | 22.25% | 93.4% | 99.5% | 96.3% |

On the unified path, boosting lifts vocabulary recall by **+38 points (51.0% → 89.1%)** at essentially unchanged precision while **improving** WER (15.72% → 13.99%). The TDT reference rows use that engine's existing `.default` rescorer config (no ITN floors): it buys ~4 more recall points but costs 6.6 WER points — the floors are why the unified numbers don't pay that tax. RTFx ~69 for unified boosted. (Numbers include the expanded-span guard from review: a candidate span already containing the exact term no longer collapses to the bare term, which was deleting correct neighboring words — that fix alone moved unified boosted WER 15.11 → 13.99% and recall 88.1 → 89.1%.)

Qualitative spot-check (streaming engine, `4482641_chunk_19`, dictionary "Mechatronics systems"): baseline transcribes "Megatronic systems"; boosted corrects both occurrences, and the replacement profile matches the TDT batch path on the same fixture.

## Testing

- `UnifiedVocabularySegmentTests`: word-boundary cut rules (frontier hold-back, no mid-word splits), segment-clock rebasing, ITN config floors.
- E2E via CLI on earnings22-kws fixtures for both unified engines (batch + streaming) and the TDT path (unchanged behavior after the extraction).
- `swift build` + `swift format lint` clean; XCTest runs in CI.
