### PR TITLE
fix(asr/streaming): seam reconciliation decides by word text, not frames (#897 corpus follow-up)

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -111,15 +111,59 @@ extension AsrManager {
         return core.unicodeScalars.allSatisfy { CharacterSet.punctuationCharacters.contains($0) }
     }
 
-    /// Letters/digits of a word's pieces, lower-cased: boundary markers, spaces
-    /// and punctuation stripped. Empty when the pieces carry no word.
+    /// Comparison form of a word's pieces: boundary markers and surrounding
+    /// whitespace/punctuation stripped, lower-cased, curly apostrophes
+    /// normalized — but *interior* apostrophes and hyphens kept, so `well` and
+    /// `we'll` (or `cant` and `can't`) never compare equal. Empty when the
+    /// pieces carry no word.
     nonisolated internal static func wordCore<S: Sequence>(_ pieces: S) -> String where S.Element == String {
-        pieces.joined().lowercased().unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) }
-            .map { String($0) }.joined()
+        let joined = pieces.joined()
+            .replacingOccurrences(of: ASRConstants.sentencePieceWordBoundary, with: " ")
+            .replacingOccurrences(of: "\u{2019}", with: "'")
+            .lowercased()
+        let scalars = Array(joined.unicodeScalars)
+        let isEdge: (Unicode.Scalar) -> Bool = {
+            CharacterSet.whitespaces.contains($0) || CharacterSet.punctuationCharacters.contains($0)
+        }
+        guard let first = scalars.firstIndex(where: { !isEdge($0) }),
+            let last = scalars.lastIndex(where: { !isEdge($0) })
+        else { return "" }
+        return String(String.UnicodeScalarView(scalars[first...last]))
+    }
+
+    /// A piece that joins two halves of one word (`we` `'` `ll`, `co` `-` `op`):
+    /// an apostrophe or hyphen on its own.
+    nonisolated internal static func isJoiningPunctuationPiece(_ piece: String) -> Bool {
+        let core = piece.replacingOccurrences(of: ASRConstants.sentencePieceWordBoundary, with: "")
+            .trimmingCharacters(in: .whitespaces)
+        return core == "'" || core == "\u{2019}" || core == "-"
+    }
+
+    /// Exclusive end of the word that starts at `start`: continuation pieces
+    /// follow, and a joining apostrophe/hyphen piece is absorbed when a
+    /// continuation piece follows it.
+    nonisolated internal static func wordExtent(in pieces: [String], from start: Int) -> Int {
+        func startsWord(_ p: String) -> Bool {
+            p.hasPrefix(ASRConstants.sentencePieceWordBoundary) || p.hasPrefix(" ")
+        }
+        var end = start + 1
+        while end < pieces.count {
+            let p = pieces[end]
+            if !startsWord(p), !isPunctuationPiece(p) {
+                end += 1
+            } else if isJoiningPunctuationPiece(p), end + 1 < pieces.count, !startsWord(pieces[end + 1]),
+                !isPunctuationPiece(pieces[end + 1])
+            {
+                end += 2
+            } else {
+                break
+            }
+        }
+        return end
     }
 
     /// The pieces of the first word in a token sequence: from the first
