### PR TITLE
fix(tts/kokoro-ane): adopt COLA-corrected KokoroTail_v2 + native output level for all variants

### DIFF
--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -1428,7 +1428,10 @@ public enum ModelNames {
         // re-download. See mobius laishere-coreml docs/trials-and-errors.md.
         public static let noise = "KokoroNoise_v2.mlmodelc"
         public static let vocoder = "KokoroVocoder.mlmodelc"
-        public static let tail = "KokoroTail.mlmodelc"
+        // v2: COLA-normalized iSTFT deconv weights (raw output was exactly 1.5x
+        // the PyTorch reference). Renamed (not overwritten) so cached clients
+        // re-download. See issue #852.
+        public static let tail = "KokoroTail_v2.mlmodelc"
 
         /// Auxiliary (non-CoreML) files that must accompany the mlmodelc bundles.
         public static let vocab = "vocab.json"

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
@@ -16,7 +16,7 @@ public enum KokoroAneConstants {
     /// Default voice id for the Japanese (`ANE-ja/`) variant.
     public static let defaultVoiceJapanese = "jf_alpha"
 
-    /// Output sample rate of the iSTFT in `KokoroTail.mlpackage`.
+    /// Output sample rate of the iSTFT in `KokoroTail_v2.mlpackage`.
     public static let sampleRate = 24_000
 
     /// BOS / EOS token id used by both `convert-coreml.py` and the iOS demo.

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -358,14 +358,14 @@ public actor KokoroAneManager {
 
     private func wavData(from result: KokoroAneSynthesisResult) throws -> Data {
         do {
-            // Japanese writes at the model's native level (no peak-normalization)
-            // so the output matches the PyTorch reference instead of being
-            // slammed to 0 dBFS. English/Mandarin keep peak-normalization until
-            // their tails get the same COLA-corrected iSTFT (#698 follow-up).
+            // All variants write at the model's native level (no
+            // peak-normalization) so the output matches the PyTorch reference
+            // instead of being slammed to 0 dBFS. Requires the COLA-corrected
+            // KokoroTail_v2 (#852).
             return try AudioWAV.data(
                 from: result.samples,
                 sampleRate: Double(result.sampleRate),
-                normalize: variant != .japanese)
+                normalize: false)
         } catch {
             throw KokoroAneError.audioConversionFailed(error.localizedDescription)
         }

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer+Types.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneSynthesizer+Types.swift
@@ -96,7 +96,7 @@ public enum KokoroAneStage: String, CaseIterable, Sendable {
         case .prosody: return "KokoroProsody.mlmodelc"
         case .noise: return "KokoroNoise_v2.mlmodelc"  // v2: atan2 phase-correction (HF-noise fix)
         case .vocoder: return "KokoroVocoder.mlmodelc"
-        case .tail: return "KokoroTail.mlmodelc"
+        case .tail: return "KokoroTail_v2.mlmodelc"  // v2: COLA-normalized iSTFT (level fix, #852)
         }
     }
 }

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -879,10 +879,12 @@ public struct TTS {
                 detailed = try await manager.synthesizeDetailed(
                     text: text, voice: resolvedVoice, speed: 1.0)
             }
+            // Native level for all variants — matches the PyTorch reference
+            // now that KokoroTail_v2 carries the COLA-corrected iSTFT (#852).
             let wav = try AudioWAV.data(
                 from: detailed.samples,
                 sampleRate: Double(detailed.sampleRate),
-                normalize: variant != .japanese)
+                normalize: false)
             let tSynth1 = Date()
 
             let outURL = resolveInputURL(output)


### PR DESCRIPTION
Closes #852. Completes the follow-up scoped in #699.

## Background

#699 found that `CoreMLCustomSTFT` (KokoroTail) omits the overlap-add/COLA normalization `torch.istft` applies — the interior envelope is a constant `sum(w²) = 1.5` (periodic Hann, win 20 / hop 5), so raw output is exactly 1.5× the PyTorch reference. The PR fixed the conversion and moved `.japanese` to native output level, but as #852 correctly reports, the corrected tail never made it to HuggingFace (and the script fix never made it into mobius): `.japanese` has been shipping unmasked 1.5×-hot audio, while English/Mandarin were protected only by peak normalization.

The fix is a pure weight rescale (iSTFT deconv kernels ÷ 1.5) — `model.mil` is unchanged, which is why the issue's mil-graph analysis couldn't see it; it shows only in the `weight.bin` LFS oid.

## What landed where

- **`FluidInference/kokoro-82m-coreml` commit `acac8811`** — corrected tails published as `KokoroTail_v2.mlmodelc` alongside the originals in `ANE/`, `ANE-ja/`, `ANE-zh/` (originals kept; consumers opt in by pointer change). The en/ja tail is the artifact #699 measured at 1.02× PyTorch; the zh tail carries the same corrected kernel spans (the iSTFT deconv constants are deterministic DFT×window kernels, byte-identical between en and zh).
- **mobius#83** — the conversion-script fix, reconstructed and committed (matches the #699-measured artifact to 1 ulp).
- **This PR** — points all three variants at `KokoroTail_v2.mlmodelc` and drops peak normalization for English/Mandarin (`normalize: false` in `KokoroAneManager.wavData` and the CLI), so all variants write at reference-accurate native level.

The `_v2` rename (same pattern as `KokoroNoise_v2`) doubles as cache invalidation: `DownloadUtils` skips files that already exist and the weight.bin size is unchanged, so a same-path replacement would never reach existing caches. With the rename, existing caches fetch just the missing file on the next `ensureModels`.

## Validation

- CoreML A/B (CPU_ONLY, fixed input) of v1 vs v2 tails, both en/ja and zh: interior per-sample ratio **1.500000**, correlation **1.000000000** — pure scalar, no spectral change.
- E2E on M5 Pro from an existing cache: self-heal downloaded only `KokoroTail_v2.mlmodelc` per variant; native render peaks **en 0.343 / zh 0.400 / ja 0.354** (reference territory — #699 measured PyTorch `jf_alpha` at 0.299), vs the 1.0 previously forced by 0 dBFS normalization.
- `swift build` + `swift format lint` clean.

## Behavior change

KokoroAne WAV output is no longer slammed to 0 dBFS for English/Mandarin — output now sits at the model's native (PyTorch-matched) level, consistent with `.japanese`, LuxTTS, and NeuTTS. Downstream code that assumed peak-normalized output will hear quieter (correct) levels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)