### PR TITLE
fix(asr/vocab): tokenize in-code terms, rescore every streaming window, stop volatile-text loss (#851)

### DIFF
--- a/.github/workflows/asr-benchmark.yml
+++ b/.github/workflows/asr-benchmark.yml
@@ -257,7 +257,7 @@ jobs:
         if: always()
         env:
           FLUIDAUDIO_RUN_ASR_E2E: "1"
-        run: swift test --filter SlidingWindowFinalWindowRegressionTests
+        run: swift test --filter 'SlidingWindowFinalWindowRegressionTests|SlidingWindowVocabularyBoostingStreamingTests'
         timeout-minutes: 15
 
       - name: Comment PR

--- a/Documentation/ASR/CustomVocabulary.md
+++ b/Documentation/ASR/CustomVocabulary.md
@@ -384,7 +384,9 @@ let vocabulary = CustomVocabularyContext(terms: [
 ])
 ```
 
-Each term is tokenized and scored against CTC log-probabilities. High-scoring terms are used to correct the TDT transcript.
+Terms without `ctcTokenIds` are tokenized with the CTC tokenizer when boosting is configured (`configureVocabularyBoosting` on any engine, or `VocabularyBoostingSession.init`), so the plain `CustomVocabularyTerm(text:)` form above works as written. Pre-tokenized terms (from `loadWithCtcTokens(from:)`, or an explicit `ctcTokenIds:`) are used as-is; a term that encodes to nothing is dropped with a warning. Each term is then scored against CTC log-probabilities, and high-scoring terms correct the transcript. (Before #851 this path was a silent no-op: untokenized terms were skipped without any log.)
+
+**Streaming (`SlidingWindowAsrManager`).** Every window is rescored, including windows that are still volatile (a clip shorter than `minContextForConfirmation`, a low-confidence window, the final flush) — confirmation only governs display promotion, and a window's text is promoted verbatim later.
 
 #### Alias Support
 

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyContext.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyContext.swift
@@ -122,6 +122,54 @@ public struct CustomVocabularyContext: Sendable {
         self.minTermLength = minTermLength
     }
 
+    /// Copy with the same thresholds and a different term list.
+    func replacingTerms(_ newTerms: [CustomVocabularyTerm]) -> CustomVocabularyContext {
+        CustomVocabularyContext(
+            terms: newTerms,
+            alpha: alpha,
+            minCtcScore: minCtcScore,
+            minSimilarity: minSimilarity,
+            minCombinedConfidence: minCombinedConfidence,
+            minTermLength: minTermLength
+        )
+    }
+
+    /// Fill in `ctcTokenIds` for every term that lacks them (#851).
+    ///
+    /// The spotter and rescorer silently skip terms without CTC token IDs, so a
+    /// context built in code from plain `CustomVocabularyTerm(text:)` values was a
+    /// no-op on every engine. `VocabularyBoostingSession` calls this with the CTC
+    /// tokenizer at configure time; pre-tokenized terms pass through unchanged.
+    /// `tokenIds` (Parakeet TDT IDs) are not a substitute — they index a different
+    /// vocabulary — so a term with only `tokenIds` is tokenized too.
+    ///
+    /// - Returns: The tokenized context, how many terms were tokenized, and the
+    ///   texts of terms that encoded to nothing (dropped).
+    func tokenizingMissingCtcTokens(
+        using encode: (String) -> [Int]
+    ) -> (context: CustomVocabularyContext, tokenized: Int, dropped: [String]) {
+        var tokenized = 0
+        var dropped: [String] = []
+        let newTerms = terms.compactMap { term -> CustomVocabularyTerm? in
+            if let ids = term.ctcTokenIds, !ids.isEmpty { return term }
+            let ids = encode(term.text)
+            guard !ids.isEmpty else {
+                dropped.append(term.text)
+                return nil
+            }
+            tokenized += 1
+            return CustomVocabularyTerm(
+                text: term.text,
+                weight: term.weight,
+                aliases: term.aliases,
+                tokenIds: term.tokenIds,
+                ctcTokenIds: ids,
+                minSimilarity: term.minSimilarity
+            )
+        }
+        return (replacingTerms(newTerms), tokenized, dropped)
+    }
+
     /// Load a custom vocabulary JSON file produced by the analysis tooling.
     public static func load(from url: URL) throws -> CustomVocabularyContext {
         let logger = AppLogger(category: "CustomVocabulary")

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyBoostingSession.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyBoostingSession.swift
@@ -34,16 +34,39 @@ public struct VocabularyBoostingSession: Sendable {
     ///
     /// - Parameters:
     ///   - vocabulary: Custom vocabulary context with terms to detect. Terms
-    ///     must carry `ctcTokenIds` (e.g. via
-    ///     `CustomVocabularyContext.loadWithCtcTokens(from:ctcVariant:)`).
+    ///     without `ctcTokenIds` are tokenized here with the CTC tokenizer
+    ///     shipped alongside `ctcModels` (#851); pre-tokenized terms (e.g. via
+    ///     `CustomVocabularyContext.loadWithCtcTokens(from:ctcVariant:)`) are
+    ///     used as-is.
     ///   - ctcModels: Pre-loaded CTC models for keyword spotting
     ///   - config: Optional rescorer configuration (default: `.default`)
-    /// - Throws: Error if rescorer initialization fails
+    /// - Throws: Error if the CTC tokenizer cannot be loaded for untokenized
+    ///   terms, or if rescorer initialization fails
     public init(
         vocabulary: CustomVocabularyContext,
         ctcModels: CtcModels,
         config: VocabularyRescorer.Config? = nil
     ) async throws {
+        let ctcModelDir = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
+
+        // Terms built in code arrive without CTC token IDs, and every consumer
+        // (spotter, rescorer) skips such terms without a word — the documented
+        // `CustomVocabularyContext(terms: [CustomVocabularyTerm(text:)])` path
+        // was a silent no-op on every engine (#851). Tokenize them here.
+        var vocabulary = vocabulary
+        let needsTokens = vocabulary.terms.contains { ($0.ctcTokenIds ?? []).isEmpty }
+        if needsTokens {
+            let tokenizer = try await CtcTokenizer.load(from: ctcModelDir)
+            let result = vocabulary.tokenizingMissingCtcTokens(using: tokenizer.encode)
+            vocabulary = result.context
+            logger.info("Tokenized \(result.tokenized) vocabulary term(s) with the CTC tokenizer")
+            for text in result.dropped {
+                logger.warning("Vocabulary term '\(text)' produced no CTC tokens; dropped")
+            }
+        }
+        if vocabulary.terms.isEmpty {
+            logger.warning("Vocabulary boosting configured with no usable terms; rescoring will be a no-op")
+        }
         self.vocabulary = vocabulary
 
         let blankId = ctcModels.vocabulary.count
@@ -53,7 +76,6 @@ public struct VocabularyBoostingSession: Sendable {
         self.vocabSizeConfig = ContextBiasingConstants.rescorerConfig(
             forVocabSize: vocabulary.terms.count)
 
-        let ctcModelDir = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
         self.rescorer = try await VocabularyRescorer.create(
             spotter: spotter,
             vocabulary: vocabulary,

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -491,9 +491,13 @@ public actor SlidingWindowAsrManager {
             let isHighConfidence = Double(interim.confidence) >= config.confirmationThreshold
             let shouldConfirm = isHighConfidence && hasMinimumContext
 
-            // Rescore before updating transcript state so finish() returns rescored content
+            // Rescore before updating transcript state so finish() returns rescored content.
+            // Every window is rescored, not only confirmed ones: confirmation is a display
+            // promotion, but a window's text is promoted verbatim later, so a window that
+            // was volatile when decoded (short clip under `minContextForConfirmation`, low
+            // confidence, the final flush) would otherwise never see its vocabulary (#851).
             var displayResult = interim
-            if shouldConfirm && vocabBoostingEnabled,
+            if vocabBoostingEnabled,
                 let chunkLocalResult = await asrManager?.processTranscriptionResult(
                     tokenIds: tokens,
                     timestamps: timestamps,  // Original chunk-local timestamps (not adjusted)
@@ -568,7 +572,12 @@ public actor SlidingWindowAsrManager {
                 "CONFIRMED (\(result.confidence), \(String(format: "%.1f", totalAudioProcessed))s context): promoted to confirmed; new volatile '\(result.text)'"
             )
         } else {
-            volatileTranscript = result.text
+            // Each window carries new audio, so an unconfirmed window extends the
+            // volatile tail rather than replacing it. Overwriting lost the previous
+            // window's text whenever two consecutive windows went unconfirmed — with
+            // boosting on, finish() builds from this text, and a trailing empty flush
+            // window returned an empty transcript for a 15 s clip (#851).
+            volatileTranscript = Self.appendingVolatile(volatileTranscript, result.text)
             let hasMinimumContext = totalAudioProcessed >= config.minContextForConfirmation
             let reason =
                 !hasMinimumContext
@@ -577,7 +586,13 @@ public actor SlidingWindowAsrManager {
         }
     }
 
-    /// Apply vocabulary rescoring to confirmed text using CTC-based constrained decoding.
+    /// Join the still-volatile text with a newer unconfirmed window's text.
+    /// Empty pieces (a silent flush window) contribute nothing. Pure, for testability.
+    static func appendingVolatile(_ existing: String, _ incoming: String) -> String {
+        [existing, incoming].filter { !$0.isEmpty }.joined(separator: " ")
+    }
+
+    /// Apply vocabulary rescoring to a window's text using CTC-based constrained decoding.
     ///
     /// This runs CTC inference on the chunk audio and applies vocabulary rescoring
     /// to replace misrecognized words with vocabulary terms when acoustic evidence supports it.

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -81,8 +81,10 @@ public actor SlidingWindowAsrManager {
 
     /// Configure vocabulary boosting for streaming transcription
     ///
-    /// When configured, vocabulary terms will be rescored when text is confirmed during streaming.
-    /// This provides real-time vocabulary corrections visible in confirmed updates.
+    /// When configured, every window is rescored against CTC evidence as it is
+    /// decoded — confirmed or not (#851) — so corrections appear in both volatile
+    /// and confirmed updates and in `finish()`. Terms without `ctcTokenIds` are
+    /// tokenized here with the CTC tokenizer.
     ///
     /// - Parameters:
     ///   - vocabulary: Custom vocabulary context with terms to detect

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyTests.swift
@@ -235,4 +235,49 @@ final class CustomVocabularyTests: XCTestCase {
         XCTAssertNotNil(term.aliases)
         XCTAssertTrue(term.aliases?.isEmpty == true)
     }
+
+    // MARK: - Automatic CTC tokenization (#851)
+
+    private func fakeEncode(_ text: String) -> [Int] {
+        // Deterministic stand-in for CtcTokenizer.encode: one id per character.
+        text.unicodeScalars.map { Int($0.value) }
+    }
+
+    func testTokenizingMissingCtcTokensFillsUntokenizedTerms() {
+        let context = CustomVocabularyContext(
+            terms: [CustomVocabularyTerm(text: "NVIDIA"), CustomVocabularyTerm(text: "PyTorch", weight: 2)],
+            minSimilarity: 0.42, minTermLength: 4)
+        let result = context.tokenizingMissingCtcTokens(using: fakeEncode)
+        XCTAssertEqual(result.tokenized, 2)
+        XCTAssertTrue(result.dropped.isEmpty)
+        XCTAssertEqual(result.context.terms.map(\.text), ["NVIDIA", "PyTorch"])
+        XCTAssertEqual(result.context.terms[0].ctcTokenIds, fakeEncode("NVIDIA"))
+        XCTAssertEqual(result.context.terms[1].weight, 2, "per-term settings survive")
+        XCTAssertEqual(result.context.minSimilarity, 0.42, accuracy: 0.001, "thresholds survive")
+        XCTAssertEqual(result.context.minTermLength, 4)
+    }
+
+    func testTokenizingMissingCtcTokensLeavesPreTokenizedTermsAlone() {
+        let pre = CustomVocabularyTerm(text: "Bose", ctcTokenIds: [7, 8, 9])
+        let result = CustomVocabularyContext(terms: [pre]).tokenizingMissingCtcTokens(using: fakeEncode)
+        XCTAssertEqual(result.tokenized, 0)
+        XCTAssertEqual(result.context.terms[0].ctcTokenIds, [7, 8, 9])
+    }
+
+    /// TDT `tokenIds` index a different vocabulary; they must not stand in for CTC ids.
+    func testTokenizingMissingCtcTokensIgnoresTdtTokenIds() {
+        let tdtOnly = CustomVocabularyTerm(text: "Bose", tokenIds: [100, 200])
+        let result = CustomVocabularyContext(terms: [tdtOnly]).tokenizingMissingCtcTokens(using: fakeEncode)
+        XCTAssertEqual(result.tokenized, 1)
+        XCTAssertEqual(result.context.terms[0].ctcTokenIds, fakeEncode("Bose"))
+        XCTAssertEqual(result.context.terms[0].tokenIds, [100, 200])
+    }
+
+    func testTokenizingMissingCtcTokensDropsTermsThatEncodeToNothing() {
+        let result = CustomVocabularyContext(terms: [
+            CustomVocabularyTerm(text: "keep"), CustomVocabularyTerm(text: "drop"),
+        ]).tokenizingMissingCtcTokens(using: { $0 == "drop" ? [] : self.fakeEncode($0) })
+        XCTAssertEqual(result.context.terms.map(\.text), ["keep"])
+        XCTAssertEqual(result.dropped, ["drop"])
+    }
 }

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
@@ -307,4 +307,17 @@ final class SlidingWindowAsrManagerTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Volatile text accumulation (#851)
+
+    func testAppendingVolatileExtendsRatherThanReplaces() {
+        XCTAssertEqual(
+            SlidingWindowAsrManager.appendingVolatile("first window", "second window"), "first window second window")
+    }
+
+    func testAppendingVolatileIgnoresEmptyFlushWindow() {
+        XCTAssertEqual(SlidingWindowAsrManager.appendingVolatile("first window", ""), "first window")
+        XCTAssertEqual(SlidingWindowAsrManager.appendingVolatile("", "only"), "only")
+        XCTAssertEqual(SlidingWindowAsrManager.appendingVolatile("", ""), "")
+    }
 }

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowVocabularyBoostingStreamingTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowVocabularyBoostingStreamingTests.swift
@@ -4,18 +4,21 @@ import XCTest
 @testable import FluidAudio
 
 /// End-to-end check of the three #851 defects on a real recording, through the
-/// public API exactly as an integrator uses it:
+/// public API exactly as an integrator uses it. `minContextForConfirmation` is
+/// set above the clip length so **no window ever confirms**, which is the state
+/// every defect hid behind:
 ///
 /// 1. terms built in code (`CustomVocabularyTerm(text:)`, no token IDs) must be
-///    tokenized at configure time instead of silently ignored;
-/// 2. a window that is never confirmed (this clip has two windows; the second is
-///    the flush) must still be rescored;
-/// 3. an unconfirmed trailing window must not erase the previous window's text —
-///    with boosting on, `finish()` builds from that text and returned "".
+///    tokenized at configure time instead of silently ignored — asserted by the
+///    corrected spelling `follow-up` (unboosted decode says `follow up`);
+/// 2. an unconfirmed window must still be rescored — same assertion, since the
+///    word sits in the second, never-confirmed window;
+/// 3. an unconfirmed window must not erase the previous window's volatile text —
+///    asserted by the opening phrase surviving; with boosting on, `finish()`
+///    builds from that text and returned "" before the fix.
 ///
-/// Asserts the transcript is non-empty, keeps the recording's tail, and still
-/// contains the vocabulary term's word. Needs the Parakeet v3 and CTC models;
-/// runs when both are cached or `FLUIDAUDIO_RUN_ASR_E2E=1` allows a download.
+/// Needs the Parakeet v3 and CTC models; runs when both are cached or
+/// `FLUIDAUDIO_RUN_ASR_E2E=1` allows a download.
 @available(macOS 14.0, iOS 17.0, *)
 final class SlidingWindowVocabularyBoostingStreamingTests: XCTestCase {
 
@@ -36,7 +39,9 @@ final class SlidingWindowVocabularyBoostingStreamingTests: XCTestCase {
 
         let asrModels = try await AsrModels.downloadAndLoad()
         let ctcModels = try await CtcModels.downloadAndLoad()
-        let manager = SlidingWindowAsrManager()
+        // 60 s > 21.4 s clip: every window stays volatile for the whole stream.
+        let config = SlidingWindowAsrConfig(minContextForConfirmation: 60)
+        let manager = SlidingWindowAsrManager(config: config)
         try await manager.loadModels(asrModels)
         // Untokenized on purpose: this is the documented in-code path.
         let vocabulary = CustomVocabularyContext(terms: [
@@ -60,7 +65,13 @@ final class SlidingWindowVocabularyBoostingStreamingTests: XCTestCase {
         let folded = text.lowercased()
 
         XCTAssertFalse(folded.isEmpty, "boosted streaming transcript must not be empty")
+        // Fix 3: the first (volatile) window's text survives the second volatile window.
+        XCTAssertTrue(folded.contains("before we go to them"), "first window lost: \(text)")
+        // #855 fixture contract: the final window's tail survives.
         XCTAssertTrue(folded.contains("help them out"), "tail lost: \(text)")
+        // Fixes 1 + 2: the in-code term was tokenized and applied inside a window
+        // that never confirmed. Unboosted decode of this clip says "follow up".
+        XCTAssertTrue(folded.contains("follow-up"), "term not applied in unconfirmed window: \(text)")
         XCTAssertTrue(folded.contains("codex"), "vocabulary word missing from: \(text)")
     }
 

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowVocabularyBoostingStreamingTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowVocabularyBoostingStreamingTests.swift
@@ -1,0 +1,94 @@
+import AVFoundation
+import XCTest
+
+@testable import FluidAudio
+
+/// End-to-end check of the three #851 defects on a real recording, through the
+/// public API exactly as an integrator uses it:
+///
+/// 1. terms built in code (`CustomVocabularyTerm(text:)`, no token IDs) must be
+///    tokenized at configure time instead of silently ignored;
+/// 2. a window that is never confirmed (this clip has two windows; the second is
+///    the flush) must still be rescored;
+/// 3. an unconfirmed trailing window must not erase the previous window's text —
+///    with boosting on, `finish()` builds from that text and returned "".
+///
+/// Asserts the transcript is non-empty, keeps the recording's tail, and still
+/// contains the vocabulary term's word. Needs the Parakeet v3 and CTC models;
+/// runs when both are cached or `FLUIDAUDIO_RUN_ASR_E2E=1` allows a download.
+@available(macOS 14.0, iOS 17.0, *)
+final class SlidingWindowVocabularyBoostingStreamingTests: XCTestCase {
+
+    func testInMemoryTermsRescoreAndKeepTailOnRealRecording() async throws {
+        let allowDownload = ProcessInfo.processInfo.environment["FLUIDAUDIO_RUN_ASR_E2E"] == "1"
+        let asrCached = AsrModels.modelsExist(at: AsrModels.defaultCacheDirectory())
+        let ctcCached = CtcModels.modelsExist(at: CtcModels.defaultCacheDirectory())
+        try XCTSkipUnless(
+            (asrCached && ctcCached) || allowDownload,
+            "Parakeet v3 + CTC models not cached; set FLUIDAUDIO_RUN_ASR_E2E=1 to download")
+
+        guard
+            let url = Bundle.module.url(forResource: "Fixtures/01-validation-request-21.4s", withExtension: "wav")
+                ?? Bundle.module.url(forResource: "01-validation-request-21.4s", withExtension: "wav")
+        else {
+            throw XCTSkip("fixture missing from test bundle")
+        }
+
+        let asrModels = try await AsrModels.downloadAndLoad()
+        let ctcModels = try await CtcModels.downloadAndLoad()
+        let manager = SlidingWindowAsrManager()
+        try await manager.loadModels(asrModels)
+        // Untokenized on purpose: this is the documented in-code path.
+        let vocabulary = CustomVocabularyContext(terms: [
+            CustomVocabularyTerm(text: "Codex"), CustomVocabularyTerm(text: "follow-up"),
+        ])
+        try await manager.configureVocabularyBoosting(vocabulary: vocabulary, ctcModels: ctcModels)
+        try await manager.startStreaming()
+
+        let samples = try Self.loadSamples(url)
+        var position = 0
+        while position < samples.count {
+            let end = min(position + 16_000, samples.count)
+            guard let buffer = Self.makeChunk(samples[position..<end]) else {
+                XCTFail("could not allocate chunk buffer")
+                break
+            }
+            await manager.streamAudio(buffer)
+            position = end
+        }
+        let text = try await manager.finish()
+        let folded = text.lowercased()
+
+        XCTAssertFalse(folded.isEmpty, "boosted streaming transcript must not be empty")
+        XCTAssertTrue(folded.contains("help them out"), "tail lost: \(text)")
+        XCTAssertTrue(folded.contains("codex"), "vocabulary word missing from: \(text)")
+    }
+
+    private static func loadSamples(_ url: URL) throws -> [Float] {
+        let file = try AVAudioFile(forReading: url)
+        guard
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: file.processingFormat, frameCapacity: AVAudioFrameCount(file.length))
+        else { throw XCTSkip("could not allocate a buffer for \(url.lastPathComponent)") }
+        try file.read(into: buffer)
+        guard let channel = buffer.floatChannelData?[0] else {
+            throw XCTSkip("fixture is not float PCM")
+        }
+        return Array(UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength)))
+    }
+
+    private nonisolated static func makeChunk(_ samples: ArraySlice<Float>) -> AVAudioPCMBuffer? {
+        guard
+            let format = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32, sampleRate: 16_000, channels: 1, interleaved: false),
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count)),
+            let channel = buffer.floatChannelData?[0]
+        else { return nil }
+        for (offset, sample) in samples.enumerated() {
+            channel[offset] = sample
+        }
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        return buffer
+    }
+}


### PR DESCRIPTION
Fixes the three defects behind the #851 follow-up ("`configureVocabularyBoosting` is byte-identical to unboosted on both managers", 0/5 terms on a 7.1 s clip). Each was reproduced on real audio and is fixed here.

## 1. In-code terms were never tokenized, and everything skipped them silently

The documented `CustomVocabularyContext(terms: [CustomVocabularyTerm(text: "NVIDIA")])` form produces terms with no `ctcTokenIds`. `CtcKeywordSpotter` and `VocabularyRescorer` both `continue` past such terms with no log, so boosting was a no-op on every engine. Only the file loader `loadWithCtcTokens(from:)` tokenized. That's the reporter's Q3, and it explains their unified-engine result.

`VocabularyBoostingSession.init` now tokenizes any term lacking `ctcTokenIds` with the CTC tokenizer that ships beside the CTC models (`CustomVocabularyContext.tokenizingMissingCtcTokens(using:)`), drops terms that encode to nothing with a warning, and warns when no usable term remains. TDT `tokenIds` are not accepted as a stand-in; they index a different vocabulary.

## 2. Sliding-window streaming only rescored confirmed windows

Confirmation needs confidence ≥ 0.85 **and** ≥ `minContextForConfirmation` (10 s). A 7.1 s or 9 s clip never confirms, so it was never rescored even with tokenized terms; the log says "insufficient context (9.0s)" at confidence 0.92. Every window is rescored now. Confirmation only governs display promotion, and a window's text is promoted verbatim later, so gating rescoring on it just lost the vocabulary for volatile windows.

## 3. An unconfirmed window overwrote the previous window's volatile text

`updateTranscriptionState` set `volatileTranscript = result.text` on every unconfirmed window. Confirming a window only promotes the window *before* it, so the first window's (rescored) text sat in the volatile slot, the trailing flush window decoded to `""` at confidence 0.1 and replaced it, and `finish()` returned an empty transcript for a 15 s clip. The non-boosting path hid this by rebuilding from tokens; the boosting path builds from text. Unconfirmed windows now extend the volatile tail.

## Verification (release build, earnings22 fixture `4482641_chunk_19`, term "Mechatronics systems")

| path | main | this PR |
|---|---|---|
| 9 s clip, streaming boosted | "Mechatonic" uncorrected | "Mechatronics" |
| 15 s clip, streaming boosted | **empty transcript** | complete, corrected |
| 15 s clip, batch boosted | corrected | unchanged |
| streaming unboosted | — | unchanged |

One pre-existing behaviour surfaced while testing, unchanged by this PR: on the #855 clip 01 with the term "Codex", the sliding-window rescorer's `.default` rescue floors replace the opening "Hey" with "Codex" on `main` too (batch keeps "Hey"). That's the rescue-floor over-fire already noted for the TDT path in #862; separate issue.

## Review round

- The first version of the e2e test ran with the default 10 s confirmation context, so both windows confirmed and its assertions held on the unboosted transcript. Now forces every window volatile and asserts the corrected spelling.
- `configureVocabularyBoosting` doc no longer says rescoring happens only on confirmed text.

## Tests

- Unit: `tokenizingMissingCtcTokens` (fills untokenized, leaves pre-tokenized alone, ignores TDT ids, drops empty encodings, preserves thresholds) and `appendingVolatile`.
- End-to-end: `SlidingWindowVocabularyBoostingStreamingTests` feeds **untokenized** in-code terms through `SlidingWindowAsrManager` on the public #855 clip 01 with `minContextForConfirmation` set above the clip length, so **no window ever confirms** — the state all three defects hid behind. It asserts the opening phrase survives (fix 3), the tail survives, and the corrected spelling `follow-up` appears (fixes 1 + 2; the unboosted decode says `follow up`). Verified via the CLI that this configuration discriminates. Runs when the v3 + CTC models are cached or `FLUIDAUDIO_RUN_ASR_E2E=1`; added to the ASR benchmark job next to the #855 fixture test.
- Docs: `CustomVocabulary.md` states the tokenization contract and the streaming rescoring rule.

@codedbybencorp this should turn your 0/5 into real corrections on both managers without any change on your side beyond the version bump; the tokenization workaround from my earlier comment is no longer needed. If you can run the clip against this branch I'd like to hear the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UHoFANi4DcvU6TzyTPnHH
