### PR TITLE
fix(offline-diarizer): hold speaker caps against both cluster censuses

### DIFF
--- a/Sources/FluidAudio/Diarizer/Offline/Clustering/VBxClustering.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Clustering/VBxClustering.swift
@@ -27,6 +27,7 @@ struct VBxClustering {
     private let config: OfflineDiarizerConfig
     private let pldaTransform: PLDATransform
     private let logger = AppLogger(category: "OfflineVBx")
+    private static let constraintLogger = AppLogger(category: "OfflineVBx")
     private let signposter = OSSignposter(
         subsystem: "com.fluidaudio.diarization",
         category: .pointsOfInterest
@@ -690,23 +691,64 @@ struct VBxClustering {
     ) -> VBxOutput {
         let output = refine(rhoFeatures: rhoFeatures, initialClusters: initialClusters)
 
+        return Self.applyConstraints(
+            to: output,
+            trainingEmbeddings: trainingEmbeddings,
+            constraints: constraints
+        )
+    }
+
+    /// Re-clusters a VBx output to satisfy speaker count constraints.
+    ///
+    /// Split out of `refineWithConstraints` and made static so the constraint
+    /// decision can be exercised without PLDA models: everything below the VBx
+    /// refinement itself is pure arithmetic over the output.
+    ///
+    /// - Parameters:
+    ///   - output: The VBx refinement to check.
+    ///   - trainingEmbeddings: Original embeddings for K-Means re-clustering.
+    ///   - constraints: Speaker count constraints; `nil` leaves `output` untouched.
+    /// - Returns: `output`, or a K-Means re-clustering of it at the target count.
+    static func applyConstraints(
+        to output: VBxOutput,
+        trainingEmbeddings: [[Double]],
+        constraints: SpeakerCountConstraints?
+    ) -> VBxOutput {
         guard let constraints = constraints else {
             return output
         }
 
-        // Compare against the clusters embeddings actually land in, not the AHC
-        // warm-start count (re-clusters even when VBx already agrees, #801) and
-        // not the pi > epsilon census: a cluster can keep trace mixture weight
-        // while winning no embedding's argmax, so it vanishes from the output.
-        // Gating on the pi census then silently ignores a numSpeakers request
-        // that matches it while the caller sees fewer speakers (#802 review).
-        let detectedCount = output.assignedClusterCount
+        // Both censuses have to fit the bounds, because both are visible
+        // downstream, and neither is the AHC warm-start count (gating on that
+        // re-clusters even when VBx already agrees, #801).
+        //
+        // The argmax census is the count embeddings actually land in: a cluster
+        // can keep trace mixture weight while winning no embedding's argmax, so
+        // gating on the pi census alone silently ignores a numSpeakers request
+        // that matches it while the caller sees fewer speakers (#802).
+        //
+        // The pi census still has to fit too. Centroid construction covers every
+        // cluster with pi > epsilon — pyannote parity, so constrained assignment
+        // can place a speaker sharing a chunk onto a cluster that won no argmax.
+        // That revives a cluster this check had excluded, and the result exceeds
+        // numSpeakers/maxSpeakers with no adjustment having run.
+        //
+        // The argmax census leads when both are out of bounds: it is what #802
+        // tuned the adjustment around, so an under-count still re-clusters to
+        // the same target as before. The pi census only decides cases the argmax
+        // census called satisfied.
+        let assignedCount = output.assignedClusterCount
+        let activeCount = output.activeClusterCount
+        let detectedCount =
+            constraints.needsAdjustment(detectedCount: assignedCount)
+            ? assignedCount
+            : activeCount
         guard constraints.needsAdjustment(detectedCount: detectedCount) else {
             return output
         }
 
         let targetCount = constraints.targetCount(detectedCount: detectedCount)
-        logger.info(
+        constraintLogger.info(
             "Speaker count \(detectedCount) outside bounds [\(constraints.minSpeakers), \(constraints.maxSpeakers)]; re-clustering to \(targetCount)"
         )
 

--- a/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
+++ b/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift
@@ -407,37 +407,13 @@ public final class OfflineDiarizerManager {
             )
         }
 
-        let centroidComputation = computeCentroids(
-            trainingEmbeddings: trainingEmbeddings,
+        let (centroids, assignments) = clusterAssignments(
             vbxOutput: vbxOutput,
-            initialClusters: initialClusters
+            trainingEmbeddings: trainingEmbeddings,
+            embeddingFeatures: embeddingFeatures,
+            initialClusters: initialClusters,
+            chunkIndices: timedEmbeddings.map(\.chunkIndex)
         )
-        var centroids = centroidComputation.centroids
-        if centroids.isEmpty {
-            centroids = computeFallbackCentroids(from: embeddingFeatures)
-        }
-        // pyannote parity: constrain co-chunk speakers to distinct clusters, but
-        // not when the count was forced via K-Means — the constraint can then
-        // artificially inflate the number of speakers.
-        let useConstrainedAssignment =
-            config.clustering.constrainedAssignment
-            && !vbxOutput.wasAdjusted
-            && centroids.count > 1
-        let assignments: [Int]
-        if useConstrainedAssignment {
-            assignments = ConstrainedClusterAssignment.assign(
-                scores: centroidScores(
-                    embeddingFeatures: embeddingFeatures,
-                    centroids: centroids
-                ),
-                chunkIndices: timedEmbeddings.map(\.chunkIndex)
-            )
-        } else {
-            assignments = assignEmbeddings(
-                embeddingFeatures: embeddingFeatures,
-                centroids: centroids
-            )
-        }
 
         let chunkAssignments = buildChunkAssignments(
             segmentation: segmentation,
@@ -673,6 +649,54 @@ public final class OfflineDiarizerManager {
         }
 
         return selected
+    }
+
+    /// Turns a VBx output into per-embedding cluster assignments.
+    ///
+    /// Split out of `cluster(_:)` so the centroid census and the assignment rule
+    /// can be exercised together without CoreML models: given a `VBxOutput`, the
+    /// rest of this stage is pure arithmetic. The speaker count a caller finally
+    /// observes is `Set(assignments).count`, which is what speaker count
+    /// constraints have to hold for.
+    func clusterAssignments(
+        vbxOutput: VBxOutput,
+        trainingEmbeddings: [[Double]],
+        embeddingFeatures: [[Double]],
+        initialClusters: [Int],
+        chunkIndices: [Int]
+    ) -> (centroids: [[Double]], assignments: [Int]) {
+        let centroidComputation = computeCentroids(
+            trainingEmbeddings: trainingEmbeddings,
+            vbxOutput: vbxOutput,
+            initialClusters: initialClusters
+        )
+        var centroids = centroidComputation.centroids
+        if centroids.isEmpty {
+            centroids = computeFallbackCentroids(from: embeddingFeatures)
+        }
+        // pyannote parity: constrain co-chunk speakers to distinct clusters, but
+        // not when the count was forced via K-Means — the constraint can then
+        // artificially inflate the number of speakers.
+        let useConstrainedAssignment =
+            config.clustering.constrainedAssignment
+            && !vbxOutput.wasAdjusted
+            && centroids.count > 1
+        let assignments: [Int]
+        if useConstrainedAssignment {
+            assignments = ConstrainedClusterAssignment.assign(
+                scores: centroidScores(
+                    embeddingFeatures: embeddingFeatures,
+                    centroids: centroids
+                ),
+                chunkIndices: chunkIndices
+            )
+        } else {
+            assignments = assignEmbeddings(
+                embeddingFeatures: embeddingFeatures,
+                centroids: centroids
+            )
+        }
+        return (centroids, assignments)
     }
 
     private func computeCentroids(

--- a/Tests/FluidAudioTests/Diarizer/Offline/OfflineSpeakerCapTests.swift
+++ b/Tests/FluidAudioTests/Diarizer/Offline/OfflineSpeakerCapTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// End-to-end checks that a speaker count request survives every stage below the
+/// VBx refinement: the constraint gate, centroid construction, and assignment.
+///
+/// These run the real assignment rather than inspecting an intermediate census,
+/// because that is where a cap is finally kept or broken — `Set(assignments).count`
+/// is the speaker count a caller observes.
+@available(macOS 14.0, iOS 17.0, *)
+final class OfflineSpeakerCapTests: XCTestCase {
+
+    /// Two embeddings sharing one segmentation chunk.
+    private let embeddings = [[1.0, 0.0], [0.0, 1.0]]
+    private let chunkIndices = [0, 0]
+    private let initialClusters = [0, 1]
+
+    /// VBx keeps two mixture components, but column 1 wins no embedding's argmax:
+    /// `assignedClusterCount` is 1 while `activeClusterCount` is 2.
+    private func splitOutput() -> VBxOutput {
+        VBxOutput(
+            gamma: [[0.6, 0.4], [0.6, 0.4]],
+            pi: [0.6, 0.4],
+            hardClusters: [[0, 0]],
+            centroids: [],
+            numClusters: 2,
+            elbos: []
+        )
+    }
+
+    private func assignments(
+        for output: VBxOutput,
+        numSpeakers: Int?,
+        maxSpeakers: Int? = nil
+    ) -> [Int] {
+        let constraints: SpeakerCountConstraints? =
+            (numSpeakers == nil && maxSpeakers == nil)
+            ? nil
+            : SpeakerCountConstraints.resolve(
+                numEmbeddings: embeddings.count,
+                numSpeakers: numSpeakers,
+                minSpeakers: nil,
+                maxSpeakers: maxSpeakers
+            )
+
+        let constrained = VBxClustering.applyConstraints(
+            to: output,
+            trainingEmbeddings: embeddings,
+            constraints: constraints
+        )
+
+        return OfflineDiarizerManager().clusterAssignments(
+            vbxOutput: constrained,
+            trainingEmbeddings: embeddings,
+            embeddingFeatures: embeddings,
+            initialClusters: initialClusters,
+            chunkIndices: chunkIndices
+        ).assignments
+    }
+
+    // MARK: - The cap must hold
+
+    func testNumSpeakersOneYieldsOneSpeaker() {
+        let result = assignments(for: splitOutput(), numSpeakers: 1)
+        XCTAssertEqual(
+            Set(result).count, 1,
+            "numSpeakers: 1 must not produce \(Set(result).count) speakers")
+    }
+
+    func testMaxSpeakersOneYieldsOneSpeaker() {
+        let result = assignments(for: splitOutput(), numSpeakers: nil, maxSpeakers: 1)
+        XCTAssertEqual(
+            Set(result).count, 1,
+            "maxSpeakers: 1 must not produce \(Set(result).count) speakers")
+    }
+
+    // MARK: - pyannote parity when nothing was requested
+
+    /// Without a speaker count request, pyannote keeps every `sp > 1e-7` component
+    /// as a centroid and lets constrained assignment place a co-chunk speaker on a
+    /// component that won no argmax. Tightening the centroid census would silently
+    /// change this default-config result, so it is pinned here.
+    func testUnconstrainedRunKeepsBothMixtureComponents() {
+        let result = assignments(for: splitOutput(), numSpeakers: nil)
+        XCTAssertEqual(
+            Set(result).count, 2,
+            "an unconstrained run must keep pyannote's centroid census")
+    }
+
+    // MARK: - The adjustment itself
+
+    /// #802: a request the argmax census misses must still re-cluster, and the
+    /// count reported as detected is that census — not the wider pi census.
+    func testUnderCountReclustersOnTheArgmaxCensus() {
+        // Both rows win column 0, so one cluster is assigned while two survive.
+        let output = VBxOutput(
+            gamma: [[0.9, 0.1], [0.8, 0.2]],
+            pi: [0.7, 0.3],
+            hardClusters: [[0, 0]],
+            centroids: [],
+            numClusters: 2,
+            elbos: []
+        )
+        let constraints = SpeakerCountConstraints.resolve(
+            numEmbeddings: embeddings.count,
+            numSpeakers: nil,
+            minSpeakers: 2,
+            maxSpeakers: nil
+        )
+
+        let adjusted = VBxClustering.applyConstraints(
+            to: output,
+            trainingEmbeddings: embeddings,
+            constraints: constraints
+        )
+
+        XCTAssertTrue(adjusted.wasAdjusted)
+        XCTAssertEqual(adjusted.numClusters, 2)
+        XCTAssertEqual(
+            adjusted.originalClusterCount, 1,
+            "the argmax census is what the adjustment reports as detected")
+    }
+
+    /// #801: when both censuses already fit, nothing is re-clustered.
+    func testBothCensusesWithinBoundsLeaveTheOutputUntouched() {
+        let constraints = SpeakerCountConstraints.resolve(
+            numEmbeddings: embeddings.count,
+            numSpeakers: nil,
+            minSpeakers: nil,
+            maxSpeakers: 2
+        )
+
+        let adjusted = VBxClustering.applyConstraints(
+            to: splitOutput(),
+            trainingEmbeddings: embeddings,
+            constraints: constraints
+        )
+
+        XCTAssertFalse(adjusted.wasAdjusted, "VBx already agrees; K-Means must not run")
+        XCTAssertNil(adjusted.originalClusterCount)
+    }
+}


### PR DESCRIPTION
> **Updated after review.** The first version filtered the centroid census, which
> changed the unconstrained default path — thanks @Alex-Wengg for catching that. This
> version takes the route you described: centroids stay on the pi census, and the gate
> in `refineWithConstraints` checks both counts. Rebased onto current `main`.

## Problem

`OfflineDiarizerManager` can return more speakers than `clustering.numSpeakers` or
`clustering.maxSpeakers` allows. The count correction concludes no adjustment is needed, and a
later stage reintroduces a cluster that conclusion had already excluded.

Deterministic counterexample, no audio or models needed:

- `gamma = [[0.6, 0.4], [0.6, 0.4]]`, `pi = [0.6, 0.4]`, `numClusters = 2`
- two local speakers sharing one segmentation chunk
- requested `numSpeakers = 1` (or `maxSpeakers = 1`)

Expected one speaker; the assignment comes back `[0, 1]` — two.

## Why

Three stages currently use three different definitions of a surviving cluster:

1. The count check reads **argmax winners** — `output.assignedClusterCount`
   ([VBxClustering.swift#L703](https://github.com/FluidInference/FluidAudio/blob/b980fc2e/Sources/FluidAudio/Diarizer/Offline/Clustering/VBxClustering.swift#L703)).
   Column 1 wins no argmax, so the detected count is 1, `needsAdjustment` is false, and
   `refineWithConstraints` returns without re-clustering.
2. Centroid construction keeps **every cluster with `pi > 1e-7`**
   ([OfflineDiarizerManager.swift#L701](https://github.com/FluidInference/FluidAudio/blob/b980fc2e/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift#L701)),
   so column 1 gets a centroid anyway.
3. Constrained assignment is enabled whenever the count was not adjusted and more than one
   centroid exists
   ([OfflineDiarizerManager.swift#L422](https://github.com/FluidInference/FluidAudio/blob/b980fc2e/Sources/FluidAudio/Diarizer/Offline/Core/OfflineDiarizerManager.swift#L422)).
   Its pyannote-parity rule forces two speakers sharing a chunk onto distinct clusters, so the
   second speaker lands on the revived column.

Setting `clustering.constrainedAssignment = false` does not close it — plain cosine assignment
over the same retained centroids can select the non-winning column too.

## This change

Stage 2 is deliberate pyannote parity (`VBxClustering.__call__` keeps every `sp > 1e-7`
component and assigns over all of them), so the fix belongs in stage 1: **re-cluster when
either census falls outside the bounds.**

```swift
let assignedCount = output.assignedClusterCount
let activeCount = output.activeClusterCount
let detectedCount =
    constraints.needsAdjustment(detectedCount: assignedCount) ? assignedCount : activeCount
guard constraints.needsAdjustment(detectedCount: detectedCount) else { return output }
```

The argmax census leads when both are out of bounds, so an under-count still re-clusters to the
target #802 chose and reports the same detected count; the pi census only decides cases the
argmax census called satisfied. It also catches a pi census above `maxSpeakers`.

Unconstrained runs return before the gate, so nothing about the default path moves — centroid
construction is untouched.

## Two extractions, to make it testable

The gate sits below a PLDA-model-dependent refinement, so there was no model-free path from a
`VBxOutput` to actual assignments — which is why the first version's tests could not see the
regression they introduced. Both moves are pure, no behaviour change:

- `VBxClustering.applyConstraints(to:trainingEmbeddings:constraints:)` — the constraint gate,
  static, split out of `refineWithConstraints`.
- `OfflineDiarizerManager.clusterAssignments(...)` — centroid construction plus the assignment
  rule, split out of `cluster(_:)`.

They exist only to make the tests possible. Happy to reshape them if you would rather the seams
were drawn differently — different names, a different split, an injectable instead of a static.

## Tests

New `OfflineSpeakerCapTests` asserts the speaker count a caller actually observes,
`Set(assignments).count`, by running the real assignment:

- `numSpeakers: 1` and `maxSpeakers: 1` on the toy case each yield 1 speaker. Both fail on
  `main` with `("2") is not equal to ("1")`.
- **`testUnconstrainedRunKeepsBothMixtureComponents`** — the same input with no request must
  still yield 2. Passes before and after; it is the regression the first version would have
  caused.
- `#802` guard: an argmax under-count still re-clusters and reports that census as detected.
- `#801` guard: when both censuses fit, K-Means does not run.

`VBxConstraintTests` 10/10. Full diarizer/clustering selection: 236 tests, 7 failures — all 7 in
`SpeakerEnrollmentTests` (`inferenceFailed("Missing chunk_pre_encoder_embs_out")`), identical on
an unmodified `main` checkout here, so pre-existing and unrelated. `swift build --arch x86_64`
clean.

## Relationship to #802

This is a side effect of #802, which is otherwise a clear improvement: the count check became
more accurate, but the downstream stages were not moved to the same definition.

One detail worth stating precisely, because it is easy to misread. Before #802 the check read
`output.numClusters`, which at that point was `max(1, Set(initialClusters).count)` — the **AHC
warm-start count**, not the surviving mixture-weight census. With 2 initial clusters against a
request of 1, `needsAdjustment` was true and K-Means re-clustered to 1, so the constraint held.
#802 rightly stopped gating on the warm-start count (it re-clustered even when VBx already
agreed, #801). The gap is only that the other definitions remained downstream.

## Context

Found while qualifying an upgrade from v0.15.5 for an app with a user-facing "at most N other
speakers" control, where exceeding the limit is visible to the user. I have not measured how often
this occurs on real audio; the report is source analysis plus the deterministic case above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

