### PR TITLE
fix(download): latch pre-attach cancellation so cancelled downloads never start

### DIFF
--- a/Sources/FluidAudio/Shared/Download/FileDownloader.swift
+++ b/Sources/FluidAudio/Shared/Download/FileDownloader.swift
@@ -425,6 +425,12 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
         var watchdog: DispatchSourceTimer?
         var bytesAtWindowStart: Int64 = 0
         var stalled = false
+        // Latches a caller `cancel()` that arrives before `attach()` registers
+        // the task — a Swift task that is already cancelled runs its
+        // cancellation handler before the operation, so without the latch the
+        // request would start anyway (e.g. siblings of a failed download in
+        // ModelHub's bounded task group).
+        var cancelled = false
     }
 
     /// Serial queue that fires every download's stall-watchdog timer; shared so
@@ -466,27 +472,58 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
     /// cancels the task if fewer than `minStallBytes` arrived since the last
     /// wake — catching a frozen CDN connection in seconds rather than waiting
     /// out the request's idle `timeout`.
+    ///
+    /// When `cancel()` already ran (a pre-cancelled Swift task fires its
+    /// cancellation handler before the operation body), the continuation is
+    /// failed here directly: the URLSession task is cancelled before its
+    /// `resume()`, so it never loads and never delivers
+    /// `didCompleteWithError` — waiting on the delegate would hang.
     func attach(
         continuation: CheckedContinuation<HTTPURLResponse, Error>,
         task: URLSessionDataTask
     ) {
-        let timer: DispatchSourceTimer? =
-            (minStallBytes > 0 && stallWindow > 0)
-            ? DispatchSource.makeTimerSource(queue: Self.watchdogQueue) : nil
-        state.withLockUnchecked {
-            $0.continuation = continuation
-            $0.task = task
-            $0.watchdog = timer
+        let alreadyCancelled = state.withLockUnchecked { st -> Bool in
+            if st.cancelled {
+                st.finished = true
+                return true
+            }
+            st.continuation = continuation
+            st.task = task
+            return false
         }
-        if let timer {
-            timer.schedule(deadline: .now() + stallWindow, repeating: stallWindow)
-            timer.setEventHandler { [weak self] in self?.checkStall() }
+        if alreadyCancelled {
+            task.cancel()
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+
+        guard minStallBytes > 0 && stallWindow > 0 else { return }
+        let timer = DispatchSource.makeTimerSource(queue: Self.watchdogQueue)
+        let armed = state.withLockUnchecked { st -> Bool in
+            guard !st.finished else { return false }
+            st.watchdog = timer
+            return true
+        }
+        guard armed else {
+            // The transfer finished (or was cancelled) between the two lock
+            // scopes, so nothing will ever cancel this timer. A suspended
+            // DispatchSource cannot be released; resume-then-cancel disposes
+            // it safely (no handler is set, so it fires into nothing).
             timer.resume()
+            timer.cancel()
+            return
         }
+        timer.schedule(deadline: .now() + stallWindow, repeating: stallWindow)
+        timer.setEventHandler { [weak self] in self?.checkStall() }
+        timer.resume()
     }
 
     func cancel() {
-        state.withLockUnchecked { $0.task }?.cancel()
+        let task = state.withLockUnchecked { st -> URLSessionTask? in
+            st.cancelled = true
+            return st.task
+        }
+        task?.cancel()
     }
 
     /// One watchdog tick: cancel the task if the byte count advanced by less

--- a/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Assets/PocketTtsResourceDownloader.swift
@@ -59,6 +59,10 @@ public enum PocketTtsResourceDownloader {
         if allPresent {
             logger.info(
                 "PocketTTS \(language.rawValue) (\(precision)) models found in cache")
+            // Caches downloaded before the #853 variant-aware filter may still
+            // hold the unused FlowLM precision; complete caches return from
+            // this branch, so the post-download cleanup below never sees them.
+            removeUnusedFlowlmVariant(at: languageRoot, keeping: precision)
             // Pre-#592 caches lack `constants_bin/bos_before_voice.bin`. The
             // language-pack files are otherwise complete, so try to fetch just
             // the missing constant rather than re-downloading the whole subdir.

--- a/Tests/FluidAudioTests/Shared/FileDownloaderCancellationTests.swift
+++ b/Tests/FluidAudioTests/Shared/FileDownloaderCancellationTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import XCTest
+
+@testable import FluidAudio
+
+/// Regression tests for the pre-cancelled download race (#863 follow-up): a
+/// Swift task that is already cancelled runs `withTaskCancellationHandler`'s
+/// handler BEFORE the operation body, so `StreamingDownloadDelegate.cancel()`
+/// fired with no URLSession task registered — and the request then started
+/// anyway. The delegate now latches the cancel and `attach` fails the
+/// continuation without ever resuming the URLSession task.
+final class FileDownloaderCancellationTests: XCTestCase {
+
+    private var workDir: URL!
+
+    override func setUpWithError() throws {
+        workDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("FileDownloaderCancel-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+        ResumeStubURLProtocol.reset()
+    }
+
+    override func tearDownWithError() throws {
+        ResumeStubURLProtocol.reset()
+        try? FileManager.default.removeItem(at: workDir)
+    }
+
+    private var stubConfiguration: URLSessionConfiguration {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [ResumeStubURLProtocol.self]
+        return config
+    }
+
+    func testPreCancelledDownloadThrowsCancellationWithoutStartingARequest() async throws {
+        // A scripted 200 the download would consume if it (wrongly) ran.
+        ResumeStubURLProtocol.enqueue(
+            .init(
+                status: 200, headers: ["ETag": "\"v1\""],
+                chunks: [Data("BINARYCONTENT-0123456789".utf8)]))
+
+        let request = URLRequest(url: URL(string: "https://stub.test/repo/resolve/main/model.bin")!)
+        let partial = workDir.appendingPathComponent("model.bin.partial")
+        let configuration = stubConfiguration
+
+        let task = Task<URL, Error> {
+            // Enter the download only once cancellation has definitely landed,
+            // so streamDownload begins inside an already-cancelled task and
+            // its onCancel handler runs before the operation body.
+            while !Task.isCancelled { await Task.yield() }
+            return try await FileDownloader.download(
+                request: request,
+                path: "model.bin",
+                expectedSize: 24,
+                partialFileURL: partial,
+                onProgress: nil,
+                maxAttempts: 3,
+                minBackoff: 0.01,
+                configuration: configuration
+            )
+        }
+        task.cancel()
+        let result = await task.result
+
+        guard case .failure(let error) = result else {
+            return XCTFail("pre-cancelled download must throw, got a result")
+        }
+        XCTAssertTrue(
+            RetryPolicy.isCancellation(error),
+            "pre-cancelled download must surface a cancellation (not retry or succeed), got \(error)")
+        XCTAssertTrue(
+            ResumeStubURLProtocol.recordedRequests().isEmpty,
+            "a pre-cancelled download must not start a network request")
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: partial.path),
+            "a pre-cancelled download must not leave a partial file")
+    }
+}


### PR DESCRIPTION
Follow-up to #863, addressing the post-merge review finding.

## The race

`withTaskCancellationHandler` runs its handler **before** the operation body when the Swift task is already cancelled. `StreamingDownloadDelegate.cancel()` therefore fired with no URLSession task registered, and the already-cancelled task then proceeded to start the request anyway. With #863's bounded task group, siblings of a failed download could still open network connections that the group then waits on — contradicting the stated abort-and-resume semantics.

## The fix

`cancel()` now latches into the delegate's locked state. `attach()` observes the latch, marks the transfer finished, cancels the URLSession task before its `resume()`, and fails the continuation with `CancellationError` directly:

- A task cancelled before `resume()` never touches the transport (verified by probe: `URLProtocol.startLoading` count 0).
- The direct continuation resume matters because a never-resumed task delivers no `didCompleteWithError` to wait on; when the no-op `resume()` does trigger a completion, the existing `finished` guard makes it a no-op — no double-resume.
- `RetryPolicy` classifies `CancellationError` as non-retryable cancellation, so it propagates without burning retry attempts.
- The stall-watchdog timer is now created only after the latch check; if the transfer finishes between the two lock scopes, the unarmed timer is disposed via resume-then-cancel (releasing a suspended `DispatchSource` crashes).

## Also from review (non-blocking finding)

The #863 claim that `removeUnusedFlowlmVariant` cleans pre-existing caches was wrong: the `allPresent` fast path returns before the post-download cleanup, so an already-complete cache kept the unused FlowLM precision forever. The fast path now runs the (idempotent) cleanup too, matching the documented only-the-requested-precision-on-disk contract.

## Tests

`FileDownloaderCancellationTests` pins the race end-to-end: a pre-cancelled task entering `FileDownloader.download` must throw a cancellation, record **zero** transport requests (via `ResumeStubURLProtocol`'s request log), and leave no `.partial` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)