-    /// word-start piece through the piece before the next word start.
+    /// word-start piece through the end of that word (see `wordExtent`).
     nonisolated internal static func firstWordPieces(_ pieces: [String]) -> [String] {
         func startsWord(_ p: String) -> Bool {
             p.hasPrefix(ASRConstants.sentencePieceWordBoundary) || p.hasPrefix(" ")
@@ -127,11 +171,7 @@ extension AsrManager {
         guard let start = pieces.firstIndex(where: { startsWord($0) && !isPunctuationPiece($0) }) else {
             return []
         }
-        var end = start + 1
-        while end < pieces.count, !startsWord(pieces[end]), !isPunctuationPiece(pieces[end]) {
-            end += 1
-        }
-        return Array(pieces[start..<end])
+        return Array(pieces[start..<wordExtent(in: pieces, from: start)])
     }
 
     /// Seam reconciliation for the final streaming window (#897).
@@ -214,8 +254,16 @@ extension AsrManager {
 
         // 1. Leading continuation pieces: the tail of the previous last word.
         var head = 0
-        while head < currentTokens.count, !startsWord(head), !isPunctuation(head) {
-            head += 1
+        while head < currentTokens.count {
+            if !startsWord(head), !isPunctuation(head) {
+                head += 1
+            } else if isJoiningPunctuationPiece(piece(head)), head + 1 < currentTokens.count,
+                !startsWord(head + 1), !isPunctuation(head + 1)
+            {
+                head += 2
+            } else {
+                break
+            }
         }
 
         // 2. The first real word of the re-decode.
@@ -258,10 +306,7 @@ extension AsrManager {
         // so id-level duplicate matching cannot be relied on for it.
         var droppedCurrent = head
         if !retire, currentWord == previousWord, overlapsPrevious, let firstIndex = firstWordIndex {
-            var end = firstIndex + 1
-            while end < currentTokens.count, !startsWord(end), !isPunctuation(end) {
-                end += 1
-            }
+            var end = wordExtent(in: currentPieces, from: firstIndex)
             // Punctuation policy: the kept previous copy already carries its own
             // trailing punctuation, so the re-decode's is a duplicate — drop it.
             // If the previous copy has none, the re-decoded punctuation is the

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -142,6 +142,22 @@ extension AsrManager {
         return piece == "'" || piece == "\u{2019}" || piece == "-"
     }
 
+    /// Whether the piece at `index` starts a word: a boundary-marked piece that
+    /// is not punctuation — or a boundary-marked apostrophe/hyphen immediately
+    /// followed by a continuation piece (`▁'` `cause`), which is the first
+    /// piece of that word rather than leading punctuation.
+    nonisolated internal static func startsWordPiece(in pieces: [String], at index: Int) -> Bool {
+        let p = pieces[index]
+        guard p.hasPrefix(ASRConstants.sentencePieceWordBoundary) || p.hasPrefix(" ") else { return false }
+        if !isPunctuationPiece(p) { return true }
+        let core = p.replacingOccurrences(of: ASRConstants.sentencePieceWordBoundary, with: "")
+            .trimmingCharacters(in: .whitespaces)
+        guard core == "'" || core == "\u{2019}" || core == "-", index + 1 < pieces.count else { return false }
+        let next = pieces[index + 1]
+        return !next.hasPrefix(ASRConstants.sentencePieceWordBoundary) && !next.hasPrefix(" ")
+            && !isPunctuationPiece(next)
+    }
+
     /// Exclusive end of the word that starts at `start`: continuation pieces
     /// follow, and a joining apostrophe/hyphen piece is absorbed when a
     /// continuation piece follows it.
@@ -171,7 +187,7 @@ extension AsrManager {
         func startsWord(_ p: String) -> Bool {
             p.hasPrefix(ASRConstants.sentencePieceWordBoundary) || p.hasPrefix(" ")
         }
-        guard let start = pieces.firstIndex(where: { startsWord($0) && !isPunctuationPiece($0) }) else {
+        guard let start = pieces.indices.first(where: { startsWordPiece(in: pieces, at: $0) }) else {
             return []
         }
         return Array(pieces[start..<wordExtent(in: pieces, from: start)])
@@ -224,7 +240,6 @@ extension AsrManager {
         currentTimestamps: [Int],
         currentPieces: [String] = [],
         previousPieces: [String] = [],
-        punctuationTokens: [Int] = ASRConstants.punctuationTokens,
         jitterFrames: Int = redecodeEmissionJitterFrames,
         frameTolerance: Int = ASRConstants.duplicateFrameTolerance
     ) -> (droppedPrevious: Int, droppedCurrent: Int) {
@@ -240,11 +255,10 @@ extension AsrManager {
         else { return (0, 0) }
 
         func piece(_ index: Int) -> String { currentPieces[index] }
-        // `ASRConstants.punctuationTokens` lists only sentence-final marks; the
-        // seam artifact is usually a comma, so classify by the piece text too.
-        func isPunctuation(_ index: Int) -> Bool {
-            punctuationTokens.contains(currentTokens[index]) || isPunctuationPiece(piece(index))
-        }
+        // Classify by piece text only. Token ids are model-dependent:
+        // `ASRConstants.punctuationTokens` was written for an older vocabulary
+        // and maps to `й` / `ó` in v3.
+        func isPunctuation(_ index: Int) -> Bool { isPunctuationPiece(piece(index)) }
         func startsWord(_ index: Int) -> Bool {
             let p = piece(index)
             return p.hasPrefix(ASRConstants.sentencePieceWordBoundary) || p.hasPrefix(" ")
@@ -273,7 +287,7 @@ extension AsrManager {
         let previousWord = wordCore(previousPieces.dropFirst(trailingWordStart))
         let firstWord = firstWordPieces(Array(currentPieces.dropFirst(head)))
         let currentWord = wordCore(firstWord)
-        let firstWordIndex = (head..<currentTokens.count).first { startsWord($0) && !isPunctuation($0) }
+        let firstWordIndex = (head..<currentTokens.count).first { startsWordPiece(in: currentPieces, at: $0) }
         let firstWordFrame = firstWordIndex.map { currentTimestamps[$0] }
 
         let overlapsPrevious = firstWordFrame.map { $0 <= previousLastFrame + jitterFrames } ?? false

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -149,8 +149,11 @@ extension AsrManager {
     ///    the tail of the previous last word whose start fell under the cutoff
     ///    (`box` + `x, but`). They are dropped and never justify retiring.
     /// 2. The first real word of the re-decode then decides the previous word's
-    ///    fate. Same word: keep the previous copy (it carries the sentence-final
-    ///    punctuation a re-decode at the audio end omits), drop the re-emission.
+    ///    fate. Same word starting within the previous word's span: keep the
+    ///    previous copy (it carries the sentence-final punctuation a re-decode
+    ///    at the audio end omits), drop the re-emission and — when the kept copy
+    ///    ends with punctuation — the re-decode's punctuation behind it. A same
+    ///    word starting later is a genuine repetition and stays.
     ///    Previous text a strict prefix of it (`an`→`analyzing`,
     ///    `every`→`everything`): a fragment, retire. A different word that
     ///    overlaps the previous word's span and was started by the re-decode
@@ -254,12 +257,19 @@ extension AsrManager {
         // segmentation, casing or punctuation may differ from the kept copy,
         // so id-level duplicate matching cannot be relied on for it.
         var droppedCurrent = head
-        if !retire, currentWord == previousWord, let firstIndex = firstWordIndex {
+        if !retire, currentWord == previousWord, overlapsPrevious, let firstIndex = firstWordIndex {
             var end = firstIndex + 1
             while end < currentTokens.count, !startsWord(end), !isPunctuation(end) {
                 end += 1
             }
-            // Punctuation between the head and the word is a seam artifact too.
+            // Punctuation policy: the kept previous copy already carries its own
+            // trailing punctuation, so the re-decode's is a duplicate — drop it.
+            // If the previous copy has none, the re-decoded punctuation is the
+            // only one and stays.
+            let previousEndsWithPunctuation = previousPieces.last.map { isPunctuationPiece($0) } ?? false
+            while previousEndsWithPunctuation, end < currentTokens.count, isPunctuation(end) {
+                end += 1
+            }
             droppedCurrent = end
         }
         for index in droppedCurrent..<currentTokens.count {

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -168,7 +168,8 @@ extension AsrManager {
     ///
     /// Returns how many trailing previous tokens to drop (the whole last word
     /// or none) and how many leading current tokens to drop. Pure, for
-    /// testability; timestamps are global frames.
+    /// testability; timestamps are global frames. Both piece arrays must be
+    /// aligned with their token arrays, otherwise the result is a no-op.
     nonisolated internal static func reconcileFinalWindowSeam(
         previousTokens: [Int],
         previousTimestamps: [Int],
@@ -181,13 +182,18 @@ extension AsrManager {
         jitterFrames: Int = redecodeEmissionJitterFrames,
         frameTolerance: Int = ASRConstants.duplicateFrameTolerance
     ) -> (droppedPrevious: Int, droppedCurrent: Int) {
+        // The decision is by piece text, so both piece arrays must be aligned
+        // with their token arrays; without them the only safe answer is a no-op
+        // (an unknown piece would otherwise read as a continuation and drop).
         guard trailingWordStart > 0, trailingWordStart < previousTokens.count,
             previousTimestamps.count == previousTokens.count,
             currentTimestamps.count == currentTokens.count,
+            currentPieces.count == currentTokens.count,
+            previousPieces.count == previousTokens.count,
             !currentTokens.isEmpty
         else { return (0, 0) }
 
-        func piece(_ index: Int) -> String { index < currentPieces.count ? currentPieces[index] : "" }
+        func piece(_ index: Int) -> String { currentPieces[index] }
         // `ASRConstants.punctuationTokens` lists only sentence-final marks; the
         // seam artifact is usually a comma, so classify by the piece text too.
         func isPunctuation(_ index: Int) -> Bool {
@@ -216,14 +222,18 @@ extension AsrManager {
         let firstWordIndex = (head..<currentTokens.count).first { startsWord($0) && !isPunctuation($0) }
         let firstWordFrame = firstWordIndex.map { currentTimestamps[$0] }
 
+        let overlapsPrevious = firstWordFrame.map { $0 <= previousLastFrame + jitterFrames } ?? false
         let retire: Bool
         if !extendsBeyondPrevious || currentWord.isEmpty || previousWord.isEmpty {
             retire = false
         } else if currentWord == previousWord {
             retire = false
-        } else if currentWord.hasPrefix(previousWord) {
+        } else if currentWord.hasPrefix(previousWord), overlapsPrevious {
+            // A fragment's replacement starts where the fragment started. A
+            // later word that merely happens to extend the previous text
+            // (`an` … `another`) is a new word; keep the previous one.
             retire = true
-        } else if head == 0, let frame = firstWordFrame, frame <= previousLastFrame + jitterFrames {
+        } else if head == 0, overlapsPrevious {
             // Overlapping different word, and the re-decode started it itself
             // (no continuation head): it disagrees with more context. Behind a
             // continuation head the first real word is the *next* word by
@@ -238,9 +248,21 @@ extension AsrManager {
             zip(previousTokens, previousTimestamps).prefix(retire ? trailingWordStart : previousTokens.count))
         let keptLastFrame = keptPrevious.last?.1 ?? -1
 
-        // 4. Strip the seam artifacts from the re-decode's head.
+        // 4. Strip the seam artifacts from the re-decode's head. When the
+        // previous word is kept because the re-decode's first word is the same
+        // word, consume that word's whole piece range explicitly — its
+        // segmentation, casing or punctuation may differ from the kept copy,
+        // so id-level duplicate matching cannot be relied on for it.
         var droppedCurrent = head
-        for index in head..<currentTokens.count {
+        if !retire, currentWord == previousWord, let firstIndex = firstWordIndex {
+            var end = firstIndex + 1
+            while end < currentTokens.count, !startsWord(end), !isPunctuation(end) {
+                end += 1
+            }
+            // Punctuation between the head and the word is a seam artifact too.
+            droppedCurrent = end
+        }
+        for index in droppedCurrent..<currentTokens.count {
             let id = currentTokens[index]
             let frame = currentTimestamps[index]
             if isPunctuation(index), frame <= lastWordStartFrame {

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -132,11 +132,14 @@ extension AsrManager {
     }
 
     /// A piece that joins two halves of one word (`we` `'` `ll`, `co` `-` `op`):
-    /// an apostrophe or hyphen on its own.
+    /// a *bare* apostrophe or hyphen. The v3 vocabulary also carries
+    /// boundary-marked variants (`▁'`, `▁-`, normalized to a leading space)
+    /// that start a new word; those are never joiners.
     nonisolated internal static func isJoiningPunctuationPiece(_ piece: String) -> Bool {
-        let core = piece.replacingOccurrences(of: ASRConstants.sentencePieceWordBoundary, with: "")
-            .trimmingCharacters(in: .whitespaces)
-        return core == "'" || core == "\u{2019}" || core == "-"
+        guard !piece.hasPrefix(ASRConstants.sentencePieceWordBoundary), !piece.hasPrefix(" ") else {
+            return false
+        }
+        return piece == "'" || piece == "\u{2019}" || piece == "-"
     }
 
     /// Exclusive end of the word that starts at `start`: continuation pieces

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -144,12 +144,31 @@ extension AsrManager {
     /// and a boundary punctuation the decoder attaches at its emission start
     /// blocks the suffix–prefix match.
     ///
-    /// Returns how many trailing previous tokens to drop (the whole last word,
-    /// only when the re-decode extends past the previous window's last frame)
-    /// and how many leading current tokens to drop: punctuation emitted at or
-    /// before the previous last word's frame (a seam artifact), and tokens that
-    /// duplicate a kept previous token within `frameTolerance` inside the jitter
-    /// region. Pure, for testability; timestamps are global frames.
+    /// Decision, from the token shapes in the #897 corpus run:
+    /// 1. Leading *continuation* pieces of the re-decode (no word boundary) are
+    ///    the tail of the previous last word whose start fell under the cutoff
+    ///    (`box` + `x, but`). They are dropped and never justify retiring.
+    /// 2. The first real word of the re-decode then decides the previous word's
+    ///    fate. Same word: keep the previous copy (it carries the sentence-final
+    ///    punctuation a re-decode at the audio end omits), drop the re-emission.
+    ///    Previous text a strict prefix of it (`an`→`analyzing`,
+    ///    `every`→`everything`): a fragment, retire. A different word that
+    ///    overlaps the previous word's span and was started by the re-decode
+    ///    itself (no continuation head): it disagrees with more context, retire.
+    ///    Behind a continuation head the first real word is the next word by
+    ///    construction, so only the prefix rule can retire. A different word
+    ///    starting later: the re-decode skipped the previous word, keep it.
+    /// 3. Retiring additionally requires the re-decode to reach past the
+    ///    previous window's last frame; an empty or early-ending final window
+    ///    keeps the previous word.
+    /// 4. The re-decode's head is then stripped of seam artifacts: punctuation
+    ///    at or before the previous last word's frame, and tokens — punctuation
+    ///    included — that duplicate a kept previous token within
+    ///    `frameTolerance` inside the jitter region.
+    ///
+    /// Returns how many trailing previous tokens to drop (the whole last word
+    /// or none) and how many leading current tokens to drop. Pure, for
+    /// testability; timestamps are global frames.
     nonisolated internal static func reconcileFinalWindowSeam(
         previousTokens: [Int],
         previousTimestamps: [Int],
@@ -164,45 +183,66 @@ extension AsrManager {
     ) -> (droppedPrevious: Int, droppedCurrent: Int) {
         guard trailingWordStart > 0, trailingWordStart < previousTokens.count,
             previousTimestamps.count == previousTokens.count,
-            currentTimestamps.count == currentTokens.count
+            currentTimestamps.count == currentTokens.count,
+            !currentTokens.isEmpty
         else { return (0, 0) }
 
+        func piece(_ index: Int) -> String { index < currentPieces.count ? currentPieces[index] : "" }
         // `ASRConstants.punctuationTokens` lists only sentence-final marks; the
         // seam artifact is usually a comma, so classify by the piece text too.
         func isPunctuation(_ index: Int) -> Bool {
-            if punctuationTokens.contains(currentTokens[index]) { return true }
-            guard index < currentPieces.count else { return false }
-            return isPunctuationPiece(currentPieces[index])
+            punctuationTokens.contains(currentTokens[index]) || isPunctuationPiece(piece(index))
+        }
+        func startsWord(_ index: Int) -> Bool {
+            let p = piece(index)
+            return p.hasPrefix(ASRConstants.sentencePieceWordBoundary) || p.hasPrefix(" ")
         }
 
         let lastWordStartFrame = previousTimestamps[trailingWordStart]
         let previousLastFrame = previousTimestamps[previousTokens.count - 1]
-
-        // Retire the previous word only when the re-decode saw more audio than
-        // the previous window did — a token past the previous window's last
-        // frame (plus jitter). That is the only case in which the previous word
-        // can be an edge-cut fragment. A final window that ends where the
-        // previous one ended (a 0.4 s flush after "…help them out.") keeps the
-        // previous word, punctuation included, and its re-emission is a
-        // duplicate to strip.
         let extendsBeyondPrevious =
             (currentTimestamps.max() ?? Int.min) > previousLastFrame + jitterFrames
 
-        // If the re-decode's first word is the same word the previous window
-        // ended on, that word was complete, not a fragment: keep the previous
-        // copy (it carries any sentence-final punctuation the re-decode omits at
-        // the audio end) and let the re-emission fall to the duplicate rule.
+        // 1. Leading continuation pieces: the tail of the previous last word.
+        var head = 0
+        while head < currentTokens.count, !startsWord(head), !isPunctuation(head) {
+            head += 1
+        }
+
+        // 2. The first real word of the re-decode.
         let previousWord = wordCore(previousPieces.dropFirst(trailingWordStart))
-        let currentWord = wordCore(firstWordPieces(currentPieces))
-        let sameWord = !previousWord.isEmpty && previousWord == currentWord
-        let retire = extendsBeyondPrevious && !sameWord
+        let firstWord = firstWordPieces(Array(currentPieces.dropFirst(head)))
+        let currentWord = wordCore(firstWord)
+        let firstWordIndex = (head..<currentTokens.count).first { startsWord($0) && !isPunctuation($0) }
+        let firstWordFrame = firstWordIndex.map { currentTimestamps[$0] }
+
+        let retire: Bool
+        if !extendsBeyondPrevious || currentWord.isEmpty || previousWord.isEmpty {
+            retire = false
+        } else if currentWord == previousWord {
+            retire = false
+        } else if currentWord.hasPrefix(previousWord) {
+            retire = true
+        } else if head == 0, let frame = firstWordFrame, frame <= previousLastFrame + jitterFrames {
+            // Overlapping different word, and the re-decode started it itself
+            // (no continuation head): it disagrees with more context. Behind a
+            // continuation head the first real word is the *next* word by
+            // construction (`box` + `x, but`), so only the prefix rule applies.
+            retire = true
+        } else {
+            retire = false
+        }
+
         let droppedPrevious = retire ? previousTokens.count - trailingWordStart : 0
         let keptPrevious = Array(
             zip(previousTokens, previousTimestamps).prefix(retire ? trailingWordStart : previousTokens.count))
         let keptLastFrame = keptPrevious.last?.1 ?? -1
 
-        var droppedCurrent = 0
-        for (index, (id, frame)) in zip(currentTokens, currentTimestamps).enumerated() {
+        // 4. Strip the seam artifacts from the re-decode's head.
+        var droppedCurrent = head
+        for index in head..<currentTokens.count {
+            let id = currentTokens[index]
+            let frame = currentTimestamps[index]
             if isPunctuation(index), frame <= lastWordStartFrame {
                 droppedCurrent += 1
                 continue

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -328,8 +328,11 @@ extension AsrManager {
             // trailing punctuation, so the re-decode's is a duplicate — drop it.
             // If the previous copy has none, the re-decoded punctuation is the
             // only one and stays.
+            // Never a boundary-marked piece that begins the next word (`▁'` `cause`).
             let previousEndsWithPunctuation = previousPieces.last.map { isPunctuationPiece($0) } ?? false
-            while previousEndsWithPunctuation, end < currentTokens.count, isPunctuation(end) {
+            while previousEndsWithPunctuation, end < currentTokens.count, isPunctuation(end),
+                !startsWordPiece(in: currentPieces, at: end)
+            {
                 end += 1
             }
             droppedCurrent = end
@@ -337,7 +340,7 @@ extension AsrManager {
         for index in droppedCurrent..<currentTokens.count {
             let id = currentTokens[index]
             let frame = currentTimestamps[index]
-            if isPunctuation(index), frame <= lastWordStartFrame {
+            if isPunctuation(index), !startsWordPiece(in: currentPieces, at: index), frame <= lastWordStartFrame {
                 droppedCurrent += 1
                 continue
             }

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -748,6 +748,35 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertEqual(seam.droppedCurrent, 2, "exactly the re-emitted `'cause`; `every` stays")
     }
 
+    /// After keeping a punctuated previous word (`said` `.`), the trailing
+    /// punctuation cleanup must stop at a boundary-marked apostrophe that begins
+    /// the next word (`▁'` `cause`): only the re-emitted `said` goes.
+    func testReconcileFinalWindowSeam_PunctuationCleanupStopsAtNextWordStart() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 7883],  // ▁he ▁said .
+            previousTimestamps: [96, 100, 103],
+            trailingWordStart: 1,
+            currentTokens: [2, 30, 31, 32],  // ▁said ▁' cause ▁more
+            currentTimestamps: [101, 104, 105, 112],
+            currentPieces: [" said", " '", "cause", " more"],
+            previousPieces: [" he", " said", "."]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0)
+        XCTAssertEqual(seam.droppedCurrent, 1, "only the re-emitted `said`; `'cause more` is intact")
+        // The generic head rule has the same protection: a word-starting apostrophe
+        // before the previous word's onset is not a seam artifact.
+        let head = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2],
+            previousTimestamps: [96, 100],
+            trailingWordStart: 1,
+            currentTokens: [30, 31, 32],  // ▁' cause ▁more
+            currentTimestamps: [99, 101, 112],
+            currentPieces: [" '", "cause", " more"],
+            previousPieces: [" just", " so"]
+        )
+        XCTAssertEqual(head.droppedCurrent, 0)
+    }
+
     /// Token ids are not punctuation evidence: id 7948 is `ó` in the v3
     /// vocabulary although it sits in `ASRConstants.punctuationTokens`. A word
     /// starting with it must not be dropped as a seam artifact.

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -684,6 +684,43 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertEqual(seam.droppedCurrent, 1, "only the re-emitted word; its period is the only one")
     }
 
+    /// `well` vs `we'll`: the comparison form keeps interior apostrophes, so the
+    /// re-decoded contraction is a *different* overlapping word and retires the
+    /// earlier `well` instead of being consumed as a re-emission of it. Both
+    /// tokenizations of the contraction are covered.
+    func testReconcileFinalWindowSeam_ContractionIsNotTheSameWord() {
+        XCTAssertNotEqual(AsrManager.wordCore([" well"]), AsrManager.wordCore([" we'll"]))
+        XCTAssertNotEqual(AsrManager.wordCore([" cant"]), AsrManager.wordCore([" can\u{2019}t"]))
+        XCTAssertEqual(AsrManager.wordCore([" we", "'", "ll"]), "we'll")
+        XCTAssertEqual(AsrManager.wordCore([" out", "."]), "out")
+        XCTAssertEqual(AsrManager.firstWordPieces([" we", "'", "ll", " go"]), [" we", "'", "ll"])
+
+        let singlePiece = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2],  // ▁and ▁well
+            previousTimestamps: [96, 100],
+            trailingWordStart: 1,
+            currentTokens: [30, 31],  // ▁we'll ▁go
+            currentTimestamps: [101, 108],
+            currentPieces: [" we'll", " go"],
+            previousPieces: [" and", " well"]
+        )
+        XCTAssertEqual(singlePiece.droppedPrevious, 1, "the re-decoded contraction replaces `well`")
+        XCTAssertEqual(singlePiece.droppedCurrent, 0)
+
+        let splitPieces = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2],
+            previousTimestamps: [96, 100],
+            trailingWordStart: 1,
+            currentTokens: [30, 99, 32, 33],  // ▁we ' ll ▁go
+            currentTimestamps: [101, 102, 103, 108],
+            currentPieces: [" we", "'", "ll", " go"],
+            previousPieces: [" and", " well"],
+            punctuationTokens: []
+        )
+        XCTAssertEqual(splitPieces.droppedPrevious, 1)
+        XCTAssertEqual(splitPieces.droppedCurrent, 0)
+    }
+
     /// A genuine later repetition of the same word (`go` … `go again`) must not
     /// be consumed: the same-word rule applies only when the re-emission starts
     /// within the previous word's span.

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -646,22 +646,71 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertFalse(AsrManager.isPunctuationPiece(""))
     }
 
-    func testReconcileFinalWindowSeam_EmptyEarlyAndDegenerateInputsKeepPrevious() {
+    /// Same word, different segmentation: the previous `▁out` is one piece, the
+    /// re-decode spells it `▁o` `ut` with a comma behind. Id-level matching
+    /// cannot see the duplicate, so the same-word branch must consume the whole
+    /// re-emitted word range itself.
+    func testReconcileFinalWindowSeam_SameWordDifferentSegmentationIsConsumed() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3],  // ▁them ▁out .
+            previousTimestamps: [254, 258, 261],
+            trailingWordStart: 1,
+            currentTokens: [40, 41, 99, 50],  // ▁o ut , ▁and
+            currentTimestamps: [259, 260, 262, 270],
+            currentPieces: [" o", "ut", ",", " and"],
+            previousPieces: [" them", " out", "."],
+            punctuationTokens: []
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0)
+        XCTAssertEqual(seam.droppedCurrent, 2, "both pieces of the re-emitted `out` go; the comma and `and` stay")
+    }
+
+    /// Adversarial for the prefix rule: a continuation head followed by a new
+    /// word that merely extends the previous text (`an` … `another`). The new
+    /// word starts after the previous word's span, so it is kept as a new word
+    /// and the previous `an` survives.
+    func testReconcileFinalWindowSeam_LaterExtendingWordDoesNotRetire() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2],
+            previousTimestamps: [96, 100],
+            trailingWordStart: 1,
+            currentTokens: [30, 31, 32],
+            currentTimestamps: [103, 112, 116],
+            currentPieces: ["x", " another", " thing"],
+            previousPieces: [" is", " an"]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0, "`another` at 112 starts after `an`'s span; not a replacement")
+        XCTAssertEqual(seam.droppedCurrent, 1, "the continuation head still goes")
+    }
+
+    func testReconcileFinalWindowSeam_EmptyEarlyMisalignedAndDegenerateInputsKeepPrevious() {
         let empty = AsrManager.reconcileFinalWindowSeam(
             previousTokens: [1, 2, 3, 4], previousTimestamps: [250, 254, 258, 261], trailingWordStart: 2,
-            currentTokens: [], currentTimestamps: [])
+            currentTokens: [], currentTimestamps: [], currentPieces: [], previousPieces: [" a", " b", " c", " d"])
         XCTAssertEqual(empty.droppedPrevious, 0)
         XCTAssertEqual(empty.droppedCurrent, 0)
         // Only a punctuation before the previous word's onset: nothing re-emitted.
         let earlyOnly = AsrManager.reconcileFinalWindowSeam(
             previousTokens: [1, 2, 3, 4], previousTimestamps: [250, 254, 258, 261], trailingWordStart: 2,
-            currentTokens: [7883], currentTimestamps: [240], currentPieces: ["."], punctuationTokens: [])
+            currentTokens: [7883], currentTimestamps: [240], currentPieces: ["."],
+            previousPieces: [" a", " b", " out", "."], punctuationTokens: [])
         XCTAssertEqual(earlyOnly.droppedPrevious, 0)
         XCTAssertEqual(earlyOnly.droppedCurrent, 1, "punctuation before the previous word's onset is a seam artifact")
+        // Missing or misaligned piece arrays: a no-op, never a mass drop.
+        let noPieces = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3], previousTimestamps: [100, 104, 108], trailingWordStart: 2,
+            currentTokens: [9, 10], currentTimestamps: [110, 114])
+        XCTAssertEqual(noPieces.droppedPrevious, 0)
+        XCTAssertEqual(noPieces.droppedCurrent, 0)
+        let misaligned = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3], previousTimestamps: [100, 104, 108], trailingWordStart: 2,
+            currentTokens: [9, 10], currentTimestamps: [110, 114], currentPieces: [" only"],
+            previousPieces: [" a", " b", " c"])
+        XCTAssertEqual(misaligned.droppedCurrent, 0)
         XCTAssertEqual(
             AsrManager.reconcileFinalWindowSeam(
                 previousTokens: [1], previousTimestamps: [5], trailingWordStart: 0,
-                currentTokens: [2], currentTimestamps: [6]
+                currentTokens: [2], currentTimestamps: [6], currentPieces: [" x"], previousPieces: [" y"]
             ).droppedPrevious, 0)
     }
 }

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -529,8 +529,7 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
             currentTokens: [99, 3, 5, 6, 7, 8],
             currentTimestamps: [152, 155, 159, 162, 164, 166],
             currentPieces: [",", " and", " anal", "y", "z", "ing"],
-            previousPieces: [" c", "ode", " and", " an"],
-            punctuationTokens: []
+            previousPieces: [" c", "ode", " and", " an"]
         )
         XCTAssertEqual(seam.droppedPrevious, 1)
         XCTAssertEqual(seam.droppedCurrent, 2)
@@ -548,8 +547,7 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
             currentTokens: [30, 99, 31, 32],
             currentTimestamps: [308, 309, 311, 314],
             currentPieces: ["x", ",", " but", " she"],
-            previousPieces: [" in", " the", " box"],
-            punctuationTokens: []
+            previousPieces: [" in", " the", " box"]
         )
         XCTAssertEqual(seam.droppedPrevious, 0, "`but` is not `box` nor an extension of it")
         XCTAssertEqual(seam.droppedCurrent, 1, "only the continuation tail `x` goes; the comma stays")
@@ -658,8 +656,7 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
             currentTokens: [40, 41, 99, 50],  // ▁o ut , ▁and
             currentTimestamps: [259, 260, 262, 270],
             currentPieces: [" o", "ut", ",", " and"],
-            previousPieces: [" them", " out", "."],
-            punctuationTokens: []
+            previousPieces: [" them", " out", "."]
         )
         XCTAssertEqual(seam.droppedPrevious, 0)
         XCTAssertEqual(
@@ -726,11 +723,45 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
             currentTokens: [30, 99, 32, 33],  // ▁we ' ll ▁go
             currentTimestamps: [101, 102, 103, 108],
             currentPieces: [" we", "'", "ll", " go"],
-            previousPieces: [" and", " well"],
-            punctuationTokens: []
+            previousPieces: [" and", " well"]
         )
         XCTAssertEqual(splitPieces.droppedPrevious, 1)
         XCTAssertEqual(splitPieces.droppedCurrent, 0)
+    }
+
+    /// A word that begins with a boundary-marked apostrophe (`▁'` `cause`) is one
+    /// word, not leading punctuation plus a stray continuation. Same-word
+    /// consumption must cover exactly that word.
+    func testReconcileFinalWindowSeam_LeadingApostropheWordIsOneWord() {
+        XCTAssertEqual(AsrManager.firstWordPieces([" '", "cause", " every"]), [" '", "cause"])
+        XCTAssertEqual(AsrManager.wordCore([" '", "cause"]), "cause")
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3],  // ▁just ▁' cause
+            previousTimestamps: [96, 100, 101],
+            trailingWordStart: 1,
+            currentTokens: [2, 3, 9],  // ▁' cause ▁every
+            currentTimestamps: [100, 102, 110],
+            currentPieces: [" '", "cause", " every"],
+            previousPieces: [" just", " '", "cause"]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0)
+        XCTAssertEqual(seam.droppedCurrent, 2, "exactly the re-emitted `'cause`; `every` stays")
+    }
+
+    /// Token ids are not punctuation evidence: id 7948 is `ó` in the v3
+    /// vocabulary although it sits in `ASRConstants.punctuationTokens`. A word
+    /// starting with it must not be dropped as a seam artifact.
+    func testReconcileFinalWindowSeam_ClassifiesPunctuationByPieceNotId() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2],
+            previousTimestamps: [96, 100],
+            trailingWordStart: 1,
+            currentTokens: [7948, 9],
+            currentTimestamps: [99, 112],
+            currentPieces: [" ó", " si"],
+            previousPieces: [" digo", " que"]
+        )
+        XCTAssertEqual(seam.droppedCurrent, 0, "`ó` is a word, not punctuation, regardless of its id")
     }
 
     /// A genuine later repetition of the same word (`go` … `go again`) must not
@@ -778,7 +809,7 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         let earlyOnly = AsrManager.reconcileFinalWindowSeam(
             previousTokens: [1, 2, 3, 4], previousTimestamps: [250, 254, 258, 261], trailingWordStart: 2,
             currentTokens: [7883], currentTimestamps: [240], currentPieces: ["."],
-            previousPieces: [" a", " b", " out", "."], punctuationTokens: [])
+            previousPieces: [" a", " b", " out", "."])
         XCTAssertEqual(earlyOnly.droppedPrevious, 0)
         XCTAssertEqual(earlyOnly.droppedCurrent, 1, "punctuation before the previous word's onset is a seam artifact")
         // Missing or misaligned piece arrays: a no-op, never a mass drop.

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -757,10 +757,11 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
             previousTimestamps: [96, 100],
             trailingWordStart: 1,
             currentTokens: [7948, 9],
-            currentTimestamps: [99, 112],
+            currentTimestamps: [107, 112],  // starts after the previous word's span: a new word
             currentPieces: [" ó", " si"],
             previousPieces: [" digo", " que"]
         )
+        XCTAssertEqual(seam.droppedPrevious, 0)
         XCTAssertEqual(seam.droppedCurrent, 0, "`ó` is a word, not punctuation, regardless of its id")
     }
 

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -694,6 +694,18 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertEqual(AsrManager.wordCore([" we", "'", "ll"]), "we'll")
         XCTAssertEqual(AsrManager.wordCore([" out", "."]), "out")
         XCTAssertEqual(AsrManager.firstWordPieces([" we", "'", "ll", " go"]), [" we", "'", "ll"])
