### PR TITLE
fix(podspec): sync version to v0.15.6 + CI guard against tag drift

### DIFF
--- a/.github/workflows/podspec-version.yml
+++ b/.github/workflows/podspec-version.yml
@@ -1,0 +1,24 @@
+name: Podspec Version Check
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  check-version:
+    name: Podspec matches tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify podspec version matches tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PODSPEC=$(grep -E 'spec\.version\s*=' FluidAudio.podspec | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "Tag version:     $TAG"
+          echo "Podspec version: $PODSPEC"
+          if [ "$TAG" != "$PODSPEC" ]; then
+            echo "::error file=FluidAudio.podspec::Podspec version ($PODSPEC) does not match tag ($TAG). Bump spec.version before tagging — consumers pinning by tag read this file."
+            exit 1
+          fi

--- a/FluidAudio.podspec
+++ b/FluidAudio.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "FluidAudio"
-  spec.version      = "0.12.2"
+  spec.version      = "0.15.6"
   spec.summary      = "Speaker diarization, voice-activity-detection and transcription with CoreML"
   spec.description  = <<-DESC
                        Fluid Audio is a Swift SDK for fully local, low-latency audio AI on Apple devices,


### PR DESCRIPTION
## Summary
- Bump `spec.version` in `FluidAudio.podspec` from 0.12.2 to 0.15.6 — the string hadn't been touched since the v0.12.2 release while tags advanced three minor versions, so consumers resolving by version constraint were told the tag contains something it doesn't (surfaced in FluidInference/react-native-fluidaudio#4).
- Add `podspec-version.yml`: on any `v*` tag push, fail if the podspec version at that tag doesn't match the tag name, so the mismatch is caught at release time instead of in downstream Podfiles.

Already-published tags keep the stale string (history is immutable); tag-only Podfile pins are unaffected either way. Starting with the next release the version string will be accurate again.

## Test plan
- `pod ipc spec FluidAudio.podspec` parses clean with the new version.
- Ran the workflow's grep/sed extraction locally against the bumped podspec: extracts `0.15.6`, matches tag `v0.15.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)