### PR TITLE
feat(asr/v3): opt-in int8-linear Encoder_v2 encoder precision (#760)

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -234,63 +234,6 @@ extension AsrModels {
         encoderComputeUnits: MLComputeUnits? = nil,
         progressHandler: ProgressHandler? = nil
     ) async throws -> AsrModels {
-        let effectivePrecision = resolveEncoderPrecision(
-            encoderPrecision, version: version, directory: directory)
-        if effectivePrecision != encoderPrecision {
-            do {
-                return try await loadResolved(
-                    from: directory, configuration: configuration, version: version,
-                    encoderPrecision: effectivePrecision,
-                    encoderComputeUnits: encoderComputeUnits, progressHandler: progressHandler)
-            } catch {
-                // Cancellation is the caller's abort, not v2 unavailability —
-                // falling back would start a second multi-hundred-MB fetch.
-                if RetryPolicy.isCancellation(error) { throw error }
-                logger.warning(
-                    "\(effectivePrecision.encoderFileName) unavailable, falling back to \(encoderPrecision.encoderFileName): \(error.localizedDescription)"
-                )
-            }
-        }
-        return try await loadResolved(
-            from: directory, configuration: configuration, version: version,
-            encoderPrecision: encoderPrecision,
-            encoderComputeUnits: encoderComputeUnits, progressHandler: progressHandler)
-    }
-
-    /// Issue #760: the original v3 "int8" encoder (`Encoder.mlmodelc`, actually
-    /// 6-bit-LUT palettized) corrupts tokens under specific right-context; the
-    /// int8-per-channel-linear rebuild ships as `Encoder_v2.mlmodelc` alongside
-    /// it. `.int8` requests resolve to whichever encoder is already load-ready
-    /// on disk (no surprise re-download for existing caches), preferring v2
-    /// when both are. Load-ready means a complete compiled bundle — an
-    /// interrupted v2 download (partial weights left behind for resume) must
-    /// not outrank a valid original. Fresh installs try v2 first;
-    /// `load`/`download` fall back to the original for mirrors and pinned
-    /// local dirs that predate the file.
-    static func resolveEncoderPrecision(
-        _ precision: ParakeetEncoderPrecision,
-        version: AsrModelVersion,
-        directory: URL
-    ) -> ParakeetEncoderPrecision {
-        guard version == .v3, precision == .int8 else { return precision }
-        let repoDir = repoPath(from: directory, version: version)
-        if ModelCache.isCacheComplete(at: repoDir, requiredFiles: [Names.encoderV2File]) {
-            return .int8V2
-        }
-        if ModelCache.isCacheComplete(at: repoDir, requiredFiles: [Names.encoderFile]) {
-            return .int8
-        }
-        return .int8V2
-    }
-
-    private static func loadResolved(
-        from directory: URL,
-        configuration: MLModelConfiguration? = nil,
-        version: AsrModelVersion = .v3,
-        encoderPrecision: ParakeetEncoderPrecision = .int8,
-        encoderComputeUnits: MLComputeUnits? = nil,
-        progressHandler: ProgressHandler? = nil
-    ) async throws -> AsrModels {
         logger.info("Loading ASR models from: \(directory.path)")
 
         let config = configuration ?? defaultConfiguration()
@@ -544,43 +487,6 @@ extension AsrModels {
         encoderPrecision: ParakeetEncoderPrecision = .int8,
         progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
-        let resolveDir = directory ?? defaultCacheDirectory(for: version)
-        // force wipes the cache, so resolve like a fresh install (prefer v2)
-        // instead of pinning to the encoder file currently on disk.
-        let effectivePrecision: ParakeetEncoderPrecision
-        if force, version == .v3, encoderPrecision == .int8 {
-            effectivePrecision = .int8V2
-        } else {
-            effectivePrecision = resolveEncoderPrecision(
-                encoderPrecision, version: version, directory: resolveDir)
-        }
-        if effectivePrecision != encoderPrecision {
-            do {
-                return try await downloadResolved(
-                    to: directory, force: force, version: version,
-                    encoderPrecision: effectivePrecision, progressHandler: progressHandler)
-            } catch {
-                // Cancellation is the caller's abort, not v2 unavailability —
-                // falling back would start a second multi-hundred-MB fetch.
-                if RetryPolicy.isCancellation(error) { throw error }
-                logger.warning(
-                    "\(effectivePrecision.encoderFileName) unavailable, falling back to \(encoderPrecision.encoderFileName): \(error.localizedDescription)"
-                )
-            }
-        }
-        return try await downloadResolved(
-            to: directory, force: force, version: version,
-            encoderPrecision: encoderPrecision, progressHandler: progressHandler)
-    }
-
-    @discardableResult
-    private static func downloadResolved(
-        to directory: URL? = nil,
-        force: Bool = false,
-        version: AsrModelVersion = .v3,
-        encoderPrecision: ParakeetEncoderPrecision = .int8,
-        progressHandler: ProgressHandler? = nil
-    ) async throws -> URL {
         let targetDir = directory ?? defaultCacheDirectory(for: version)
         logger.info("Downloading ASR models to: \(targetDir.path)")
         let parentDir = targetDir.deletingLastPathComponent()
@@ -715,9 +621,7 @@ extension AsrModels {
         encoderPrecision: ParakeetEncoderPrecision = .int8
     ) -> Bool {
         let fileManager = FileManager.default
-        let effectivePrecision = resolveEncoderPrecision(
-            encoderPrecision, version: version, directory: directory)
-        let requiredFiles = getRequiredModels(version: version, encoderPrecision: effectivePrecision)
+        let requiredFiles = getRequiredModels(version: version, encoderPrecision: encoderPrecision)
 
         // Check in the ModelHub repo structure
         let repoPath = repoPath(from: directory, version: version)
@@ -753,9 +657,7 @@ extension AsrModels {
         let config = MLModelConfiguration()
         config.computeUnits = .cpuOnly
 
-        let effectivePrecision = resolveEncoderPrecision(
-            encoderPrecision, version: version, directory: cacheDir)
-        let fileNames = getModelFileNames(version: version, encoderPrecision: effectivePrecision)
+        let fileNames = getModelFileNames(version: version, encoderPrecision: encoderPrecision)
         var modelsToValidate = [
             ("Preprocessor", ModelNames.ASR.preprocessorFile),
             ("Decoder", fileNames.decoder),

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -243,6 +243,9 @@ extension AsrModels {
                     encoderPrecision: effectivePrecision,
                     encoderComputeUnits: encoderComputeUnits, progressHandler: progressHandler)
             } catch {
+                // Cancellation is the caller's abort, not v2 unavailability —
+                // falling back would start a second multi-hundred-MB fetch.
+                if RetryPolicy.isCancellation(error) { throw error }
                 logger.warning(
                     "\(effectivePrecision.encoderFileName) unavailable, falling back to \(encoderPrecision.encoderFileName): \(error.localizedDescription)"
                 )
@@ -257,10 +260,13 @@ extension AsrModels {
     /// Issue #760: the original v3 "int8" encoder (`Encoder.mlmodelc`, actually
     /// 6-bit-LUT palettized) corrupts tokens under specific right-context; the
     /// int8-per-channel-linear rebuild ships as `Encoder_v2.mlmodelc` alongside
-    /// it. `.int8` requests resolve to whichever file is already on disk
-    /// (no surprise re-download for existing caches), preferring v2 when both
-    /// are present. Fresh installs try v2 first; `load`/`download` fall back to
-    /// the original for mirrors and pinned local dirs that predate the file.
+    /// it. `.int8` requests resolve to whichever encoder is already load-ready
+    /// on disk (no surprise re-download for existing caches), preferring v2
+    /// when both are. Load-ready means a complete compiled bundle — an
+    /// interrupted v2 download (partial weights left behind for resume) must
+    /// not outrank a valid original. Fresh installs try v2 first;
+    /// `load`/`download` fall back to the original for mirrors and pinned
+    /// local dirs that predate the file.
     static func resolveEncoderPrecision(
         _ precision: ParakeetEncoderPrecision,
         version: AsrModelVersion,
@@ -268,15 +274,10 @@ extension AsrModels {
     ) -> ParakeetEncoderPrecision {
         guard version == .v3, precision == .int8 else { return precision }
         let repoDir = repoPath(from: directory, version: version)
-        let fileManager = FileManager.default
-        if fileManager.fileExists(
-            atPath: repoDir.appendingPathComponent(Names.encoderV2File).path)
-        {
+        if ModelCache.isCacheComplete(at: repoDir, requiredFiles: [Names.encoderV2File]) {
             return .int8V2
         }
-        if fileManager.fileExists(
-            atPath: repoDir.appendingPathComponent(Names.encoderFile).path)
-        {
+        if ModelCache.isCacheComplete(at: repoDir, requiredFiles: [Names.encoderFile]) {
             return .int8
         }
         return .int8V2
@@ -559,6 +560,9 @@ extension AsrModels {
                     to: directory, force: force, version: version,
                     encoderPrecision: effectivePrecision, progressHandler: progressHandler)
             } catch {
+                // Cancellation is the caller's abort, not v2 unavailability —
+                // falling back would start a second multi-hundred-MB fetch.
+                if RetryPolicy.isCancellation(error) { throw error }
                 logger.warning(
                     "\(effectivePrecision.encoderFileName) unavailable, falling back to \(encoderPrecision.encoderFileName): \(error.localizedDescription)"
                 )

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrModels.swift
@@ -234,6 +234,62 @@ extension AsrModels {
         encoderComputeUnits: MLComputeUnits? = nil,
         progressHandler: ProgressHandler? = nil
     ) async throws -> AsrModels {
+        let effectivePrecision = resolveEncoderPrecision(
+            encoderPrecision, version: version, directory: directory)
+        if effectivePrecision != encoderPrecision {
+            do {
+                return try await loadResolved(
+                    from: directory, configuration: configuration, version: version,
+                    encoderPrecision: effectivePrecision,
+                    encoderComputeUnits: encoderComputeUnits, progressHandler: progressHandler)
+            } catch {
+                logger.warning(
+                    "\(effectivePrecision.encoderFileName) unavailable, falling back to \(encoderPrecision.encoderFileName): \(error.localizedDescription)"
+                )
+            }
+        }
+        return try await loadResolved(
+            from: directory, configuration: configuration, version: version,
+            encoderPrecision: encoderPrecision,
+            encoderComputeUnits: encoderComputeUnits, progressHandler: progressHandler)
+    }
+
+    /// Issue #760: the original v3 "int8" encoder (`Encoder.mlmodelc`, actually
+    /// 6-bit-LUT palettized) corrupts tokens under specific right-context; the
+    /// int8-per-channel-linear rebuild ships as `Encoder_v2.mlmodelc` alongside
+    /// it. `.int8` requests resolve to whichever file is already on disk
+    /// (no surprise re-download for existing caches), preferring v2 when both
+    /// are present. Fresh installs try v2 first; `load`/`download` fall back to
+    /// the original for mirrors and pinned local dirs that predate the file.
+    static func resolveEncoderPrecision(
+        _ precision: ParakeetEncoderPrecision,
+        version: AsrModelVersion,
+        directory: URL
+    ) -> ParakeetEncoderPrecision {
+        guard version == .v3, precision == .int8 else { return precision }
+        let repoDir = repoPath(from: directory, version: version)
+        let fileManager = FileManager.default
+        if fileManager.fileExists(
+            atPath: repoDir.appendingPathComponent(Names.encoderV2File).path)
+        {
+            return .int8V2
+        }
+        if fileManager.fileExists(
+            atPath: repoDir.appendingPathComponent(Names.encoderFile).path)
+        {
+            return .int8
+        }
+        return .int8V2
+    }
+
+    private static func loadResolved(
+        from directory: URL,
+        configuration: MLModelConfiguration? = nil,
+        version: AsrModelVersion = .v3,
+        encoderPrecision: ParakeetEncoderPrecision = .int8,
+        encoderComputeUnits: MLComputeUnits? = nil,
+        progressHandler: ProgressHandler? = nil
+    ) async throws -> AsrModels {
         logger.info("Loading ASR models from: \(directory.path)")
 
         let config = configuration ?? defaultConfiguration()
@@ -487,6 +543,40 @@ extension AsrModels {
         encoderPrecision: ParakeetEncoderPrecision = .int8,
         progressHandler: ProgressHandler? = nil
     ) async throws -> URL {
+        let resolveDir = directory ?? defaultCacheDirectory(for: version)
+        // force wipes the cache, so resolve like a fresh install (prefer v2)
+        // instead of pinning to the encoder file currently on disk.
+        let effectivePrecision: ParakeetEncoderPrecision
+        if force, version == .v3, encoderPrecision == .int8 {
+            effectivePrecision = .int8V2
+        } else {
+            effectivePrecision = resolveEncoderPrecision(
+                encoderPrecision, version: version, directory: resolveDir)
+        }
+        if effectivePrecision != encoderPrecision {
+            do {
+                return try await downloadResolved(
+                    to: directory, force: force, version: version,
+                    encoderPrecision: effectivePrecision, progressHandler: progressHandler)
+            } catch {
+                logger.warning(
+                    "\(effectivePrecision.encoderFileName) unavailable, falling back to \(encoderPrecision.encoderFileName): \(error.localizedDescription)"
+                )
+            }
+        }
+        return try await downloadResolved(
+            to: directory, force: force, version: version,
+            encoderPrecision: encoderPrecision, progressHandler: progressHandler)
+    }
+
+    @discardableResult
+    private static func downloadResolved(
+        to directory: URL? = nil,
+        force: Bool = false,
+        version: AsrModelVersion = .v3,
+        encoderPrecision: ParakeetEncoderPrecision = .int8,
+        progressHandler: ProgressHandler? = nil
+    ) async throws -> URL {
         let targetDir = directory ?? defaultCacheDirectory(for: version)
         logger.info("Downloading ASR models to: \(targetDir.path)")
         let parentDir = targetDir.deletingLastPathComponent()
@@ -621,7 +711,9 @@ extension AsrModels {
         encoderPrecision: ParakeetEncoderPrecision = .int8
     ) -> Bool {
         let fileManager = FileManager.default
-        let requiredFiles = getRequiredModels(version: version, encoderPrecision: encoderPrecision)
+        let effectivePrecision = resolveEncoderPrecision(
+            encoderPrecision, version: version, directory: directory)
+        let requiredFiles = getRequiredModels(version: version, encoderPrecision: effectivePrecision)
 
         // Check in the ModelHub repo structure
         let repoPath = repoPath(from: directory, version: version)
@@ -657,7 +749,9 @@ extension AsrModels {
         let config = MLModelConfiguration()
         config.computeUnits = .cpuOnly
 
-        let fileNames = getModelFileNames(version: version, encoderPrecision: encoderPrecision)
+        let effectivePrecision = resolveEncoderPrecision(
+            encoderPrecision, version: version, directory: cacheDir)
+        let fileNames = getModelFileNames(version: version, encoderPrecision: effectivePrecision)
         var modelsToValidate = [
             ("Preprocessor", ModelNames.ASR.preprocessorFile),
             ("Decoder", fileNames.decoder),

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -317,12 +317,20 @@ public enum Repo: String, CaseIterable, Sendable {
 /// Encoder precision for the v3 Parakeet TDT 0.6B encoder.
 public enum ParakeetEncoderPrecision: String, Sendable, CaseIterable {
     case int8
+    /// int8 per-channel linear re-quantization of the v3 encoder
+    /// (`Encoder_v2.mlmodelc`). Fixes token corruption caused by the original
+    /// 6-bit-LUT palettized `Encoder.mlmodelc` (issue #760). `.int8` requests
+    /// auto-resolve to this file when it is available; see
+    /// `AsrModels.resolveEncoderPrecision`.
+    case int8V2 = "int8-v2"
     case int4
 
     public var encoderFileName: String {
         switch self {
         case .int8:
             return ModelNames.ASR.encoderFile
+        case .int8V2:
+            return ModelNames.ASR.encoderV2File
         case .int4:
             return ModelNames.ASR.encoderInt4File
         }
@@ -391,6 +399,10 @@ public enum ModelNames {
         /// Joint decoder variant for v3 that exposes top-K outputs
         /// (`top_k_ids`, `top_k_logits`) used for language-aware script filtering.
         public static let jointV3File = "JointDecisionv3.mlmodelc"
+        /// v3 encoder re-quantized as int8 per-channel linear (issue #760).
+        /// Published alongside the immutable original `Encoder.mlmodelc`;
+        /// HF repo files are never mutated in place, fixes ship as new names.
+        public static let encoderV2File = "Encoder_v2.mlmodelc"
         public static let encoderInt4File = "EncoderInt4.mlmodelc"
         public static let ctcHeadFile = ctcHead + ".mlmodelc"
 

--- a/Sources/FluidAudio/ModelNames.swift
+++ b/Sources/FluidAudio/ModelNames.swift
@@ -317,11 +317,12 @@ public enum Repo: String, CaseIterable, Sendable {
 /// Encoder precision for the v3 Parakeet TDT 0.6B encoder.
 public enum ParakeetEncoderPrecision: String, Sendable, CaseIterable {
     case int8
-    /// int8 per-channel linear re-quantization of the v3 encoder
-    /// (`Encoder_v2.mlmodelc`). Fixes token corruption caused by the original
-    /// 6-bit-LUT palettized `Encoder.mlmodelc` (issue #760). `.int8` requests
-    /// auto-resolve to this file when it is available; see
-    /// `AsrModels.resolveEncoderPrecision`.
+    /// Opt-in int8 per-channel linear re-quantization of the v3 encoder
+    /// (`Encoder_v2.mlmodelc`, 568M vs 425M). Avoids token corruption the
+    /// original 6-bit-LUT palettized `Encoder.mlmodelc` exhibits under
+    /// specific right-context (issue #760). `.int8` remains the default and
+    /// keeps loading the original file; select this explicitly to use the
+    /// rebuild.
     case int8V2 = "int8-v2"
     case int4
 

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -1023,7 +1023,8 @@ enum TranscribeCommand {
                 --output-json <file>           Save full transcription to JSON
                 --model-version <v2|v3|110m>   ASR model version (default: v3)
                 --model-dir <path>             Local model directory (skips download)
-                --encoder-precision <int8|int4> Encoder quantization (default: int8)
+                --encoder-precision <int8|int8-v2|int4> Encoder quantization (default: int8;
+                                               auto-upgrades to int8-v2 when available, #760)
                 --language <code>              Language hint (e.g., en, de, fr, es)
                 --custom-vocab <file>          Apply vocabulary boosting in batch mode
                 --no-mel-context               Disable 80ms mel-context prepend for long-form batch ASR

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -1024,7 +1024,7 @@ enum TranscribeCommand {
                 --model-version <v2|v3|110m>   ASR model version (default: v3)
                 --model-dir <path>             Local model directory (skips download)
                 --encoder-precision <int8|int8-v2|int4> Encoder quantization (default: int8;
-                                               auto-upgrades to int8-v2 when available, #760)
+                                               int8-v2 = int8-linear rebuild, avoids #760)
                 --language <code>              Language hint (e.g., en, de, fr, es)
                 --custom-vocab <file>          Apply vocabulary boosting in batch mode
                 --no-mel-context               Disable 80ms mel-context prepend for long-form batch ASR

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/AsrModelsEncoderV2Tests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/AsrModelsEncoderV2Tests.swift
@@ -2,45 +2,8 @@ import XCTest
 
 @testable import FluidAudio
 
-/// Encoder_v2 (int8-linear, issue #760) file resolution.
+/// Opt-in Encoder_v2 (int8-linear, issue #760) precision selection.
 final class AsrModelsEncoderV2Tests: XCTestCase {
-
-    private var parentDir: URL!
-    private var repoDir: URL!
-    /// Directory handed to AsrModels APIs; its parent must contain the repo folder.
-    private var modelsDir: URL!
-
-    override func setUpWithError() throws {
-        parentDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("AsrModelsEncoderV2Tests-\(UUID().uuidString)")
-        repoDir = parentDir.appendingPathComponent(Repo.parakeetV3.folderName)
-        modelsDir = repoDir
-        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
-    }
-
-    override func tearDownWithError() throws {
-        try? FileManager.default.removeItem(at: parentDir)
-    }
-
-    /// Create a load-ready compiled bundle: resolution requires a complete
-    /// `.mlmodelc` (layout check + no `.partial` staging files), so a bare
-    /// directory must NOT count as a usable encoder.
-    private func place(_ fileName: String) throws {
-        let bundle = repoDir.appendingPathComponent(fileName)
-        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
-        try Data().write(to: bundle.appendingPathComponent("coremldata.bin"))
-    }
-
-    private func placeIncomplete(_ fileName: String, partial: Bool) throws {
-        let bundle = repoDir.appendingPathComponent(fileName)
-        try FileManager.default.createDirectory(
-            at: bundle.appendingPathComponent("weights"), withIntermediateDirectories: true)
-        if partial {
-            try Data().write(to: bundle.appendingPathComponent("coremldata.bin"))
-            try Data().write(
-                to: bundle.appendingPathComponent("weights/weight.bin.partial"))
-        }
-    }
 
     func testEncoderFileNames() {
         XCTAssertEqual(ParakeetEncoderPrecision.int8.encoderFileName, "Encoder.mlmodelc")
@@ -56,104 +19,41 @@ final class AsrModelsEncoderV2Tests: XCTestCase {
         }
     }
 
-    func testRequiredModelsV3IncludesV2Encoder() {
-        let required = ModelNames.ASR.requiredModelsV3(precision: .int8V2)
-        XCTAssertTrue(required.contains("Encoder_v2.mlmodelc"))
-        XCTAssertFalse(required.contains("Encoder.mlmodelc"))
+    func testRequiredModelsV3PerPrecision() {
+        // int8 stays the default and keeps requiring the original encoder;
+        // int8-v2 is strictly opt-in.
+        let int8 = ModelNames.ASR.requiredModelsV3(precision: .int8)
+        XCTAssertTrue(int8.contains("Encoder.mlmodelc"))
+        XCTAssertFalse(int8.contains("Encoder_v2.mlmodelc"))
+
+        let int8V2 = ModelNames.ASR.requiredModelsV3(precision: .int8V2)
+        XCTAssertTrue(int8V2.contains("Encoder_v2.mlmodelc"))
+        XCTAssertFalse(int8V2.contains("Encoder.mlmodelc"))
     }
 
-    func testResolvePrefersV2WhenBothPresent() throws {
-        try place(ModelNames.ASR.encoderFile)
-        try place(ModelNames.ASR.encoderV2File)
-        XCTAssertEqual(
-            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
-            .int8V2)
-    }
+    func testModelsExistChecksPrecisionSpecificEncoder() throws {
+        let parentDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AsrModelsEncoderV2Tests-\(UUID().uuidString)")
+        let repoDir = parentDir.appendingPathComponent(Repo.parakeetV3.folderName)
+        defer { try? FileManager.default.removeItem(at: parentDir) }
 
-    func testResolveKeepsOriginalWhenOnlyOldPresent() throws {
-        // Existing caches keep working without a surprise re-download.
-        try place(ModelNames.ASR.encoderFile)
-        XCTAssertEqual(
-            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
-            .int8)
-    }
-
-    func testResolvePicksV2WhenOnlyV2Present() throws {
-        try place(ModelNames.ASR.encoderV2File)
-        XCTAssertEqual(
-            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
-            .int8V2)
-    }
-
-    func testResolveFreshInstallTriesV2First() {
-        XCTAssertEqual(
-            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
-            .int8V2)
-    }
-
-    func testIncompleteV2DoesNotOutrankValidOriginal() throws {
-        // An interrupted v2 download leaves a partial bundle for resume; it
-        // must not be selected over a load-ready original encoder.
-        try place(ModelNames.ASR.encoderFile)
-        try placeIncomplete(ModelNames.ASR.encoderV2File, partial: false)
-        XCTAssertEqual(
-            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
-            .int8)
-
-        try FileManager.default.removeItem(
-            at: repoDir.appendingPathComponent(ModelNames.ASR.encoderV2File))
-        try placeIncomplete(ModelNames.ASR.encoderV2File, partial: true)
-        XCTAssertEqual(
-            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
-            .int8)
-    }
-
-    func testBothIncompleteResolvesToV2ForResume() throws {
-        // Neither bundle is usable: resolve like a fresh install so the v2
-        // download runs (and resumes its partial file).
-        try placeIncomplete(ModelNames.ASR.encoderFile, partial: false)
-        try placeIncomplete(ModelNames.ASR.encoderV2File, partial: true)
-        XCTAssertEqual(
-            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
-            .int8V2)
-    }
-
-    func testResolvePassesThroughExplicitPrecisions() throws {
-        try place(ModelNames.ASR.encoderV2File)
-        XCTAssertEqual(
-            AsrModels.resolveEncoderPrecision(.int4, version: .v3, directory: modelsDir),
-            .int4)
-        XCTAssertEqual(
-            AsrModels.resolveEncoderPrecision(.int8V2, version: .v3, directory: modelsDir),
-            .int8V2)
-    }
-
-    func testResolvePassesThroughNonV3Versions() throws {
-        try place(ModelNames.ASR.encoderV2File)
-        XCTAssertEqual(
-            AsrModels.resolveEncoderPrecision(.int8, version: .v2, directory: modelsDir),
-            .int8)
-    }
-
-    func testModelsExistAcceptsEitherEncoderFile() throws {
         for file in [
             ModelNames.ASR.preprocessorFile,
             ModelNames.ASR.decoderFile,
             ModelNames.ASR.jointV3File,
+            ModelNames.ASR.encoderV2File,
         ] {
-            try place(file)
+            try FileManager.default.createDirectory(
+                at: repoDir.appendingPathComponent(file), withIntermediateDirectories: true)
         }
         try Data("{}".utf8).write(
             to: repoDir.appendingPathComponent(ModelNames.ASR.vocabularyFile))
 
-        XCTAssertFalse(AsrModels.modelsExist(at: modelsDir, version: .v3, encoderPrecision: .int8))
-
-        try place(ModelNames.ASR.encoderFile)
-        XCTAssertTrue(AsrModels.modelsExist(at: modelsDir, version: .v3, encoderPrecision: .int8))
-
-        try FileManager.default.removeItem(
-            at: repoDir.appendingPathComponent(ModelNames.ASR.encoderFile))
-        try place(ModelNames.ASR.encoderV2File)
-        XCTAssertTrue(AsrModels.modelsExist(at: modelsDir, version: .v3, encoderPrecision: .int8))
+        // Only Encoder_v2 on disk: satisfies an explicit int8-v2 request but
+        // NOT the int8 default (which still requires Encoder.mlmodelc).
+        XCTAssertTrue(
+            AsrModels.modelsExist(at: repoDir, version: .v3, encoderPrecision: .int8V2))
+        XCTAssertFalse(
+            AsrModels.modelsExist(at: repoDir, version: .v3, encoderPrecision: .int8))
     }
 }

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/AsrModelsEncoderV2Tests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/AsrModelsEncoderV2Tests.swift
@@ -22,9 +22,24 @@ final class AsrModelsEncoderV2Tests: XCTestCase {
         try? FileManager.default.removeItem(at: parentDir)
     }
 
+    /// Create a load-ready compiled bundle: resolution requires a complete
+    /// `.mlmodelc` (layout check + no `.partial` staging files), so a bare
+    /// directory must NOT count as a usable encoder.
     private func place(_ fileName: String) throws {
+        let bundle = repoDir.appendingPathComponent(fileName)
+        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+        try Data().write(to: bundle.appendingPathComponent("coremldata.bin"))
+    }
+
+    private func placeIncomplete(_ fileName: String, partial: Bool) throws {
+        let bundle = repoDir.appendingPathComponent(fileName)
         try FileManager.default.createDirectory(
-            at: repoDir.appendingPathComponent(fileName), withIntermediateDirectories: true)
+            at: bundle.appendingPathComponent("weights"), withIntermediateDirectories: true)
+        if partial {
+            try Data().write(to: bundle.appendingPathComponent("coremldata.bin"))
+            try Data().write(
+                to: bundle.appendingPathComponent("weights/weight.bin.partial"))
+        }
     }
 
     func testEncoderFileNames() {
@@ -71,6 +86,33 @@ final class AsrModelsEncoderV2Tests: XCTestCase {
     }
 
     func testResolveFreshInstallTriesV2First() {
+        XCTAssertEqual(
+            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
+            .int8V2)
+    }
+
+    func testIncompleteV2DoesNotOutrankValidOriginal() throws {
+        // An interrupted v2 download leaves a partial bundle for resume; it
+        // must not be selected over a load-ready original encoder.
+        try place(ModelNames.ASR.encoderFile)
+        try placeIncomplete(ModelNames.ASR.encoderV2File, partial: false)
+        XCTAssertEqual(
+            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
+            .int8)
+
+        try FileManager.default.removeItem(
+            at: repoDir.appendingPathComponent(ModelNames.ASR.encoderV2File))
+        try placeIncomplete(ModelNames.ASR.encoderV2File, partial: true)
+        XCTAssertEqual(
+            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
+            .int8)
+    }
+
+    func testBothIncompleteResolvesToV2ForResume() throws {
+        // Neither bundle is usable: resolve like a fresh install so the v2
+        // download runs (and resumes its partial file).
+        try placeIncomplete(ModelNames.ASR.encoderFile, partial: false)
+        try placeIncomplete(ModelNames.ASR.encoderV2File, partial: true)
         XCTAssertEqual(
             AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
             .int8V2)

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/AsrModelsEncoderV2Tests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/AsrModelsEncoderV2Tests.swift
@@ -1,0 +1,117 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Encoder_v2 (int8-linear, issue #760) file resolution.
+final class AsrModelsEncoderV2Tests: XCTestCase {
+
+    private var parentDir: URL!
+    private var repoDir: URL!
+    /// Directory handed to AsrModels APIs; its parent must contain the repo folder.
+    private var modelsDir: URL!
+
+    override func setUpWithError() throws {
+        parentDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AsrModelsEncoderV2Tests-\(UUID().uuidString)")
+        repoDir = parentDir.appendingPathComponent(Repo.parakeetV3.folderName)
+        modelsDir = repoDir
+        try FileManager.default.createDirectory(at: repoDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: parentDir)
+    }
+
+    private func place(_ fileName: String) throws {
+        try FileManager.default.createDirectory(
+            at: repoDir.appendingPathComponent(fileName), withIntermediateDirectories: true)
+    }
+
+    func testEncoderFileNames() {
+        XCTAssertEqual(ParakeetEncoderPrecision.int8.encoderFileName, "Encoder.mlmodelc")
+        XCTAssertEqual(ParakeetEncoderPrecision.int8V2.encoderFileName, "Encoder_v2.mlmodelc")
+        XCTAssertEqual(ParakeetEncoderPrecision.int4.encoderFileName, "EncoderInt4.mlmodelc")
+    }
+
+    func testVariantStringRoundTrip() {
+        // The download variant string must map back to the same precision so
+        // ModelHub's required-model set matches the file AsrModels loads.
+        for precision in ParakeetEncoderPrecision.allCases {
+            XCTAssertEqual(ParakeetEncoderPrecision(rawValue: precision.rawValue), precision)
+        }
+    }
+
+    func testRequiredModelsV3IncludesV2Encoder() {
+        let required = ModelNames.ASR.requiredModelsV3(precision: .int8V2)
+        XCTAssertTrue(required.contains("Encoder_v2.mlmodelc"))
+        XCTAssertFalse(required.contains("Encoder.mlmodelc"))
+    }
+
+    func testResolvePrefersV2WhenBothPresent() throws {
+        try place(ModelNames.ASR.encoderFile)
+        try place(ModelNames.ASR.encoderV2File)
+        XCTAssertEqual(
+            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
+            .int8V2)
+    }
+
+    func testResolveKeepsOriginalWhenOnlyOldPresent() throws {
+        // Existing caches keep working without a surprise re-download.
+        try place(ModelNames.ASR.encoderFile)
+        XCTAssertEqual(
+            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
+            .int8)
+    }
+
+    func testResolvePicksV2WhenOnlyV2Present() throws {
+        try place(ModelNames.ASR.encoderV2File)
+        XCTAssertEqual(
+            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
+            .int8V2)
+    }
+
+    func testResolveFreshInstallTriesV2First() {
+        XCTAssertEqual(
+            AsrModels.resolveEncoderPrecision(.int8, version: .v3, directory: modelsDir),
+            .int8V2)
+    }
+
+    func testResolvePassesThroughExplicitPrecisions() throws {
+        try place(ModelNames.ASR.encoderV2File)
+        XCTAssertEqual(
+            AsrModels.resolveEncoderPrecision(.int4, version: .v3, directory: modelsDir),
+            .int4)
+        XCTAssertEqual(
+            AsrModels.resolveEncoderPrecision(.int8V2, version: .v3, directory: modelsDir),
+            .int8V2)
+    }
+
+    func testResolvePassesThroughNonV3Versions() throws {
+        try place(ModelNames.ASR.encoderV2File)
+        XCTAssertEqual(
+            AsrModels.resolveEncoderPrecision(.int8, version: .v2, directory: modelsDir),
+            .int8)
+    }
+
+    func testModelsExistAcceptsEitherEncoderFile() throws {
+        for file in [
+            ModelNames.ASR.preprocessorFile,
+            ModelNames.ASR.decoderFile,
+            ModelNames.ASR.jointV3File,
+        ] {
+            try place(file)
+        }
+        try Data("{}".utf8).write(
+            to: repoDir.appendingPathComponent(ModelNames.ASR.vocabularyFile))
+
+        XCTAssertFalse(AsrModels.modelsExist(at: modelsDir, version: .v3, encoderPrecision: .int8))
+
+        try place(ModelNames.ASR.encoderFile)
+        XCTAssertTrue(AsrModels.modelsExist(at: modelsDir, version: .v3, encoderPrecision: .int8))
+
+        try FileManager.default.removeItem(
+            at: repoDir.appendingPathComponent(ModelNames.ASR.encoderFile))
+        try place(ModelNames.ASR.encoderV2File)
+        XCTAssertTrue(AsrModels.modelsExist(at: modelsDir, version: .v3, encoderPrecision: .int8))
+    }
+}


### PR DESCRIPTION
## Root cause (#760)

The shipped v3 `Encoder.mlmodelc` (labeled "int8", actually Mixed Float16 + **6-bit LUT palettization**) corrupts tokens under specific right-context. On the reporter's Ukrainian repro, a ≤15s single-window cut deterministically decodes `фоновий процес` → non-word `фоновиц` (confidence 0.885 — silently wrong). Not a window-composition/seam issue: all three cuts decode in a single window.

Full encoder-substitution sweep on identical audio with identical stock companions (Swift CLI):

| Encoder | Size | A (tail 2s) | B (tail 6s) | C control |
|---|---|---|---|---|
| stock 6-bit LUT | 425M | ✅ | ❌ `фоновиц` | ✅ |
| int4 (`EncoderInt4`) | 285M | ❌ `фіновий` + deleted clause | ⚠️ | ❌ `афоновий` |
| **int8 linear per-channel (new)** | 568M | ✅ | ✅ | ✅ |
| fp16 | 1.1G | ✅ | ✅ | ✅ |
| fp32 | 2.2G | ✅ | ✅ | ✅ |
| parakeet-mlx (reference) | — | ✅ | ✅ | ✅ |

Each quantization level has its own error sites — int4 passing B in isolation was rounding luck.

## Change (strictly opt-in — defaults unchanged)

The re-quantized encoder (int8 per-channel linear, data-free `cto.linear_quantize_weights` on the fp16 export, +143MB) is published as **`Encoder_v2.mlmodelc`** alongside the untouched original ([merged on HF](https://huggingface.co/FluidInference/parakeet-tdt-0.6b-v3-coreml/discussions/4)).

- `.int8` (default) continues to mean the original `Encoder.mlmodelc` everywhere, including fresh installs. **No behavior change for any existing caller.**
- New `ParakeetEncoderPrecision.int8V2` (`"int8-v2"`) selects `Encoder_v2.mlmodelc`, via the API parameter or `--encoder-precision int8-v2`. It rides the existing generic `encoderPrecision` plumbing — `AsrModels.swift` is untouched; the diff is the enum case, a filename constant, CLI help text, and tests.
- `config.json` on HF now records the true weight format of each encoder file (the original is `palettized_lut6_mixed_fp16`, not int8), so the historical mislabel can't recur.

## Verification

- E2E (built CLI, reporter's cuts, model dir containing both encoders): default loads the original (B reproduces `фоновиц`, proving no silent preference change); `--encoder-precision int8-v2` loads v2 and B decodes `фоновий процес` ✅. Fresh-download of the v2 file from live HF verified.
- Unit tests: filename mapping, variant round-trip, per-precision required-model sets, `modelsExist` distinguishing the two precisions.
- `swift build -c release` clean, swift-format lint clean.

## Follow-ups (before recommending int8-v2 broadly)

- [ ] WER regression run (FLEURS uk + standard ASR benchmark) for the v2 encoder
- [ ] ANE RTFx spot-check (linear-quantized weights take a different ANE path than palettized LUTs)

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)