+        // Only a bare apostrophe/hyphen joins; the boundary-marked variants the v3
+        // vocabulary also carries (" '" = 7306, " -" = 5071) start a new word.
+        for joiner in ["'", "\u{2019}", "-"] {
+            XCTAssertTrue(AsrManager.isJoiningPunctuationPiece(joiner), joiner)
+            XCTAssertFalse(AsrManager.isJoiningPunctuationPiece(" " + joiner), "space-marked " + joiner)
+            XCTAssertFalse(AsrManager.isJoiningPunctuationPiece("▁" + joiner), "boundary-marked " + joiner)
+        }
+        XCTAssertFalse(AsrManager.isJoiningPunctuationPiece(","))
+        XCTAssertEqual(
+            AsrManager.firstWordPieces([" rock", " -", "and", " roll"]), [" rock"],
+            "a boundary-marked hyphen ends the word; it is not absorbed")
+        XCTAssertEqual(AsrManager.firstWordPieces([" rock", "-", "and", " roll"]), [" rock", "-", "and"])
 
         let singlePiece = AsrManager.reconcileFinalWindowSeam(
             previousTokens: [1, 2],  // ▁and ▁well

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -518,20 +518,123 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertNil(AsrManager.trailingWordStartIndex(pieces: []))
     }
 
