### PR TITLE
fix(asr/streaming): reconcile the final-window seam — retire the previous window's edge-cut word (#897)

### DIFF
--- a/Documentation/ASR/LongTranscription.md
+++ b/Documentation/ASR/LongTranscription.md
@@ -423,8 +423,19 @@ that dedup strips. Two rules make this safe:
   exceed dedup's bounded search; suppressing at the source keeps dedup's job
   to the jitter margin.
 
-Known residue: a word cut by the previous window's edge (`and an` → `and
-analyzing`) can survive as a fragment, since dedup matches whole tokens.
+**Seam reconciliation (#897).** The previous window's last word may be a
+fragment cut by the window edge (`and an` for `and analyzing`), which dedup
+can never repair: the fragment never equals the full word, a re-emitted single
+token is below the substring matcher's two-token minimum, and a punctuation
+token the decoder attaches at its emission start blocks the suffix–prefix
+match. So the cutoff anchors at the previous window's *last word start*
+(`lastWordStartFrame`), the final window re-decodes that word in full, and
+`AsrManager.reconcileFinalWindowSeam` retires the previous last word from the
+accumulated tokens and text (`droppedPreviousTokens`) while stripping the
+re-decode's seam artifacts: punctuation emitted at or before that word's
+frame, and tokens duplicating a kept previous token inside the jitter region.
+Clip 03 of the fixtures pins it: `code and an, and analyzing` → `code and
+analyzing`, matching batch.
 
 Regression fixtures: `Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/Fixtures`
 (three real recordings, cleared for release by the speaker), exercised by

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -445,7 +445,22 @@ public actor SlidingWindowAsrManager {
             // Update stored decoder state
             self.decoderState = state
 
-            let (tokens, timestamps, confidences, _) = result
+            let (tokens, timestamps, confidences, _, droppedPreviousTokens) = result
+
+            // Final window re-decoded the previous window's last word in full (#897):
+            // retire that word from the accumulated tokens and from the text state.
+            if droppedPreviousTokens > 0, droppedPreviousTokens < accumulatedTokens.count {
+                let dropped = Array(accumulatedTokens.suffix(droppedPreviousTokens))
+                accumulatedTokens.removeLast(droppedPreviousTokens)
+                accumulatedTokenTimestamps.removeLast(min(droppedPreviousTokens, accumulatedTokenTimestamps.count))
+                if let droppedText = await asrManager?.convertTokensToText(dropped), !droppedText.isEmpty {
+                    if let trimmed = Self.removingTrailingWord(droppedText, from: volatileTranscript) {
+                        volatileTranscript = trimmed
+                    } else if let trimmed = Self.removingTrailingWord(droppedText, from: confirmedTranscript) {
+                        confirmedTranscript = trimmed
+                    }
+                }
+            }
 
             let adjustedTimestamps = Self.applyGlobalFrameOffset(
                 to: timestamps,
@@ -590,6 +605,14 @@ public actor SlidingWindowAsrManager {
                 ? "insufficient context (\(String(format: "%.1f", totalAudioProcessed))s)" : "low confidence"
             logger.debug("VOLATILE (\(result.confidence)): \(reason) - updated volatile '\(result.text)'")
         }
+    }
+
+    /// `text` without its trailing `word` when `text` ends with that word as a
+    /// whole word (equal, or preceded by a space); nil otherwise. Pure.
+    static func removingTrailingWord(_ word: String, from text: String) -> String? {
+        if text == word { return "" }
+        guard text.hasSuffix(" " + word) else { return nil }
+        return String(text.dropLast(word.count + 1))
     }
 
     /// Join the still-volatile text with a newer unconfirmed window's text.

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -71,14 +71,105 @@ extension AsrManager {
         isLastChunk: Bool,
         previousTokens: [Int],
         previousTokenTimestamps: [Int]?,
-        globalFrameOffset: Int
+        globalFrameOffset: Int,
+        lastWordStartFrame: Int? = nil
     ) -> (initialTimeIndexOverride: Int?, emitTokensAfterFrame: Int?) {
         guard isLastChunk, let previousTimestamps = previousTokenTimestamps, !previousTokens.isEmpty else {
             return (nil, nil)
         }
-        let lastEmittedGlobalFrame = previousTimestamps.max() ?? 0
-        let cutoff = max(0, lastEmittedGlobalFrame - globalFrameOffset - redecodeEmissionJitterFrames)
+        // Anchor the cutoff at the previous window's last *word*, not its last
+        // token: that word may have been cut by the window edge (#897), and the
+        // re-decode must be free to re-emit it in full.
+        let anchorGlobalFrame = lastWordStartFrame ?? (previousTimestamps.max() ?? 0)
+        let cutoff = max(0, anchorGlobalFrame - globalFrameOffset - redecodeEmissionJitterFrames)
         return (0, cutoff)
+    }
+
+    /// Index of the first token of the previous window's last word — a piece
+    /// carrying the SentencePiece word boundary, or the leading space the loaded
+    /// vocabulary normalizes it to — or nil when the sequence has no word start
+    /// after its first token (dropping index 0 would discard the whole window).
+    /// Pure, for testability.
+    nonisolated internal static func trailingWordStartIndex(pieces: [String]) -> Int? {
+        guard
+            let idx = pieces.lastIndex(where: {
+                $0.hasPrefix(ASRConstants.sentencePieceWordBoundary) || $0.hasPrefix(" ")
+            }), idx > 0
+        else { return nil }
+        return idx
+    }
+
+    /// A vocabulary piece that is nothing but punctuation once the word
+    /// boundary (marker or normalized leading space) is stripped.
+    nonisolated internal static func isPunctuationPiece(_ piece: String) -> Bool {
+        var core = piece
+        if core.hasPrefix(ASRConstants.sentencePieceWordBoundary) {
+            core.removeFirst(ASRConstants.sentencePieceWordBoundary.count)
+        }
+        core = core.trimmingCharacters(in: .whitespaces)
+        guard !core.isEmpty else { return false }
+        return core.unicodeScalars.allSatisfy { CharacterSet.punctuationCharacters.contains($0) }
+    }
+
+    /// Seam reconciliation for the final streaming window (#897).
+    ///
+    /// The previous window's trailing word may be a fragment cut by the window
+    /// edge (`and an` for `and analyzing`); the re-decoded final window emits
+    /// that word in full from `trailingWordStart`'s frame minus the jitter
+    /// margin. Dedup cannot fix this — the fragment never equals the full word,
+    /// a re-emitted single token is below the substring matcher's minimum run,
+    /// and a boundary punctuation the decoder attaches at its emission start
+    /// blocks the suffix–prefix match.
+    ///
+    /// Returns how many trailing previous tokens to drop (the whole last word)
+    /// and how many leading current tokens to drop: punctuation emitted at or
+    /// before the previous last word's frame (a seam artifact), and tokens that
+    /// duplicate a kept previous token within `frameTolerance` inside the jitter
+    /// region. Pure, for testability; timestamps are global frames.
+    nonisolated internal static func reconcileFinalWindowSeam(
+        previousTokens: [Int],
+        previousTimestamps: [Int],
+        trailingWordStart: Int,
+        currentTokens: [Int],
+        currentTimestamps: [Int],
+        currentPieces: [String] = [],
+        punctuationTokens: [Int] = ASRConstants.punctuationTokens,
+        jitterFrames: Int = redecodeEmissionJitterFrames,
+        frameTolerance: Int = ASRConstants.duplicateFrameTolerance
+    ) -> (droppedPrevious: Int, droppedCurrent: Int) {
+        guard trailingWordStart > 0, trailingWordStart < previousTokens.count,
+            previousTimestamps.count == previousTokens.count,
+            currentTimestamps.count == currentTokens.count
+        else { return (0, 0) }
+
+        // `ASRConstants.punctuationTokens` lists only sentence-final marks; the
+        // seam artifact is usually a comma, so classify by the piece text too.
+        func isPunctuation(_ index: Int) -> Bool {
+            if punctuationTokens.contains(currentTokens[index]) { return true }
+            guard index < currentPieces.count else { return false }
+            return isPunctuationPiece(currentPieces[index])
+        }
+
+        let droppedPrevious = previousTokens.count - trailingWordStart
+        let lastWordStartFrame = previousTimestamps[trailingWordStart]
+        let keptPrevious = Array(zip(previousTokens, previousTimestamps).prefix(trailingWordStart))
+        let keptLastFrame = keptPrevious.last?.1 ?? -1
+
+        var droppedCurrent = 0
+        for (index, (id, frame)) in zip(currentTokens, currentTimestamps).enumerated() {
+            if isPunctuation(index), frame <= lastWordStartFrame {
+                droppedCurrent += 1
+                continue
+            }
+            if frame <= keptLastFrame + jitterFrames,
+                keptPrevious.contains(where: { $0.0 == id && abs($0.1 - frame) <= frameTolerance })
+            {
+                droppedCurrent += 1
+                continue
+            }
+            break
+        }
+        return (droppedPrevious, droppedCurrent)
     }
 
     /// Chunk transcription that preserves decoder state between calls.
@@ -91,7 +182,10 @@ extension AsrManager {
         globalFrameOffset: Int = 0,
         isLastChunk: Bool = false,
         language: Language? = nil
-    ) async throws -> (tokens: [Int], timestamps: [Int], confidences: [Float], encoderSequenceLength: Int) {
+    ) async throws -> (
+        tokens: [Int], timestamps: [Int], confidences: [Float], encoderSequenceLength: Int,
+        droppedPreviousTokens: Int
+    ) {
         let (alignedSamples, frameAlignedLength) = frameAlignedAudio(
             chunkSamples, allowAlignment: previousTokens.isEmpty)
         let padded = padAudioIfNeeded(alignedSamples, targetLength: ASRConstants.maxModelSamples)
@@ -110,11 +204,18 @@ extension AsrManager {
         // tokens for 9 s of never-seen speech (#855 follow-up, three real
         // recordings). The 2 s left context is enough for a fresh state to
         // re-establish itself before the cutoff.
+        // The previous window's last word is re-decoded in full by the final
+        // window and dropped from the accumulated output afterwards (#897).
+        let trailingWordStart: Int? =
+            isLastChunk && previousTokenTimestamps?.count == previousTokens.count
+            ? Self.trailingWordStartIndex(pieces: previousTokens.map { vocabulary[$0] ?? "" })
+            : nil
         let redecodePlan = Self.lastChunkRedecodePlan(
             isLastChunk: isLastChunk,
             previousTokens: previousTokens,
             previousTokenTimestamps: previousTokenTimestamps,
-            globalFrameOffset: globalFrameOffset
+            globalFrameOffset: globalFrameOffset,
+            lastWordStartFrame: trailingWordStart.flatMap { previousTokenTimestamps?[$0] }
         )
         if redecodePlan.initialTimeIndexOverride == 0 {
             decoderState = TdtDecoderState.make(decoderLayers: decoderLayerCount)
@@ -131,26 +232,62 @@ extension AsrManager {
             initialTimeIndexOverride: redecodePlan.initialTimeIndexOverride
         )
 
+        var currentTokens = hypothesis.ySequence
+        var currentTimestamps = hypothesis.timestamps
+        var currentConfidences = hypothesis.tokenConfidences
+        var effectivePrevious = previousTokens
+        var effectivePreviousTimestamps = previousTokenTimestamps
+        var droppedPrevious = 0
+
+        // Final window: replace the previous window's (possibly edge-cut) last
+        // word with the re-decoded one, and strip the seam artifacts the
+        // re-decode emits ahead of it (#897).
+        if redecodePlan.initialTimeIndexOverride == 0, let trailingWordStart,
+            let previousTimestamps = previousTokenTimestamps
+        {
+            let seam = Self.reconcileFinalWindowSeam(
+                previousTokens: previousTokens,
+                previousTimestamps: previousTimestamps,
+                trailingWordStart: trailingWordStart,
+                currentTokens: currentTokens,
+                currentTimestamps: currentTimestamps.map { $0 + globalFrameOffset },
+                currentPieces: currentTokens.map { vocabulary[$0] ?? "" }
+            )
+            droppedPrevious = seam.droppedPrevious
+            if seam.droppedCurrent > 0 {
+                currentTokens.removeFirst(seam.droppedCurrent)
+                currentTimestamps.removeFirst(seam.droppedCurrent)
+                currentConfidences.removeFirst(min(seam.droppedCurrent, currentConfidences.count))
+            }
+            effectivePrevious = Array(previousTokens.prefix(trailingWordStart))
+            effectivePreviousTimestamps = Array(previousTimestamps.prefix(trailingWordStart))
+            if droppedPrevious > 0 || seam.droppedCurrent > 0 {
+                logger.debug(
+                    "Final-window seam: dropped \(droppedPrevious) trailing previous token(s), \(seam.droppedCurrent) leading current token(s)"
+                )
+            }
+        }
+
         // Apply token deduplication if previous tokens are provided
-        if !previousTokens.isEmpty && hypothesis.hasTokens {
+        if !effectivePrevious.isEmpty && !currentTokens.isEmpty {
             // Convert this chunk's local frame timestamps into the same global frame
             // space as `previousTokenTimestamps` so dedup can require temporal adjacency.
             let currentGlobalTimestamps: [Int]? =
-                previousTokenTimestamps != nil ? hypothesis.timestamps.map { $0 + globalFrameOffset } : nil
+                effectivePreviousTimestamps != nil ? currentTimestamps.map { $0 + globalFrameOffset } : nil
             let (deduped, removedCount) = removeDuplicateTokenSequence(
-                previous: previousTokens, current: hypothesis.ySequence,
-                previousTimestamps: previousTokenTimestamps,
+                previous: effectivePrevious, current: currentTokens,
+                previousTimestamps: effectivePreviousTimestamps,
                 currentTimestamps: currentGlobalTimestamps)
             let adjustedTimestamps =
-                removedCount > 0 ? Array(hypothesis.timestamps.dropFirst(removedCount)) : hypothesis.timestamps
+                removedCount > 0 ? Array(currentTimestamps.dropFirst(removedCount)) : currentTimestamps
             let adjustedConfidences =
                 removedCount > 0
-                ? Array(hypothesis.tokenConfidences.dropFirst(removedCount)) : hypothesis.tokenConfidences
+                ? Array(currentConfidences.dropFirst(removedCount)) : currentConfidences
 
-            return (deduped, adjustedTimestamps, adjustedConfidences, encLen)
+            return (deduped, adjustedTimestamps, adjustedConfidences, encLen, droppedPrevious)
         }
 
-        return (hypothesis.ySequence, hypothesis.timestamps, hypothesis.tokenConfidences, encLen)
+        return (currentTokens, currentTimestamps, currentConfidences, encLen, droppedPrevious)
     }
 
     internal func processTranscriptionResult(

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -111,6 +111,29 @@ extension AsrManager {
         return core.unicodeScalars.allSatisfy { CharacterSet.punctuationCharacters.contains($0) }
     }
 
+    /// Letters/digits of a word's pieces, lower-cased: boundary markers, spaces
+    /// and punctuation stripped. Empty when the pieces carry no word.
+    nonisolated internal static func wordCore<S: Sequence>(_ pieces: S) -> String where S.Element == String {
+        pieces.joined().lowercased().unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) }
+            .map { String($0) }.joined()
+    }
+
+    /// The pieces of the first word in a token sequence: from the first
+    /// word-start piece through the piece before the next word start.
+    nonisolated internal static func firstWordPieces(_ pieces: [String]) -> [String] {
+        func startsWord(_ p: String) -> Bool {
+            p.hasPrefix(ASRConstants.sentencePieceWordBoundary) || p.hasPrefix(" ")
+        }
+        guard let start = pieces.firstIndex(where: { startsWord($0) && !isPunctuationPiece($0) }) else {
+            return []
+        }
+        var end = start + 1
+        while end < pieces.count, !startsWord(pieces[end]), !isPunctuationPiece(pieces[end]) {
+            end += 1
+        }
+        return Array(pieces[start..<end])
+    }
+
     /// Seam reconciliation for the final streaming window (#897).
     ///
     /// The previous window's trailing word may be a fragment cut by the window
@@ -121,7 +144,8 @@ extension AsrManager {
     /// and a boundary punctuation the decoder attaches at its emission start
     /// blocks the suffix–prefix match.
     ///
-    /// Returns how many trailing previous tokens to drop (the whole last word)
+    /// Returns how many trailing previous tokens to drop (the whole last word,
+    /// only when the re-decode extends past the previous window's last frame)
     /// and how many leading current tokens to drop: punctuation emitted at or
     /// before the previous last word's frame (a seam artifact), and tokens that
     /// duplicate a kept previous token within `frameTolerance` inside the jitter
@@ -133,6 +157,7 @@ extension AsrManager {
         currentTokens: [Int],
         currentTimestamps: [Int],
         currentPieces: [String] = [],
+        previousPieces: [String] = [],
         punctuationTokens: [Int] = ASRConstants.punctuationTokens,
         jitterFrames: Int = redecodeEmissionJitterFrames,
         frameTolerance: Int = ASRConstants.duplicateFrameTolerance
@@ -150,9 +175,30 @@ extension AsrManager {
             return isPunctuationPiece(currentPieces[index])
         }
 
-        let droppedPrevious = previousTokens.count - trailingWordStart
         let lastWordStartFrame = previousTimestamps[trailingWordStart]
-        let keptPrevious = Array(zip(previousTokens, previousTimestamps).prefix(trailingWordStart))
+        let previousLastFrame = previousTimestamps[previousTokens.count - 1]
+
+        // Retire the previous word only when the re-decode saw more audio than
+        // the previous window did — a token past the previous window's last
+        // frame (plus jitter). That is the only case in which the previous word
+        // can be an edge-cut fragment. A final window that ends where the
+        // previous one ended (a 0.4 s flush after "…help them out.") keeps the
+        // previous word, punctuation included, and its re-emission is a
+        // duplicate to strip.
+        let extendsBeyondPrevious =
+            (currentTimestamps.max() ?? Int.min) > previousLastFrame + jitterFrames
+
+        // If the re-decode's first word is the same word the previous window
+        // ended on, that word was complete, not a fragment: keep the previous
+        // copy (it carries any sentence-final punctuation the re-decode omits at
+        // the audio end) and let the re-emission fall to the duplicate rule.
+        let previousWord = wordCore(previousPieces.dropFirst(trailingWordStart))
+        let currentWord = wordCore(firstWordPieces(currentPieces))
+        let sameWord = !previousWord.isEmpty && previousWord == currentWord
+        let retire = extendsBeyondPrevious && !sameWord
+        let droppedPrevious = retire ? previousTokens.count - trailingWordStart : 0
+        let keptPrevious = Array(
+            zip(previousTokens, previousTimestamps).prefix(retire ? trailingWordStart : previousTokens.count))
         let keptLastFrame = keptPrevious.last?.1 ?? -1
 
         var droppedCurrent = 0
@@ -251,7 +297,8 @@ extension AsrManager {
                 trailingWordStart: trailingWordStart,
                 currentTokens: currentTokens,
                 currentTimestamps: currentTimestamps.map { $0 + globalFrameOffset },
-                currentPieces: currentTokens.map { vocabulary[$0] ?? "" }
+                currentPieces: currentTokens.map { vocabulary[$0] ?? "" },
+                previousPieces: previousTokens.map { vocabulary[$0] ?? "" }
             )
             droppedPrevious = seam.droppedPrevious
             if seam.droppedCurrent > 0 {

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
@@ -320,4 +320,14 @@ final class SlidingWindowAsrManagerTests: XCTestCase {
         XCTAssertEqual(SlidingWindowAsrManager.appendingVolatile("", "only"), "only")
         XCTAssertEqual(SlidingWindowAsrManager.appendingVolatile("", ""), "")
     }
+
+    // MARK: - Trailing-word retirement (#897)
+
+    func testRemovingTrailingWordOnlyMatchesWholeWords() {
+        XCTAssertEqual(
+            SlidingWindowAsrManager.removingTrailingWord("an", from: "the net new code and an"), "the net new code and")
+        XCTAssertEqual(SlidingWindowAsrManager.removingTrailingWord("an", from: "an"), "")
+        XCTAssertNil(SlidingWindowAsrManager.removingTrailingWord("an", from: "we have a plan"), "suffix inside a word")
+        XCTAssertNil(SlidingWindowAsrManager.removingTrailingWord("an", from: "and so"))
+    }
 }

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowFinalWindowRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowFinalWindowRegressionTests.swift
@@ -21,12 +21,20 @@ final class SlidingWindowFinalWindowRegressionTests: XCTestCase {
         let file: String
         /// Words that only the final window can produce, lower-cased.
         let tail: String
+        /// Seam text that must be spelled as batch does (#897), lower-cased.
+        var seam: String? = nil
+        /// Seam artifact that must not survive (#897), lower-cased.
+        var seamArtifact: String? = nil
     }
 
     private let fixtures: [Fixture] = [
         Fixture(file: "01-validation-request-21.4s.wav", tail: "help them out"),
         Fixture(file: "02-release-readiness-19.8s.wav", tail: "cutting a release"),
-        Fixture(file: "03-diff-explanation-16.9s.wav", tail: "in that difference"),
+        // Window 1 ends on the fragment "an" of "analyzing"; the final window
+        // re-decodes the word. Before #897: "code and an, and analyzing".
+        Fixture(
+            file: "03-diff-explanation-16.9s.wav", tail: "in that difference",
+            seam: "code and analyzing", seamArtifact: "and an,"),
     ]
 
     private func loadModels() async throws -> AsrModels {
@@ -113,6 +121,14 @@ final class SlidingWindowFinalWindowRegressionTests: XCTestCase {
             XCTAssertTrue(
                 text.contains(fixture.tail),
                 "\(fixture.file): streaming transcript lost its tail; expected '\(fixture.tail)' in: \(text)")
+            if let seam = fixture.seam {
+                XCTAssertTrue(
+                    text.contains(seam), "\(fixture.file): seam not reconciled; expected '\(seam)' in: \(text)")
+            }
+            if let artifact = fixture.seamArtifact {
+                XCTAssertFalse(
+                    text.contains(artifact), "\(fixture.file): seam artifact '\(artifact)' survived in: \(text)")
+            }
         }
     }
 }

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -480,4 +480,95 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         )
         XCTAssertNil(firstWindow.initialTimeIndexOverride, "Single-window streams have nothing to re-decode")
     }
+
+    // MARK: - Issue #897: final-window seam reconciliation
+
+    /// Clip 03 of the #855 fixtures: window 1 ends `▁and`@153 `▁an`@156 (the
+    /// fragment of "analyzing" cut by the window edge); the re-decoded final
+    /// window emits `,`@152 `▁and`@155 `▁anal`@159 `y`@162 … The cutoff must
+    /// anchor at the last word start, the fragment must go, and the seam
+    /// comma plus the re-emitted `and` must not survive as duplicates.
+    func testRedecodePlan_CutoffAnchorsAtLastWordStart() {
+        let plan = AsrManager.lastChunkRedecodePlan(
+            isLastChunk: true,
+            previousTokens: [10, 11, 12, 13],
+            previousTokenTimestamps: [147, 149, 153, 156],
+            globalFrameOffset: 112,
+            lastWordStartFrame: 156
+        )
+        XCTAssertEqual(plan.emitTokensAfterFrame, 156 - 112 - AsrManager.redecodeEmissionJitterFrames)
+        // A multi-token last word anchors at its first token, not its last.
+        let multi = AsrManager.lastChunkRedecodePlan(
+            isLastChunk: true,
+            previousTokens: [10, 11, 12],
+            previousTokenTimestamps: [140, 150, 160],
+            globalFrameOffset: 112,
+            lastWordStartFrame: 150
+        )
+        XCTAssertEqual(multi.emitTokensAfterFrame, 150 - 112 - AsrManager.redecodeEmissionJitterFrames)
+    }
+
+    func testTrailingWordStartIndex() {
+        XCTAssertEqual(AsrManager.trailingWordStartIndex(pieces: ["▁c", "ode", "▁and", "▁an"]), 3)
+        // The loaded vocabulary normalizes the boundary to a leading space.
+        XCTAssertEqual(AsrManager.trailingWordStartIndex(pieces: [" c", "ode", " and", " an"]), 3)
+        XCTAssertEqual(AsrManager.trailingWordStartIndex(pieces: ["▁c", "ode", "▁anal", "y", "z"]), 2)
+        XCTAssertNil(AsrManager.trailingWordStartIndex(pieces: ["▁one", "word"]), "index 0 would drop everything")
+        XCTAssertNil(AsrManager.trailingWordStartIndex(pieces: ["no", "starts"]))
+        XCTAssertNil(AsrManager.trailingWordStartIndex(pieces: []))
+    }
+
+    func testReconcileFinalWindowSeam_DropsFragmentSeamCommaAndReemittedWord() {
+        // The comma is not in ASRConstants.punctuationTokens; it is recognized by piece text.
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4],  // ▁c ode ▁and ▁an
+            previousTimestamps: [147, 149, 153, 156],
+            trailingWordStart: 3,
+            currentTokens: [99, 3, 5, 6, 7, 8],  // , ▁and ▁anal y z ing
+            currentTimestamps: [152, 155, 159, 162, 164, 166],
+            currentPieces: [",", " and", " anal", "y", "z", "ing"],
+            punctuationTokens: []
+        )
+        XCTAssertEqual(seam.droppedPrevious, 1, "the fragment `an` is retired")
+        XCTAssertEqual(seam.droppedCurrent, 2, "seam comma + re-emitted `and` (dup of the kept `and`@153)")
+    }
+
+    func testIsPunctuationPiece() {
+        XCTAssertTrue(AsrManager.isPunctuationPiece(","))
+        XCTAssertTrue(AsrManager.isPunctuationPiece("▁."))
+        XCTAssertTrue(AsrManager.isPunctuationPiece(" ?"))
+        XCTAssertFalse(AsrManager.isPunctuationPiece(" and"))
+        XCTAssertFalse(AsrManager.isPunctuationPiece("▁"))
+        XCTAssertFalse(AsrManager.isPunctuationPiece(""))
+    }
+
+    func testReconcileFinalWindowSeam_KeepsGenuineLeadingTokens() {
+        // Current starts with a new word that duplicates nothing: nothing dropped from it.
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3],
+            previousTimestamps: [100, 104, 108],
+            trailingWordStart: 2,
+            currentTokens: [9, 10],
+            currentTimestamps: [110, 114],
+            punctuationTokens: [7883]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 1)
+        XCTAssertEqual(seam.droppedCurrent, 0)
+        // Punctuation after the last word start is real, not a seam artifact.
+        let late = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3],
+            previousTimestamps: [100, 104, 108],
+            trailingWordStart: 2,
+            currentTokens: [7883, 9],
+            currentTimestamps: [120, 124],
+            punctuationTokens: [7883]
+        )
+        XCTAssertEqual(late.droppedCurrent, 0)
+        // Degenerate inputs are a no-op.
+        XCTAssertEqual(
+            AsrManager.reconcileFinalWindowSeam(
+                previousTokens: [1], previousTimestamps: [5], trailingWordStart: 0,
+                currentTokens: [2], currentTimestamps: [6]
+            ).droppedPrevious, 0)
+    }
 }

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -527,6 +527,7 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
             currentTokens: [99, 3, 5, 6, 7, 8],  // , ▁and ▁anal y z ing
             currentTimestamps: [152, 155, 159, 162, 164, 166],
             currentPieces: [",", " and", " anal", "y", "z", "ing"],
+            previousPieces: [" c", "ode", " and", " an"],
             punctuationTokens: []
         )
         XCTAssertEqual(seam.droppedPrevious, 1, "the fragment `an` is retired")
@@ -564,6 +565,56 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
             punctuationTokens: [7883]
         )
         XCTAssertEqual(late.droppedCurrent, 0)
+        // The final window re-emitted nothing for the previous word (empty flush,
+        // or only tokens before its onset): keep the previous word, drop nothing.
+        let emptyFinal = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4],  // … ▁them ▁out .
+            previousTimestamps: [250, 254, 258, 261],
+            trailingWordStart: 2,
+            currentTokens: [],
+            currentTimestamps: []
+        )
+        XCTAssertEqual(emptyFinal.droppedPrevious, 0, "nothing re-emitted the word; the tail must survive")
+        XCTAssertEqual(emptyFinal.droppedCurrent, 0)
+        let earlyOnly = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4],
+            previousTimestamps: [250, 254, 258, 261],
+            trailingWordStart: 2,
+            currentTokens: [7883],
+            currentTimestamps: [240],
+            currentPieces: ["."],
+            punctuationTokens: []
+        )
+        XCTAssertEqual(earlyOnly.droppedPrevious, 0)
+        // A short final window that ends where the previous one ended re-emits
+        // "out" but not the "."; keep the previous "out." and strip the re-emission.
+        let sameEnd = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4],  // … ▁them ▁out .
+            previousTimestamps: [250, 254, 258, 261],
+            trailingWordStart: 2,
+            currentTokens: [3],  // ▁out
+            currentTimestamps: [259]
+        )
+        XCTAssertEqual(sameEnd.droppedPrevious, 0, "re-decode saw no more audio than the previous window")
+        XCTAssertEqual(sameEnd.droppedCurrent, 1, "the re-emitted `out` duplicates the kept one")
+        // The re-decode saw more audio but its first word IS the previous last
+        // word: it was complete, so keep the previous copy (with its period) and
+        // drop the re-emission. Only a *different* first word retires it.
+        let sameWord = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4],  // … ▁them ▁out .
+            previousTimestamps: [250, 254, 258, 261],
+            trailingWordStart: 2,
+            currentTokens: [3, 9],  // ▁out <silence-token>
+            currentTimestamps: [259, 270],
+            currentPieces: [" out", " uh"],
+            previousPieces: [" help", " them", " out", "."]
+        )
+        XCTAssertEqual(sameWord.droppedPrevious, 0)
+        XCTAssertEqual(sameWord.droppedCurrent, 1)
+        XCTAssertEqual(AsrManager.wordCore([" out", "."]), "out")
+        XCTAssertEqual(AsrManager.wordCore([" anal", "y", "z", "ing"]), "analyzing")
+        XCTAssertEqual(AsrManager.firstWordPieces([",", " and", " anal", "y"]), [" and"])
+        XCTAssertEqual(AsrManager.firstWordPieces([" anal", "y", "z", "ing", " if"]), [" anal", "y", "z", "ing"])
         // Degenerate inputs are a no-op.
         XCTAssertEqual(
             AsrManager.reconcileFinalWindowSeam(


### PR DESCRIPTION
Addresses the mid-word join class in #897 (the first of its two findings). The interior-seam duplications (`just just` / `make make`) are a different mechanism and stay open there.

## Mechanism (clip 03 of the #855 fixtures, token trace)

Window 1 ends `▁and`@153 `▁an`@156 — the fragment of "analyzing", cut by the window edge. The final window's cutoff was anchored at that fragment's frame, so the re-decode emitted `,`@152 `▁and`@155 `▁anal`@159 `y` `z` `ing` after it. Dedup could not repair the join: the fragment never equals the full word, a re-emitted single token is below the substring matcher's two-token minimum, and the comma the decoder attaches at its emission start blocks the suffix–prefix match. Output: `code and an, and analyzing`. The reporter's corpus shows the same class yielding a non-word (`everyturing`).

## Fix

- The cutoff anchors at the previous window's **last word start**, so the final window re-decodes that word in full.
- `reconcileFinalWindowSeam` (pure) retires the previous last word from the accumulated output and strips the re-decode's seam artifacts: punctuation emitted at or before that word's frame (classified by piece text; `ASRConstants.punctuationTokens` lists only sentence-final marks and the artifact is a comma), and tokens duplicating a kept previous token inside the jitter region.
- `transcribeChunk` reports `droppedPreviousTokens`; `SlidingWindowAsrManager` retires them from the token arrays and trims the word from the volatile/confirmed text (whole-word suffix only), so both the token path and the boosting text path see the reconciled seam.

## Verification (release, M5 Pro)

| clip | before | after |
|---|---|---|
| 03 streaming | `code and an, and analyzing` | `code and analyzing` (= batch) |
| 01 / 02 streaming | complete | unchanged |
| repro-2 (#861 case) | 5 / 5 | 5 / 5 |
| earnings 9 s / 15 s, boosted streaming | corrected | unchanged |
| clip 01, boosted, no confirmed window | `follow-up`, tail intact | unchanged |

## Review round (CI)

The first revision passed the clip-03 fixture assertion on CI but the boosting e2e (1 s buffers, which yields an empty 0.4 s flush window) lost its final word: the previous window's `out.` was retired on the promise of a re-decode that emitted nothing. Two guards, both pinned by unit tests on the token shapes:

- retire the previous last word only when the re-decode has a token past the previous window's last frame (plus jitter), the only case in which that word can be an edge-cut fragment; an empty or early-ending final window keeps it;
- if the re-decode's first word is the same word the previous window ended on, it was complete: keep the previous copy (it carries the sentence-final punctuation a re-decode at the audio end tends to omit) and drop the re-emission as a duplicate. Only a different first word (`an` vs `analyzing`) retires it.

Re-verified across chunk sizes 7 / 10 / 11, boosted and unboosted: clip 03 still equals batch at the seam, every tail intact, repro-2 5/5, earnings corrections unchanged. (At chunk 10 the interior window itself decodes `help them out` without a period and the flush window is empty; that is the decoder's output, identical on `main`.)

Two gotchas hit on the way, both now covered by tests: the loaded vocabulary stores word-initial pieces with a leading space rather than the SentencePiece marker (the batch chunker already checks both), and the punctuation id constant has no comma.

Tests: plan anchoring, `trailingWordStartIndex` (both boundary forms), `isPunctuationPiece`, reconciliation on the clip-03 token shape and on genuine leading tokens, `removingTrailingWord`; the real-recording fixture test asserts clip 03 contains `code and analyzing` and not `and an,`, and runs in the ASR benchmark job.

@saurabhav88 if the corpus is still frozen, the `0A575FDA` recording (`everyturing`) is the one to re-run on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UHoFANi4DcvU6TzyTPnHH
