### PR TITLE
fix(asr/tdt): default v3 long-form to the no-mel path (silence-aligned starts)

### DIFF
--- a/Documentation/ASR/LongTranscription.md
+++ b/Documentation/ASR/LongTranscription.md
@@ -71,9 +71,9 @@ phrase at the wrong point.
 
 | Path | Enabled by | Scope | Purpose |
 |---|---|---|---|
-| Default mel-context | `ASRConfig.melChunkContext = true` | Batch TDT long audio | Preserves the existing 80 ms left-context behavior for non-first chunks. |
-| v3 no-mel | `ASRConfig.melChunkContext = false`, CLI `--no-mel-context` | Parakeet TDT v3 batch long audio | Avoids the v3 multilingual drift introduced by prepending mel context at chunk boundaries. |
-| v3 dual-decode arbitration | `melChunkContext = false` plus `ASRConfig.dualDecodeArbitration = true`, CLI `--no-mel-context --dual-decode-arbitration` | Parakeet TDT v3 no-mel batch long audio | Opt-in quality mode for files where one boundary strategy is clearly safer than another. |
+| Mel-context | `ASRConfig.melChunkContext = true`, CLI `--mel-context` (default for non-v3 models) | Batch TDT long audio | Preserves the existing 80 ms left-context behavior for non-first chunks. |
+| v3 no-mel | Default for v3 (`melChunkContext = nil`); explicit via `ASRConfig.melChunkContext = false`, CLI `--no-mel-context` | Parakeet TDT v3 batch long audio | Avoids the v3 multilingual drift introduced by prepending mel context at chunk boundaries (#594), and — via silence-aligned chunk starts — the quiet-speech drops near long mid-file silence runs (#803). |
+| v3 dual-decode arbitration | `ASRConfig.dualDecodeArbitration = true` on the v3 no-mel path, CLI `--dual-decode-arbitration` | Parakeet TDT v3 no-mel batch long audio | Opt-in quality mode for files where one boundary strategy is clearly safer than another. |
 | Parallel chunk workers | `ASRConfig.parallelChunkConcurrency` (default `4`, clamped to `>= 1`) | Stateless chunked batch TDT (all of the above) | Decodes independent chunks concurrently across a worker pool of cloned `AsrManager` instances. |
 | Post-merge repair pass | `ASRConfig.seamGapRepair = true` (default), CLI `--no-seam-gap-repair` | Multi-chunk batch TDT (all of the above) | Re-decodes suspicious inter-token gaps with fresh seam-free windows, splicing recovered tokens in. See "Post-Merge Repair Pass". |
 
@@ -136,7 +136,8 @@ but the two mechanisms behave differently:
   the chunk so the FastConformer encoder's depthwise convolutions have stable
   left context for the first emitted frame. The decoder is told to *skip*
   those leading frames via `contextSamples`; they do not produce tokens.
-  Enabled when `ASRConfig.melChunkContext = true` (the default).
+  Enabled when `ASRConfig.melChunkContext` resolves to `true` (the default
+  for non-v3 models; v3 defaults to the no-mel path).
 - **Warmup prefix** (`warmupPrefixSamples`, 0–7 encoder frames). Real audio
   from before the chunk start, decoded normally from frame 0; emitted tokens
   are suppressed up to the chunk start via `emitTokensAfterFrame`. Used only
@@ -515,12 +516,15 @@ RMS exceeds `0.008 / 0.3 ≈ 0.027`.
   with a quiet gap clamps to the ceiling, so that gap is gated as if the
   whole file were loud. A gap-local reference window would close this.
 - The dead-silence-at-window-end pathology also afflicts **mid-file**
-  windows whose fixed-stride end lands inside a silence run (observed: a
-  LibriVox recording whose quiet outro credit falls in such a window loses
-  it — on `main` and on this branch alike). Snapping *every* window end to
-  the last speech-bearing frame was tried and reverted: it perturbs dozens
-  of mid-file windows per hour of audio for a net-neutral WER change. A
-  targeted fix needs its own issue and regression run.
+  windows on the mel-context path (issue #803; observed: a LibriVox
+  recording whose quiet outro credit falls in such a window loses it).
+  Snapping window ends to the last speech-bearing frame was tried twice and
+  reverted both times — the failing window decodes all-blank even when
+  trimmed and backfilled to end in speech, because the trigger is
+  fixed-stride window *starts* landing mid-word on quiet speech, not the
+  trailing silence. The v3 no-mel path's silence-aligned starts avoid the
+  class (validated on the LibriVox case), which is why v3 now defaults to
+  no-mel; the mel-context path retains the limitation.
 - Repair validation corpora are English conference and quiet dictation
   audio; multilingual and music-heavy content is less exercised.
 

--- a/Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift
@@ -27,9 +27,16 @@ public struct ASRConfig: Sendable {
     /// blank-boundary fix). `nil` (default) resolves per model version:
     /// `false` on v3 — the no-mel path's silence-aligned chunk starts avoid
     /// both the multilingual drift (issue #594) and quiet-speech drops near
-    /// long silence runs (issue #803) — and `true` elsewhere. See "Current
-    /// Paths" in Documentation/ASR/LongTranscription.md.
-    public let melChunkContext: Bool?
+    /// long silence runs (issue #803) — and `true` elsewhere. Set via the
+    /// `melChunkContext:` init parameter. See "Current Paths" in
+    /// Documentation/ASR/LongTranscription.md.
+    public let melChunkContextOverride: Bool?
+
+    /// Legacy Boolean view of `melChunkContextOverride`. Reports the explicit
+    /// setting, or the non-v3 default (`true`) when unset — it cannot see the
+    /// version-aware resolution applied at model load (v3 resolves to `false`).
+    @available(*, deprecated, renamed: "melChunkContextOverride")
+    public var melChunkContext: Bool { melChunkContextOverride ?? true }
 
     /// Opt-in probe-then-commit chunking arbitration for the v3 + no-mel
     /// batch path (default `false`) — strategies, commitment rationale, and
@@ -66,7 +73,7 @@ public struct ASRConfig: Sendable {
         self.parallelChunkConcurrency = max(1, parallelChunkConcurrency)
         self.streamingEnabled = streamingEnabled
         self.streamingThreshold = streamingThreshold
-        self.melChunkContext = melChunkContext
+        self.melChunkContextOverride = melChunkContext
         self.dualDecodeArbitration = dualDecodeArbitration
         self.seamGapRepair = seamGapRepair
         self.seamGapRepairMinGapSeconds = max(0.5, seamGapRepairMinGapSeconds)
@@ -74,7 +81,7 @@ public struct ASRConfig: Sendable {
 
     /// Resolve the mel-context tri-state against the loaded model version.
     func resolvedMelChunkContext(for modelVersion: AsrModelVersion?) -> Bool {
-        melChunkContext ?? (modelVersion != .v3)
+        melChunkContextOverride ?? (modelVersion != .v3)
     }
 }
 

--- a/Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift
@@ -24,10 +24,12 @@ public struct ASRConfig: Sendable {
     public let streamingThreshold: Int
 
     /// 80ms mel-context prepend on non-first long-form chunks (PR #264
-    /// blank-boundary fix). Set `false` for v3 multilingual long-form batch
-    /// transcription (issue #594 English-prior drift) — see "Current Paths"
-    /// in Documentation/ASR/LongTranscription.md.
-    public let melChunkContext: Bool
+    /// blank-boundary fix). `nil` (default) resolves per model version:
+    /// `false` on v3 — the no-mel path's silence-aligned chunk starts avoid
+    /// both the multilingual drift (issue #594) and quiet-speech drops near
+    /// long silence runs (issue #803) — and `true` elsewhere. See "Current
+    /// Paths" in Documentation/ASR/LongTranscription.md.
+    public let melChunkContext: Bool?
 
     /// Opt-in probe-then-commit chunking arbitration for the v3 + no-mel
     /// batch path (default `false`) — strategies, commitment rationale, and
@@ -53,7 +55,7 @@ public struct ASRConfig: Sendable {
         parallelChunkConcurrency: Int = 4,
         streamingEnabled: Bool = true,
         streamingThreshold: Int = 480_000,
-        melChunkContext: Bool = true,
+        melChunkContext: Bool? = nil,
         dualDecodeArbitration: Bool = false,
         seamGapRepair: Bool = true,
         seamGapRepairMinGapSeconds: Double = 1.5
@@ -68,6 +70,11 @@ public struct ASRConfig: Sendable {
         self.dualDecodeArbitration = dualDecodeArbitration
         self.seamGapRepair = seamGapRepair
         self.seamGapRepairMinGapSeconds = max(0.5, seamGapRepairMinGapSeconds)
+    }
+
+    /// Resolve the mel-context tri-state against the loaded model version.
+    func resolvedMelChunkContext(for modelVersion: AsrModelVersion?) -> Bool {
+        melChunkContext ?? (modelVersion != .v3)
     }
 }
 

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
@@ -33,11 +33,12 @@ public actor AsrManager {
         config.parallelChunkConcurrency
     }
 
-    /// Issue #594: opt-out flag exposed to `ChunkProcessor`. When `false`,
-    /// disables PR #264's 80ms mel-context prepend so v3 multilingual
-    /// long-form audio can use the no-mel boundary warmup path.
+    /// Resolved mel-context flag exposed to `ChunkProcessor`. When `false`,
+    /// disables PR #264's 80ms mel-context prepend so v3 long-form audio
+    /// uses the no-mel boundary warmup path with silence-aligned chunk
+    /// starts (issues #594, #803). Unset config resolves to `false` on v3.
     internal var melChunkContext: Bool {
-        config.melChunkContext
+        config.resolvedMelChunkContext(for: modelVersion)
     }
 
     /// Opt-in dual-decode arbitration flag exposed to `ChunkProcessor`.

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
@@ -262,7 +262,7 @@ public actor AsrManager {
                 parallelChunkConcurrency: workingConfig.parallelChunkConcurrency,
                 streamingEnabled: workingConfig.streamingEnabled,
                 streamingThreshold: workingConfig.streamingThreshold,
-                melChunkContext: workingConfig.melChunkContext,
+                melChunkContext: workingConfig.melChunkContextOverride,
                 dualDecodeArbitration: workingConfig.dualDecodeArbitration
             )
         }
@@ -277,7 +277,7 @@ public actor AsrManager {
                 parallelChunkConcurrency: workingConfig.parallelChunkConcurrency,
                 streamingEnabled: workingConfig.streamingEnabled,
                 streamingThreshold: workingConfig.streamingThreshold,
-                melChunkContext: workingConfig.melChunkContext,
+                melChunkContext: workingConfig.melChunkContextOverride,
                 dualDecodeArbitration: workingConfig.dualDecodeArbitration
             )
         } else {

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV2.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV2.swift
@@ -77,7 +77,7 @@ internal struct TdtDecoderV2 {
             parallelChunkConcurrency: config.parallelChunkConcurrency,
             streamingEnabled: config.streamingEnabled,
             streamingThreshold: config.streamingThreshold,
-            melChunkContext: config.melChunkContext,
+            melChunkContext: config.melChunkContextOverride,
             dualDecodeArbitration: config.dualDecodeArbitration
         )
     }

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/AsrBenchmark.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/AsrBenchmark.swift
@@ -653,7 +653,7 @@ extension ASRBenchmark {
         var useStreamingEou = false
         var longAudioOnly = false
         var modelVersion: AsrModelVersion = .v3  // Default to v3
-        var melChunkContext = true  // Issue #594: opt-out of PR #264's 80ms mel-context prepend
+        var melChunkContext: Bool?  // nil = auto (disabled on v3); see ASRConfig.melChunkContext
         var encoderComputeUnits: MLComputeUnits?  // nil = library default (ANE); see --encoder-compute-units
 
         // Check for help flag first
@@ -726,6 +726,8 @@ extension ASRBenchmark {
                 }
             case "--no-mel-context":
                 melChunkContext = false
+            case "--mel-context":
+                melChunkContext = true
             case "--encoder-compute-units":
                 if i + 1 < arguments.count {
                     switch arguments[i + 1].lowercased() {
@@ -769,7 +771,8 @@ extension ASRBenchmark {
         logger.info("   Auto-download: \(autoDownload ? "enabled" : "disabled")")
         logger.info("   Test streaming: \(testStreaming ? "enabled" : "disabled")")
         logger.info("   Streaming EOU: \(useStreamingEou ? "enabled" : "disabled")")
-        logger.info("   Mel chunk context (PR #264): \(melChunkContext ? "enabled" : "disabled")")
+        logger.info(
+            "   Mel chunk context (PR #264): \(melChunkContext.map { $0 ? "enabled" : "disabled" } ?? "auto")")
         if testStreaming {
             logger.info("   Chunk duration: \(streamingChunkDuration)s")
         }
@@ -1066,6 +1069,8 @@ extension ASRBenchmark {
                 --long-audio-only          Only process files with 4-20 second duration
                 --dump-features            Dump CoreML mel features to JSON (requires --streaming-eou + --single-file)
                 --no-mel-context           Disable 80ms mel-context prepend for long-form batch ASR
+                                           (default: disabled on v3, enabled otherwise)
+                --mel-context              Force-enable the mel-context prepend (v3 opt-in)
                 --encoder-compute-units <u> Encoder placement: ane (default), gpu (~+8% RTFx on Apple Silicon, WER-neutral), cpu, all
                 --help, -h                Show this help message
 

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -209,7 +209,7 @@ enum TranscribeCommand {
         var parakeetVariant: StreamingModelVariant?
         var language: Language?
         var encoderPrecision: ParakeetEncoderPrecision = .int8
-        var melChunkContext = true
+        var melChunkContext: Bool? = nil
         var dualDecodeArbitration = false
         var seamGapRepair = true
         var streamingMode = false
@@ -316,6 +316,8 @@ enum TranscribeCommand {
                 }
             case "--no-mel-context":
                 parsed.melChunkContext = false
+            case "--mel-context":
+                parsed.melChunkContext = true
             case "--dual-decode-arbitration":
                 parsed.dualDecodeArbitration = true
             case "--no-seam-gap-repair":
@@ -1025,6 +1027,8 @@ enum TranscribeCommand {
                 --language <code>              Language hint (e.g., en, de, fr, es)
                 --custom-vocab <file>          Apply vocabulary boosting in batch mode
                 --no-mel-context               Disable 80ms mel-context prepend for long-form batch ASR
+                                               (default: disabled on v3, enabled otherwise)
+                --mel-context                  Force-enable the mel-context prepend (v3 opt-in)
                 --dual-decode-arbitration      Enable v3/no-mel long-form boundary arbitration
 
             STREAMING MODE OPTIONS (--streaming, SlidingWindowAsrManager):

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessorTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/ChunkProcessorTests.swift
@@ -166,6 +166,24 @@ final class ChunkProcessorTests: XCTestCase {
         XCTAssertEqual(audio.count, 480_000, "30 second audio should be 480,000 samples")
     }
 
+    func testMelChunkContextAutoResolution() {
+        // Issue #803: unset config resolves to no-mel on v3 (silence-aligned
+        // starts), mel elsewhere; explicit values are preserved on all versions.
+        let auto = ASRConfig()
+        XCTAssertFalse(auto.resolvedMelChunkContext(for: .v3))
+        XCTAssertTrue(auto.resolvedMelChunkContext(for: .v2))
+        XCTAssertTrue(auto.resolvedMelChunkContext(for: .tdtCtc110m))
+        XCTAssertTrue(auto.resolvedMelChunkContext(for: nil))
+
+        let explicitMel = ASRConfig(melChunkContext: true)
+        XCTAssertTrue(explicitMel.resolvedMelChunkContext(for: .v3))
+        XCTAssertTrue(explicitMel.resolvedMelChunkContext(for: .v2))
+
+        let explicitNoMel = ASRConfig(melChunkContext: false)
+        XCTAssertFalse(explicitNoMel.resolvedMelChunkContext(for: .v3))
+        XCTAssertFalse(explicitNoMel.resolvedMelChunkContext(for: .v2))
+    }
+
     func testNoMelV3DefaultPathKeepsWarmupDisabled() {
         let audio = createMockAudioSamples(durationSeconds: 30.0)
         let processor = ChunkProcessor(audioSamples: audio)

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV2Tests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV2Tests.swift
@@ -27,7 +27,7 @@ final class TdtDecoderV2Tests: XCTestCase {
             adaptedConfig.tdtConfig.consecutiveBlankLimit,
             baseConfig.tdtConfig.consecutiveBlankLimit
         )
-        XCTAssertEqual(adaptedConfig.melChunkContext, baseConfig.melChunkContext)
+        XCTAssertEqual(adaptedConfig.melChunkContextOverride, baseConfig.melChunkContextOverride)
         XCTAssertEqual(adaptedConfig.dualDecodeArbitration, baseConfig.dualDecodeArbitration)
     }
 
@@ -47,7 +47,7 @@ final class TdtDecoderV2Tests: XCTestCase {
             adaptedConfig.tdtConfig.consecutiveBlankLimit,
             baseConfig.tdtConfig.consecutiveBlankLimit
         )
-        XCTAssertEqual(adaptedConfig.melChunkContext, baseConfig.melChunkContext)
+        XCTAssertEqual(adaptedConfig.melChunkContextOverride, baseConfig.melChunkContextOverride)
         XCTAssertEqual(adaptedConfig.dualDecodeArbitration, baseConfig.dualDecodeArbitration)
     }
 


### PR DESCRIPTION
Addresses #803 for the v3 default path. The opt-in mel-context path (`--mel-context` / explicit `melChunkContext: true`) and v2/110m — which keep the PR #264 prepend they were validated with — retain the interior-silence limitation; #803 stays open as the tracker for those paths (documented in `LongTranscription.md` → Known Limitations).

## Problem

A sliding window whose fixed-stride boundary interacts with quiet speech near long silence runs decodes degenerately, silently dropping content mid-file (#803's librivox-0000 quiet chapter outro is the acceptance case).

## Why not the trim fix the issue sketched

The issue proposed snapping a window's declared end back past a trailing dead-silence run. Implemented and validated — **not viable**:

- The failing outro window decodes all-blank (`rawNonBlank=0`, probed in `TdtDecoderV3`) even when trimmed **and** backfilled to a full 15s of real audio ending in speech — trailing silence is not the trigger.
- Applying the trim to the silence-aligned path *regressed* the case that path already handled.

The real trigger is fixed-stride window **starts** landing mid-word on quiet speech (the #594 SOS-collapse family). The v3 no-mel path's `silenceAlignedChunkStarts` avoids the class — it already recovers the librivox outro on `main` behind `melChunkContext = false`.

## Change

The mel-context setting becomes tri-state, stored as `ASRConfig.melChunkContextOverride: Bool?`. `nil` (new default) resolves per model version at load: **`false` on v3** (no-mel + silence-aligned starts), `true` elsewhere. Explicit opt-ins in either direction are preserved; CLI gains `--mel-context` to force the prepend back on.

**API compatibility:** the init parameter label is unchanged (`melChunkContext:` — existing constructor call sites compile as-is, `Bool` promotes to `Bool?`), and the old `melChunkContext: Bool` property remains as a deprecated computed view, so consumers that read the flag keep compiling with a deprecation warning steering them to the tri-state.

## Validation

| check | result |
|---|---|
| librivox-0000 (444s, quiet outro ~428–438s), new default | outro **present** ("…End of four classes that constitute a menace by Grace Duffield Goodwin.") |
| same file, `--mel-context` (old default) | outro **dropped** (ends "They would be overwhelmed.") |
| single-window clips | byte-identical to `main` (layout only differs multi-window) |
| Earnings-22 4× hour-long A/B (mel vs no-mel, prior run) | net-neutral: 16.69% vs 16.86% aggregate WER, per-file within ±1.5% |
| concatenated FLEURS long-form A/B (prior run) | no-mel better or tied on every v3 language: en 6.38→5.47, de 3.98→3.10, es 5.01→3.13, fr 16.61→15.61, it 4.67→2.64, pt 7.66→5.11 |

Unit test added for the tri-state resolution (`testMelChunkContextAutoResolution`). Docs updated (`LongTranscription.md`: Current Paths table + Known Limitations bullet rewritten with the measured mechanism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)