-    func testReconcileFinalWindowSeam_DropsFragmentSeamCommaAndReemittedWord() {
-        // The comma is not in ASRConstants.punctuationTokens; it is recognized by piece text.
+    /// Clip 03 of the #855 fixtures: previous `▁c ode ▁and ▁an`, re-decode
+    /// `, ▁and ▁anal y z ing`. `an` is a strict prefix of `analyzing`: retire it;
+    /// the seam comma and the re-emitted `and` (dup of the kept `and`@153) go.
+    func testReconcileFinalWindowSeam_FragmentPrefixRetiresAndStripsSeam() {
         let seam = AsrManager.reconcileFinalWindowSeam(
-            previousTokens: [1, 2, 3, 4],  // ▁c ode ▁and ▁an
+            previousTokens: [1, 2, 3, 4],
             previousTimestamps: [147, 149, 153, 156],
             trailingWordStart: 3,
-            currentTokens: [99, 3, 5, 6, 7, 8],  // , ▁and ▁anal y z ing
+            currentTokens: [99, 3, 5, 6, 7, 8],
             currentTimestamps: [152, 155, 159, 162, 164, 166],
             currentPieces: [",", " and", " anal", "y", "z", "ing"],
             previousPieces: [" c", "ode", " and", " an"],
             punctuationTokens: []
         )
-        XCTAssertEqual(seam.droppedPrevious, 1, "the fragment `an` is retired")
-        XCTAssertEqual(seam.droppedCurrent, 2, "seam comma + re-emitted `and` (dup of the kept `and`@153)")
+        XCTAssertEqual(seam.droppedPrevious, 1)
+        XCTAssertEqual(seam.droppedCurrent, 2)
+    }
+
+    /// #897 corpus `99C654B5`: previous `… ▁in ▁the ▁box`, re-decode `x , ▁but …`.
+    /// The leading `x` is a continuation piece — the tail of `box`, whose start
+    /// fell under the cutoff — so `box` is kept and `x` dropped; the comma is
+    /// real. The first version of this rule produced `in thex`.
+    func testReconcileFinalWindowSeam_ContinuationHeadKeepsPreviousWord() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3],
+            previousTimestamps: [300, 303, 306],
+            trailingWordStart: 2,
+            currentTokens: [30, 99, 31, 32],
+            currentTimestamps: [308, 309, 311, 314],
+            currentPieces: ["x", ",", " but", " she"],
+            previousPieces: [" in", " the", " box"],
+            punctuationTokens: []
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0, "`but` is not `box` nor an extension of it")
+        XCTAssertEqual(seam.droppedCurrent, 1, "only the continuation tail `x` goes; the comma stays")
+    }
+
+    /// #897 corpus `0A575FDA`: previous `… ▁capture ▁every`, re-decode
+    /// `turing ▁everything ▁saying`. The continuation `turing` is dropped, and
+    /// `every` is a strict prefix of `everything`: retire the fragment.
+    func testReconcileFinalWindowSeam_ContinuationThenPrefixRetires() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2],
+            previousTimestamps: [400, 404],
+            trailingWordStart: 1,
+            currentTokens: [40, 41, 42],
+            currentTimestamps: [407, 409, 414],
+            currentPieces: ["turing", " everything", " saying"],
+            previousPieces: [" capture", " every"]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 1)
+        XCTAssertEqual(seam.droppedCurrent, 1)
+    }
+
+    /// Same word re-emitted: keep the previous copy (it carries the period the
+    /// re-decode omits at the audio end) and drop the re-emission as a duplicate.
+    func testReconcileFinalWindowSeam_SameWordKeepsPreviousAndDropsReemission() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4],  // … ▁them ▁out .
+            previousTimestamps: [250, 254, 258, 261],
+            trailingWordStart: 2,
+            currentTokens: [3, 9],
+            currentTimestamps: [259, 270],
+            currentPieces: [" out", " uh"],
+            previousPieces: [" help", " them", " out", "."]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0)
+        XCTAssertEqual(seam.droppedCurrent, 1)
+    }
+
+    /// #897 corpus doubled-word shape: previous `… ▁two .`, re-decode `. ▁two ▁in`.
+    /// The re-emitted period duplicates the kept one and the word behind it
+    /// duplicates `two`: both go, nothing is retired.
+    func testReconcileFinalWindowSeam_DuplicatePunctuationThenWordBothDropped() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 7883],  // ▁or ▁two .
+            previousTimestamps: [200, 203, 205],
+            trailingWordStart: 1,
+            currentTokens: [7883, 2, 5],
+            currentTimestamps: [204, 206, 212],
+            currentPieces: [".", " two", " in"],
+            previousPieces: [" or", " two", "."]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0)
+        XCTAssertEqual(seam.droppedCurrent, 2)
+    }
+
+    /// A different word overlapping the previous word's span (`properly.` vs
+    /// `correctly.`): the re-decode disagrees with more context — retire.
+    func testReconcileFinalWindowSeam_DifferentOverlappingWordRetires() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 7883],
+            previousTimestamps: [100, 104, 108],
+            trailingWordStart: 1,
+            currentTokens: [9, 7883, 10],
+            currentTimestamps: [105, 109, 120],
+            currentPieces: [" correctly", ".", " and"],
+            previousPieces: [" it", " properly", "."]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 2)
+        XCTAssertEqual(seam.droppedCurrent, 0)
+    }
+
+    /// A different word that starts *after* the previous word's span: the
+    /// re-decode skipped the previous word — keep it, drop nothing.
+    func testReconcileFinalWindowSeam_LaterWordKeepsPrevious() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3],
+            previousTimestamps: [100, 104, 108],
+            trailingWordStart: 2,
+            currentTokens: [9, 10],
+            currentTimestamps: [130, 134],
+            currentPieces: [" later", " words"],
+            previousPieces: [" a", " b", " kept"]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0)
+        XCTAssertEqual(seam.droppedCurrent, 0)
     }
 
     func testIsPunctuationPiece() {
@@ -543,79 +646,18 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertFalse(AsrManager.isPunctuationPiece(""))
     }
 
