### PR TITLE
fix(asr/nemotron-multilingual): rescue pause-delimited speech spans that decode to all-blank (#838)

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/NemotronMultilingualStreamingConfig.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/NemotronMultilingualStreamingConfig.swift
@@ -4,7 +4,8 @@ import Foundation
 ///
 /// Loaded from `metadata.json`. Differs from the English variant in three ways:
 ///   1. Larger vocab (13,087 tokens) and matching `blank_idx`.
-///   2. Smaller channel cache: `[1, 24, 56, 1024]` (att_context_size=[56, 0]).
+///   2. Cache shapes per `metadata.json` (published artifacts ship
+///      `att_context_size=[42, 13]`, channel cache `[1, 24, 42, 1024]`).
 ///   3. The encoder takes an additional `prompt_id` int32 [1] input per chunk
 ///      which selects the language hint embedding. The model also emits a leading
 ///      `<xx-XX>` language-tag token whose IDs are listed in `lang_tag_token_ids`.

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+BlankRescue.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+BlankRescue.swift
@@ -1,0 +1,300 @@
+import Accelerate
+@preconcurrency import CoreML
+import Foundation
+
+/// Blank-span rescue (issue #838).
+///
+/// The cache-aware encoder + RNN-T decoder carry state across chunks. After
+/// certain preceding audio, the greedy decode can collapse to blank for an
+/// entire short, pause-delimited word — silently dropping it. The same span
+/// decodes correctly from fresh state, so the rescue re-decodes exactly the
+/// spans that produced nothing:
+///
+///   1. Track speech spans with a per-encoder-frame (80 ms) RMS gate.
+///   2. When a span closes (240 ms of silence) and no token timing falls
+///      inside it, re-decode the buffered span audio on fresh encoder caches
+///      and decoder state, appending any recovered tokens to the transcript.
+///   3. Restore the live stream's state afterwards — the main decode path is
+///      byte-identical whenever spans emit normally.
+///
+/// A span that was never speech (noise, clicks) re-decodes to nothing and the
+/// rescue is a no-op, so a false trigger costs only the extra decode.
+extension StreamingNemotronMultilingualAsrManager {
+
+    /// RMS below this is silence for span tracking. Independent of the
+    /// opt-in VAD-skip threshold; 0 disables the rescue entirely.
+    nonisolated internal static let rescueRmsThreshold: Float = {
+        if let raw = ProcessInfo.processInfo.environment["FLUIDAUDIO_RESCUE_RMS_THRESHOLD"],
+            let value = Float(raw)
+        {
+            return value
+        }
+        return 0.0025
+    }()
+
+    nonisolated internal static let blankRescueEnabled: Bool = {
+        if let raw = ProcessInfo.processInfo.environment["FLUIDAUDIO_DISABLE_BLANK_RESCUE"] {
+            let lowered = raw.lowercased()
+            return lowered == "0" || lowered == "false" || lowered == "no"
+        }
+        return true
+    }()
+
+    /// Span-tracking geometry, in 80 ms RMS windows (1 encoder frame each).
+    private static let closeSilentWindows = 2  // span closes after 160 ms of silence
+    private static let preRollWindows = 3  // 240 ms of audio kept before speech onset
+    private static let minSpeechWindows = 2  // spans shorter than 160 ms are not rescued
+    private static let maxSpanSamples = 15 * 16000  // give up past 15 s (span emitted nothing that long)
+
+    /// `processChunk` plus blank-span bookkeeping. All streaming call sites
+    /// route through this; the rescue itself calls `processChunk` directly.
+    internal func processChunkTracked(_ samples: [Float], nextChunkSamples: [Float]? = nil) async throws {
+        guard Self.blankRescueEnabled, Self.rescueRmsThreshold > 0, !inBlankRescue else {
+            try await processChunk(samples, nextChunkSamples: nextChunkSamples)
+            return
+        }
+        let chunkStartFrame = rescueFrameCursor
+        try await processChunk(samples, nextChunkSamples: nextChunkSamples)
+        rescueFrameCursor += samples.count / ASRConstants.samplesPerEncoderFrame
+        try await updateRescueSpans(chunk: samples, chunkStartFrame: chunkStartFrame)
+    }
+
+    /// Close a span left open by end-of-stream. Called from `finish()` after
+    /// the trailing chunk is processed and before the transcript is decoded.
+    internal func finalizeRescueSpanIfNeeded() async throws {
+        guard Self.blankRescueEnabled, Self.rescueRmsThreshold > 0, rescueSpanOpen else { return }
+        try await closeSpanAndMaybeRescue()
+    }
+
+    /// Walk the chunk in 80 ms windows, advancing the span state machine.
+    private func updateRescueSpans(chunk: [Float], chunkStartFrame: Int) async throws {
+        let windowSamples = ASRConstants.samplesPerEncoderFrame
+        let windowCount = chunk.count / windowSamples
+        for index in 0..<windowCount {
+            let start = index * windowSamples
+            var rms: Float = 0
+            chunk.withUnsafeBufferPointer { buf in
+                vDSP_rmsqv(buf.baseAddress! + start, 1, &rms, vDSP_Length(windowSamples))
+            }
+            let silent = rms < Self.rescueRmsThreshold
+            let frame = chunkStartFrame + index
+
+            if rescueSpanOpen {
+                if silent {
+                    rescueSilentWindowRun += 1
+                } else {
+                    rescueSilentWindowRun = 0
+                    rescueSpanLastSpeechFrame = frame
+                    rescueSpanSpeechWindows += 1
+                }
+            } else if !silent {
+                rescueSpanOpen = true
+                rescueSpanStartFrame = frame
+                rescueSpanLastSpeechFrame = frame
+                rescueSpanSpeechWindows = 1
+                rescueSilentWindowRun = 0
+                rescueSpanAudio = rescuePreRollTail
+                rescueSpanPreRollFrames = rescuePreRollTail.count / windowSamples
+                rescueSpanOverflowed = false
+            }
+
+            if rescueSpanOpen, !rescueSpanOverflowed {
+                rescueSpanAudio.append(contentsOf: chunk[start..<(start + windowSamples)])
+                if rescueSpanAudio.count > Self.maxSpanSamples {
+                    rescueSpanOverflowed = true
+                    rescueSpanAudio = []
+                }
+            } else if !rescueSpanOpen {
+                rescuePreRollTail.append(contentsOf: chunk[start..<(start + windowSamples)])
+                let maxPreRoll = Self.preRollWindows * windowSamples
+                if rescuePreRollTail.count > maxPreRoll {
+                    rescuePreRollTail.removeFirst(rescuePreRollTail.count - maxPreRoll)
+                }
+            }
+
+            if rescueSpanOpen, rescueSilentWindowRun >= Self.closeSilentWindows {
+                try await closeSpanAndMaybeRescue()
+            }
+        }
+    }
+
+    /// Evaluate the just-closed span: if no token timing falls inside it,
+    /// re-decode the buffered audio from fresh state.
+    private func closeSpanAndMaybeRescue() async throws {
+        let spanAudio = rescueSpanAudio
+        let startFrame = rescueSpanStartFrame
+        let lastSpeechFrame = rescueSpanLastSpeechFrame
+        let speechWindows = rescueSpanSpeechWindows
+        let preRollFrames = rescueSpanPreRollFrames
+        let overflowed = rescueSpanOverflowed
+        rescueSpanOpen = false
+        rescueSpanAudio = []
+        rescueSpanSpeechWindows = 0
+        rescueSilentWindowRun = 0
+        rescueSpanOverflowed = false
+        // The silence that closed the span is this span's pre-roll history.
+        rescuePreRollTail = []
+
+        guard !overflowed, speechWindows >= Self.minSpeechWindows else { return }
+
+        // One frame of onset slack (the RMS gate can trail the acoustics);
+        // five frames (400 ms) of closing slack because RNN-T emissions lag
+        // the audio — a span's token often lands a few frames into the
+        // trailing silence, and counting it prevents a duplicate emission
+        // from the rescue.
+        let openSec =
+            (Double(startFrame) - 1) * ASRConstants.secondsPerEncoderFrame
+        let closeSec =
+            (Double(lastSpeechFrame) + 5) * ASRConstants.secondsPerEncoderFrame
+        // Only lexical tokens count as span output: with long pauses the
+        // decode often spends the span's frames emitting the previous
+        // sentence's terminal punctuation ("afternoon." + dropped word) —
+        // punctuation alone must not mask a swallowed word.
+        let spanEmitted = accumulatedTokenTimings.contains {
+            $0.startTime >= openSec && $0.startTime <= closeSec
+                && Self.containsLexicalContent($0.token)
+        }
+        guard !spanEmitted else { return }
+
+        try await rescueDecode(span: spanAudio, spanStartFrame: startFrame - preRollFrames)
+    }
+
+    /// Re-decode `span` on fresh encoder caches and decoder state, appending
+    /// recovered tokens to the transcript, then restore the live stream state.
+    private func rescueDecode(span: [Float], spanStartFrame: Int) async throws {
+        guard encoder != nil, config.chunkSamples > 0 else { return }
+
+        // Save the live stream's carried state. Loopback outputs are never
+        // output-backed (see makePredictionOptions), so these references stay
+        // valid across the rescue's predictions.
+        let savedCacheChannel = cacheChannel
+        let savedCacheTime = cacheTime
+        let savedCacheLen = cacheLen
+        let savedEncoderState = encoderState
+        let savedMelCache = melCache
+        let savedHState = hState
+        let savedCState = cState
+        let savedLastToken = lastToken
+        let savedPrefetchedMel = prefetchedMel
+        let savedPrefetchedEncoded = prefetchedEncoded
+        let savedPrefetchedEncoderProj = prefetchedEncoderProj
+        let savedPrefetchedCacheChannel = prefetchedCacheChannel
+        let savedPrefetchedCacheTime = prefetchedCacheTime
+        let savedPrefetchedCacheLen = prefetchedCacheLen
+        let savedAbsoluteFrameBase = absoluteFrameBase
+        let savedChunkCount = chunkCount
+        let savedProcessedChunks = processedChunks
+        let savedVadRun = vadConsecutiveLowChunks
+
+        inBlankRescue = true
+        defer {
+            cacheChannel = savedCacheChannel
+            cacheTime = savedCacheTime
+            cacheLen = savedCacheLen
+            encoderState = savedEncoderState
+            melCache = savedMelCache
+            hState = savedHState
+            cState = savedCState
+            lastToken = savedLastToken
+            prefetchedMel = savedPrefetchedMel
+            prefetchedEncoded = savedPrefetchedEncoded
+            prefetchedEncoderProj = savedPrefetchedEncoderProj
+            prefetchedCacheChannel = savedPrefetchedCacheChannel
+            prefetchedCacheTime = savedPrefetchedCacheTime
+            prefetchedCacheLen = savedPrefetchedCacheLen
+            absoluteFrameBase = savedAbsoluteFrameBase
+            chunkCount = savedChunkCount
+            processedChunks = savedProcessedChunks
+            vadConsecutiveLowChunks = savedVadRun
+            inBlankRescue = false
+        }
+
+        try resetStatesForRescue()
+        // Sessions with a forced language re-seed the lang-tag prefix so the
+        // rescue decodes in the same language as the live stream.
+        try await applyForcedPrefixIfNeeded()
+        // Rescue tokens keep their true position on the stream timeline.
+        absoluteFrameBase = max(0, spanStartFrame)
+
+        let chunkSamples = config.chunkSamples
+        var audio = span
+        let remainder = audio.count % chunkSamples
+        if remainder != 0 {
+            audio.append(contentsOf: repeatElement(0, count: chunkSamples - remainder))
+        }
+        // One trailing silent chunk so the final speech frames decode with
+        // their full attention lookahead (mirrors finish()'s zero-pad).
+        audio.append(contentsOf: repeatElement(0, count: chunkSamples))
+
+        let tokensBefore = accumulatedTokenIds.count
+        var offset = 0
+        while offset < audio.count {
+            try await processChunk(Array(audio[offset..<(offset + chunkSamples)]))
+            offset += chunkSamples
+        }
+        let recovered = accumulatedTokenIds.count - tokensBefore
+        if recovered > 0 {
+            blankRescueCount += 1
+            logger.info(
+                "Blank-span rescue recovered \(recovered) token(s) from a "
+                    + String(format: "%.2f", Double(span.count) / 16000.0) + "s span at frame \(spanStartFrame)"
+            )
+        }
+    }
+
+    /// True when the raw token piece carries letters/digits (any script) —
+    /// i.e. is more than word-boundary markers and punctuation.
+    nonisolated internal static func containsLexicalContent(_ rawToken: String) -> Bool {
+        rawToken.unicodeScalars.contains { CharacterSet.alphanumerics.contains($0) }
+    }
+
+    /// Fresh caches + decoder state for the rescue decode. Mirrors
+    /// `resetStates()` but leaves transcript accumulation, language
+    /// detection, and span bookkeeping untouched.
+    private func resetStatesForRescue() throws {
+        let cacheConfig = EncoderCacheManager.CacheConfig(
+            channelShape: config.cacheChannelShape,
+            timeShape: config.cacheTimeShape,
+            lenShape: [1]
+        )
+        let caches = try EncoderCacheManager.createInitialCaches(config: cacheConfig)
+        cacheChannel = caches.channel
+        cacheTime = caches.time
+        cacheLen = caches.len
+        if #available(macOS 15, iOS 18, *) {
+            if let enc = encoder, !enc.modelDescription.stateDescriptionsByName.isEmpty {
+                encoderState = enc.makeState()
+            }
+        }
+        // Same 1-frame preamble as resetStates(): keeps the encoder's
+        // slice_by_index off the zero-length-slice path.
+        cacheLen?[0] = 1
+        melCache = nil
+        prefetchedMel = nil
+        prefetchedEncoded = nil
+        prefetchedEncoderProj = nil
+        prefetchedCacheChannel = nil
+        prefetchedCacheTime = nil
+        prefetchedCacheLen = nil
+        hState = try EncoderCacheManager.createZeroArray(
+            shape: [config.decoderLayers, 1, config.decoderHidden])
+        cState = try EncoderCacheManager.createZeroArray(
+            shape: [config.decoderLayers, 1, config.decoderHidden])
+        lastToken = Int32(config.blankIdx)
+    }
+
+    /// Reset span bookkeeping. Called from `resetStates()` on session reset.
+    internal func resetRescueState() {
+        rescueFrameCursor = 0
+        rescueSpanOpen = false
+        rescueSpanStartFrame = 0
+        rescueSpanLastSpeechFrame = 0
+        rescueSpanSpeechWindows = 0
+        rescueSpanPreRollFrames = 0
+        rescueSilentWindowRun = 0
+        rescueSpanAudio = []
+        rescueSpanOverflowed = false
+        rescuePreRollTail = []
+        inBlankRescue = false
+    }
+}

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+BlankRescue.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager+BlankRescue.swift
@@ -156,13 +156,31 @@ extension StreamingNemotronMultilingualAsrManager {
         }
         guard !spanEmitted else { return }
 
