### PR TITLE
feat(tts/kokoro-ane): any Kokoro-82M v1.0 voice for the English variant (#896)

### DIFF
--- a/Documentation/TTS/KokoroAne.md
+++ b/Documentation/TTS/KokoroAne.md
@@ -156,11 +156,21 @@ is a flat `[510, 256]` fp32 matrix. Row index = `min(max(phonemeCount - 1,
 + Prosody).
 
 The English bundle stores voice packs flat at the bundle root
-(`<voice>.bin`); the Mandarin bundle nests them under `voices/<voice>.bin`.
-This single-voice-per-variant constraint is intrinsic to the upstream
-conversion — adding voices requires re-converting `KokoroPostAlbert` /
-`KokoroProsody` / `KokoroNoise` / `KokoroVocoder` against the new style
-embeddings.
+(`<voice>.bin`); the Mandarin and Japanese bundles nest them under
+`voices/<voice>.bin`.
+
+**Any Kokoro-82M v1.0 voice works with the English chain.** The four style
+consumers take `style_s` / `style_timbre` as runtime inputs — nothing is baked
+into the converted models — so a voice is just another `[510, 256]` pack. The
+English bundle publishes only `af_heart.bin` pre-converted; for any other name
+`KokoroAneResourceDownloader.ensureVoicePack` fetches the repo-root
+`voices/<name>.json` (the upstream v1.0 set, 54 voices, see
+`KokoroAneConstants.englishVoices`) and converts it on first use — row `k` of
+the flat pack is JSON key `"k+1"`, verified byte-exact against `af_heart.bin`
+(#896). Pick with `KokoroAneManager(defaultVoice:)` or `synthesize(text:voice:)`;
+an unknown name throws `KokoroAneError.voiceNotFound` listing the catalog.
+The Mandarin bundle ships 103 voices and the Japanese bundle 5, all
+pre-converted (`KokoroAneConstants.mandarinVoices` / `japaneseVoices`).
 
 ## Mandarin G2P
 
@@ -200,7 +210,7 @@ viable upgrades — the current pipeline trades them for a zero-network
 - **Phonemes:** ≤ 510 IPA / Bopomofo chars per call (ALBERT context = 512
   incl. BOS/EOS). No built-in chunker — split upstream if you need longer
   inputs.
-- **Voices:** `af_heart` only (English) / `zf_001` only (Mandarin).
+- **Voices:** any pack in the variant's catalog (`KokoroAneVariant.knownVoices`): 54 English (converted on first use), 103 Mandarin, 5 Japanese. See "Voice packs" above.
 - **Custom lexicon / SSML / Markdown overrides:** not supported. The pipeline
   goes `text → G2P → phonemes → token ids` with no interception point.
 - **Acoustic frames:** `T_a ≤ 2000` (compile-time `--max-frames` baked into

--- a/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Assets/KokoroAneResourceDownloader.swift
@@ -333,9 +333,13 @@ public enum KokoroAneResourceDownloader {
     /// Default voice for each variant is included in `requiredModels(Zh)`; this
     /// helper covers any additional voice that ships separately.
     ///
-    /// Mandarin (`ANE-zh/`) voice packs live under a `voices/` subdirectory,
-    /// both remotely and on disk. English (`ANE/`) voice packs sit at the
-    /// bundle root.
+    /// Mandarin (`ANE-zh/`) and Japanese voice packs live under a `voices/`
+    /// subdirectory, both remotely and on disk. English (`ANE/`) voice packs
+    /// sit at the bundle root, and only `af_heart.bin` is published there:
+    /// any other English voice is fetched from the repo-root
+    /// `voices/<name>.json` (the Kokoro-82M v1.0 set, see
+    /// `KokoroAneConstants.englishVoices`) and converted on first use (#896).
+    /// Throws `KokoroAneError.voiceNotFound` with the known list otherwise.
     @discardableResult
     public static func ensureVoicePack(
         _ voice: String,
@@ -370,15 +374,41 @@ public enum KokoroAneResourceDownloader {
         } else {
             remoteFilePath = relativePath
         }
-        let remoteURL = try ModelRegistry.resolveModel(repo.remotePath, remoteFilePath)
-        let data = try await AssetDownloader.fetchData(
-            from: remoteURL,
-            description: "\(sanitized) voice pack",
-            logger: logger
-        )
-        try data.write(to: localURL, options: [.atomic])
-        logger.info("Downloaded voice pack '\(sanitized)' (\(data.count / 1024) KB)")
-        return localURL
+        let expectedBytes =
+            KokoroAneConstants.voicePackRows * KokoroAneConstants.voicePackCols
+            * MemoryLayout<Float>.size
+
+        // 1. The variant bundle's own pre-converted `.bin` (Mandarin/Japanese
+        //    ship every voice this way; English ships only `af_heart`).
+        if let remoteURL = try? ModelRegistry.resolveModel(repo.remotePath, remoteFilePath),
+            let data = try? await AssetDownloader.fetchData(
+                from: remoteURL, description: "\(sanitized) voice pack", logger: logger),
+            data.count == expectedBytes
+        {
+            try data.write(to: localURL, options: [.atomic])
+            logger.info("Downloaded voice pack '\(sanitized)' (\(data.count / 1024) KB)")
+            return localURL
+        }
+
+        // 2. English: the Kokoro-82M v1.0 pack hosted as `voices/<name>.json`
+        //    at the repository root, converted to the flat fp32 layout (#896).
+        //    The chain takes style vectors as runtime inputs, so this is the
+        //    same data `af_heart.bin` carries, byte-exact after conversion.
+        if variant == .english,
+            let jsonURL = try? ModelRegistry.resolveModel(repo.remotePath, "voices/\(sanitized).json"),
+            let json = try? await AssetDownloader.fetchData(
+                from: jsonURL, description: "\(sanitized) voice pack (json)", logger: logger),
+            let pack = try? KokoroAneVoicePack.load(fromJSON: json)
+        {
+            try pack.binaryData.write(to: localURL, options: [.atomic])
+            logger.info(
+                "Converted voice pack '\(sanitized)' from voices/\(sanitized).json (\(json.count / 1024) KB → \(expectedBytes / 1024) KB)"
+            )
+            return localURL
+        }
+
+        throw KokoroAneError.voiceNotFound(
+            voice: voice, variant: variant, available: variant.knownVoices)
     }
 
     // MARK: - Private

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneConstants.swift
@@ -16,6 +16,54 @@ public enum KokoroAneConstants {
     /// Default voice id for the Japanese (`ANE-ja/`) variant.
     public static let defaultVoiceJapanese = "jf_alpha"
 
+    /// Voice packs published for the English (`ANE/`) variant. Only
+    /// `af_heart.bin` ships pre-converted; every other name is the Kokoro-82M
+    /// v1.0 pack hosted as `voices/<name>.json` at the repository root, which
+    /// `KokoroAneResourceDownloader.ensureVoicePack` converts to the flat
+    /// `[510, 256]` fp32 layout on first use (#896). The 7-stage chain takes
+    /// the style vectors as runtime inputs, so any v1.0 pack works with it;
+    /// non-English-prefixed packs (`zf_*`, `jf_*`, …) still speak English
+    /// phonemes here, just with that voice's timbre.
+    /// Listing as of 2026-09-09 (huggingface.co/FluidInference/kokoro-82m-coreml/tree/main/voices).
+    public static let englishVoices: [String] = [
+        "af_alloy", "af_aoede", "af_bella", "af_heart", "af_jessica", "af_kore",
+        "af_nicole", "af_nova", "af_river", "af_sarah", "af_sky", "am_adam",
+        "am_echo", "am_eric", "am_fenrir", "am_liam", "am_michael", "am_onyx",
+        "am_puck", "am_santa", "bf_alice", "bf_emma", "bf_isabella", "bf_lily",
+        "bm_daniel", "bm_fable", "bm_george", "bm_lewis", "ef_dora", "em_alex",
+        "em_santa", "ff_siwis", "hf_alpha", "hf_beta", "hm_omega", "hm_psi",
+        "if_sara", "im_nicola", "jf_alpha", "jf_gongitsune", "jf_nezumi", "jf_tebukuro",
+        "jm_kumo", "pf_dora", "pm_alex", "pm_santa", "zf_xiaobei", "zf_xiaoni",
+        "zf_xiaoxiao", "zf_xiaoyi", "zm_yunjian", "zm_yunxi", "zm_yunxia", "zm_yunyang",
+    ]
+
+    /// Voice packs in the Mandarin (`ANE-zh/voices/`) bundle, as of 2026-09-09.
+    public static let mandarinVoices: [String] = [
+        "af_maple", "af_sol", "bf_vale", "zf_001", "zf_002", "zf_003",
+        "zf_004", "zf_005", "zf_006", "zf_007", "zf_008", "zf_017",
+        "zf_018", "zf_019", "zf_021", "zf_022", "zf_023", "zf_024",
+        "zf_026", "zf_027", "zf_028", "zf_032", "zf_036", "zf_038",
+        "zf_039", "zf_040", "zf_042", "zf_043", "zf_044", "zf_046",
+        "zf_047", "zf_048", "zf_049", "zf_051", "zf_059", "zf_060",
+        "zf_067", "zf_070", "zf_071", "zf_072", "zf_073", "zf_074",
+        "zf_075", "zf_076", "zf_077", "zf_078", "zf_079", "zf_083",
+        "zf_084", "zf_085", "zf_086", "zf_087", "zf_088", "zf_090",
+        "zf_092", "zf_093", "zf_094", "zf_099", "zm_009", "zm_010",
+        "zm_011", "zm_012", "zm_013", "zm_014", "zm_015", "zm_016",
+        "zm_020", "zm_025", "zm_029", "zm_030", "zm_031", "zm_033",
+        "zm_034", "zm_035", "zm_037", "zm_041", "zm_045", "zm_050",
+        "zm_052", "zm_053", "zm_054", "zm_055", "zm_056", "zm_057",
+        "zm_058", "zm_061", "zm_062", "zm_063", "zm_064", "zm_065",
+        "zm_066", "zm_068", "zm_069", "zm_080", "zm_081", "zm_082",
+        "zm_089", "zm_091", "zm_095", "zm_096", "zm_097", "zm_098",
+        "zm_100",
+    ]
+
+    /// Voice packs in the Japanese (`ANE-ja/voices/`) bundle, as of 2026-09-09.
+    public static let japaneseVoices: [String] = [
+        "jf_alpha", "jf_gongitsune", "jf_nezumi", "jf_tebukuro", "jm_kumo",
+    ]
+
     /// Output sample rate of the iSTFT in `KokoroTail_v2.mlpackage`.
     public static let sampleRate = 24_000
 
@@ -149,6 +197,17 @@ public enum KokoroAneVariant: String, CaseIterable, Sendable {
         switch self {
         case .english: return false
         case .mandarin, .japanese: return true
+        }
+    }
+
+    /// Voice ids known to be available for this variant (see
+    /// `KokoroAneConstants.englishVoices` etc.). Used for error messages and
+    /// the CLI listing; a name outside the list is still attempted.
+    public var knownVoices: [String] {
+        switch self {
+        case .english: return KokoroAneConstants.englishVoices
+        case .mandarin: return KokoroAneConstants.mandarinVoices
+        case .japanese: return KokoroAneConstants.japaneseVoices
         }
     }
 

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneError.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneError.swift
@@ -7,6 +7,7 @@ public enum KokoroAneError: Error, LocalizedError {
     case vocabMissing(URL)
     case vocabParseFailed(URL, String)
     case voicePackMissing(URL)
+    case voiceNotFound(voice: String, variant: KokoroAneVariant, available: [String])
     case invalidVoicePack(String)
     case phonemeSequenceTooLong(Int)
     case inputProcessingFailed(String)
@@ -26,6 +27,10 @@ public enum KokoroAneError: Error, LocalizedError {
             return "KokoroAne vocab.json not found at \(url.path)."
         case .vocabParseFailed(let url, let detail):
             return "KokoroAne vocab.json at \(url.path) is malformed: \(detail)"
+        case .voiceNotFound(let voice, let variant, let available):
+            return
+                "KokoroAne voice '\(voice)' is not available for the \(variant.rawValue) variant. "
+                + "Available: \(available.joined(separator: ", "))"
         case .voicePackMissing(let url):
             return "KokoroAne voice pack not found at \(url.path)."
         case .invalidVoicePack(let detail):

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneVoicePack.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneVoicePack.swift
@@ -40,6 +40,37 @@ public struct KokoroAneVoicePack: Sendable {
         return try KokoroAneVoicePack(storage: storage)
     }
 
+    /// Build a pack from a Kokoro-82M v1.0 JSON voice file (the
+    /// `voices/<name>.json` layout hosted at the repo root): an object whose
+    /// keys `"1"` … `"510"` hold the 256-float row for that phoneme count.
+    /// Row `k` of the flat pack is key `"k+1"` — verified byte-exact against
+    /// the shipped `af_heart.bin` (#896). Any extra keys (`"embedding"`) are
+    /// ignored.
+    public static func load(fromJSON data: Data) throws -> KokoroAneVoicePack {
+        let rows = KokoroAneConstants.voicePackRows
+        let cols = KokoroAneConstants.voicePackCols
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw KokoroAneError.invalidVoicePack("JSON voice pack is not an object")
+        }
+        var storage: [Float] = []
+        storage.reserveCapacity(rows * cols)
+        for row in 1...rows {
+            guard let values = object[String(row)] as? [NSNumber], values.count == cols else {
+                throw KokoroAneError.invalidVoicePack(
+                    "JSON voice pack row \(row) missing or not \(cols) numbers")
+            }
+            for value in values {
+                storage.append(value.floatValue)
+            }
+        }
+        return try KokoroAneVoicePack(storage: storage)
+    }
+
+    /// Flat little-endian fp32 bytes in the `<voice>.bin` layout.
+    public var binaryData: Data {
+        storage.withUnsafeBufferPointer { Data(buffer: $0) }
+    }
+
     /// Pick the row that matches the phoneme-length bucket.
     /// Returns `(styleS, styleTimbre)` each of length 128.
     public func slice(for phonemeCount: Int) -> (styleS: [Float], styleTimbre: [Float]) {

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVoiceCatalogE2ETests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVoiceCatalogE2ETests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+@testable import FluidAudio
+
+/// Real-download check for #896: an English voice other than `af_heart` is
+/// fetched from the repo-root `voices/<name>.json`, converted, and synthesizes.
+/// Heavy (downloads the ANE bundle on a cold cache); gated like the TTS→ASR
+/// roundtrip tests.
+@available(macOS 14.0, iOS 17.0, *)
+final class KokoroAneVoiceCatalogE2ETests: XCTestCase {
+
+    func testNonDefaultEnglishVoiceSynthesizes() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["FLUIDAUDIO_RUN_KOKOROANE_E2E"] == "1",
+            "Set FLUIDAUDIO_RUN_KOKOROANE_E2E=1 to run KokoroAne download tests.")
+
+        let manager = KokoroAneManager(defaultVoice: "am_michael")
+        try await manager.initialize()
+        let detailed = try await manager.synthesizeDetailed(text: "Hello from FluidAudio.", voice: nil, speed: 1.0)
+        XCTAssertGreaterThan(detailed.samples.count, detailed.sampleRate / 2, "expected at least 0.5 s of audio")
+    }
+
+    func testUnknownVoiceReportsCatalog() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["FLUIDAUDIO_RUN_KOKOROANE_E2E"] == "1",
+            "Set FLUIDAUDIO_RUN_KOKOROANE_E2E=1 to run KokoroAne download tests.")
+
+        let manager = KokoroAneManager(defaultVoice: "no_such_voice")
+        do {
+            try await manager.initialize()
+            XCTFail("initialize() should fail for an unknown voice")
+        } catch KokoroAneError.voiceNotFound(let voice, let variant, let available) {
+            XCTAssertEqual(voice, "no_such_voice")
+            XCTAssertEqual(variant, .english)
+            XCTAssertTrue(available.contains("af_heart"))
+        }
+    }
+}

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVoiceCatalogE2ETests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVoiceCatalogE2ETests.swift
@@ -1,5 +1,4 @@
-// BISECT: temporarily compiled out to isolate a CI segfault (#901).
-#if false
+import Foundation
 import XCTest
 
 @testable import FluidAudio
@@ -8,13 +7,19 @@ import XCTest
 /// fetched from the repo-root `voices/<name>.json`, converted, and synthesizes.
 /// Heavy (downloads the ANE bundle on a cold cache); gated like the TTS→ASR
 /// roundtrip tests.
-@available(macOS 14.0, iOS 17.0, *)
+///
+/// Shape mirrors `KokoroAneAsrRoundtripTests` on purpose: a first revision with
+/// an `@available` class attribute and an enum-pattern `catch` inside the async
+/// test body segfaulted the CI test worker (Swift 6.1) even though both tests
+/// skip on their first line.
 final class KokoroAneVoiceCatalogE2ETests: XCTestCase {
 
+    private var shouldRunHeavy: Bool {
+        ProcessInfo.processInfo.environment["FLUIDAUDIO_RUN_KOKOROANE_E2E"] == "1"
+    }
+
     func testNonDefaultEnglishVoiceSynthesizes() async throws {
-        try XCTSkipUnless(
-            ProcessInfo.processInfo.environment["FLUIDAUDIO_RUN_KOKOROANE_E2E"] == "1",
-            "Set FLUIDAUDIO_RUN_KOKOROANE_E2E=1 to run KokoroAne download tests.")
+        try XCTSkipUnless(shouldRunHeavy, "Set FLUIDAUDIO_RUN_KOKOROANE_E2E=1 to run KokoroAne download tests.")
 
         let manager = KokoroAneManager(defaultVoice: "am_michael")
         try await manager.initialize()
@@ -23,19 +28,24 @@ final class KokoroAneVoiceCatalogE2ETests: XCTestCase {
     }
 
     func testUnknownVoiceReportsCatalog() async throws {
-        try XCTSkipUnless(
-            ProcessInfo.processInfo.environment["FLUIDAUDIO_RUN_KOKOROANE_E2E"] == "1",
-            "Set FLUIDAUDIO_RUN_KOKOROANE_E2E=1 to run KokoroAne download tests.")
+        try XCTSkipUnless(shouldRunHeavy, "Set FLUIDAUDIO_RUN_KOKOROANE_E2E=1 to run KokoroAne download tests.")
 
         let manager = KokoroAneManager(defaultVoice: "no_such_voice")
+        var caught: Error?
         do {
             try await manager.initialize()
-            XCTFail("initialize() should fail for an unknown voice")
-        } catch KokoroAneError.voiceNotFound(let voice, let variant, let available) {
+        } catch {
+            caught = error
+        }
+        XCTAssertNotNil(caught, "initialize() should fail for an unknown voice")
+        let unwrapped = caught as? KokoroAneError
+        XCTAssertNotNil(unwrapped, "expected KokoroAneError, got \(String(describing: caught))")
+        if case .voiceNotFound(let voice, let variant, let available)? = unwrapped {
             XCTAssertEqual(voice, "no_such_voice")
             XCTAssertEqual(variant, .english)
             XCTAssertTrue(available.contains("af_heart"))
+        } else {
+            XCTFail("expected voiceNotFound, got \(String(describing: unwrapped))")
         }
     }
 }
-#endif

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVoiceCatalogE2ETests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVoiceCatalogE2ETests.swift
@@ -1,3 +1,5 @@
+// BISECT: temporarily compiled out to isolate a CI segfault (#901).
+#if false
 import XCTest
 
 @testable import FluidAudio
@@ -36,3 +38,4 @@ final class KokoroAneVoiceCatalogE2ETests: XCTestCase {
         }
     }
 }
+#endif

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVoicePackTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneVoicePackTests.swift
@@ -104,4 +104,60 @@ final class KokoroAneVoicePackTests: XCTestCase {
             }
         }
     }
+
+    // MARK: - Kokoro-82M v1.0 JSON packs (#896)
+
+    /// Serialize a pack the way the hosted `voices/<name>.json` files are laid
+    /// out: keys "1"…"510", each a 256-number row, plus an ignored "embedding".
+    private func jsonData(for pack: KokoroAneVoicePack, dropRow: Int? = nil) throws -> Data {
+        var object: [String: Any] = ["embedding": Array(repeating: 0.0, count: cols)]
+        for r in 0..<rows where r + 1 != dropRow {
+            object[String(r + 1)] = Array(pack.storage[(r * cols)..<((r + 1) * cols)]).map { Double($0) }
+        }
+        return try JSONSerialization.data(withJSONObject: object)
+    }
+
+    func testLoadFromJSONMapsKeyKPlusOneToRowK() throws {
+        let pack = try makePack()
+        let loaded = try KokoroAneVoicePack.load(fromJSON: jsonData(for: pack))
+        XCTAssertEqual(loaded.storage, pack.storage)
+        // Row 0 is key "1": cell (0, 5) encodes 0*1000 + 5.
+        XCTAssertEqual(loaded.storage[5], 5)
+        // Row 509 is key "510".
+        XCTAssertEqual(loaded.storage[509 * cols + 7], 509_000 + 7)
+        XCTAssertEqual(loaded.binaryData.count, rows * cols * MemoryLayout<Float>.size)
+    }
+
+    func testBinaryDataRoundTripsThroughLoad() throws {
+        let pack = try makePack()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kokoro-pack-\(UUID().uuidString).bin")
+        try pack.binaryData.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+        XCTAssertEqual(try KokoroAneVoicePack.load(from: url).storage, pack.storage)
+    }
+
+    func testLoadFromJSONRejectsMissingRow() throws {
+        let data = try jsonData(for: makePack(), dropRow: 42)
+        XCTAssertThrowsError(try KokoroAneVoicePack.load(fromJSON: data)) { error in
+            guard case KokoroAneError.invalidVoicePack(let detail) = error else {
+                return XCTFail("Expected invalidVoicePack, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("row 42"), detail)
+        }
+    }
+
+    func testLoadFromJSONRejectsNonObject() {
+        XCTAssertThrowsError(try KokoroAneVoicePack.load(fromJSON: Data("[1, 2, 3]".utf8)))
+    }
+
+    func testVoiceCatalogsIncludeDefaultsAndReporterVoices() {
+        XCTAssertTrue(KokoroAneVariant.english.knownVoices.contains(KokoroAneConstants.defaultVoice))
+        XCTAssertTrue(KokoroAneVariant.mandarin.knownVoices.contains(KokoroAneConstants.defaultVoiceMandarin))
+        XCTAssertTrue(KokoroAneVariant.japanese.knownVoices.contains(KokoroAneConstants.defaultVoiceJapanese))
+        // The two voices named in #896.
+        XCTAssertTrue(KokoroAneVariant.english.knownVoices.contains("af_bella"))
+        XCTAssertTrue(KokoroAneVariant.english.knownVoices.contains("am_michael"))
+        XCTAssertEqual(KokoroAneVariant.english.knownVoices.count, 54)
+    }
 }


### PR DESCRIPTION
Closes #896.

## The claim in the docs was wrong

`KokoroAne.md` said the single-voice limit was "intrinsic to the upstream conversion" and that adding voices needed a re-conversion of `PostAlbert` / `Prosody` / `Noise` / `Vocoder`. The chain takes `style_s` and `style_timbre` as **runtime inputs** (`KokoroAneSynthesizer`), nothing is baked in, and a voice is just another `[510, 256]` fp32 pack. The repo root already hosts the complete Kokoro-82M v1.0 set as `voices/<name>.json` (54 voices); row `k` of the flat pack is JSON key `"k+1"`, verified byte-exact against the shipped `ANE/af_heart.bin` (max diff 0.0 over all 510 rows).

## Change

- `ensureVoicePack`: after the bundle's own `.bin` (validated by size), the English variant falls back to the repo-root JSON pack, converts it, and caches it as `<voice>.bin`. An unknown name throws `KokoroAneError.voiceNotFound(voice:variant:available:)` listing the catalog, instead of a bare download failure.
- `KokoroAneVoicePack.load(fromJSON:)` + `binaryData`.
- `KokoroAneConstants.englishVoices` (54) / `mandarinVoices` (103, already shipped pre-converted) / `japaneseVoices` (5), via `KokoroAneVariant.knownVoices`.
- Docs rewritten; the "af_heart only" limit is gone.

## Verification (M5 Pro, real download path, cache cleared of the packs first)

| voice | source | median f0 | ASR round trip |
|---|---|---|---|
| `af_heart` | bundled `.bin` | ≈197 Hz | exact |
| `af_bella` | `voices/af_bella.json` → converted | ≈190 Hz | exact |
| `am_michael` | `voices/am_michael.json` → converted | ≈113 Hz | exact |

The converted `am_michael.bin` is byte-identical to an independent Python conversion. `--voice no_such_voice` → `voiceNotFound` with the 54-name list.

Same works from the CLI today: `fluidaudiocli tts "…" --backend kokoro-ane --voice am_michael`.

@Abusayid693 both voices from your report (`af_bella`, `am_michael`) are the ones verified above; the re-conversion question in your issue is moot, no per-voice export is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UHoFANi4DcvU6TzyTPnHH