-    func testReconcileFinalWindowSeam_KeepsGenuineLeadingTokens() {
-        // Current starts with a new word that duplicates nothing: nothing dropped from it.
-        let seam = AsrManager.reconcileFinalWindowSeam(
-            previousTokens: [1, 2, 3],
-            previousTimestamps: [100, 104, 108],
-            trailingWordStart: 2,
-            currentTokens: [9, 10],
-            currentTimestamps: [110, 114],
-            punctuationTokens: [7883]
-        )
-        XCTAssertEqual(seam.droppedPrevious, 1)
-        XCTAssertEqual(seam.droppedCurrent, 0)
-        // Punctuation after the last word start is real, not a seam artifact.
-        let late = AsrManager.reconcileFinalWindowSeam(
-            previousTokens: [1, 2, 3],
-            previousTimestamps: [100, 104, 108],
-            trailingWordStart: 2,
-            currentTokens: [7883, 9],
-            currentTimestamps: [120, 124],
-            punctuationTokens: [7883]
-        )
-        XCTAssertEqual(late.droppedCurrent, 0)
-        // The final window re-emitted nothing for the previous word (empty flush,
-        // or only tokens before its onset): keep the previous word, drop nothing.
-        let emptyFinal = AsrManager.reconcileFinalWindowSeam(
-            previousTokens: [1, 2, 3, 4],  // … ▁them ▁out .
-            previousTimestamps: [250, 254, 258, 261],
-            trailingWordStart: 2,
-            currentTokens: [],
-            currentTimestamps: []
-        )
-        XCTAssertEqual(emptyFinal.droppedPrevious, 0, "nothing re-emitted the word; the tail must survive")
-        XCTAssertEqual(emptyFinal.droppedCurrent, 0)
+    func testReconcileFinalWindowSeam_EmptyEarlyAndDegenerateInputsKeepPrevious() {
+        let empty = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4], previousTimestamps: [250, 254, 258, 261], trailingWordStart: 2,
+            currentTokens: [], currentTimestamps: [])
+        XCTAssertEqual(empty.droppedPrevious, 0)
+        XCTAssertEqual(empty.droppedCurrent, 0)
+        // Only a punctuation before the previous word's onset: nothing re-emitted.
         let earlyOnly = AsrManager.reconcileFinalWindowSeam(
-            previousTokens: [1, 2, 3, 4],
-            previousTimestamps: [250, 254, 258, 261],
-            trailingWordStart: 2,
-            currentTokens: [7883],
-            currentTimestamps: [240],
-            currentPieces: ["."],
-            punctuationTokens: []
-        )
+            previousTokens: [1, 2, 3, 4], previousTimestamps: [250, 254, 258, 261], trailingWordStart: 2,
+            currentTokens: [7883], currentTimestamps: [240], currentPieces: ["."], punctuationTokens: [])
         XCTAssertEqual(earlyOnly.droppedPrevious, 0)
