### PR TITLE
fix(asr/vocab): bound the spotter-rescue nearest-word fallback; surface spotter detections; pass rescue flags to streaming (#899)

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
@@ -1273,6 +1273,33 @@ extension VocabularyRescorer {
     /// margin is the same value.
     static let spotterRescueFallbackRadiusSeconds: Double = 0.5
 
+    /// The word whose centre is closest to `center`, and how far it is. Pure,
+    /// so the fallback bound can be unit-tested without a rescorer.
+    static func nearestWord(
+        in wordTimings: [WordTiming], toCenter center: Double
+    ) -> (index: Int, delta: Double)? {
+        var best: (index: Int, delta: Double)?
+        for (idx, w) in wordTimings.enumerated() {
+            let delta = abs((w.startTime + w.endTime) / 2.0 - center)
+            if best == nil || delta < best!.delta {
+                best = (idx, delta)
+            }
+        }
+        return best
+    }
+
+    /// The bounded-fallback decision on its own: the nearest word's index when
+    /// it lies within `radius` seconds of `center`, nil otherwise (#899).
+    static func fallbackWordIndex(
+        in wordTimings: [WordTiming], toCenter center: Double,
+        radius: Double = spotterRescueFallbackRadiusSeconds
+    ) -> Int? {
+        guard let nearest = nearestWord(in: wordTimings, toCenter: center), nearest.delta <= radius else {
+            return nil
+        }
+        return nearest.index
+    }
+
     /// Find the indices of TDT words whose [startTime, endTime] window
     /// overlaps the supplied detection range. Returns at most a small
     /// contiguous run; non-contiguous overlaps are reduced to the run
@@ -1296,29 +1323,21 @@ extension VocabularyRescorer {
         if overlapping.isEmpty {
             // Fall back to the nearest word to the detection centre, bounded.
             let center = (start + end) / 2.0
-            var bestIdx = 0
-            var bestDelta = Double.infinity
-            for (idx, w) in wordTimings.enumerated() {
-                let mid = (w.startTime + w.endTime) / 2.0
-                let delta = abs(mid - center)
-                if delta < bestDelta {
-                    bestDelta = delta
-                    bestIdx = idx
-                }
-            }
-            guard bestDelta <= fallbackRadius else {
+            let nearest = Self.nearestWord(in: wordTimings, toCenter: center)
+            guard let nearest else { return [] }
+            guard nearest.delta <= fallbackRadius else {
                 debugLog(
                     String(
                         format:
                             "  [SPOTTER-RESCUE] detection %.2f–%.2fs overlaps no word; nearest '%@' is %.2fs away (> %.2fs), skipped",
-                        start, end, wordTimings[bestIdx].word, bestDelta, fallbackRadius))
+                        start, end, wordTimings[nearest.index].word, nearest.delta, fallbackRadius))
                 return []
             }
             debugLog(
                 String(
                     format: "  [SPOTTER-RESCUE] detection %.2f–%.2fs overlaps no word; using nearest '%@' (%.2fs away)",
-                    start, end, wordTimings[bestIdx].word, bestDelta))
-            return [bestIdx]
+                    start, end, wordTimings[nearest.index].word, nearest.delta))
+            return [nearest.index]
         }
         // Ensure contiguity (consecutive indices).
         var contiguous: [Int] = [overlapping[0]]

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer+TokenRescoring.swift
@@ -1264,14 +1264,26 @@ extension VocabularyRescorer {
         }
     }
 
+    /// How far (seconds, detection centre to word centre) the nearest-word
+    /// fallback may reach when no TDT word overlaps a spotter detection.
+    /// Unbounded, a spurious low-score detection in the first 0.5 s of a
+    /// window snapped onto whatever word was nearest — `Hey` 0.68 s away on
+    /// one machine, `validate` on another (#899). Half a second covers the
+    /// CTC-vs-TDT timestamp skew a near miss can have; the session's search
+    /// margin is the same value.
+    static let spotterRescueFallbackRadiusSeconds: Double = 0.5
+
     /// Find the indices of TDT words whose [startTime, endTime] window
     /// overlaps the supplied detection range. Returns at most a small
     /// contiguous run; non-contiguous overlaps are reduced to the run
