### PR TITLE
feat(tts/pocket): per-stage compute-unit overrides (#881)

### DIFF
--- a/Documentation/TTS/PocketTTS.md
+++ b/Documentation/TTS/PocketTTS.md
@@ -167,6 +167,16 @@ Splitting priority:
 ## CoreML Details
 
 - Per-model compute units (measured fastest, v2.1): `flowlm`/`flow_decoder_fused` `.all`, `cond_prefill` `.all` (GPU), `mimi_decoder` `.cpuOnly`. Only the fused flow decoder reaches the ANE; mimi stays off the ANE (fp16 streaming-state feedback causes audible artifacts there)
+- **Overriding compute units (#881).** The defaults above are measured on M-series / macOS 26 and are not tunable through `placement`, which only swaps model variants. Some hardware/OS pairs reject a default placement — an M1 Max on macOS 26.6.2 aborts `flow_decoder_fused` on the ANE (`ANEProgramProcessRequestDirect status=0x16`) at both precisions and both placements. Pass `PocketTtsComputeUnits` to `PocketTtsManager` / `PocketTtsModelStore`; every field is optional and `nil` keeps that stage's default:
+
+  ```swift
+  // Keep every stage off the Neural Engine (GPU for the transformer stages, CPU for mimi)
+  let tts = PocketTtsManager(computeUnits: .avoidNeuralEngine)
+  // Or move just the failing stage
+  let tts = PocketTtsManager(computeUnits: PocketTtsComputeUnits(flowDecoder: .cpuAndGPU))
+  ```
+
+  CLI: `fluidaudiocli tts "…" --backend pocket --compute-units no-ane` (also `default`, `all`, `cpu-gpu`, `cpu-ane`, `cpu-only`). Under `.aneState` placement the `flowLM` field governs the fused `pocket_state` functions; that placement is ANE-resident by design, so pair `.avoidNeuralEngine` with `.gpu`.
 - Models compiled from `.mlpackage` → `.mlmodelc` on first load, cached on disk
 - `PocketTtsModelStore` is an actor — thread-safe access to loaded models
 - Voice data cached per voice name to avoid reloading

--- a/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/Pipeline/PocketTtsModelStore.swift
@@ -38,6 +38,7 @@ public actor PocketTtsModelStore {
     public let language: PocketTtsLanguage
     public let precision: PocketTtsPrecision
     public let placement: PocketTtsModelPlacement
+    public let computeUnits: PocketTtsComputeUnits
 
     /// - Parameters:
     ///   - language: Which upstream language pack to load. Defaults to
@@ -55,16 +56,21 @@ public actor PocketTtsModelStore {
     ///   ignores `precision` for the FlowLM (fp16 only). `.aneState` loads
     ///   the Trial 23 `pocket_state.mlmodelc` multifunction package (MLState
     ///   KV cache; macOS 15+/iOS 18+ at runtime, fp16 only).
+    /// - Parameter computeUnits: Per-stage compute-unit overrides (#881).
+    ///   `.default` keeps the measured-fastest routing below; set a stage, or
+    ///   use `.avoidNeuralEngine`, on hardware where the ANE rejects one.
     public init(
         language: PocketTtsLanguage = .english,
         directory: URL? = nil,
         precision: PocketTtsPrecision = .fp16,
-        placement: PocketTtsModelPlacement = .gpu
+        placement: PocketTtsModelPlacement = .gpu,
+        computeUnits: PocketTtsComputeUnits = .default
     ) {
         self.language = language
         self.directory = directory
         self.precision = precision
         self.placement = placement
+        self.computeUnits = computeUnits
     }
 
     /// Load all four CoreML models and the constants bundle.
@@ -125,10 +131,13 @@ public actor PocketTtsModelStore {
         // M-series — the trade buys a GPU-free decode loop). cond_prefill_ane
         // is 92% ANE-capable but its single fat T=256 call is ~2x faster on
         // GPU, so it stays `.all` and lets the scheduler pick.
-        let condConfig = config(.all)
-        let flowlmConfig = config(placement == .ane ? .cpuAndNeuralEngine : .all)
-        let flowDecoderConfig = config(.all)
-        let mimiConfig = config(.cpuOnly)
+        // Callers can override any stage (#881: M1 Max / macOS 26.6 aborts
+        // `flow_decoder_fused` on the ANE, and no placement avoids `.all`).
+        let units = computeUnits.resolved(for: placement)
+        let condConfig = config(units.conditioner)
+        let flowlmConfig = config(units.flowLM)
+        let flowDecoderConfig = config(units.flowDecoder)
+        let mimiConfig = config(units.mimiDecoder)
 
         let loadStart = Date()
 
@@ -155,7 +164,7 @@ public actor PocketTtsModelStore {
             let modelURL = languageRoot.appendingPathComponent(spec.file)
             let model = try MLModel(contentsOf: modelURL, configuration: spec.config)
             loadedModels.append(model)
-            logger.info("Loaded \(spec.file) (computeUnits=\(spec.config.computeUnits.rawValue))")
+            logger.info("Loaded \(spec.file) (computeUnits=\(spec.config.computeUnits.pocketTtsLabel))")
         }
 
         // In v2.1 the conditioner IS cond_prefill (no per-token cond_step).
@@ -224,9 +233,10 @@ public actor PocketTtsModelStore {
         let stateURL = languageRoot.appendingPathComponent(
             ModelNames.PocketTTS.pocketStateFile)
 
+        let stateUnits = computeUnits.resolvedStatePipeline
         func functionConfig(_ functionName: String) -> MLModelConfiguration {
             let c = MLModelConfiguration()
-            c.computeUnits = .cpuAndNeuralEngine
+            c.computeUnits = stateUnits
             c.functionName = functionName
             return c
         }
@@ -239,16 +249,17 @@ public actor PocketTtsModelStore {
             configuration: functionConfig(ModelNames.PocketTTS.StateFunction.generate))
         stateModelsStore = PocketTtsStateModels(prefill: prefill, generate: generate)
         logger.info(
-            "Loaded \(ModelNames.PocketTTS.pocketStateFile) (functions: prefill, generate; computeUnits=cpuAndNeuralEngine)"
+            "Loaded \(ModelNames.PocketTTS.pocketStateFile) (functions: prefill, generate; computeUnits=\(stateUnits.pocketTtsLabel))"
         )
 
         let mimiConfig = MLModelConfiguration()
-        mimiConfig.computeUnits = .cpuOnly
+        mimiConfig.computeUnits = computeUnits.mimiDecoder ?? .cpuOnly
         let mimiURL = languageRoot.appendingPathComponent(ModelNames.PocketTTS.mimiDecoderFile)
         let mimi = try MLModel(contentsOf: mimiURL, configuration: mimiConfig)
         mimiDecoderModel = mimi
         mimiDecoderKeysCache = try PocketTtsMimiKeys.discover(from: mimi)
-        logger.info("Loaded \(ModelNames.PocketTTS.mimiDecoderFile) (computeUnits=cpuOnly)")
+        logger.info(
+            "Loaded \(ModelNames.PocketTTS.mimiDecoderFile) (computeUnits=\(mimiConfig.computeUnits.pocketTtsLabel))")
 
         let elapsed = Date().timeIntervalSince(loadStart)
         logger.info("PocketTTS state-pipeline models loaded in \(String(format: "%.2f", elapsed))s")
@@ -394,7 +405,7 @@ public actor PocketTtsModelStore {
         guard mimiEncoderModel == nil else { return }
 
         let config = MLModelConfiguration()
-        config.computeUnits = .cpuAndGPU
+        config.computeUnits = computeUnits.resolvedMimiEncoder
 
         if language != .english,
             let packURL = try await PocketTtsResourceDownloader.ensurePackMimiEncoder(

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsComputeUnits.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsComputeUnits.swift
@@ -1,0 +1,95 @@
+import CoreML
+import Foundation
+
+/// Per-stage Core ML compute-unit overrides for PocketTTS (#881).
+///
+/// Every field defaults to `nil`, which keeps the measured-fastest routing
+/// for that stage and placement (documented in `PocketTtsModelStore`). Set a
+/// field to move a single stage. Use `avoidNeuralEngine` when the ANE rejects
+/// a stage on a given machine/OS — e.g. `flow_decoder_fused` aborting with
+/// `ANEProgramProcessRequestDirect status=0x16` on an M1 Max under macOS 26.6,
+/// where the default `.all` places it on the ANE and no `placement` avoids it.
+public struct PocketTtsComputeUnits: Sendable, Hashable {
+    /// `cond_prefill` (or `cond_prefill_ane`). Default `.all`.
+    public var conditioner: MLComputeUnits?
+    /// `flowlm_step` / `flowlm_stepv2` / `flowlm_step_ane`. Default `.all`,
+    /// or `.cpuAndNeuralEngine` under `.ane` placement. Under `.aneState`
+    /// this governs the fused `pocket_state` prefill/generate functions
+    /// (default `.cpuAndNeuralEngine`), which subsume the flow decoder.
+    public var flowLM: MLComputeUnits?
+    /// `flow_decoder_fused`. Default `.all` (the one stage that is 100% ANE).
+    public var flowDecoder: MLComputeUnits?
+    /// `mimi_decoder`. Default `.cpuOnly`; keep it off the ANE — its fp16
+    /// streaming-state feedback compounds into audible beeps there.
+    public var mimiDecoder: MLComputeUnits?
+    /// `mimi_encoder` (voice cloning only). Default `.cpuAndGPU`.
+    public var mimiEncoder: MLComputeUnits?
+
+    public init(
+        conditioner: MLComputeUnits? = nil,
+        flowLM: MLComputeUnits? = nil,
+        flowDecoder: MLComputeUnits? = nil,
+        mimiDecoder: MLComputeUnits? = nil,
+        mimiEncoder: MLComputeUnits? = nil
+    ) {
+        self.conditioner = conditioner
+        self.flowLM = flowLM
+        self.flowDecoder = flowDecoder
+        self.mimiDecoder = mimiDecoder
+        self.mimiEncoder = mimiEncoder
+    }
+
+    /// The measured-fastest routing for every stage.
+    public static let `default` = PocketTtsComputeUnits()
+
+    /// Every stage on the same units. Prefer `avoidNeuralEngine` for the
+    /// #881 case: it keeps `mimi_decoder` on the CPU, where it is fastest.
+    public static func uniform(_ units: MLComputeUnits) -> PocketTtsComputeUnits {
+        PocketTtsComputeUnits(
+            conditioner: units, flowLM: units, flowDecoder: units,
+            mimiDecoder: units, mimiEncoder: units)
+    }
+
+    /// No stage may be scheduled on the Neural Engine: GPU for the
+    /// transformer stages, CPU for the mimi decoder. Pair with `.gpu`
+    /// placement; `.aneState` is ANE-resident by design.
+    public static let avoidNeuralEngine = PocketTtsComputeUnits(
+        conditioner: .cpuAndGPU, flowLM: .cpuAndGPU, flowDecoder: .cpuAndGPU,
+        mimiDecoder: .cpuOnly, mimiEncoder: .cpuAndGPU)
+
+    /// Fully resolved units for the four IO-pipeline models.
+    struct Resolved: Hashable {
+        let conditioner: MLComputeUnits
+        let flowLM: MLComputeUnits
+        let flowDecoder: MLComputeUnits
+        let mimiDecoder: MLComputeUnits
+    }
+
+    /// Overrides applied over the defaults for `placement` (`.gpu` / `.ane`).
+    func resolved(for placement: PocketTtsModelPlacement) -> Resolved {
+        Resolved(
+            conditioner: conditioner ?? .all,
+            flowLM: flowLM ?? (placement == .ane ? .cpuAndNeuralEngine : .all),
+            flowDecoder: flowDecoder ?? .all,
+            mimiDecoder: mimiDecoder ?? .cpuOnly
+        )
+    }
+
+    /// Units for the `.aneState` multifunction package (prefill + generate).
+    var resolvedStatePipeline: MLComputeUnits { flowLM ?? .cpuAndNeuralEngine }
+
+    var resolvedMimiEncoder: MLComputeUnits { mimiEncoder ?? .cpuAndGPU }
+}
+
+extension MLComputeUnits {
+    /// Stable log label (the raw value is an opaque integer).
+    var pocketTtsLabel: String {
+        switch self {
+        case .cpuOnly: return "cpuOnly"
+        case .cpuAndGPU: return "cpuAndGPU"
+        case .cpuAndNeuralEngine: return "cpuAndNeuralEngine"
+        case .all: return "all"
+        @unknown default: return "unknown(\(rawValue))"
+        }
+    }
+}

--- a/Sources/FluidAudio/TTS/PocketTTS/PocketTtsManager.swift
+++ b/Sources/FluidAudio/TTS/PocketTTS/PocketTtsManager.swift
@@ -39,18 +39,23 @@ public actor PocketTtsManager {
     ///   - placement: `.gpu` (default) loads the v2.1 rank-5 models;
     ///     `.ane` loads the rank-4 ANE-eligible variants (`flowlm_step_ane`,
     ///     `cond_prefill_ane`) with the FlowLM pinned to the Neural Engine.
+    ///   - computeUnits: Per-stage compute-unit overrides (#881). `.default`
+    ///     keeps the measured-fastest routing; `.avoidNeuralEngine` keeps
+    ///     every stage off the ANE on hardware where it aborts a stage.
     public init(
         defaultVoice: String = PocketTtsConstants.defaultVoice,
         language: PocketTtsLanguage = .english,
         directory: URL? = nil,
         precision: PocketTtsPrecision = .fp16,
-        placement: PocketTtsModelPlacement = .gpu
+        placement: PocketTtsModelPlacement = .gpu,
+        computeUnits: PocketTtsComputeUnits = .default
     ) {
         self.modelStore = PocketTtsModelStore(
             language: language,
             directory: directory,
             precision: precision,
-            placement: placement
+            placement: placement,
+            computeUnits: computeUnits
         )
         self.defaultVoice = defaultVoice
         self.language = language

--- a/Sources/FluidAudioCLI/Commands/TTSCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/TTSCommand.swift
@@ -80,6 +80,7 @@ public struct TTS {
         var saveVoicePath: String? = nil
         var pocketLanguage: PocketTtsLanguage = .english
         var pocketPlacement: PocketTtsModelPlacement = .gpu
+        var pocketComputeUnits: PocketTtsComputeUnits = .default
         var pocketTemperature: Float = PocketTtsConstants.temperature
         // PocketTTS deterministic-seed mode (uses session API for fixed RNG).
         var pocketSeed: UInt64? = nil
@@ -300,6 +301,23 @@ public struct TTS {
                     saveVoicePath = arguments[i + 1]
                     i += 1
                 }
+            case "--compute-units":
+                if i + 1 < arguments.count {
+                    switch arguments[i + 1].lowercased() {
+                    case "default": pocketComputeUnits = .default
+                    case "no-ane", "avoid-ane": pocketComputeUnits = .avoidNeuralEngine
+                    case "all": pocketComputeUnits = .uniform(.all)
+                    case "cpu-gpu", "gpu": pocketComputeUnits = .uniform(.cpuAndGPU)
+                    case "cpu-ane", "ane": pocketComputeUnits = .uniform(.cpuAndNeuralEngine)
+                    case "cpu-only", "cpu": pocketComputeUnits = .uniform(.cpuOnly)
+                    default:
+                        logger.error(
+                            "Unknown --compute-units '\(arguments[i + 1])'. Supported: default, no-ane, all, cpu-gpu, cpu-ane, cpu-only"
+                        )
+                        return
+                    }
+                    i += 1
+                }
             case "--placement":
                 if i + 1 < arguments.count {
                     let raw = arguments[i + 1].lowercased()
@@ -351,7 +369,8 @@ public struct TTS {
                 metricsPath: metricsPath, cloneVoicePath: cloneVoicePath,
                 voiceFilePath: voiceFilePath, saveVoicePath: saveVoicePath,
                 language: pocketLanguage, seed: pocketSeed,
-                placement: pocketPlacement, temperature: pocketTemperature)
+                placement: pocketPlacement, computeUnits: pocketComputeUnits,
+                temperature: pocketTemperature)
         case .kokoroAne:
             await runKokoroAne(
                 text: text, output: output, voice: voice, metricsPath: metricsPath,
@@ -698,6 +717,7 @@ public struct TTS {
         language: PocketTtsLanguage,
         seed: UInt64? = nil,
         placement: PocketTtsModelPlacement = .gpu,
+        computeUnits: PocketTtsComputeUnits = .default,
         temperature: Float = PocketTtsConstants.temperature
     ) async {
         do {
@@ -706,7 +726,8 @@ public struct TTS {
                 voice == TtsConstants.recommendedVoice
                 ? PocketTtsConstants.defaultVoice : voice
             let manager = PocketTtsManager(
-                defaultVoice: pocketVoice, language: language, placement: placement)
+                defaultVoice: pocketVoice, language: language, placement: placement,
+                computeUnits: computeUnits)
             logger.info(
                 "PocketTTS language: \(language.rawValue), placement: \(placement.rawValue)")
 
@@ -1385,6 +1406,8 @@ public struct TTS {
                                    Note: French is 24-layer only (no 6-layer pack upstream)
               --seed N             Deterministic-mode seed (uses session API for fixed RNG)
               --temperature T      Generation temperature (default 0.7)
+              --compute-units U    PocketTTS per-stage routing: default, no-ane (keep every
+                                   stage off the Neural Engine, #881), all, cpu-gpu, cpu-ane, cpu-only
               --placement P        Model placement: gpu (default), ane (rank-4 ANE models),
                                    ane-state (Trial 23 MLState multifunction pipeline;
                                    macOS 15+/iOS 18+, requires pocket_state.mlmodelc)

--- a/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsComputeUnitsTests.swift
+++ b/Tests/FluidAudioTests/TTS/PocketTTS/PocketTtsComputeUnitsTests.swift
@@ -1,0 +1,83 @@
+import CoreML
+import XCTest
+
+@testable import FluidAudio
+
+/// Pure-logic tests for the per-stage compute-unit overrides (#881). No model
+/// files or network access required.
+final class PocketTtsComputeUnitsTests: XCTestCase {
+
+    // MARK: - Defaults reproduce the measured-fastest routing
+
+    func testDefaultGpuPlacementMatchesMeasuredRouting() {
+        let r = PocketTtsComputeUnits.default.resolved(for: .gpu)
+        XCTAssertEqual(r.conditioner, .all)
+        XCTAssertEqual(r.flowLM, .all)
+        XCTAssertEqual(r.flowDecoder, .all)
+        XCTAssertEqual(r.mimiDecoder, .cpuOnly)
+    }
+
+    func testDefaultAnePlacementPinsFlowLMToNeuralEngine() {
+        let r = PocketTtsComputeUnits.default.resolved(for: .ane)
+        XCTAssertEqual(r.conditioner, .all)
+        XCTAssertEqual(r.flowLM, .cpuAndNeuralEngine)
+        XCTAssertEqual(r.flowDecoder, .all)
+        XCTAssertEqual(r.mimiDecoder, .cpuOnly)
+    }
+
+    func testDefaultStatePipelineAndMimiEncoder() {
+        XCTAssertEqual(PocketTtsComputeUnits.default.resolvedStatePipeline, .cpuAndNeuralEngine)
+        XCTAssertEqual(PocketTtsComputeUnits.default.resolvedMimiEncoder, .cpuAndGPU)
+    }
+
+    // MARK: - Overrides
+
+    /// #881: the failing stage is `flow_decoder_fused`, which no `placement`
+    /// value moves off `.all`. A single-stage override must reach it while
+    /// leaving the other stages on their defaults.
+    func testSingleStageOverrideOnlyMovesThatStage() {
+        let units = PocketTtsComputeUnits(flowDecoder: .cpuAndGPU)
+        let r = units.resolved(for: .gpu)
+        XCTAssertEqual(r.flowDecoder, .cpuAndGPU)
+        XCTAssertEqual(r.conditioner, .all)
+        XCTAssertEqual(r.flowLM, .all)
+        XCTAssertEqual(r.mimiDecoder, .cpuOnly)
+    }
+
+    func testOverrideBeatsPlacementDefaultForFlowLM() {
+        let units = PocketTtsComputeUnits(flowLM: .cpuAndGPU)
+        XCTAssertEqual(units.resolved(for: .ane).flowLM, .cpuAndGPU)
+        XCTAssertEqual(units.resolvedStatePipeline, .cpuAndGPU)
+    }
+
+    func testAvoidNeuralEngineSchedulesNoStageOnTheANE() {
+        let units = PocketTtsComputeUnits.avoidNeuralEngine
+        for placement in [PocketTtsModelPlacement.gpu, .ane] {
+            let r = units.resolved(for: placement)
+            for stage in [r.conditioner, r.flowLM, r.flowDecoder, r.mimiDecoder] {
+                XCTAssertNotEqual(stage, .all, "\(placement)")
+                XCTAssertNotEqual(stage, .cpuAndNeuralEngine, "\(placement)")
+            }
+            XCTAssertEqual(r.mimiDecoder, .cpuOnly, "mimi stays on the CPU, where it is fastest")
+        }
+        XCTAssertEqual(units.resolvedMimiEncoder, .cpuAndGPU)
+    }
+
+    func testUniformAppliesToEveryStage() {
+        let units = PocketTtsComputeUnits.uniform(.cpuOnly)
+        let r = units.resolved(for: .gpu)
+        XCTAssertEqual([r.conditioner, r.flowLM, r.flowDecoder, r.mimiDecoder], Array(repeating: .cpuOnly, count: 4))
+        XCTAssertEqual(units.resolvedStatePipeline, .cpuOnly)
+        XCTAssertEqual(units.resolvedMimiEncoder, .cpuOnly)
+    }
+
+    func testDefaultIsAllNil() {
+        let d = PocketTtsComputeUnits.default
+        XCTAssertNil(d.conditioner)
+        XCTAssertNil(d.flowLM)
+        XCTAssertNil(d.flowDecoder)
+        XCTAssertNil(d.mimiDecoder)
+        XCTAssertNil(d.mimiEncoder)
+        XCTAssertEqual(d, PocketTtsComputeUnits())
+    }
+}


### PR DESCRIPTION
Closes #881.

## Problem

`PocketTtsModelStore` hardcodes each stage's compute units (`cond_prefill` / `flowlm_step` / `flow_decoder_fused` at `.all`, `mimi_decoder` at `.cpuOnly`); only the FlowLM varies with `placement`. On an M1 Max under macOS 26.6.2, `.all` places `flow_decoder_fused` on the ANE, where it aborts (`ANEProgramProcessRequestDirect status=0x16`) at both precisions and both placements, and there is no supported way to move it. Same class as #742.

## Change

`PocketTtsComputeUnits`: one optional `MLComputeUnits` per stage (`conditioner`, `flowLM`, `flowDecoder`, `mimiDecoder`, `mimiEncoder`). `nil` keeps the measured-fastest default for that stage and placement, so nothing changes for existing callers.

```swift
PocketTtsManager(computeUnits: .avoidNeuralEngine)                             // GPU transformer stages, CPU mimi
PocketTtsManager(computeUnits: PocketTtsComputeUnits(flowDecoder: .cpuAndGPU)) // move only the failing stage
```

- Threaded through `PocketTtsModelStore.init` and `PocketTtsManager.init`. `.aneState` takes its units from `flowLM`; the cloning mimi encoder from `mimiEncoder`.
- Load logs print the unit name instead of the raw integer.
- CLI: `tts --backend pocket --compute-units default|no-ane|all|cpu-gpu|cpu-ane|cpu-only`.
- `PocketTtsComputeUnitsTests`: defaults per placement equal the previous hardcodes, a single-stage override reaches `flow_decoder_fused` alone, `.avoidNeuralEngine` schedules nothing on the ANE, `uniform`, state-pipeline / encoder resolution.
- `Documentation/TTS/PocketTTS.md`: "Overriding compute units".

## Verification

M5 Pro / macOS 26.7, english pack, same sentence:

| `--compute-units` | cond / flowlm / flow_decoder / mimi | audio |
|---|---|---|
| default | all / all / all / cpuOnly | 2.96 s |
| no-ane | cpuAndGPU / cpuAndGPU / cpuAndGPU / cpuOnly | 2.56 s |
| cpu-gpu | cpuAndGPU ×4 | 2.88 s |

The M1 Max abort doesn't reproduce here. @vitryr, your harness with `computeUnits: .avoidNeuralEngine` (or `--compute-units no-ane`) on the M1 Max is the confirming run; your patched numbers (151 ms to first audio, RTF 1.76×) should carry over since the routing is the same.

`swift build` and `swift format lint` clean; XCTest is unavailable locally, tests run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UHoFANi4DcvU6TzyTPnHH