-        // A short final window that ends where the previous one ended re-emits
-        // "out" but not the "."; keep the previous "out." and strip the re-emission.
-        let sameEnd = AsrManager.reconcileFinalWindowSeam(
-            previousTokens: [1, 2, 3, 4],  // … ▁them ▁out .
-            previousTimestamps: [250, 254, 258, 261],
-            trailingWordStart: 2,
-            currentTokens: [3],  // ▁out
-            currentTimestamps: [259]
-        )
-        XCTAssertEqual(sameEnd.droppedPrevious, 0, "re-decode saw no more audio than the previous window")
-        XCTAssertEqual(sameEnd.droppedCurrent, 1, "the re-emitted `out` duplicates the kept one")
-        // The re-decode saw more audio but its first word IS the previous last
-        // word: it was complete, so keep the previous copy (with its period) and
-        // drop the re-emission. Only a *different* first word retires it.
-        let sameWord = AsrManager.reconcileFinalWindowSeam(
-            previousTokens: [1, 2, 3, 4],  // … ▁them ▁out .
-            previousTimestamps: [250, 254, 258, 261],
-            trailingWordStart: 2,
-            currentTokens: [3, 9],  // ▁out <silence-token>
-            currentTimestamps: [259, 270],
-            currentPieces: [" out", " uh"],
-            previousPieces: [" help", " them", " out", "."]
-        )
-        XCTAssertEqual(sameWord.droppedPrevious, 0)
-        XCTAssertEqual(sameWord.droppedCurrent, 1)
-        XCTAssertEqual(AsrManager.wordCore([" out", "."]), "out")
-        XCTAssertEqual(AsrManager.wordCore([" anal", "y", "z", "ing"]), "analyzing")
-        XCTAssertEqual(AsrManager.firstWordPieces([",", " and", " anal", "y"]), [" and"])
-        XCTAssertEqual(AsrManager.firstWordPieces([" anal", "y", "z", "ing", " if"]), [" anal", "y", "z", "ing"])
-        // Degenerate inputs are a no-op.
+        XCTAssertEqual(earlyOnly.droppedCurrent, 1, "punctuation before the previous word's onset is a seam artifact")
         XCTAssertEqual(
             AsrManager.reconcileFinalWindowSeam(
                 previousTokens: [1], previousTimestamps: [5], trailingWordStart: 0,

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -662,7 +662,43 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
             punctuationTokens: []
         )
         XCTAssertEqual(seam.droppedPrevious, 0)
-        XCTAssertEqual(seam.droppedCurrent, 2, "both pieces of the re-emitted `out` go; the comma and `and` stay")
+        XCTAssertEqual(
+            seam.droppedCurrent, 3,
+            "both pieces of the re-emitted `out` go, and so does the comma behind it: the kept `out.` already carries its punctuation"
+        )
+    }
+
+    /// Punctuation policy, the other way round: the kept previous word has no
+    /// trailing punctuation, so the re-decoded period is the only one and stays.
+    func testReconcileFinalWindowSeam_SameWordKeepsRedecodedPunctuationWhenPreviousHasNone() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2],  // ▁them ▁out
+            previousTimestamps: [254, 258],
+            trailingWordStart: 1,
+            currentTokens: [2, 7883, 50],  // ▁out . ▁and
+            currentTimestamps: [259, 261, 270],
+            currentPieces: [" out", ".", " and"],
+            previousPieces: [" them", " out"]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0)
+        XCTAssertEqual(seam.droppedCurrent, 1, "only the re-emitted word; its period is the only one")
+    }
+
+    /// A genuine later repetition of the same word (`go` … `go again`) must not
+    /// be consumed: the same-word rule applies only when the re-emission starts
+    /// within the previous word's span.
+    func testReconcileFinalWindowSeam_LaterRepetitionOfSameWordIsKept() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2],  // ▁let's ▁go
+            previousTimestamps: [96, 100],
+            trailingWordStart: 1,
+            currentTokens: [30, 2, 31],  // o ▁go ▁again
+            currentTimestamps: [103, 115, 119],
+            currentPieces: ["o", " go", " again"],
+            previousPieces: [" let's", " go"]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0)
+        XCTAssertEqual(seam.droppedCurrent, 1, "only the continuation head; the later `go` is a new word")
     }
 
     /// Adversarial for the prefix rule: a continuation head followed by a new


