### PR TITLE
perf(download): skip unused PocketTTS variants + concurrent subdirectory fetches

### DIFF
--- a/Sources/FluidAudio/Shared/Download/DownloadTypes.swift
+++ b/Sources/FluidAudio/Shared/Download/DownloadTypes.swift
@@ -78,14 +78,23 @@ public struct DownloadConfig: Sendable {
     /// 120 s.
     public let stallWindow: TimeInterval
 
+    /// Maximum number of files fetched concurrently by subdirectory downloads
+    /// (#853). HuggingFace serves LFS objects through a CDN that handles
+    /// concurrent range requests fine, so a small fan-out cuts wall-clock for
+    /// many-file packs without hammering the server. Values below 1 are
+    /// treated as 1. Defaults to 4.
+    public let maxConcurrentFiles: Int
+
     public init(
         timeout: TimeInterval = 1800,  // 30 minutes for large models
         minStallBytes: Int64 = 1 << 20,  // 1 MiB
-        stallWindow: TimeInterval = 120
+        stallWindow: TimeInterval = 120,
+        maxConcurrentFiles: Int = 4
     ) {
         self.timeout = timeout
         self.minStallBytes = minStallBytes
         self.stallWindow = stallWindow
+        self.maxConcurrentFiles = maxConcurrentFiles
     }
 
     public static let `default` = DownloadConfig()

--- a/Sources/FluidAudio/Shared/Download/ModelHub.swift
+++ b/Sources/FluidAudio/Shared/Download/ModelHub.swift
@@ -568,7 +568,31 @@ public enum ModelHub {
         progressHandler: ProgressHandler? = nil,
         shouldSkip: (@Sendable (String) -> Bool)? = nil
     ) async throws {
+        try await download(
+            repo, subdirectory: subdirectory, to: repoDirectory,
+            config: config, progressHandler: progressHandler, shouldSkip: shouldSkip,
+            configuration: nil)
+    }
+
+    /// Internal seam: `configuration` overrides the session used for tree
+    /// listing and per-file downloads so tests can drive the pipeline with a
+    /// stub `URLProtocol` (see `SubdirectoryDownloadTests`).
+    static func download(
+        _ repo: Repo,
+        subdirectory: String,
+        to repoDirectory: URL,
+        config: DownloadConfig = .default,
+        progressHandler: ProgressHandler? = nil,
+        shouldSkip: (@Sendable (String) -> Bool)? = nil,
+        configuration: URLSessionConfiguration?
+    ) async throws {
         try ensureOnlineAllowed("download(\(repo.folderName)/\(subdirectory))")
+
+        let listingSession = configuration.map { URLSession(configuration: $0) } ?? session
+        defer {
+            if configuration != nil { listingSession.finishTasksAndInvalidate() }
+        }
+
         // Subdirectory downloads have no compile phase: download spans 0-1.
         let reporter = ProgressReporter(handler: progressHandler, downloadPhaseWeight: 1.0)
         reporter.listing()
@@ -576,7 +600,7 @@ public enum ModelHub {
             repoRemotePath: repo.remotePath,
             startingAt: subdirectory,
             include: { itemPath, _ in shouldSkip?(itemPath) != true },
-            fetch: HFTreeLister.fetch(using: session)
+            fetch: HFTreeLister.fetch(using: listingSession)
         )
         let totalFiles = filesToDownload.count
         logger.info("Found \(totalFiles) files in \(subdirectory)")
@@ -584,55 +608,83 @@ public enum ModelHub {
         // Compute total known bytes for byte-weighted progress.
         // Files with unknown sizes (size == -1) are treated as 0 for weighting.
         let totalBytes: Int64 = filesToDownload.reduce(0) { $0 + Int64(max(0, $1.size)) }
-        var completedBytes: Int64 = 0
 
         reporter.fileBoundary(
-            completedBytes: completedBytes,
+            completedBytes: 0,
             totalBytes: totalBytes,
             completedFiles: 0,
             totalFiles: totalFiles)
 
-        for (index, file) in filesToDownload.enumerated() {
-            let destPath = repoDirectory.appendingPathComponent(file.path)
-
-            // Only stream live byte progress for files with a known size: an
-            // unknown-size file (-1) carries zero weight in totalBytes, so its
-            // real bytesWritten would inflate the fraction mid-file and snap
-            // back at the boundary. Boundary emits keep progress monotonic.
-            let onBytes =
-                file.size > 0
-                ? reporter.liveBytesCallback(
-                    baseBytes: completedBytes,
-                    totalBytes: totalBytes,
-                    fileIndex: index,
-                    totalFiles: totalFiles)
-                : nil
-
-            // Fail loudly on blocked paths: subdirectory downloads land in
-            // caller-provided directories, so a regular file where a directory
-            // belongs is surfaced, never silently deleted.
-            let outcome = try await FileDownloader.ensure(
-                file: file,
-                from: repo.remotePath,
-                at: destPath,
-                recoveringBlockedPaths: false,
-                config: config,
-                onBytes: onBytes
-            )
-            completedBytes += Int64(max(0, file.size))
-
-            reporter.fileBoundary(
-                completedBytes: completedBytes,
-                totalBytes: totalBytes,
-                completedFiles: index + 1,
-                totalFiles: totalFiles)
-
-            if outcome != .alreadyPresent, (index + 1) % 5 == 0 || index == totalFiles - 1 {
-                logger.info("Downloaded \(index + 1)/\(totalFiles) \(subdirectory) files")
+        // Fetch files through a bounded task group (#853): the sequential
+        // loop paid one network round-trip of latency per file, which
+        // dominated wall-clock for many-file packs. The first thrown error
+        // cancels the group (in-flight `.partial` files resume by byte range
+        // on the next attempt). ConcurrentProgress owns the byte/file
+        // counters so emissions stay monotonic across out-of-order finishes.
+        let progress = ConcurrentProgress(
+            reporter: reporter, totalBytes: totalBytes, totalFiles: totalFiles)
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            var nextIndex = 0
+            func addNextTask() {
+                guard nextIndex < filesToDownload.count else { return }
+                let index = nextIndex
+                let file = filesToDownload[index]
+                nextIndex += 1
+                group.addTask {
+                    try await downloadSubdirectoryFile(
+                        file, index: index, repo: repo, subdirectory: subdirectory,
+                        repoDirectory: repoDirectory, totalFiles: totalFiles,
+                        config: config, configuration: configuration, progress: progress)
+                }
+            }
+            for _ in 0..<min(max(1, config.maxConcurrentFiles), totalFiles) {
+                addNextTask()
+            }
+            while try await group.next() != nil {
+                addNextTask()
             }
         }
 
         logger.info("Downloaded \(subdirectory) from \(repo.folderName)")
+    }
+
+    /// One file of a subdirectory download, run inside the bounded task group.
+    private static func downloadSubdirectoryFile(
+        _ file: RemoteFile,
+        index: Int,
+        repo: Repo,
+        subdirectory: String,
+        repoDirectory: URL,
+        totalFiles: Int,
+        config: DownloadConfig,
+        configuration: URLSessionConfiguration?,
+        progress: ConcurrentProgress
+    ) async throws {
+        let destPath = repoDirectory.appendingPathComponent(file.path)
+
+        // Only stream live byte progress for files with a known size: an
+        // unknown-size file (-1) carries zero weight in totalBytes, so its
+        // real bytesWritten would inflate the fraction mid-file and snap
+        // back at the boundary. Boundary emits keep progress monotonic.
+        let onBytes = file.size > 0 ? progress.liveBytesCallback(fileIndex: index) : nil
+
+        // Fail loudly on blocked paths: subdirectory downloads land in
+        // caller-provided directories, so a regular file where a directory
+        // belongs is surfaced, never silently deleted.
+        let outcome = try await FileDownloader.ensure(
+            file: file,
+            from: repo.remotePath,
+            at: destPath,
+            recoveringBlockedPaths: false,
+            config: config,
+            configuration: configuration,
+            onBytes: onBytes
+        )
+
+        let completed = progress.fileCompleted(fileIndex: index, size: file.size)
+        if outcome != .alreadyPresent, completed % 5 == 0 || completed == totalFiles {
+            logger.info("Downloaded \(completed)/\(totalFiles) \(subdirectory) files")
+        }
     }
 
     /// Fetch a single file from HuggingFace with the converged retry policy

--- a/Sources/FluidAudio/Shared/Download/ProgressReporter.swift
+++ b/Sources/FluidAudio/Shared/Download/ProgressReporter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Models download-operation progress as weighted phases (#765 Wave 4),
 /// replacing the fraction math previously copy-pasted at call sites.
@@ -97,5 +98,82 @@ struct ProgressReporter: Sendable {
     /// The operation is complete.
     func finished() {
         emit(1.0, .compiling(modelName: ""))
+    }
+}
+
+/// Progress bookkeeping for a download loop whose files complete out of
+/// order (#853). The sequential loops thread `completedBytes` through as a
+/// plain running total; with a bounded task group that bookkeeping races, so
+/// this class owns the counters instead. Byte updates and file boundaries
+/// arrive from concurrent tasks; both the counter update and the handler
+/// call happen under one lock, so emissions stay ordered and
+/// `fractionCompleted` keeps the documented monotonic invariant.
+final class ConcurrentProgress: Sendable {
+    private struct Counters {
+        /// Cumulative bytes reported so far by each still-downloading file.
+        var inFlightBytes: [Int: Int64] = [:]
+        var completedBytes: Int64 = 0
+        var completedFiles = 0
+        /// High-water mark; emissions below it are lifted to it so a file
+        /// boundary landing behind another file's live bytes never regresses.
+        var maxFraction = 0.0
+    }
+
+    private let state = OSAllocatedUnfairLock<Counters>(initialState: Counters())
+    private let reporter: ProgressReporter
+    private let totalBytes: Int64
+    private let totalFiles: Int
+
+    init(reporter: ProgressReporter, totalBytes: Int64, totalFiles: Int) {
+        self.reporter = reporter
+        self.totalBytes = totalBytes
+        self.totalFiles = totalFiles
+    }
+
+    /// Live byte callback for file `index`; nil when there is no handler
+    /// (skip the closure allocation and delegate churn entirely).
+    func liveBytesCallback(fileIndex: Int) -> (@Sendable (Int64, Int64) -> Void)? {
+        guard reporter.handler != nil else { return nil }
+        return { bytesWritten, _ in
+            self.updateBytes(fileIndex: fileIndex, bytesWritten: bytesWritten)
+        }
+    }
+
+    /// Record that file `index` finished (downloaded, cached, or created
+    /// empty) and emit its boundary. Returns the new completed-file count
+    /// for the caller's log cadence.
+    func fileCompleted(fileIndex: Int, size: Int) -> Int {
+        state.withLock { counters in
+            counters.inFlightBytes[fileIndex] = nil
+            counters.completedBytes += Int64(max(0, size))
+            counters.completedFiles += 1
+            emitLocked(&counters, phaseFiles: counters.completedFiles)
+            return counters.completedFiles
+        }
+    }
+
+    private func updateBytes(fileIndex: Int, bytesWritten: Int64) {
+        // Unknown-size files carry zero weight in totalBytes, so their real
+        // bytes would inflate the fraction mid-file and snap back at the
+        // boundary. Mirrors the sequential loop's guard.
+        guard totalBytes > 0 else { return }
+        state.withLock { counters in
+            counters.inFlightBytes[fileIndex] = bytesWritten
+            emitLocked(&counters, phaseFiles: counters.completedFiles)
+        }
+    }
+
+    private func emitLocked(_ counters: inout Counters, phaseFiles: Int) {
+        let bytes = counters.completedBytes + counters.inFlightBytes.values.reduce(0, +)
+        let fraction =
+            reporter.downloadPhaseWeight
+            * ProgressReporter.downloadFraction(
+                completedBytes: bytes, totalBytes: totalBytes,
+                completedFiles: phaseFiles, totalFiles: totalFiles)
+        counters.maxFraction = max(counters.maxFraction, fraction)
+        reporter.handler?(
+            DownloadProgress(
+                fractionCompleted: counters.maxFraction,
+                phase: .downloading(completedFiles: phaseFiles, totalFiles: totalFiles)))
     }
 }

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -23,11 +23,11 @@ public enum PocketTtsResourceDownloader {
     /// - Returns: The directory that contains the requested `.mlmodelc`
     ///   packages plus `constants_bin/` for the requested language.
     ///
-    /// Note: the upstream `v2/<lang>/` directory ships both flowlm variants,
-    /// so a fresh download pulls the unused variant too. After download
-    /// completes, the unused FlowLM `.mlmodelc` directory is deleted so only
-    /// the requested precision occupies disk (~140 MB savings for `.int8`,
-    /// ~75 MB savings for `.fp16`).
+    /// Note: the upstream `v2/<lang>/` directory ships every precision and
+    /// placement variant side by side (both FlowLM precisions plus the
+    /// `_ane`/`pocket_state` packages). The download filter skips any
+    /// `.mlmodelc` outside `ModelNames.PocketTTS.requiredModels(precision:placement:)`,
+    /// so only the variants this call loads come over the network (#853).
     ///
     /// The downloader also skips redundant repo artifacts entirely:
     /// `.mlpackage` sources (CoreML never loads them — the compiled
@@ -96,11 +96,11 @@ public enum PocketTtsResourceDownloader {
             subdirectory: subdir,
             to: repoDir,
             progressHandler: progressHandler,
-            shouldSkip: Self.shouldSkipAsset(at:)
+            shouldSkip: { Self.shouldSkipAsset(at: $0, required: required) }
         )
 
-        // The HF subdir contains both FlowLM precisions; delete the one we
-        // don't need so disk usage matches the loaded models.
+        // The filter above keeps the unused FlowLM variant off the network for
+        // fresh downloads; this cleans it off disk for caches that predate it.
         removeUnusedFlowlmVariant(at: languageRoot, keeping: precision)
 
         // The Trial 23 multifunction state package is not published on
@@ -148,13 +148,25 @@ public enum PocketTtsResourceDownloader {
     /// holds intermediate `.npy/.npz` files whose binary equivalents live
     /// under `constants_bin/`; `verify.wav` is an upstream debug artifact;
     /// `.DS_Store` is macOS junk.
-    @Sendable
-    private static func shouldSkipAsset(at path: String) -> Bool {
+    ///
+    /// `required` is the exact model set for the caller's precision +
+    /// placement (`ModelNames.PocketTTS.requiredModels(precision:placement:)`).
+    /// Any `.mlmodelc` bundle outside it is skipped whole — the upstream
+    /// directory ships every precision/placement variant side by side, and
+    /// without this the unused variants all came over the network (#853).
+    /// Skipping a directory path prunes the whole subtree in the lister, so
+    /// excluded bundles cost no tree-API calls either.
+    static func shouldSkipAsset(at path: String, required: Set<String>) -> Bool {
         let basename = (path as NSString).lastPathComponent
         if basename == ".DS_Store" || basename == "verify.wav" {
             return true
         }
         if basename.hasSuffix(".mlpackage") || path.contains(".mlpackage/") {
+            return true
+        }
+        if let bundle = path.split(separator: "/").first(where: { $0.hasSuffix(".mlmodelc") }),
+            !required.contains(String(bundle))
+        {
             return true
         }
         // Only skip the intermediate "constants/" subdirectory, never

--- a/Tests/FluidAudioTests/Shared/SubdirectoryDownloadTests.swift
+++ b/Tests/FluidAudioTests/Shared/SubdirectoryDownloadTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Drives `ModelHub.download(_:subdirectory:...)` through the
+/// `configuration:` seam with a stub transport. Pins the behavior the #853
+/// concurrent rewrite must preserve: every listed file lands on disk,
+/// `shouldSkip` prunes subtrees, already-present files are not refetched,
+/// and progress stays monotonic in [0, 1] with accurate file counters even
+/// though files now finish out of order.
+final class SubdirectoryDownloadTests: XCTestCase {
+
+    private var workDir: URL!
+
+    override func setUpWithError() throws {
+        workDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SubdirDownload-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+        TreeStubURLProtocol.reset()
+    }
+
+    override func tearDownWithError() throws {
+        TreeStubURLProtocol.reset()
+        try? FileManager.default.removeItem(at: workDir)
+    }
+
+    private var stubConfiguration: URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [TreeStubURLProtocol.self]
+        return config
+    }
+
+    /// A pack with more files than the concurrency width (default 4), so the
+    /// task-group refill path is exercised, plus a nested directory and a
+    /// zero-byte file (created locally, never fetched).
+    private func stubPack(fileCount: Int, bodySize: Int) {
+        var rootItems: [[String: Any]] = (0..<fileCount).map {
+            ["path": "pack/file\($0).bin", "type": "file", "size": bodySize]
+        }
+        rootItems.append(["path": "pack/sub", "type": "directory"])
+        rootItems.append(["path": "pack/empty.bin", "type": "file", "size": 0])
+        TreeStubURLProtocol.trees = [
+            "pack": rootItems,
+            "pack/sub": [["path": "pack/sub/nested.bin", "type": "file", "size": bodySize]],
+        ]
+        TreeStubURLProtocol.fileBody = Data(String(repeating: "x", count: bodySize).utf8)
+    }
+
+    func testDownloadsEveryListedFile() async throws {
+        stubPack(fileCount: 9, bodySize: 32)
+
+        try await ModelHub.download(
+            .vad, subdirectory: "pack", to: workDir,
+            configuration: stubConfiguration)
+
+        for index in 0..<9 {
+            let file = workDir.appendingPathComponent("pack/file\(index).bin")
+            XCTAssertEqual(try Data(contentsOf: file).count, 32, "missing or truncated \(file.path)")
+        }
+        XCTAssertEqual(
+            try Data(contentsOf: workDir.appendingPathComponent("pack/sub/nested.bin")).count, 32)
+        XCTAssertEqual(
+            try Data(contentsOf: workDir.appendingPathComponent("pack/empty.bin")).count, 0)
+    }
+
+    func testProgressIsMonotonicAndReachesAllFiles() async throws {
+        stubPack(fileCount: 9, bodySize: 32)
+
+        let recorder = ProgressStreamRecorder()
+        try await ModelHub.download(
+            .vad, subdirectory: "pack", to: workDir,
+            progressHandler: { recorder.append($0) },
+            configuration: stubConfiguration)
+
+        let events = recorder.snapshot()
+        XCTAssertFalse(events.isEmpty)
+
+        guard case .listing = events[0].phase else {
+            return XCTFail("first emission should be .listing, got \(events[0].phase)")
+        }
+        XCTAssertEqual(events[0].fractionCompleted, 0.0)
+
+        // Subdirectory downloads span the full 0-1 range (no compile phase).
+        var previousFraction = -Double.infinity
+        var previousCompleted = -1
+        for event in events {
+            XCTAssertGreaterThanOrEqual(event.fractionCompleted, previousFraction)
+            XCTAssertLessThanOrEqual(event.fractionCompleted, 1.0)
+            previousFraction = event.fractionCompleted
+            if case .downloading(let completed, let total) = event.phase {
+                XCTAssertEqual(total, 11)  // 9 root + 1 nested + 1 empty
+                XCTAssertLessThanOrEqual(completed, total)
+                // Completed-file counts never regress across emissions: the
+                // aggregator updates and emits under one lock.
+                XCTAssertGreaterThanOrEqual(completed, previousCompleted)
+                previousCompleted = completed
+            }
+        }
+
+        guard case .downloading(let completed, let total) = events.last!.phase else {
+            return XCTFail("last emission should be .downloading, got \(events.last!.phase)")
+        }
+        XCTAssertEqual(completed, total)
+        XCTAssertEqual(events.last!.fractionCompleted, 1.0, accuracy: 0.0001)
+    }
+
+    func testShouldSkipPrunesFilesAndSubtrees() async throws {
+        stubPack(fileCount: 3, bodySize: 16)
+
+        try await ModelHub.download(
+            .vad, subdirectory: "pack", to: workDir,
+            shouldSkip: { path in
+                path == "pack/sub" || path.hasSuffix("file1.bin")
+            },
+            configuration: stubConfiguration)
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: workDir.appendingPathComponent("pack/file0.bin").path))
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: workDir.appendingPathComponent("pack/file1.bin").path))
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: workDir.appendingPathComponent("pack/sub/nested.bin").path))
+    }
+
+    func testAlreadyPresentFileIsNotRefetched() async throws {
+        stubPack(fileCount: 2, bodySize: 16)
+        let existing = workDir.appendingPathComponent("pack/file0.bin")
+        try FileManager.default.createDirectory(
+            at: existing.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let localContent = Data("local-content".utf8)
+        try localContent.write(to: existing)
+
+        try await ModelHub.download(
+            .vad, subdirectory: "pack", to: workDir,
+            configuration: stubConfiguration)
+
+        XCTAssertEqual(try Data(contentsOf: existing), localContent)
+        XCTAssertEqual(
+            try Data(contentsOf: workDir.appendingPathComponent("pack/file1.bin")).count, 16)
+    }
+}
+
+/// Unit tests for `ConcurrentProgress` — the counter object the concurrent
+/// loop shares across tasks. Exercises the orderings the end-to-end stub
+/// tests can't force deterministically.
+final class ConcurrentProgressTests: XCTestCase {
+
+    func testRetryByteResetIsLiftedToHighWaterMark() throws {
+        let recorder = ProgressStreamRecorder()
+        let reporter = ProgressReporter(handler: { recorder.append($0) }, downloadPhaseWeight: 1.0)
+        let progress = ConcurrentProgress(reporter: reporter, totalBytes: 100, totalFiles: 2)
+
+        let onBytes = try XCTUnwrap(progress.liveBytesCallback(fileIndex: 0))
+        onBytes(50, 100)
+        // A retry that restarts the file from byte 0 reports fewer cumulative
+        // bytes; the emission must hold the high-water mark, not regress.
+        onBytes(10, 100)
+
+        let fractions = recorder.snapshot().map(\.fractionCompleted)
+        XCTAssertEqual(fractions, [0.5, 0.5])
+    }
+
+    func testFileCompletedCountsAndFinalFraction() {
+        let recorder = ProgressStreamRecorder()
+        let reporter = ProgressReporter(handler: { recorder.append($0) }, downloadPhaseWeight: 1.0)
+        let progress = ConcurrentProgress(reporter: reporter, totalBytes: 100, totalFiles: 2)
+
+        // Files complete out of order relative to their indices.
+        XCTAssertEqual(progress.fileCompleted(fileIndex: 1, size: 60), 1)
+        XCTAssertEqual(progress.fileCompleted(fileIndex: 0, size: 40), 2)
+
+        let events = recorder.snapshot()
+        XCTAssertEqual(events.count, 2)
+        guard case .downloading(let completed, let total) = events.last!.phase else {
+            return XCTFail("expected .downloading, got \(events.last!.phase)")
+        }
+        XCTAssertEqual(completed, 2)
+        XCTAssertEqual(total, 2)
+        XCTAssertEqual(events.last!.fractionCompleted, 1.0, accuracy: 0.0001)
+    }
+
+    func testUnknownTotalBytesFallsBackToFileCounts() {
+        let recorder = ProgressStreamRecorder()
+        let reporter = ProgressReporter(handler: { recorder.append($0) }, downloadPhaseWeight: 1.0)
+        // All sizes unknown: totalBytes 0, fractions come from file counts.
+        let progress = ConcurrentProgress(reporter: reporter, totalBytes: 0, totalFiles: 4)
+
+        XCTAssertEqual(progress.fileCompleted(fileIndex: 2, size: -1), 1)
+        let fractions = recorder.snapshot().map(\.fractionCompleted)
+        XCTAssertEqual(fractions, [0.25])
+    }
+}

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsDownloadFilterTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsDownloadFilterTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Pins `PocketTtsResourceDownloader.shouldSkipAsset(at:required:)` — the
+/// download-time filter that keeps unused precision/placement variants off
+/// the network (#853). The upstream `v2/<lang>/` directory ships every
+/// FlowLM precision plus the `_ane`/`pocket_state` packages side by side;
+/// only the bundles in `ModelNames.PocketTTS.requiredModels(precision:placement:)`
+/// may come through.
+final class PocketTtsDownloadFilterTests: XCTestCase {
+
+    private func skips(
+        _ path: String, precision: PocketTtsPrecision = .fp16,
+        placement: PocketTtsModelPlacement = .gpu
+    ) -> Bool {
+        PocketTtsResourceDownloader.shouldSkipAsset(
+            at: path,
+            required: ModelNames.PocketTTS.requiredModels(
+                precision: precision, placement: placement))
+    }
+
+    // MARK: - Precision (gpu placement)
+
+    func testFp16KeepsDefaultFlowlmAndSkipsInt8Variant() {
+        XCTAssertFalse(skips("v2.1/english/flowlm_step.mlmodelc", precision: .fp16))
+        XCTAssertFalse(skips("v2.1/english/flowlm_step.mlmodelc/model.mil", precision: .fp16))
+        XCTAssertTrue(skips("v2.1/english/flowlm_stepv2.mlmodelc", precision: .fp16))
+        XCTAssertTrue(skips("v2.1/english/flowlm_stepv2.mlmodelc/weights/weight.bin", precision: .fp16))
+    }
+
+    func testInt8KeepsV2FlowlmAndSkipsDefaultVariant() {
+        XCTAssertFalse(skips("v2.1/english/flowlm_stepv2.mlmodelc", precision: .int8))
+        XCTAssertTrue(skips("v2.1/english/flowlm_step.mlmodelc", precision: .int8))
+    }
+
+    // MARK: - Placement
+
+    func testGpuPlacementSkipsAneAndStateVariants() {
+        XCTAssertTrue(skips("v2.1/english/flowlm_step_ane.mlmodelc"))
+        XCTAssertTrue(skips("v2.1/english/cond_prefill_ane.mlmodelc"))
+        XCTAssertTrue(skips("v2.1/english/pocket_state.mlmodelc"))
+        XCTAssertFalse(skips("v2.1/english/cond_prefill.mlmodelc"))
+        XCTAssertFalse(skips("v2.1/english/flow_decoder_fused.mlmodelc"))
+        XCTAssertFalse(skips("v2.1/english/mimi_decoder.mlmodelc"))
+    }
+
+    func testAnePlacementKeepsAneVariantsAndSkipsGpuOnes() {
+        XCTAssertFalse(skips("v2.1/english/flowlm_step_ane.mlmodelc", placement: .ane))
+        XCTAssertFalse(skips("v2.1/english/cond_prefill_ane.mlmodelc", placement: .ane))
+        XCTAssertFalse(skips("v2.1/english/flow_decoder_fused.mlmodelc", placement: .ane))
+        XCTAssertTrue(skips("v2.1/english/cond_prefill.mlmodelc", placement: .ane))
+        XCTAssertTrue(skips("v2.1/english/flowlm_step.mlmodelc", placement: .ane))
+        XCTAssertTrue(skips("v2.1/english/flowlm_stepv2.mlmodelc", placement: .ane))
+        XCTAssertTrue(skips("v2.1/english/pocket_state.mlmodelc", placement: .ane))
+    }
+
+    func testAneStatePlacementKeepsOnlyStateAndMimi() {
+        XCTAssertFalse(skips("v2.1/english/pocket_state.mlmodelc", placement: .aneState))
+        XCTAssertFalse(skips("v2.1/english/mimi_decoder.mlmodelc", placement: .aneState))
+        XCTAssertTrue(skips("v2.1/english/cond_prefill.mlmodelc", placement: .aneState))
+        XCTAssertTrue(skips("v2.1/english/flowlm_step.mlmodelc", placement: .aneState))
+        XCTAssertTrue(skips("v2.1/english/flow_decoder_fused.mlmodelc", placement: .aneState))
+    }
+
+    // MARK: - Non-model assets are unaffected by the required set
+
+    func testConstantsBinAndLooseFilesAreKept() {
+        XCTAssertFalse(skips("v2.1/english/constants_bin"))
+        XCTAssertFalse(skips("v2.1/english/constants_bin/tokenizer.model"))
+        XCTAssertFalse(skips("v2.1/english/constants_bin/alba.safetensors"))
+        XCTAssertFalse(skips("v2.1/english/manifest.json"))
+    }
+
+    func testHistoricalExclusionsStillApply() {
+        // .mlpackage sources are skipped even for a required model name.
+        XCTAssertTrue(skips("v2.1/english/cond_prefill.mlpackage"))
+        XCTAssertTrue(skips("v2.1/english/cond_prefill.mlpackage/Data/weight.bin"))
+        XCTAssertTrue(skips("v2.1/english/constants"))
+        XCTAssertTrue(skips("v2.1/english/constants/embed.npy"))
+        XCTAssertTrue(skips("v2.1/english/verify.wav"))
+        XCTAssertTrue(skips("v2.1/english/.DS_Store"))
+    }
+}


### PR DESCRIPTION
Closes #853.

Two fixes to the PocketTTS first-download path:

## 1. Variant-aware skip filter

The upstream `v2/<lang>/` directory ships every FlowLM precision plus the `_ane`/`pocket_state` placement packages side by side, and `shouldSkipAsset` only excluded `.mlpackage` sources, `constants/`, and incidental files — so a `.gpu`/`.int8` caller still pulled the unused FlowLM precision AND all ANE-only bundles over the network, deleting only the FlowLM afterwards.

The filter now takes the exact required set from `ModelNames.PocketTTS.requiredModels(precision:placement:)` — which matches what `PocketTtsModelStore` actually loads per combination — and skips any `.mlmodelc` bundle outside it. Directory skips prune the whole subtree in `HFTreeLister`, so excluded bundles cost no tree-API calls either. `removeUnusedFlowlmVariant` stays to clean pre-existing caches.

## 2. Bounded-concurrency subdirectory downloads

`ModelHub.download(subdirectory:)` fetched files strictly sequentially — one `await` per file, paying a full network round-trip of latency each. The loop now runs through a `withThrowingTaskGroup` bounded by the new `DownloadConfig.maxConcurrentFiles` (default 4). The first thrown error cancels the group, and in-flight `.partial` files resume by byte range on the next attempt, preserving the sequential loop's abort-and-resume semantics. StyleTTS2 / Supertonic3 / Kokoro / LS-EEND subdirectory downloads get the same speedup.

The sequential loop threaded `completedBytes` through as a plain running total, which races under concurrency, so the new `ConcurrentProgress` owns the byte/file counters: updates and handler emissions happen under one lock, with a high-water-mark lift so out-of-order boundaries and retry byte resets never regress `fractionCompleted` (the documented monotonic invariant).

The repo-path loop in `ModelHub.download(_:to:)` is deliberately left sequential — its emissions are pinned by `ProgressSequenceTests` and the pre-#765 progress asymmetry note; possible follow-up.

## Validation

- Real from-scratch download (english, `.int8`, temp cache dir): **13.07 s**, only the six required entries on disk (`cond_prefill`, `flowlm_stepv2`, `flow_decoder_fused`, `mimi_decoder`, `constants_bin`, `manifest.json`); loading + synthesis from the filtered cache verified. Issue reports 19.66 s downstream with both fixes vs "a few minutes" before.
- `download(subdirectory:)` gains the `configuration:` test seam the repo path already had; `SubdirectoryDownloadTests` drives the concurrent loop end-to-end over `TreeStubURLProtocol` (all files land, `shouldSkip` prunes, already-present files untouched, progress monotonic in [0, 1] with accurate counters), `ConcurrentProgressTests` covers the orderings the stub can't force, and `PocketTtsDownloadFilterTests` pins the filter across all precision/placement combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)