-        try await rescueDecode(span: spanAudio, spanStartFrame: startFrame - preRollFrames)
+        recordDetectedBlankSpan()
+        try await rescueDecode(
+            span: spanAudio,
+            spanStartFrame: startFrame - preRollFrames,
+            spanEndFrame: lastSpeechFrame + 1)
     }
 
-    /// Re-decode `span` on fresh encoder caches and decoder state, appending
-    /// recovered tokens to the transcript, then restore the live stream state.
-    private func rescueDecode(span: [Float], spanStartFrame: Int) async throws {
-        guard encoder != nil, config.chunkSamples > 0 else { return }
+    /// A speech span decoded to all-blank live; a rescue is being attempted.
+    internal func recordDetectedBlankSpan() {
+        detectedBlankSpanCount += 1
+    }
+
+    /// A rescue committed lexical content to the transcript.
+    internal func recordSuccessfulRescue() {
+        blankRescueCount += 1
+    }
+
+    /// Re-decode `span` on fresh encoder caches and decoder state. The trial
+    /// decode is staged: its tokens are captured and removed, partial
+    /// callbacks are suppressed, and the result is committed only when it
+    /// contains lexical content — inserted at the span's timestamp position
+    /// so words already decoded from later audio in the same chunk keep
+    /// their order. Live stream state is restored afterwards.
+    private func rescueDecode(span: [Float], spanStartFrame: Int, spanEndFrame: Int) async throws {
+        guard encoder != nil, config.chunkSamples > 0, let tokenizer = tokenizer else { return }
 
         // Save the live stream's carried state. Loopback outputs are never
         // output-backed (see makePredictionOptions), so these references stay
@@ -185,6 +203,11 @@ extension StreamingNemotronMultilingualAsrManager {
         let savedChunkCount = chunkCount
         let savedProcessedChunks = processedChunks
         let savedVadRun = vadConsecutiveLowChunks
+        // Suppress partial callbacks for the duration of the trial decode —
+        // they would surface unvalidated, out-of-order text. A single
+        // callback fires after a successful commit instead.
+        let savedPartialCallback = partialCallback
+        partialCallback = nil
 
         inBlankRescue = true
         defer {
@@ -206,6 +229,7 @@ extension StreamingNemotronMultilingualAsrManager {
             chunkCount = savedChunkCount
             processedChunks = savedProcessedChunks
             vadConsecutiveLowChunks = savedVadRun
+            partialCallback = savedPartialCallback
             inBlankRescue = false
         }
 
@@ -227,19 +251,106 @@ extension StreamingNemotronMultilingualAsrManager {
         audio.append(contentsOf: repeatElement(0, count: chunkSamples))
 
         let tokensBefore = accumulatedTokenIds.count
+        let timingsBefore = accumulatedTokenTimings.count
         var offset = 0
         while offset < audio.count {
             try await processChunk(Array(audio[offset..<(offset + chunkSamples)]))
             offset += chunkSamples
         }
-        let recovered = accumulatedTokenIds.count - tokensBefore
-        if recovered > 0 {
-            blankRescueCount += 1
+
+        // Stage: pull the trial decode's output back out of the accumulators.
+        // Lang-tag re-emissions carry no user content (and have no timing
+        // entry) — drop them so staged ids and timings stay 1:1.
+        let stagedIds = Array(accumulatedTokenIds[tokensBefore...])
+            .filter { !config.langTagTokenIds.contains($0) }
+        // Clamp staged timings to the span's real extent: the rescue decode's
+        // own emission latency (plus the zero-pad flush) stamps trailing
+        // tokens past the span end, and a timing that bleeds into the NEXT
+        // span's attribution window would wrongly mask that span's drop.
+        let spanEndSec = Double(spanEndFrame) * ASRConstants.secondsPerEncoderFrame
+        let stagedTimings = Array(accumulatedTokenTimings[timingsBefore...]).map { t in
+            t.startTime <= spanEndSec
+                ? t
+                : TokenTiming(
+                    token: t.token, tokenId: t.tokenId, startTime: spanEndSec,
+                    endTime: spanEndSec + ASRConstants.secondsPerEncoderFrame,
+                    confidence: t.confidence)
+        }
+        accumulatedTokenIds.removeSubrange(tokensBefore...)
+        accumulatedTokenTimings.removeSubrange(timingsBefore...)
+
+        // Commit only lexical recoveries: punctuation or nothing means the
+        // span is genuinely blank (noise, or unrecoverable) — leave the
+        // transcript untouched.
+        let hasLexical = stagedIds.contains {
+            Self.containsLexicalContent(tokenizer.rawToken(for: $0) ?? "")
+        }
+        guard hasLexical else {
             logger.info(
-                "Blank-span rescue recovered \(recovered) token(s) from a "
+                "Blank-span rescue found no lexical content in a "
                     + String(format: "%.2f", Double(span.count) / 16000.0) + "s span at frame \(spanStartFrame)"
             )
+            return
         }
+
+        let spanStartSec = Double(max(0, spanStartFrame)) * ASRConstants.secondsPerEncoderFrame
+        (accumulatedTokenIds, accumulatedTokenTimings) = Self.mergeRescuedTokens(
+            liveIds: accumulatedTokenIds,
+            liveTimings: accumulatedTokenTimings,
+            rescuedIds: stagedIds,
+            rescuedTimings: stagedTimings,
+            langTagTokenIds: config.langTagTokenIds,
+            spanStartSec: spanStartSec
+        )
+        recordSuccessfulRescue()
+        logger.info(
+            "Blank-span rescue recovered \(stagedIds.count) token(s) from a "
+                + String(format: "%.2f", Double(span.count) / 16000.0) + "s span at frame \(spanStartFrame)"
+        )
+        if let callback = savedPartialCallback {
+            callback(tokenizer.decode(ids: accumulatedTokenIds).text)
+        }
+    }
+
+    /// Insert rescued tokens at the span's timestamp position instead of
+    /// appending: when a dropped span and later speech share one chunk, the
+    /// later words are already in the accumulators by the time the span
+    /// closes, and a plain append would order them "later-word rescued-word".
+    ///
+    /// `liveTimings` is 1:1 with the non-lang-tag entries of `liveIds`
+    /// (lang-tag tokens never get timings — see `appendTokenTiming`);
+    /// `rescuedIds`/`rescuedTimings` are 1:1 (lang tags already dropped).
+    nonisolated internal static func mergeRescuedTokens(
+        liveIds: [Int],
+        liveTimings: [TokenTiming],
+        rescuedIds: [Int],
+        rescuedTimings: [TokenTiming],
+        langTagTokenIds: Set<Int>,
+        spanStartSec: Double
+    ) -> (ids: [Int], timings: [TokenTiming]) {
+        let insertKey = rescuedTimings.first?.startTime ?? spanStartSec
+        let timingInsertIndex =
+            liveTimings.firstIndex { $0.startTime > insertKey } ?? liveTimings.count
+
+        // Map the timing index onto the ids array by walking past lang-tag
+        // entries, which occupy an id slot but no timing slot.
+        var idsInsertIndex = liveIds.count
+        var timedSeen = 0
+        for (index, id) in liveIds.enumerated() {
+            if timedSeen == timingInsertIndex, !langTagTokenIds.contains(id) {
+                idsInsertIndex = index
+                break
+            }
+            if !langTagTokenIds.contains(id) {
+                timedSeen += 1
+            }
+        }
+
+        var ids = liveIds
+        var timings = liveTimings
+        ids.insert(contentsOf: rescuedIds, at: idsInsertIndex)
+        timings.insert(contentsOf: rescuedTimings, at: timingInsertIndex)
+        return (ids, timings)
     }
 
     /// True when the raw token piece carries letters/digits (any script) —
@@ -296,5 +407,7 @@ extension StreamingNemotronMultilingualAsrManager {
         rescueSpanOverflowed = false
         rescuePreRollTail = []
         inBlankRescue = false
+        detectedBlankSpanCount = 0
+        blankRescueCount = 0
     }
 }

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager.swift
@@ -225,9 +225,14 @@ public actor StreamingNemotronMultilingualAsrManager {
     internal var rescueSpanOverflowed: Bool = false
     internal var rescuePreRollTail: [Float] = []
     internal var inBlankRescue: Bool = false
-    /// Number of spans whose fresh-state re-decode recovered tokens this
-    /// session. A nonzero value means the live decode silently dropped
-    /// pause-delimited speech (issue #838).
+    /// Number of speech spans this session that the live decode left
+    /// all-blank (a fresh-state rescue was attempted). A nonzero value means
+    /// the live decode silently dropped pause-delimited speech (issue #838),
+    /// whether or not the rescue recovered it. Cleared by `reset()`.
+    public internal(set) var detectedBlankSpanCount: Int = 0
+    /// Number of blank spans whose fresh-state re-decode recovered lexical
+    /// content this session (always <= `detectedBlankSpanCount`). Cleared by
+    /// `reset()`.
     public internal(set) var blankRescueCount: Int = 0
 
     // Decoder LSTM states

--- a/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/Streaming/Nemotron/StreamingNemotronMultilingualAsrManager.swift
@@ -13,7 +13,8 @@ public typealias NemotronMultilingualPartialCallback = @Sendable (String) -> Voi
 ///   1. The encoder takes an extra `prompt_id` int32 [1] input per chunk.
 ///   2. The vocab is ~13k tokens and includes language-tag pieces like
 ///      `<en-US>` which are filtered from the transcript.
-///   3. The channel cache shape is `[1, 24, 56, 1024]` (att_context_size=[56,0]).
+///   3. The cache shapes come from `metadata.json` (published artifacts ship
+///      `att_context_size=[42,13]` with channel cache `[1, 24, 42, 1024]`).
 ///
 /// **Models** are published at
 /// `FluidInference/Nemotron-3.5-ASR-Streaming-Multilingual-0.6b-CoreML`. Use
@@ -209,6 +210,25 @@ public actor StreamingNemotronMultilingualAsrManager {
     /// chunks — preserves the first low chunk after speech (consonant
     /// tails) and only skips true sustained silence.
     internal var vadConsecutiveLowChunks: Int = 0
+
+    // MARK: - Blank-span rescue bookkeeping (issue #838; see +BlankRescue.swift)
+    /// Encoder frames of audio consumed by the live stream (rescue-invariant,
+    /// unlike `absoluteFrameBase` which the rescue temporarily rebases).
+    internal var rescueFrameCursor: Int = 0
+    internal var rescueSpanOpen: Bool = false
+    internal var rescueSpanStartFrame: Int = 0
+    internal var rescueSpanLastSpeechFrame: Int = 0
+    internal var rescueSpanSpeechWindows: Int = 0
+    internal var rescueSpanPreRollFrames: Int = 0
+    internal var rescueSilentWindowRun: Int = 0
+    internal var rescueSpanAudio: [Float] = []
+    internal var rescueSpanOverflowed: Bool = false
+    internal var rescuePreRollTail: [Float] = []
+    internal var inBlankRescue: Bool = false
+    /// Number of spans whose fresh-state re-decode recovered tokens this
+    /// session. A nonzero value means the live decode silently dropped
+    /// pause-delimited speech (issue #838).
+    public internal(set) var blankRescueCount: Int = 0
 
     // Decoder LSTM states
     internal var hState: MLMultiArray?
@@ -799,7 +819,7 @@ public actor StreamingNemotronMultilingualAsrManager {
     /// language and write the resulting state back to `hState`/`cState`/`lastToken`.
     /// No-op if forced-prefix is disabled, no language is set, the tokenizer/
     /// decoder isn't loaded, or the language has no matching lang-tag token.
-    private func applyForcedPrefixIfNeeded() async throws {
+    internal func applyForcedPrefixIfNeeded() async throws {
         guard useForcedPrefix,
             let language = currentLanguageCode,
             let tokenizer = tokenizer,
@@ -904,6 +924,8 @@ public actor StreamingNemotronMultilingualAsrManager {
         )
 
         lastToken = Int32(config.blankIdx)
+
+        resetRescueState()
     }
 
     /// Append audio buffer for processing
@@ -951,7 +973,7 @@ public actor StreamingNemotronMultilingualAsrManager {
                 (self.audioBuffer.count - nextStart) >= chunkSamples
                 ? Array(self.audioBuffer[nextStart..<nextEnd])
                 : nil
-            try await processChunk(chunk, nextChunkSamples: nextChunkSamples)
+            try await processChunkTracked(chunk, nextChunkSamples: nextChunkSamples)
             self.audioBufferOffset += chunkSamples
 
             // Periodic compaction: once we've consumed enough prefix, do a
@@ -990,10 +1012,14 @@ public actor StreamingNemotronMultilingualAsrManager {
             let chunkStart = audioBufferOffset
             let chunkEnd = chunkStart + config.chunkSamples
             let chunk = Array(audioBuffer[chunkStart..<chunkEnd])
-            try await processChunk(chunk)
+            try await processChunkTracked(chunk)
             audioBuffer.removeAll()
             audioBufferOffset = 0
         }
+
+        // Issue #838: a trailing speech span that decoded to all-blank gets
+        // one fresh-state re-decode before the transcript is assembled.
+        try await finalizeRescueSpanIfNeeded()
 
         let decoded = tokenizer.decode(ids: accumulatedTokenIds)
         if firstDetectedLanguage == nil {

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronMultilingualTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronMultilingualTests.swift
@@ -280,6 +280,43 @@ final class NemotronMultilingualTests: XCTestCase {
                 tokenizerPath: tokenizer, metadataPath: metadata))
     }
 
+    // MARK: - Blank-span rescue (issue #838)
+
+    func testContainsLexicalContentWords() {
+        XCTAssertTrue(StreamingNemotronMultilingualAsrManager.containsLexicalContent("▁Gemma"))
+        XCTAssertTrue(StreamingNemotronMultilingualAsrManager.containsLexicalContent("hello"))
+        XCTAssertTrue(StreamingNemotronMultilingualAsrManager.containsLexicalContent("A"))
+        XCTAssertTrue(StreamingNemotronMultilingualAsrManager.containsLexicalContent("42"))
+        // CJK ideographs and kana are lexical.
+        XCTAssertTrue(StreamingNemotronMultilingualAsrManager.containsLexicalContent("你好"))
+        XCTAssertTrue(StreamingNemotronMultilingualAsrManager.containsLexicalContent("こんにちは"))
+        // Word piece with attached punctuation still counts.
+        XCTAssertTrue(StreamingNemotronMultilingualAsrManager.containsLexicalContent("▁afternoon."))
+    }
+
+    func testContainsLexicalContentPunctuationOnly() {
+        // Terminal punctuation emitted into a pause must not mask a
+        // swallowed word (the rescue-suppression case from #838).
+        XCTAssertFalse(StreamingNemotronMultilingualAsrManager.containsLexicalContent("."))
+        XCTAssertFalse(StreamingNemotronMultilingualAsrManager.containsLexicalContent(","))
+        XCTAssertFalse(StreamingNemotronMultilingualAsrManager.containsLexicalContent("?"))
+        XCTAssertFalse(StreamingNemotronMultilingualAsrManager.containsLexicalContent("。"))
+        XCTAssertFalse(StreamingNemotronMultilingualAsrManager.containsLexicalContent("▁"))
+        XCTAssertFalse(StreamingNemotronMultilingualAsrManager.containsLexicalContent("▁..."))
+        XCTAssertFalse(StreamingNemotronMultilingualAsrManager.containsLexicalContent(""))
+    }
+
+    func testBlankRescueDefaults() {
+        // Default-on unless FLUIDAUDIO_DISABLE_BLANK_RESCUE is set in the
+        // environment (CI does not set it).
+        if ProcessInfo.processInfo.environment["FLUIDAUDIO_DISABLE_BLANK_RESCUE"] == nil {
+            XCTAssertTrue(StreamingNemotronMultilingualAsrManager.blankRescueEnabled)
+        }
+        if ProcessInfo.processInfo.environment["FLUIDAUDIO_RESCUE_RMS_THRESHOLD"] == nil {
+            XCTAssertEqual(StreamingNemotronMultilingualAsrManager.rescueRmsThreshold, 0.0025)
+        }
+    }
+
     // MARK: - Helpers
 
     private func makeConfig(

--- a/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronMultilingualTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/Streaming/NemotronMultilingualTests.swift
@@ -306,6 +306,71 @@ final class NemotronMultilingualTests: XCTestCase {
         XCTAssertFalse(StreamingNemotronMultilingualAsrManager.containsLexicalContent(""))
     }
 
+    private func timing(_ id: Int, _ start: Double, token: String = "▁w") -> TokenTiming {
+        TokenTiming(
+            token: token, tokenId: id, startTime: start,
+            endTime: start + 0.08, confidence: 1.0)
+    }
+
+    func testMergeRescuedTokensInsertsAtTimestampPosition() {
+        // Live: word@1.0, word@5.0 (later speech from the same chunk already
+        // appended). Rescued: word@3.0 must land between them, not after.
+        let live = ([10, 20], [timing(10, 1.0), timing(20, 5.0)])
+        let merged = StreamingNemotronMultilingualAsrManager.mergeRescuedTokens(
+            liveIds: live.0, liveTimings: live.1,
+            rescuedIds: [30], rescuedTimings: [timing(30, 3.0)],
+            langTagTokenIds: [], spanStartSec: 2.9)
+        XCTAssertEqual(merged.ids, [10, 30, 20])
+        XCTAssertEqual(merged.timings.map { $0.tokenId }, [10, 30, 20])
+        XCTAssertEqual(merged.timings.map { $0.startTime }, [1.0, 3.0, 5.0])
+    }
+
+    func testMergeRescuedTokensAppendsWhenSpanIsLatest() {
+        let merged = StreamingNemotronMultilingualAsrManager.mergeRescuedTokens(
+            liveIds: [10], liveTimings: [timing(10, 1.0)],
+            rescuedIds: [30, 31], rescuedTimings: [timing(30, 3.0), timing(31, 3.1)],
+            langTagTokenIds: [], spanStartSec: 2.9)
+        XCTAssertEqual(merged.ids, [10, 30, 31])
+        XCTAssertEqual(merged.timings.map { $0.startTime }, [1.0, 3.0, 3.1])
+    }
+
+    func testMergeRescuedTokensSkipsLeadingLangTag() {
+        // Lang-tag ids occupy an id slot but no timing slot; insertion at
+        // timing index 0 must not displace the leading tag.
+        let langTag = 13000
+        let merged = StreamingNemotronMultilingualAsrManager.mergeRescuedTokens(
+            liveIds: [langTag, 10], liveTimings: [timing(10, 5.0)],
+            rescuedIds: [30], rescuedTimings: [timing(30, 2.0)],
+            langTagTokenIds: [langTag], spanStartSec: 1.9)
+        XCTAssertEqual(merged.ids, [langTag, 30, 10])
+        XCTAssertEqual(merged.timings.map { $0.startTime }, [2.0, 5.0])
+    }
+
+    func testMergeRescuedTokensEmptyLive() {
+        let merged = StreamingNemotronMultilingualAsrManager.mergeRescuedTokens(
+            liveIds: [], liveTimings: [],
+            rescuedIds: [30], rescuedTimings: [timing(30, 0.5)],
+            langTagTokenIds: [], spanStartSec: 0.4)
+        XCTAssertEqual(merged.ids, [30])
+        XCTAssertEqual(merged.timings.count, 1)
+    }
+
+    func testBlankSpanCountersClearOnReset() async {
+        let manager = StreamingNemotronMultilingualAsrManager()
+        await manager.recordDetectedBlankSpan()
+        await manager.recordDetectedBlankSpan()
+        await manager.recordSuccessfulRescue()
+        var detected = await manager.detectedBlankSpanCount
+        var rescued = await manager.blankRescueCount
+        XCTAssertEqual(detected, 2)
+        XCTAssertEqual(rescued, 1)
+        await manager.reset()
+        detected = await manager.detectedBlankSpanCount
+        rescued = await manager.blankRescueCount
+        XCTAssertEqual(detected, 0)
+        XCTAssertEqual(rescued, 0)
+    }
+
     func testBlankRescueDefaults() {
         // Default-on unless FLUIDAUDIO_DISABLE_BLANK_RESCUE is set in the
         // environment (CI does not set it).


### PR DESCRIPTION
Fixes #838.

## Problem

On the Nemotron multilingual streaming manager, a short word spoken in isolation between pauses can silently decode to all-blank, and whether it does depends on the *preceding* audio, not the word (see #838 for the original repro and narrowing).

Reproduced with the issue's `say`-clip harness, swept across 19 lead voices (the reporter's exact voices didn't fail on this machine — `say` output differs across macOS versions, and the bug is state-dependent): the same 0.39 s "Gemma" clip was silently dropped in **33 of 171** trials, with one lead voice (Karen) dropping it at **every** gap from 0 to 2000 ms and a Samantha lead never dropping it — exactly the reported shape.

## Root cause

- **Not chunk geometry.** The failure is unchanged at the 1120 ms and 2240 ms tiers, so the `[42,13]`-lookahead vs 7-frame-chunk theory from the issue thread is exonerated.
- **The carried encoder+decoder state, jointly.** Mid-stream isolation experiments: resetting only the decoder LSTM state or only the encoder cache makes decode *worse* (the two must stay coherent); resetting both — equivalent to a fresh session — recovers the word. This matches the reporter's follow-up finding that the same span always decodes correctly standalone. It is a model-level sensitivity of the cache-aware export, not a Swift pipeline bug, so the fix is a targeted repair rather than a decode-path change.

## Fix: blank-span rescue

Same shape as the #861 final-window re-decode on the sliding-window path, applied to pause-delimited spans:

- Track speech spans with an 80 ms RMS gate (span closes after 160 ms of silence; 240 ms pre-roll).
- When a span closes and **no lexical token timing** falls inside it, re-decode the buffered span audio on fresh encoder caches + decoder state, appending recovered tokens to the transcript. The live stream's state is saved and restored around the rescue (loopback outputs are never output-backed, so the saved references stay valid); forced-prefix language seeding is re-applied.
- Attribution details that mattered in practice:
  - **Lexical tokens only** — with long pauses the decode often spends the span's frames emitting the previous sentence's terminal punctuation (`"…afternoon."` + dropped word); punctuation must not mask a swallowed word.
  - **400 ms close-side slack** — RNN-T emissions lag the audio; without it a late-emitted word gets duplicated by the rescue (`"Jenna Gemma"`).
- A span that was never speech re-decodes to nothing, so a false trigger is a no-op costing only the extra decode. The normal decode path is untouched whenever spans emit normally.

The trial decode is **staged and validated** before anything reaches the transcript: its tokens are captured and removed from the accumulators, partial callbacks are suppressed for its duration (one callback fires after a successful commit), and the result is committed only when it contains lexical content — inserted at the span's **timestamp position** (lang-tag-aware index mapping), so words already decoded from later audio in the same 1120/2240 ms chunk keep their order. Staged timings are clamped to the span's real extent; without the clamp, the rescue decode's own emission latency stamps trailing tokens past the span end and masks a *second* consecutive drop (observed on the stress fixture: the utterance right after a rescued word also decoded to all-blank and was silently lost — with the clamp, back-to-back drops rescue independently and in order).

Per the issue's API ask, two counters are public and cleared on `reset()`: `detectedBlankSpanCount` (a live span decoded to all-blank — the drop signal, even when the rescue also comes back blank) and `blankRescueCount` (committed lexical recoveries, always ≤ detected). Env knobs: `FLUIDAUDIO_DISABLE_BLANK_RESCUE` opts out; `FLUIDAUDIO_RESCUE_RMS_THRESHOLD` tunes the silence gate (default 0.0025, `0` disables).

## Results

Repro matrix (19 voices × 9 gaps, 560 ms tier):

| | true silent drops |
|---|---|
| before | 33 / 171 |
| after | **7 / 171** — all at gap ≤ 200 ms |

The 7 remaining drops have no VAD-detectable pause to split the span (gap ≤ 200 ms) — the same inherent limitation as the reporter's Silero-based rescue workaround. Remaining non-drop misses are homophone mishears ("Gemma" → "Jenna"), present with and without the fix (that's #841 territory, not a drop).

Regression A/B (`FLUIDAUDIO_DISABLE_BLANK_RESCUE=1` vs default), 560 ms tier:

| dataset | WER (off / on) | CER (off / on) | RTFx (off / on) |
|---|---|---|---|
| FLEURS en_us, 50 files | 8.2 / 8.2 | 4.4 / 4.5 | 60.0 / 59.5 |
| FLEURS cmn_hans_cn, 20 files | 17.5 / 17.5 | 17.5 / 17.5 | 54.6 / 54.5 |

Also corrects the stale `att_context_size=[56,0]` comments — the published multilingual artifacts ship `[42,13]` with channel cache `[1,24,42,1024]` per their `metadata.json`.

## Not covered (follow-ups)

- Gap ≤ 200 ms drops (word butts against the previous utterance with no pause) — needs a different mechanism.
- The English `StreamingNemotronAsrManager` likely has the same failure class and could take the same rescue; untested here.
- Rescued tokens are timestamp-ordered in the timing stream (post-review); tokens decoded from the rescue's zero-pad flush are clamped to the span end, so their timings are span-accurate but not frame-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