### PR DESCRIPTION
Follow-up to #903, driven by @saurabhav88's corpus run on it (https://github.com/FluidInference/FluidAudio/pull/903#issuecomment-5613405312). Their correction was right: the #903 rule deleted `box` on one recording (`in the box` → `in thex`), the same failure class the PR set out to fix.

## Why frames can't decide it

Two shapes reach the retire decision with identical frame relations:

- `capture every` + `turing everything saying`: the continuation head `turing` is the tail of the *earlier* word; `everything` replaces the fragment `every`. Retire is right.
- `in the box` + `x, but she's …`: the continuation head `x` is the tail of the retired word itself; `but` is the next word. Retire deletes `box`.

What separates them is text, the premise the reconciliation already rested on: an edge-cut word is a **prefix** of the word that replaces it.

## Rules (each a unit test on the corpus/fixture token shapes)

1. Leading continuation pieces are the tail of the previous last word: dropped, never a reason to retire.
2. The first real word decides. Same word → keep the previous copy (it carries the sentence-final punctuation a re-decode at the audio end omits) and drop the re-emission. Previous text a strict prefix of it (`an`→`analyzing`, `every`→`everything`) → retire. A different word overlapping the previous span **and started by the re-decode itself** (no continuation head) → retire; it disagrees with more context (`properly.` → `correctly.`, which the reporter's prefix-only refinement left doubled). A different word starting later → keep.
3. Retiring still requires the re-decode to reach past the previous window's last frame.
4. Head duplicates of kept previous tokens, punctuation included, are stripped. This closes the `sentence or two. . two in the` shape that the prefix-only refinement produced: the re-emitted period duplicates the kept one, and the word behind it duplicates `two`.

## Review round

- **Same word, different segmentation.** Keeping the previous word relied on id-level duplicate matching to drop the re-emission; a re-decode that spells the same word with other pieces, casing or punctuation would have left both copies. The same-word branch now consumes the re-emitted word's whole piece range explicitly. Test: `▁out` kept vs `▁o` `ut` `,` re-emitted.
- **Piece arrays are required.** With the default `[]`, every unknown piece read as a continuation and the entire current window was dropped. Both piece arrays must now be aligned with their token arrays, otherwise the function is a no-op. Tests for missing and misaligned arrays.
- **Prefix rule bounded in time.** The adversarial shape from the review, a continuation head followed by a new word that merely extends the previous text (`an` … `another`), no longer retires: the replacement of a fragment must start within the previous word's span (plus jitter); a later word is a new word. Test added. This makes the rule a bounded heuristic rather than a proof, and the corpus decides the policy.

All fourteen unit cases were simulated against the decision logic before pushing. Public clips unchanged.

### Round 2

- **Same-word consumption needs the overlap condition.** A genuine later repetition (`go` … `go again`) was consumed whenever its text matched. The same-word rule now applies only when the re-emission starts within the previous word's span; a later same word is a new word. Test added.
- **Punctuation policy behind a consumed re-emission.** The kept previous copy already carries its trailing punctuation, so the re-decode's punctuation behind the consumed word is a duplicate and goes (`out.` kept, `o ut ,` consumed → `out. and`, not `out., and`). When the previous copy has no trailing punctuation, the re-decoded punctuation is the only one and stays (`out` + `out .` → `out. and`). Both directions tested; the segmentation test now expects the comma consumed.

Fifteen unit cases simulated against the decision logic before pushing. Public clips unchanged.

### Round 3

- **Lossy comparison form.** `wordCore` stripped every punctuation scalar, so `well` and `we'll` (or `cant` and `can't`) compared equal and the same-word branch would keep the earlier wrong word over the re-decoded contraction. The comparison form now keeps interior apostrophes and hyphens (curly apostrophes normalized), stripping only the boundary marker and surrounding whitespace/punctuation. A joining apostrophe/hyphen piece between two continuation pieces is absorbed into the word for the first-word scan, the same-word consumption and the continuation-head scan. Regression: `well` vs `we'll` in both tokenizations retires `well` as a different overlapping word.

Seventeen unit cases simulated against the decision logic before pushing. Public clips unchanged.

### Round 6

- **Trailing-punctuation cleanup stops at the next word.** After keeping a punctuated previous word (`said` `.`), the same-word cleanup walked forward over any punctuation piece, so a boundary-marked apostrophe that begins the next word (`▁'` `cause`) was swallowed and the transcript read `said cause more`. Both that loop and the generic head punctuation rule now skip pieces that start a word (`startsWordPiece`), the same guard round 4 added for joiners. Regression asserts only the re-emitted `said` is dropped and `'cause more` is intact, and that the head rule spares a word-starting apostrophe before the previous word's onset.

Twenty-one unit cases simulated against the decision logic before pushing. Public clips unchanged (chunk-7 output for clips 01/02 is byte-identical to `main`).

### Round 5

- **Leading-apostrophe words.** `▁'` `cause` is one word, not leading punctuation plus a stray continuation. `startsWordPiece` recognizes a boundary-marked apostrophe/hyphen immediately followed by a continuation piece as the first piece of that word, for both the first-word scan and the first-word index; same-word consumption now covers exactly `'cause` instead of skipping it and consuming `every`. Test added.
- **Punctuation classified by piece text only.** The reconciliation no longer consults `ASRConstants.punctuationTokens`. Verified against the installed v3 vocabulary: 7883 is `.`, but 7952 is `й` and 7948 is `ó`, while `?` and `!` are 7956 and 8020. Piece text is mandatory here, so it is the only classifier; a word starting with id 7948 is no longer dropped as a seam artifact. The constant's other uses (`TdtDecoderV3`, the dedup punctuation rule) are a separate pre-existing bug, filed as its own issue.

Nineteen unit cases simulated against the decision logic before pushing. Public clips unchanged.

### Round 4

- **Boundary-marked apostrophes and hyphens are not joiners.** The joiner classifier stripped the boundary marker before deciding, so the v3 vocabulary's boundary-marked variants (`" '"` = 7306, `" -"` = 5071) counted as joiners; the continuation-head scan could discard a new word's leading punctuation plus the piece after it, and `wordExtent` could cross a real word boundary. A joiner must now not start a word; the bare pieces (`'` = 7931, `-` = 7918, curly apostrophe) still join. Tests cover both forms of both characters and a hyphenated first-word extent in each form.

## Verification

Release, M5 Pro: clip 03 seam still equals batch (`code and analyzing`); clips 01/02/03 keep their tails at chunk sizes 7 / 10 / 11 (the chunk-10 `help them out` without a period is the decoder's rendering for that window cut, identical on `main`); repro-2 5/5; boosted streaming paths unchanged. The `box` and `every` shapes are unit-tested from the reporter's traces; I can't run them here.

@saurabhav88 this is the revision to put through the corpus. The prediction from your table: `99C654B5` returns to `in the box`, `0A575FDA` becomes `everything`, the three doubled-word recordings from the prefix refinement stay single, and `properly.` → `correctly.` retires as in `pr903`. If the distance column still doesn't move, I'll take that as the signal you described and stop refining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UHoFANi4DcvU6TzyTPnHH





