### PR TITLE
fix(cli/tts): native-level WAVs for KokoroAne in tts-asr-verify + tts-benchmark

### DIFF
--- a/Sources/FluidAudioCLI/Commands/TTSAsrVerifyCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSAsrVerifyCommand.swift
@@ -146,8 +146,10 @@ public enum TTSAsrVerifyCommand {
                 let synth0 = Date()
                 let detailed = try await manager.synthesizeDetailed(
                     text: phrase, voice: resolvedVoice, speed: 1.0)
+                // Native level — KokoroAne ships un-normalized output (#852).
                 let wav = try AudioWAV.data(
-                    from: detailed.samples, sampleRate: Double(detailed.sampleRate))
+                    from: detailed.samples, sampleRate: Double(detailed.sampleRate),
+                    normalize: false)
                 let synthS = Date().timeIntervalSince(synth0)
 
                 // Persist WAV (audioDir if set, else temp file).

--- a/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TtsBenchmarkCommand.swift
@@ -388,6 +388,8 @@ public enum TtsBenchmarkCommand {
             outputJson: outputJson,
             audioDir: audioDir,
             asrChoice: asrChoice,
+            // Native level — KokoroAne ships un-normalized output (#852).
+            normalizeWavs: false,
             extraSummary: ["voice": voice]
         ) { text in
             let t0 = Date()
@@ -483,6 +485,7 @@ public enum TtsBenchmarkCommand {
             outputJson: outputJson,
             audioDir: audioDir,
             asrChoice: asrChoice,
+            normalizeWavs: true,
             extraSummary: ["voice": voice, "language": language.rawValue]
         ) { text in
             // PocketTTS is streaming-first: we measure TTFT (time to first
@@ -567,6 +570,7 @@ public enum TtsBenchmarkCommand {
             outputJson: outputJson,
             audioDir: audioDir,
             asrChoice: asrChoice,
+            normalizeWavs: true,
             extraSummary: [
                 "reference": referenceURL.path,
                 "alpha": Double(StyleTTS2Constants.defaultAlpha),
@@ -659,6 +663,7 @@ public enum TtsBenchmarkCommand {
             outputJson: outputJson,
             audioDir: audioDir,
             asrChoice: asrChoice,
+            normalizeWavs: true,
             extraSummary: [
                 "voice_style": style.name,
                 "language": language,
@@ -701,6 +706,7 @@ public enum TtsBenchmarkCommand {
         outputJson: String?,
         audioDir: String?,
         asrChoice: AsrChoice,
+        normalizeWavs: Bool,
         extraSummary: [String: Any],
         synthOne: (String) async throws -> BackendPhraseSample
     ) async throws {
@@ -738,7 +744,8 @@ public enum TtsBenchmarkCommand {
                     .appendingPathComponent("tts-benchmark-\(UUID().uuidString).wav")
             }
             let wavData = try AudioWAV.data(
-                from: sample.samples, sampleRate: Double(sample.sampleRate))
+                from: sample.samples, sampleRate: Double(sample.sampleRate),
+                normalize: normalizeWavs)
             try wavData.write(to: wavURL)
 
             var werValue = Double.nan


### PR DESCRIPTION
Follow-up to #868 (issue #852): two CLI artifact writers still peak-normalized KokoroAne output to 0 dBFS via the `AudioWAV.data` default, contradicting the native-level behavior #868 shipped.

- **`TTSAsrVerifyCommand`** (KokoroAne-only): persisted `--audio-dir` WAVs now write at native level via `normalize: false`.
- **`TtsBenchmarkCommand`**: the shared phrase loop takes an explicit `normalizeWavs` per-backend policy — `kokoro-ane` writes native level; `pocket-tts` / `styletts2` / `supertonic3` keep peak normalization, matching each backend's own shipping output path.

ASR scoring is level-invariant, so benchmark WER/CER numbers are unaffected; only the persisted WAV levels change. `swift build` + `swift format lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)