### PR TITLE
Build the library for tvOS: make NemoTextProcessing platform-conditional

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
             dependencies: [
                 "FastClusterWrapper",
                 "MachTaskSelfWrapper",
-                "NemoTextProcessing",
+                .target(name: "NemoTextProcessing", condition: .when(platforms: [.macOS, .iOS])),
             ],
             path: "Sources/FluidAudio",
             exclude: ["ASR/Parakeet/Unified/benchmark.md"],

--- a/Sources/FluidAudio/ITN/TextNormalizer.swift
+++ b/Sources/FluidAudio/ITN/TextNormalizer.swift
@@ -1,3 +1,4 @@
+#if canImport(CNemoTextProcessing)
 import CNemoTextProcessing
 import Foundation
 import NaturalLanguage
@@ -254,3 +255,5 @@ public final class TextNormalizer: Sendable {
         return out
     }
 }
+
+#endif

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -227,7 +227,11 @@ public actor KokoroAneManager {
             // Normalize written forms to their Mandarin reading before
             // segmentation — e.g. "$5" → "五美元", "2024年" → "二零二四年" —
             // so the numeric/semiotic tokens reach MandarinG2P as Hanzi.
+            #if canImport(CNemoTextProcessing)
             let normalized = NemoTextNormalizer.normalize(text, language: .mandarin)
+            #else
+            let normalized = text
+            #endif
             if MandarinG2P.looksLikeHanzi(normalized) {
                 let g2p = try await store.mandarinG2PPipeline()
                 return try await g2p.phonemize(normalized)

--- a/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
+++ b/Sources/FluidAudio/TTS/Shared/EnglishTextNormalizer.swift
@@ -53,8 +53,12 @@ enum EnglishTextNormalizer {
     /// engine leaves the text unchanged (e.g. plain prose, or a build without
     /// the `fst-engine` feature).
     static func normalizeForFrontend(_ text: String) -> String {
+        #if canImport(CNemoTextProcessing)
         let fst = NemoTextNormalizer.normalize(text, language: .english)
         return fst == text ? normalize(text) : fst
+        #else
+        return normalize(text)
+        #endif
     }
 
     // MARK: - Boundaries

--- a/Sources/FluidAudio/TTS/Shared/NemoTextNormalizer.swift
+++ b/Sources/FluidAudio/TTS/Shared/NemoTextNormalizer.swift
@@ -1,3 +1,4 @@
+#if canImport(CNemoTextProcessing)
 import CNemoTextProcessing
 import Foundation
 
@@ -34,3 +35,5 @@ public enum NemoTextNormalizer {
         return String(cString: ptr)
     }
 }
+
+#endif


### PR DESCRIPTION
The prebuilt `NemoTextProcessing.xcframework` ships ios, ios-simulator and macos slices only, so building the `FluidAudio` library for tvOS fails with "no library for this platform was found". The framework is imported by exactly two files and used at two TTS call sites; the Parakeet ASR pipeline never touches it.

This PR:
- makes the binary dependency `.when(platforms: [.macOS, .iOS])` in `Package.swift`;
- wraps `ITN/TextNormalizer.swift` and `TTS/Shared/NemoTextNormalizer.swift` in `#if canImport(CNemoTextProcessing)`;
- lets `EnglishTextNormalizer.normalizeForFrontend` fall back to its baseline and the Mandarin Kokoro path pass text through when the FST engine is absent.

Witnessed with Xcode 27 beta: `swift build --product FluidAudio --triple arm64-apple-tvos26.0-simulator` and `--triple arm64-apple-tvos26.0` both complete. macOS and iOS builds are unchanged. `platforms:` in `Package.swift` is deliberately left alone; adding `.tvOS` there is your call.

Use case: bundling `parakeet-tdt-0.6b-v3-coreml` inside an Apple TV app for offline read-along transcripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZbYTEH3aemaaG2otBWesj