### PR TITLE
fix(tts/kokoro-ane): flag the iOS 27 line in the OS advisory; stop calling the CPU-tail route safe (#889)

### DIFF
--- a/Documentation/TTS/KokoroAne.md
+++ b/Documentation/TTS/KokoroAne.md
@@ -252,15 +252,23 @@ The following OS/runtime constraints affect the 7-stage chain:
 |-----|-----------|-------------|--------|
 | BNNS CPU segfault | `EXC_BAD_ACCESS` in `libBNNS.dylib` (`BNNSGraphContextExecute_v2` → `BnnsCpuInferenceOperation::ExecuteSync`, queue `com.apple.e5rt.concurrentExecutionQueue`) | iOS/macOS **26.4 – 26.5.x** | **Fixed in the 26.6 line.** Verified on M5/macOS 26.6: the #667 repro (repeated synthesis) passes under `cpuOnly` and `allAne`, both of which segfaulted every time on 26.5. |
 | GPU RNN JIT assert | `GPURNNOps.mm: failed assertion 'JIT not supported'` (SIGABRT) | macOS 26.5+, incl. **26.6** (M5-class) | **Still live.** Avoided by the default routing (#671/#677), which keeps RNN-bearing stages off the GPU. Do not route Prosody/Vocoder to `.cpuAndGPU`. |
+| MPSGraph abort (Metal route) | `SIGABRT` in MetalPerformanceShadersGraph while a GPU stage (noise / tail) runs under Core ML | iOS/iPadOS **27.0 through beta 8** (24A5430a), iPad17,2 and iPad16,2 | **Still live.** The default routing on OS 27 (`aneTailCpu`, #849) keeps Metal out of the chain. |
+| BNNS `vadd_fp16_sme` segfault (Metal-free route) | `SIGSEGV` in `libBNNS` `vadd_fp16_sme_internal` on the OS-27 default route (noise + tail on CPU) | iOS **27.0** (24A5418b), iPhone18,1, ~54 min into a session | **No safe Core ML route on iOS 27 is demonstrated** (#889). The model, phonemizer and voice packs are not at fault: the same Kokoro-82M v1.0 graph ran 2 h 34 min on ONNX Runtime's CPU provider on the same OS line. `initialize()` logs an advisory on the 27 line. |
 
 The BNNS segfault cannot be avoided by compute-unit routing — CoreML places
 segments on the BNNS CPU path even under `.cpuOnly` (#587), and on affected
 OS builds the same binary can flip between all-pass and all-crash across a
 day (#817). `KokoroAneManager.initialize()` logs a warning on affected OS
-builds. The only reliable remedy is updating to the 26.6 OS line.
+builds. On macOS the remedy is the 26.6 line. On iOS the 26.6 line still
+crashes (#844), and on the iOS 27 line both Core ML routes have terminated
+the process (#889), so there is currently no OS version or routing on iOS
+that is demonstrated safe for long sessions; whether Kokoro ANE should be
+disabled by default there is tracked in #889.
 
 History: #328 (26.4 beta), #587 (iOS 26.4.2), #661 (cross-manager E5RT),
-#667 (M5/macOS 26.5), #817 (time/environment-gated evidence).
+#667 (M5/macOS 26.5), #817 (time/environment-gated evidence), #843/#849
+(OS 27 Metal abort, CPU-tail default), #844 (iOS 26.6), #889 (iOS 27 BNNS
+segfault on the CPU-tail route).
 
 ## Source
 

--- a/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/KokoroAneManager.swift
@@ -66,13 +66,8 @@ public actor KokoroAneManager {
     /// Download (if missing), load all 7 mlmodelcs + vocab + default voice
     /// pack. Optionally pre-warm additional voice packs.
     public func initialize(preloadVoices: Set<String>? = nil) async throws {
-        if Self.isBnnsCrashProneOS(ProcessInfo.processInfo.operatingSystemVersion) {
-            logger.warning(
-                "This OS build has a known Apple BNNS bug that can "
-                    + "intermittently crash Kokoro synthesis (EXC_BAD_ACCESS in libBNNS) "
-                    + "regardless of compute-unit routing. macOS 26.6 fixes it; on iOS "
-                    + "the 26.6 line still crashes. "
-                    + "See https://github.com/FluidInference/FluidAudio/issues/844")
+        if let advisory = Self.osAdvisory(for: ProcessInfo.processInfo.operatingSystemVersion) {
+            logger.warning(advisory)
         }
         try await store.loadIfNeeded()
         // English G2P CoreML assets live in the kokoro repo and are loaded
@@ -117,13 +112,41 @@ public actor KokoroAneManager {
     /// The 26.4+ OS line carries an Apple BNNS bug that can intermittently
     /// crash synthesis in libBNNS on any compute-unit routing
     /// (#328/#587/#667/#817). macOS 26.6 fixes it (verified, #817); iOS 26.6
-    /// still crashes with the identical signature (#844), so on non-macOS the
-    /// whole 26.4+ line stays flagged until a fixed build is confirmed.
+    /// still crashes with the identical signature (#844), and iOS 27.0 crashes
+    /// in libBNNS (`vadd_fp16_sme_internal`) on the Metal-free route that is
+    /// the 27 default, while the Metal route aborts in MPSGraph (#843, #889).
+    /// So on non-macOS everything from 26.4 on stays flagged until a build is
+    /// shown to be safe. macOS 27 has no report and is not flagged.
     static func isBnnsCrashProneOS(
         _ version: OperatingSystemVersion, onMacOS: Bool = runningOnMacOS
     ) -> Bool {
+        if version.majorVersion >= 27 { return !onMacOS }
         guard version.majorVersion == 26, version.minorVersion >= 4 else { return false }
         return onMacOS ? version.minorVersion <= 5 : true
+    }
+
+    /// The warning `initialize()` logs on a crash-prone OS build, or nil.
+    /// Route-aware: on the iOS 27 line neither Core ML route is known to be
+    /// safe (#889), which is a different message from the 26.x BNNS bug.
+    static func osAdvisory(
+        for version: OperatingSystemVersion, onMacOS: Bool = runningOnMacOS
+    ) -> String? {
+        guard isBnnsCrashProneOS(version, onMacOS: onMacOS) else { return nil }
+        if version.majorVersion >= 27 {
+            return
+                "iOS/iPadOS 27: no Core ML route for Kokoro ANE is known to be safe. "
+                + "The default Metal-free route (noise + tail on CPU) has crashed in libBNNS "
+                + "(vadd_fp16_sme_internal SIGSEGV) after ~1 h of synthesis, and the Metal "
+                + "route aborts in MPSGraph within minutes. Both are uncatchable in-process. "
+                + "Consider disabling Kokoro ANE on this OS line until a safe route is shown. "
+                + "See https://github.com/FluidInference/FluidAudio/issues/889"
+        }
+        return
+            "This OS build has a known Apple BNNS bug that can "
+            + "intermittently crash Kokoro synthesis (EXC_BAD_ACCESS in libBNNS) "
+            + "regardless of compute-unit routing. macOS 26.6 fixes it; on iOS "
+            + "the 26.6 line still crashes. "
+            + "See https://github.com/FluidInference/FluidAudio/issues/844"
     }
 
     /// `true` once the 7 mlmodelcs + vocab are resident.

--- a/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
+++ b/Sources/FluidAudio/TTS/KokoroAne/Pipeline/KokoroAneModelStore.swift
@@ -57,7 +57,9 @@ public struct KokoroAneComputeUnits: Sendable, Equatable {
     ///
     /// On OS 27+: identical to ``aneTailCpu`` — the GPU stages abort
     /// intermittently inside MPSGraph under CoreML on the 27 line (#843,
-    /// FB24243070), so noise + tail move to `.cpuOnly`.
+    /// FB24243070), so noise + tail move to `.cpuOnly`. That route is not
+    /// known to be safe either (#889); `KokoroAneManager.initialize()` logs
+    /// the advisory on the 27 line.
     public static var `default`: KokoroAneComputeUnits {
         defaultUnits(for: ProcessInfo.processInfo.operatingSystemVersion)
     }
@@ -111,13 +113,14 @@ public struct KokoroAneComputeUnits: Sendable, Equatable {
         tail: .cpuAndGPU
     )
 
-    /// OS 27 stability: like ``aneTailGpu`` but noise + tail on `.cpuOnly`,
+    /// OS 27 default: like ``aneTailGpu`` but noise + tail on `.cpuOnly`,
     /// so Metal is never invoked. On the 27 line the GPU stages abort
     /// intermittently inside MPSGraph under CoreML (uncatchable in-process
-    /// abort, #843, FB24243070); the BNNS iSTFT path they fall back to is
-    /// fine there — the libBNNS segfault is a 26.x-line bug (#817/#844).
-    /// Field-validated on iPadOS 27.0 with imperceptible perf cost for
-    /// speech-length inputs.
+    /// abort, #843, FB24243070). This route is the lesser evil, not a safe
+    /// one: on iOS 27.0 it has crashed in libBNNS (`vadd_fp16_sme_internal`
+    /// SIGSEGV, ~54 min into a session, #889), so the 26.x libBNNS class is
+    /// not confined to 26.x. Short-run field validation on iPadOS 27.0 showed
+    /// imperceptible perf cost; long sessions are the open risk.
     public static let aneTailCpu = KokoroAneComputeUnits(
         albert: .cpuAndNeuralEngine, postAlbert: .cpuAndNeuralEngine,
         alignment: .cpuAndNeuralEngine, prosody: .cpuAndNeuralEngine,

--- a/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneOsAdvisoryTests.swift
+++ b/Tests/FluidAudioTests/TTS/KokoroAne/KokoroAneOsAdvisoryTests.swift
@@ -35,7 +35,26 @@ final class KokoroAneOsAdvisoryTests: XCTestCase {
 
     func testIOSUnaffectedLinesAreNotFlagged() {
         XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(26, 3, 1), onMacOS: false))
-        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(27, 0), onMacOS: false))
         XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(25, 5), onMacOS: false))
+    }
+
+    // #889: iOS 27.0 crashes in libBNNS (vadd_fp16_sme) on the Metal-free
+    // default route and aborts in MPSGraph on the Metal route, so the whole
+    // 27 line is flagged on non-macOS. macOS 27 has no report.
+    func testIOS27LineIsFlagged() {
+        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(27, 0), onMacOS: false))
+        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(27, 0, 1), onMacOS: false))
+        XCTAssertTrue(KokoroAneManager.isBnnsCrashProneOS(version(27, 2), onMacOS: false))
+        XCTAssertFalse(KokoroAneManager.isBnnsCrashProneOS(version(27, 0), onMacOS: true))
+    }
+
+    func testAdvisoryMessageIsRouteAwareOn27() throws {
+        let ios27 = try XCTUnwrap(KokoroAneManager.osAdvisory(for: version(27, 0), onMacOS: false))
+        XCTAssertTrue(ios27.contains("issues/889"))
+        XCTAssertTrue(ios27.contains("Metal-free"))
+        let ios26 = try XCTUnwrap(KokoroAneManager.osAdvisory(for: version(26, 6), onMacOS: false))
+        XCTAssertTrue(ios26.contains("issues/844"))
+        XCTAssertNil(KokoroAneManager.osAdvisory(for: version(26, 6), onMacOS: true))
+        XCTAssertNil(KokoroAneManager.osAdvisory(for: version(27, 0), onMacOS: true))
     }
 }


### PR DESCRIPTION
Relates to #889 (does not close it: the disable-by-default decision stays there).

## Why

#889 shows, with `.ips` evidence, that on iOS 27.0 the Metal-free route (#849's OS-27 default, noise + tail on CPU) crashes in `libBNNS` `vadd_fp16_sme_internal` about 54 minutes into a session, while the Metal route still aborts in MPSGraph on beta 8. The same Kokoro-82M v1.0 graph ran 2 h 34 min on ONNX Runtime's CPU provider on the same OS line, so the model, phonemizer and packs are cleared. Both Core ML routes can terminate the process, uncatchably. Our advisory, tests and docs said the 27 line was unaffected and that the BNNS fallback path was "fine there".

## Change

- `isBnnsCrashProneOS`: the whole 27 line is flagged on non-macOS. macOS 27 has no report and is not flagged.
- `osAdvisory(for:onMacOS:)`: the `initialize()` warning is route-aware. On iOS 27 it states that no Core ML route is known to be safe, names both signatures, suggests disabling Kokoro ANE on that line, and links #889. The 26.x message is unchanged.
- Route doc comments stop describing `aneTailCpu` as safe on 27; it's the lesser evil (minutes-to-abort on Metal vs about an hour on BNNS).
- `KokoroAne.md`: two new rows in the known-issues table and a corrected remedy paragraph.
- Tests: 27.x flagged on iOS and unflagged on macOS; advisory message contents.

## Deliberately not changed

The OS-27 default route, and whether Kokoro ANE should be disabled by default on iOS 27. That's the product call in #889; this PR only stops the library from claiming safety it doesn't have.

Docs + a warning + tests; no routing behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UHoFANi4DcvU6TzyTPnHH