-    /// containing the time-center of the detection.
+    /// containing the time-center of the detection. With no overlap, the
+    /// nearest word is used only if it lies within `fallbackRadius` of the
+    /// detection centre; otherwise the detection maps to nothing.
     private func wordIndices(
         in wordTimings: [WordTiming],
         overlapping start: Double,
-        end: Double
+        end: Double,
+        fallbackRadius: Double = spotterRescueFallbackRadiusSeconds
     ) -> [Int] {
         guard !wordTimings.isEmpty, start < end else { return [] }
 
@@ -1282,7 +1294,7 @@ extension VocabularyRescorer {
             overlapping.append(idx)
         }
         if overlapping.isEmpty {
-            // Fall back to nearest word to the detection center.
+            // Fall back to the nearest word to the detection centre, bounded.
             let center = (start + end) / 2.0
             var bestIdx = 0
             var bestDelta = Double.infinity
@@ -1294,6 +1306,18 @@ extension VocabularyRescorer {
                     bestIdx = idx
                 }
             }
+            guard bestDelta <= fallbackRadius else {
+                debugLog(
+                    String(
+                        format:
+                            "  [SPOTTER-RESCUE] detection %.2f–%.2fs overlaps no word; nearest '%@' is %.2fs away (> %.2fs), skipped",
+                        start, end, wordTimings[bestIdx].word, bestDelta, fallbackRadius))
+                return []
+            }
+            debugLog(
+                String(
+                    format: "  [SPOTTER-RESCUE] detection %.2f–%.2fs overlaps no word; using nearest '%@' (%.2fs away)",
+                    start, end, wordTimings[bestIdx].word, bestDelta))
             return [bestIdx]
         }
         // Ensure contiguity (consecutive indices).

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/Rescorer/VocabularyRescorer.swift
@@ -211,6 +211,10 @@ public struct VocabularyRescorer: Sendable {
         public let text: String
         public let replacements: [RescoringResult]
         public let wasModified: Bool
+        /// Vocabulary terms the CTC spotter detected in the audio (canonical
+        /// text, in time order, deduplicated), whether or not any replacement
+        /// was applied. Populated by `VocabularyBoostingSession.rescore` (#899).
+        public var detectedTerms: [String] = []
     }
 
     /// The discovery path that produced a vocabulary candidate.

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyBoostingSession.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/CustomVocabulary/VocabularyBoostingSession.swift
@@ -90,9 +90,11 @@ public struct VocabularyBoostingSession: Sendable {
     /// is the first sample. Callers rescoring a window or segment out of a
     /// longer stream pass segment-local timings with the segment's audio.
     ///
-    /// - Returns: The rescore output if any replacement was applied,
-    ///   nil otherwise (including on CTC inference failure, which is logged
-    ///   and absorbed — boosting must never break transcription).
+    /// - Returns: The rescore output when a replacement was applied **or** the
+    ///   spotter detected at least one vocabulary term (`detectedTerms`); the
+    ///   text is the caller's own when nothing was replaced. Nil when there is
+    ///   nothing to report, and on CTC inference failure, which is logged and
+    ///   absorbed — boosting must never break transcription.
     public func rescore(
         text: String,
         tokenTimings: [TokenTiming],
@@ -127,20 +129,45 @@ public struct VocabularyBoostingSession: Sendable {
                 minSimilarity: minSimilarity
             )
 
-            guard rescoreOutput.wasModified else { return nil }
+            let detectedTerms = Self.detectedTermTexts(spotResult.detections)
+            guard rescoreOutput.wasModified || !detectedTerms.isEmpty else { return nil }
 
-            logger.info(
-                "Vocabulary rescoring applied \(rescoreOutput.replacements.count) replacement(s)"
-            )
-            for replacement in rescoreOutput.replacements where replacement.shouldReplace {
-                logger.debug(
-                    "  '\(replacement.originalWord)' → '\(replacement.replacementWord ?? "")'"
+            if rescoreOutput.wasModified {
+                logger.info(
+                    "Vocabulary rescoring applied \(rescoreOutput.replacements.count) replacement(s)"
                 )
+                for replacement in rescoreOutput.replacements where replacement.shouldReplace {
+                    logger.debug(
+                        "  '\(replacement.originalWord)' → '\(replacement.replacementWord ?? "")'"
+                    )
+                }
             }
-            return rescoreOutput
+            // The rescorer rebuilds its text from word timings (single spaces,
+            // timing-backed words only). Only hand that back when it actually
+            // changed something; otherwise the caller keeps its own text.
+            return VocabularyRescorer.RescoreOutput(
+                text: rescoreOutput.wasModified ? rescoreOutput.text : text,
+                replacements: rescoreOutput.replacements,
+                wasModified: rescoreOutput.wasModified,
+                detectedTerms: detectedTerms
+            )
         } catch {
             logger.warning("Vocabulary rescoring failed: \(error.localizedDescription)")
             return nil
         }
+    }
+
+    /// Canonical texts of the spotter's detections, in time order, without
+    /// repeats. Pure, for testability.
+    static func detectedTermTexts(_ detections: [CtcKeywordSpotter.KeywordDetection]) -> [String] {
+        var seen = Set<String>()
+        var texts: [String] = []
+        for detection in detections.sorted(by: { $0.startTime < $1.startTime }) {
+            let text = detection.term.text
+            if seen.insert(text.lowercased()).inserted {
+                texts.append(text)
+            }
+        }
+        return texts
     }
 }

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -516,7 +516,7 @@ public actor SlidingWindowAsrManager {
                     tokenTimings: chunkLocalTimings,
                     windowSamples: windowSamples
                 ) {
-                    let detected = rescored.replacements.compactMap { $0.replacementWord }
+                    let detected = rescored.detectedTerms
                     let applied = rescored.replacements.filter { $0.shouldReplace }.compactMap {
                         $0.replacementWord
                     }
@@ -536,7 +536,9 @@ public actor SlidingWindowAsrManager {
                 confidence: interim.confidence,
                 timestamp: Date(),
                 tokenIds: tokens,
-                tokenTimings: displayResult.tokenTimings ?? []
+                tokenTimings: displayResult.tokenTimings ?? [],
+                ctcDetectedTerms: displayResult.ctcDetectedTerms,
+                ctcAppliedTerms: displayResult.ctcAppliedTerms
             )
 
             updateContinuation?.yield(update)
@@ -871,13 +873,21 @@ public struct SlidingWindowTranscriptionUpdate: Sendable {
         tokenTimings.map(\.token)
     }
 
+    /// Vocabulary terms the CTC spotter detected in this window's audio, when
+    /// boosting is configured (#899). Present even if nothing was replaced.
+    public let ctcDetectedTerms: [String]?
+    /// Vocabulary terms applied as replacements in this window's text.
+    public let ctcAppliedTerms: [String]?
+
     public init(
         text: String,
         isConfirmed: Bool,
         confidence: Float,
         timestamp: Date,
         tokenIds: [Int] = [],
-        tokenTimings: [TokenTiming] = []
+        tokenTimings: [TokenTiming] = [],
+        ctcDetectedTerms: [String]? = nil,
+        ctcAppliedTerms: [String]? = nil
     ) {
         self.text = text
         self.isConfirmed = isConfirmed
@@ -885,5 +895,7 @@ public struct SlidingWindowTranscriptionUpdate: Sendable {
         self.timestamp = timestamp
         self.tokenIds = tokenIds
         self.tokenTimings = tokenTimings
+        self.ctcDetectedTerms = ctcDetectedTerms
+        self.ctcAppliedTerms = ctcAppliedTerms
     }
 }

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -61,7 +61,8 @@ public actor SlidingWindowAsrManager {
 
     // Vocabulary boosting
     // Initialized via configureVocabularyBoosting() before start()
-    private var vocabularyBoosting: VocabularyBoostingSession?
+    // Internal (not private) so tests can inspect the configured vocabulary.
+    var vocabularyBoosting: VocabularyBoostingSession?
     private var vocabBoostingEnabled: Bool { vocabularyBoosting != nil }
 
     /// Initialize the sliding-window ASR manager
@@ -511,21 +512,22 @@ public actor SlidingWindowAsrManager {
             {
                 let chunkLocalTimings = chunkLocalResult.tokenTimings ?? []
 
-                if let rescored = await applyVocabularyRescoring(
+                // Rescoring ran for this window: report its detections even when
+                // there are none, so `ctcDetectedTerms` is nil only when boosting
+                // is not configured (a deterministic "rescored" signal, #899).
+                let rescored = await applyVocabularyRescoring(
                     text: interim.text,
                     tokenTimings: chunkLocalTimings,
                     windowSamples: windowSamples
-                ) {
-                    let detected = rescored.detectedTerms
-                    let applied = rescored.replacements.filter { $0.shouldReplace }.compactMap {
-                        $0.replacementWord
-                    }
-                    displayResult = interim.withRescoring(
-                        text: rescored.text,
-                        detected: detected.isEmpty ? nil : detected,
-                        applied: applied.isEmpty ? nil : applied
-                    )
+                )
+                let applied = (rescored?.replacements ?? []).filter { $0.shouldReplace }.compactMap {
+                    $0.replacementWord
                 }
+                displayResult = interim.withRescoring(
+                    text: rescored?.text ?? interim.text,
+                    detected: rescored?.detectedTerms ?? [],
+                    applied: applied.isEmpty ? nil : applied
+                )
             }
 
             await updateTranscriptionState(with: displayResult, shouldConfirm: shouldConfirm)
@@ -873,8 +875,10 @@ public struct SlidingWindowTranscriptionUpdate: Sendable {
         tokenTimings.map(\.token)
     }
 
-    /// Vocabulary terms the CTC spotter detected in this window's audio, when
-    /// boosting is configured (#899). Present even if nothing was replaced.
+    /// Vocabulary terms the CTC spotter detected in this window's audio (#899).
+    /// `nil` when vocabulary boosting is not configured; empty when rescoring
+    /// ran on this window and detected nothing. Present even if nothing was
+    /// replaced.
     public let ctcDetectedTerms: [String]?
     /// Vocabulary terms applied as replacements in this window's text.
     public let ctcAppliedTerms: [String]?

--- a/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
+++ b/Sources/FluidAudioCLI/Commands/ASR/Parakeet/SlidingWindow/TranscribeCommand.swift
@@ -511,21 +511,7 @@ enum TranscribeCommand {
                     let ctcModelDir = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
 
                     let vocabConfig = ContextBiasingConstants.rescorerConfig(forVocabSize: customVocab.terms.count)
-                    // #702: opt-in short-term over-fire controls. Each flag
-                    // falls back to the library default (disabled) when unset.
-                    let rescorerConfig = VocabularyRescorer.Config(
-                        shortTermCbwTaperPivot: args.vocabShortTermTaperPivot
-                            ?? ContextBiasingConstants.defaultShortTermCbwTaperPivot,
-                        spotterRescueMinSimilarity: args.vocabSpotterMinSim
-                            ?? ContextBiasingConstants.defaultSpotterRescueMinSimilarity,
-                        spotterRescueMultiWordMinSimilarity: args.vocabSpotterMinSimMulti
-                            ?? ContextBiasingConstants.defaultSpotterRescueMultiWordMinSimilarity,
-                        // #724: `--vocab-disable-spotter-rescue` forces the acoustic
-                        // rescue pass off; otherwise follow the library/env default
-                        // (on unless `FLUID_SPOTTER_RESCUE` disables it).
-                        spotterRescueEnabled: args.vocabDisableSpotterRescue
-                            ? false : ContextBiasingConstants.defaultSpotterRescueEnabled
-                    )
+                    let rescorerConfig = makeRescorerConfig(args)
 
                     let rescorer = try await VocabularyRescorer.create(
                         spotter: spotter,
@@ -668,6 +654,22 @@ enum TranscribeCommand {
 
     // MARK: - Streaming Mode
 
+    /// #702/#724 opt-in over-fire controls, shared by batch and streaming. Each
+    /// flag falls back to the library default when unset; the library/env default
+    /// for the rescue pass is on unless `FLUID_SPOTTER_RESCUE` disables it.
+    private static func makeRescorerConfig(_ args: ParsedArgs) -> VocabularyRescorer.Config {
+        VocabularyRescorer.Config(
+            shortTermCbwTaperPivot: args.vocabShortTermTaperPivot
+                ?? ContextBiasingConstants.defaultShortTermCbwTaperPivot,
+            spotterRescueMinSimilarity: args.vocabSpotterMinSim
+                ?? ContextBiasingConstants.defaultSpotterRescueMinSimilarity,
+            spotterRescueMultiWordMinSimilarity: args.vocabSpotterMinSimMulti
+                ?? ContextBiasingConstants.defaultSpotterRescueMultiWordMinSimilarity,
+            spotterRescueEnabled: args.vocabDisableSpotterRescue
+                ? false : ContextBiasingConstants.defaultSpotterRescueEnabled
+        )
+    }
+
     private static func runStreaming(
         audioFile: String, args: ParsedArgs
     ) async {
@@ -700,9 +702,12 @@ enum TranscribeCommand {
                 let (customVocab, ctcModels) = try await CustomVocabularyContext.loadWithCtcTokens(from: vocabPath)
                 logger.info("Loaded \(customVocab.terms.count) vocabulary terms for streaming")
 
+                // Same #702/#724 over-fire flags as batch mode (#899: streaming
+                // previously dropped them and always ran the library default).
                 try await streamingAsr.configureVocabularyBoosting(
                     vocabulary: customVocab,
-                    ctcModels: ctcModels
+                    ctcModels: ctcModels,
+                    config: makeRescorerConfig(args)
                 )
             }
 

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyTests.swift
@@ -280,4 +280,20 @@ final class CustomVocabularyTests: XCTestCase {
         XCTAssertEqual(result.context.terms.map(\.text), ["keep"])
         XCTAssertEqual(result.dropped, ["drop"])
     }
+
+    // MARK: - Spotter detections surfaced as ctcDetectedTerms (#899)
+
+    func testDetectedTermTextsAreTimeOrderedAndDeduplicated() {
+        func detection(_ text: String, at start: TimeInterval) -> CtcKeywordSpotter.KeywordDetection {
+            CtcKeywordSpotter.KeywordDetection(
+                term: CustomVocabularyTerm(text: text), score: -3, totalFrames: 100,
+                startFrame: Int(start * 12.5), endFrame: Int(start * 12.5) + 5,
+                startTime: start, endTime: start + 0.4)
+        }
+        let texts = VocabularyBoostingSession.detectedTermTexts([
+            detection("PyTorch", at: 9.0), detection("Codex", at: 2.0), detection("codex", at: 12.0),
+        ])
+        XCTAssertEqual(texts, ["Codex", "PyTorch"])
+        XCTAssertEqual(VocabularyBoostingSession.detectedTermTexts([]), [])
+    }
 }

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/CustomVocabulary/CustomVocabularyTests.swift
@@ -296,4 +296,32 @@ final class CustomVocabularyTests: XCTestCase {
         XCTAssertEqual(texts, ["Codex", "PyTorch"])
         XCTAssertEqual(VocabularyBoostingSession.detectedTermTexts([]), [])
     }
+
+    // MARK: - Bounded nearest-word fallback (#899)
+
+    private func word(_ text: String, _ start: Double, _ end: Double) -> VocabularyRescorer.WordTiming {
+        VocabularyRescorer.WordTiming(word: text, startTime: start, endTime: end, tokenRange: nil)
+    }
+
+    /// The #899 shape: a spurious detection in the first half second of the
+    /// window, whose nearest word starts much later. Unbounded, it snapped to
+    /// "Hey" 0.68 s away (and to "validate" on another machine).
+    func testFallbackRejectsWordOutsideRadius() {
+        let words = [word("Hey,", 0.90, 1.10), word("before", 1.10, 1.40), word("we", 1.40, 1.50)]
+        let center = (0.16 + 0.48) / 2
+        let nearest = VocabularyRescorer.nearestWord(in: words, toCenter: center)
+        XCTAssertEqual(nearest?.index, 0)
+        XCTAssertEqual(nearest?.delta ?? 0, 0.68, accuracy: 0.01)
+        XCTAssertNil(VocabularyRescorer.fallbackWordIndex(in: words, toCenter: center))
+        XCTAssertNil(VocabularyRescorer.fallbackWordIndex(in: words, toCenter: center, radius: 0.5))
+    }
+
+    /// A genuine near miss (CTC/TDT timestamp skew) still maps to the word.
+    func testFallbackAcceptsWordWithinRadius() {
+        let words = [word("Codex", 9.10, 9.50), word("and", 9.50, 9.60)]
+        // Detection just before the word, centre 0.35 s from the word centre.
+        XCTAssertEqual(VocabularyRescorer.fallbackWordIndex(in: words, toCenter: 8.95), 0)
+        XCTAssertNil(VocabularyRescorer.fallbackWordIndex(in: words, toCenter: 8.95, radius: 0.2))
+        XCTAssertNil(VocabularyRescorer.fallbackWordIndex(in: [], toCenter: 1.0))
+    }
 }

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowVocabularyBoostingStreamingTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowVocabularyBoostingStreamingTests.swift
@@ -1,6 +1,5 @@
 import AVFoundation
 import XCTest
-import os
 
 @testable import FluidAudio
 
@@ -63,13 +62,18 @@ final class SlidingWindowVocabularyBoostingStreamingTests: XCTestCase {
             "in-code terms were not tokenized: \(configuredTerms.map { ($0.text, $0.ctcTokenIds ?? []) })")
         try await manager.startStreaming()
 
-        let updates = OSAllocatedUnfairLock<[SlidingWindowTranscriptionUpdate]>(initialState: [])
-        let consumer = Task {
-            for await update in await manager.transcriptionUpdates {
-                updates.withLock { $0.append(update) }
+        // Subscribe before any audio is fed: the continuation exists only once
+        // `transcriptionUpdates` has been read, and updates yielded before that
+        // are dropped. The stream is closed by `cancel()` after `finish()`, which
+        // delivers buffered updates and ends the consumer.
+        let stream = await manager.transcriptionUpdates
+        let consumer = Task { () -> [SlidingWindowTranscriptionUpdate] in
+            var collected: [SlidingWindowTranscriptionUpdate] = []
+            for await update in stream {
+                collected.append(update)
             }
+            return collected
         }
-        defer { consumer.cancel() }
 
         let samples = try Self.loadSamples(url)
         var position = 0
@@ -83,10 +87,14 @@ final class SlidingWindowVocabularyBoostingStreamingTests: XCTestCase {
             position = end
         }
         let text = try await manager.finish()
+        await manager.cancel()  // closes the update stream; finish() leaves it open
+        let seen = await consumer.value
         let folded = text.lowercased()
-        let seen = updates.withLock { $0 }
 
         XCTAssertFalse(folded.isEmpty, "boosted streaming transcript must not be empty")
+        // #899: the spurious window-start detection must not rewrite the first
+        // word through the (now bounded) nearest-word fallback.
+        XCTAssertTrue(folded.hasPrefix("hey"), "first word rewritten by the rescue pass: \(text)")
         // Fix 3: the first (volatile) window's text survives the second volatile window.
         XCTAssertTrue(folded.contains("before we go to them"), "first window lost: \(text)")
         // #855 fixture contract: the final window's tail survives.

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowVocabularyBoostingStreamingTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowVocabularyBoostingStreamingTests.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import XCTest
+import os
 
 @testable import FluidAudio
 
@@ -9,13 +10,18 @@ import XCTest
 /// every defect hid behind:
 ///
 /// 1. terms built in code (`CustomVocabularyTerm(text:)`, no token IDs) must be
-///    tokenized at configure time instead of silently ignored — asserted by the
-///    corrected spelling `follow-up` (unboosted decode says `follow up`);
-/// 2. an unconfirmed window must still be rescored — same assertion, since the
-///    word sits in the second, never-confirmed window;
+///    tokenized at configure time instead of silently ignored — the spotter can
+///    only detect a term it has token IDs for;
+/// 2. an unconfirmed window must still be rescored — the detection is asserted
+///    on an update with `isConfirmed == false`;
 /// 3. an unconfirmed window must not erase the previous window's volatile text —
 ///    asserted by the opening phrase surviving; with boosting on, `finish()`
 ///    builds from that text and returned "" before the fix.
+///
+/// The assertion is on spotter *activity* (`ctcDetectedTerms`, #899), not on a
+/// particular misrecognition being corrected: decodes differ between machines
+/// (a CI runner already emitted "follow-up" on this clip), so a text-only
+/// assertion could pass on model output alone.
 ///
 /// Needs the Parakeet v3 and CTC models; runs when both are cached or
 /// `FLUIDAUDIO_RUN_ASR_E2E=1` allows a download.
@@ -50,6 +56,14 @@ final class SlidingWindowVocabularyBoostingStreamingTests: XCTestCase {
         try await manager.configureVocabularyBoosting(vocabulary: vocabulary, ctcModels: ctcModels)
         try await manager.startStreaming()
 
+        let updates = OSAllocatedUnfairLock<[SlidingWindowTranscriptionUpdate]>(initialState: [])
+        let consumer = Task {
+            for await update in await manager.transcriptionUpdates {
+                updates.withLock { $0.append(update) }
+            }
+        }
+        defer { consumer.cancel() }
+
         let samples = try Self.loadSamples(url)
         var position = 0
         while position < samples.count {
@@ -63,16 +77,26 @@ final class SlidingWindowVocabularyBoostingStreamingTests: XCTestCase {
         }
         let text = try await manager.finish()
         let folded = text.lowercased()
+        let seen = updates.withLock { $0 }
 
         XCTAssertFalse(folded.isEmpty, "boosted streaming transcript must not be empty")
         // Fix 3: the first (volatile) window's text survives the second volatile window.
         XCTAssertTrue(folded.contains("before we go to them"), "first window lost: \(text)")
         // #855 fixture contract: the final window's tail survives.
         XCTAssertTrue(folded.contains("help them out"), "tail lost: \(text)")
-        // Fixes 1 + 2: the in-code term was tokenized and applied inside a window
-        // that never confirmed. Unboosted decode of this clip says "follow up".
-        XCTAssertTrue(folded.contains("follow-up"), "term not applied in unconfirmed window: \(text)")
         XCTAssertTrue(folded.contains("codex"), "vocabulary word missing from: \(text)")
+
+        // Fixes 1 + 2: the spotter found "Codex" (so the in-code term had token
+        // IDs) inside a window that was never confirmed (so it was rescored).
+        XCTAssertFalse(seen.isEmpty, "no streaming updates observed")
+        XCTAssertTrue(seen.allSatisfy { !$0.isConfirmed }, "no window may confirm in this configuration")
+        let detectedInVolatile = seen.contains { update in
+            !update.isConfirmed && (update.ctcDetectedTerms ?? []).contains { $0.lowercased() == "codex" }
+        }
+        XCTAssertTrue(
+            detectedInVolatile,
+            "spotter never reported 'Codex' on an unconfirmed window; detections: \(seen.map { $0.ctcDetectedTerms ?? [] })"
+        )
     }
 
     private static func loadSamples(_ url: URL) throws -> [Float] {

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowVocabularyBoostingStreamingTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowVocabularyBoostingStreamingTests.swift
@@ -10,18 +10,18 @@ import os
 /// every defect hid behind:
 ///
 /// 1. terms built in code (`CustomVocabularyTerm(text:)`, no token IDs) must be
-///    tokenized at configure time instead of silently ignored — the spotter can
-///    only detect a term it has token IDs for;
-/// 2. an unconfirmed window must still be rescored — the detection is asserted
-///    on an update with `isConfirmed == false`;
+///    tokenized at configure time — asserted on the session's vocabulary;
+/// 2. an unconfirmed window must still be rescored — asserted by every
+///    unconfirmed update carrying a non-nil `ctcDetectedTerms`, which is set
+///    only when rescoring ran for that window (#899);
 /// 3. an unconfirmed window must not erase the previous window's volatile text —
 ///    asserted by the opening phrase surviving; with boosting on, `finish()`
 ///    builds from that text and returned "" before the fix.
 ///
-/// The assertion is on spotter *activity* (`ctcDetectedTerms`, #899), not on a
-/// particular misrecognition being corrected: decodes differ between machines
-/// (a CI runner already emitted "follow-up" on this clip), so a text-only
-/// assertion could pass on model output alone.
+/// Nothing here depends on the runner's acoustics. A CI runner's raw decode
+/// already said "follow-up" on this clip, and a later run's spotter found no
+/// "Codex" at all, so neither a text correction nor a detection is asserted;
+/// detections are only logged.
 ///
 /// Needs the Parakeet v3 and CTC models; runs when both are cached or
 /// `FLUIDAUDIO_RUN_ASR_E2E=1` allows a download.
@@ -54,6 +54,13 @@ final class SlidingWindowVocabularyBoostingStreamingTests: XCTestCase {
             CustomVocabularyTerm(text: "Codex"), CustomVocabularyTerm(text: "follow-up"),
         ])
         try await manager.configureVocabularyBoosting(vocabulary: vocabulary, ctcModels: ctcModels)
+
+        // Fix 1: the in-code terms received CTC token IDs at configure time.
+        let configuredTerms = await manager.vocabularyBoosting?.vocabulary.terms ?? []
+        XCTAssertEqual(configuredTerms.count, 2)
+        XCTAssertTrue(
+            configuredTerms.allSatisfy { !($0.ctcTokenIds ?? []).isEmpty },
+            "in-code terms were not tokenized: \(configuredTerms.map { ($0.text, $0.ctcTokenIds ?? []) })")
         try await manager.startStreaming()
 
         let updates = OSAllocatedUnfairLock<[SlidingWindowTranscriptionUpdate]>(initialState: [])
@@ -86,17 +93,16 @@ final class SlidingWindowVocabularyBoostingStreamingTests: XCTestCase {
         XCTAssertTrue(folded.contains("help them out"), "tail lost: \(text)")
         XCTAssertTrue(folded.contains("codex"), "vocabulary word missing from: \(text)")
 
-        // Fixes 1 + 2: the spotter found "Codex" (so the in-code term had token
-        // IDs) inside a window that was never confirmed (so it was rescored).
+        // Fix 2: rescoring ran on every window even though none confirmed.
         XCTAssertFalse(seen.isEmpty, "no streaming updates observed")
         XCTAssertTrue(seen.allSatisfy { !$0.isConfirmed }, "no window may confirm in this configuration")
-        let detectedInVolatile = seen.contains { update in
-            !update.isConfirmed && (update.ctcDetectedTerms ?? []).contains { $0.lowercased() == "codex" }
+        for (index, update) in seen.enumerated() where !update.text.isEmpty {
+            XCTAssertNotNil(
+                update.ctcDetectedTerms,
+                "window \(index) was not rescored (unconfirmed, boosting configured): '\(update.text.prefix(40))'")
         }
-        XCTAssertTrue(
-            detectedInVolatile,
-            "spotter never reported 'Codex' on an unconfirmed window; detections: \(seen.map { $0.ctcDetectedTerms ?? [] })"
-        )
+        // Informational: which windows the spotter found the term in.
+        print("[#851 e2e] detections per window: \(seen.map { $0.ctcDetectedTerms ?? ["<not rescored>"] })")
     }
 
     private static func loadSamples(_ url: URL) throws -> [Float] {


### PR DESCRIPTION
Steps 1–3 of the #899 plan. Step 4 (the #702 floors as the sliding-window streaming default) is deliberately left out; see the end.

## Mechanism, from the debug trace

On the #855 clip 01 with the term `Codex`, the CTC spotter reports a spurious low-score `Codex` detection in the **first half second of every window** (`0.16–0.48 s`, window-local). No TDT word overlaps it, and `wordIndices(in:overlapping:end:)` fell back to the nearest word with no distance bound. So the rescue pass rewrote whatever happened to be nearest: `Hey` 0.68 s away on an M5 Pro, `validate` on the CI runner at similarity 0.12. The word varied by machine; the cause didn't.

```
[SPOTTER-RESCUE] detection 0.16–0.48s overlaps no word; nearest 'Hey,' is 0.68s away (> 0.50s), skipped
[SPOTTER-RESCUE] detection 0.16–0.48s overlaps no word; nearest 'your' is 4.28s away (> 0.50s), skipped
```

## Changes

- **Bounded fallback.** The nearest-word fallback reaches at most 0.5 s from the detection centre (the session's CTC search margin) and logs the detection interval and the decision. Both cases above are skipped; overlapping detections (the earnings22 `Mechatronics` corrections) are unaffected.
- **Spotter detections surfaced.** `VocabularyBoostingSession.rescore` returns `RescoreOutput.detectedTerms` (time-ordered, deduplicated) even when nothing was replaced, with the caller's own text in that case — the rescorer's rebuilt text is only handed back when it changed, so the #862 whitespace gotcha stays closed. `SlidingWindowTranscriptionUpdate` carries `ctcDetectedTerms` / `ctcAppliedTerms`. `ctcDetectedTerms` is now the spotter's detections rather than a copy of the applied list.
- **CLI streaming honours the rescue flags.** `transcribe --streaming` passes `--vocab-spotter-min-sim`, `--vocab-spotter-min-sim-multi`, `--vocab-disable-spotter-rescue`, and the taper pivot through a shared `makeRescorerConfig`; it previously dropped them.
- **Test proves rescorer activity through deterministic signals.** `ctcDetectedTerms` on a streaming update is now `nil` only when boosting is not configured and empty when rescoring ran and found nothing. `SlidingWindowVocabularyBoostingStreamingTests` asserts that the session's in-code terms carry CTC token IDs (#851 fix 1) and that every never-confirmed window carries a non-nil `ctcDetectedTerms`, i.e. was rescored (#851 fix 2), plus the `hey` prefix (#899 bound), the fix-3 opening phrase and the #855 tail. Spotter detections are logged, not asserted: one CI run found `Codex` only at -7.77 through the rescue floor and the next found none at all, so a detection assertion is inherently flaky on the runner. Unit tests for `detectedTermTexts` and for the fallback bound (`nearestWord` / `fallbackWordIndex`: the 0.68 s #899 shape is rejected, a 0.35 s near miss is accepted).

## Verification (release, M5 Pro)

| case | before | after |
|---|---|---|
| clip 01, streaming, term `Codex` | `Codex before we go…` | `Hey, before we go…` |
| earnings22 9 s / 15 s, streaming, `Mechatronics systems` | corrected | corrected |
| clip 01, `--vocab-spotter-min-sim 0.30 --vocab-spotter-min-sim-multi 0.50` (streaming) | flags ignored | applied |

## Review round

- First e2e revision asserted a spotter detection and failed on the runner (no detection that run). Replaced with the deterministic signals above.
- Update collector was racy (subscribed inside a task, snapshot right after `finish()`): the stream is now created before any audio is fed, closed with `cancel()` after `finish()`, and the consumer awaited so buffered updates drain.
- `validate your findings with codex` is deliberately not asserted: on one runner that replacement came from an overlapping detection, which the similarity floors govern, not the fallback bound.

## Not in this PR: floors-by-default on sliding-window streaming

Codex's recommendation to make the #702 floors (0.30 / 0.50) the streaming default is reasonable and would have rejected the 0.12 candidate on its own, but `.default` was kept on the TDT path for brand-name recall (#862: recall 93.4 % at a WER cost). `ctc-earnings-benchmark` drives the batch `AsrManager`, so there is no streaming recall/WER number to base the change on yet. With the fallback bounded, the flags reachable from the CLI, and detections observable, that measurement is now straightforward; I'd do it as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UHoFANi4DcvU6TzyTPnHH
