### PR TITLE
fix(asr): resolve sentence-final punctuation ids from the loaded vocabulary (#905)

### DIFF
--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+TokenProcessing.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+TokenProcessing.swift
@@ -131,11 +131,14 @@ extension AsrManager {
         previous: [Int], current: [Int], maxOverlap: Int = 12,
         previousTimestamps: [Int]? = nil,
         currentTimestamps: [Int]? = nil,
-        frameTolerance: Int = ASRConstants.duplicateFrameTolerance
+        frameTolerance: Int = ASRConstants.duplicateFrameTolerance,
+        punctuationTokens: Set<Int>? = nil
     ) -> (deduped: [Int], removedCount: Int) {
 
-        // Handle single punctuation token duplicates first (domain-specific)
-        let punctuationTokens = ASRConstants.punctuationTokens
+        // Handle single punctuation token duplicates first (domain-specific).
+        // Ids are resolved from the loaded vocabulary (issue #905); the v3
+        // constant is only the fallback for callers without one.
+        let punctuationTokens = punctuationTokens ?? Set(ASRConstants.punctuationTokens)
         var workingCurrent = current
         var workingCurrentTimestamps = currentTimestamps
         var removedCount = 0

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -461,7 +461,8 @@ extension AsrManager {
             let (deduped, removedCount) = removeDuplicateTokenSequence(
                 previous: effectivePrevious, current: currentTokens,
                 previousTimestamps: effectivePreviousTimestamps,
-                currentTimestamps: currentGlobalTimestamps)
+                currentTimestamps: currentGlobalTimestamps,
+                punctuationTokens: punctuationTokenIds)
             let adjustedTimestamps =
                 removedCount > 0 ? Array(currentTimestamps.dropFirst(removedCount)) : currentTimestamps
             let adjustedConfidences =

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
@@ -59,10 +59,13 @@ public actor AsrManager {
 
     /// Cached vocabulary loaded once during initialization
     internal var vocabulary: [Int: String] = [:]
+    /// Sentence-final punctuation ids resolved from `vocabulary` (issue #905).
+    internal var punctuationTokenIds: Set<Int> = Set(ASRConstants.punctuationTokens)
     #if DEBUG
     // Test-only setter
     internal func setVocabularyForTesting(_ vocab: [Int: String]) {
         vocabulary = vocab
+        punctuationTokenIds = ASRConstants.punctuationTokenIds(in: vocab)
     }
     #endif
 
@@ -81,6 +84,7 @@ public actor AsrManager {
             self.decoderModel = models.decoder
             self.jointModel = models.joint
             self.vocabulary = models.vocabulary
+            self.punctuationTokenIds = ASRConstants.punctuationTokenIds(in: models.vocabulary)
         }
 
         // Pre-warm caches if possible
@@ -141,6 +145,7 @@ public actor AsrManager {
         self.decoderModel = models.decoder
         self.jointModel = models.joint
         self.vocabulary = models.vocabulary
+        self.punctuationTokenIds = ASRConstants.punctuationTokenIds(in: models.vocabulary)
 
         logger.info("AsrManager loaded successfully with provided models")
     }
@@ -302,6 +307,7 @@ public actor AsrManager {
                 contextFrameAdjustment: contextFrameAdjustment,
                 isLastChunk: isLastChunk,
                 globalFrameOffset: globalFrameOffset,
+                punctuationTokenIds: punctuationTokenIds,
                 emitTokensAfterGlobalFrame: emitTokensAfterGlobalFrame,
                 initialTimeIndexOverride: initialTimeIndexOverride
             )
@@ -322,6 +328,7 @@ public actor AsrManager {
                 globalFrameOffset: globalFrameOffset,
                 language: language,
                 vocabulary: vocabulary,
+                punctuationTokenIds: punctuationTokenIds,
                 emitTokensAfterGlobalFrame: emitTokensAfterGlobalFrame,
                 initialTimeIndexOverride: initialTimeIndexOverride
             )
@@ -347,6 +354,7 @@ public actor AsrManager {
                 contextFrameAdjustment: contextFrameAdjustment,
                 isLastChunk: isLastChunk,
                 globalFrameOffset: globalFrameOffset,
+                punctuationTokenIds: punctuationTokenIds,
                 emitTokensAfterGlobalFrame: emitTokensAfterGlobalFrame,
                 initialTimeIndexOverride: initialTimeIndexOverride
             )

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV2.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV2.swift
@@ -19,6 +19,7 @@ internal struct TdtDecoderV2 {
         contextFrameAdjustment: Int = 0,
         isLastChunk: Bool = false,
         globalFrameOffset: Int = 0,
+        punctuationTokenIds: Set<Int>? = nil,
         emitTokensAfterGlobalFrame: Int? = nil,
         initialTimeIndexOverride: Int? = nil
     ) async throws -> TdtHypothesis {
@@ -33,6 +34,7 @@ internal struct TdtDecoderV2 {
             contextFrameAdjustment: contextFrameAdjustment,
             isLastChunk: isLastChunk,
             globalFrameOffset: globalFrameOffset,
+            punctuationTokenIds: punctuationTokenIds,
             emitTokensAfterGlobalFrame: emitTokensAfterGlobalFrame,
             initialTimeIndexOverride: initialTimeIndexOverride
         )

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV3.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV3.swift
@@ -112,6 +112,7 @@ internal struct TdtDecoderV3: Sendable {
         globalFrameOffset: Int = 0,
         language: Language? = nil,
         vocabulary: [Int: String]? = nil,
+        punctuationTokenIds: Set<Int>? = nil,
         emitTokensAfterGlobalFrame: Int? = nil,
         initialTimeIndexOverride: Int? = nil
     ) async throws -> TdtHypothesis {
@@ -584,10 +585,11 @@ internal struct TdtDecoderV3: Sendable {
         decoderState.lastToken = hypothesis.lastToken
 
         // Clear cached predictor output if ending with punctuation
-        // This prevents punctuation from being duplicated at chunk boundaries
-        if let lastToken = hypothesis.lastToken,
-            ASRConstants.punctuationTokens.contains(lastToken)
-        {
+        // This prevents punctuation from being duplicated at chunk boundaries.
+        // Ids come from the loaded vocabulary (issue #905); the v3 constant is
+        // only the fallback when the caller has none.
+        let punctuation = punctuationTokenIds ?? Set(ASRConstants.punctuationTokens)
+        if let lastToken = hypothesis.lastToken, punctuation.contains(lastToken) {
             decoderState.predictorOutput = nil
             // Keep lastToken for linguistic context - deduplication handles duplicates at higher level
         }

--- a/Sources/FluidAudio/Shared/ASRConstants.swift
+++ b/Sources/FluidAudio/Shared/ASRConstants.swift
@@ -44,8 +44,10 @@ public enum ASRConstants {
     /// vocabulary is available. See issue #905.
     public static let punctuationTokens: [Int] = [7883, 7956, 8020]
 
-    /// Sentence-final punctuation pieces resolved by text.
-    public static let sentenceFinalPunctuation: Set<String> = [".", "?", "!"]
+    /// Sentence-final punctuation pieces resolved by text: ASCII `.` `?` `!`
+    /// plus the ideographic full stop and full-width marks the Japanese
+    /// vocabulary uses (`。` is token 1 there; `?` `!` stay ASCII in it).
+    public static let sentenceFinalPunctuation: Set<String> = [".", "?", "!", "。", "？", "！"]
 
     /// Resolve the sentence-final punctuation token ids (`.` `?` `!`) from a
     /// loaded vocabulary. A piece matches with or without a leading word

--- a/Sources/FluidAudio/Shared/ASRConstants.swift
+++ b/Sources/FluidAudio/Shared/ASRConstants.swift
@@ -36,8 +36,35 @@ public enum ASRConstants {
     /// WER threshold for detailed error analysis in benchmarks
     public static let highWERThreshold: Double = 0.15
 
-    /// Punctuation token IDs (period, question mark, exclamation mark)
-    public static let punctuationTokens: [Int] = [7883, 7952, 7948]
+    /// Sentence-final punctuation token IDs (`.` `?` `!`) in the
+    /// parakeet-tdt-0.6b-v3 vocabulary. Every other shipped vocabulary uses
+    /// different ids (v2: 841/854/885, 110m: 986/1002/1016), so runtime code
+    /// resolves the set from the loaded vocabulary via
+    /// ``punctuationTokenIds(in:)`` and only falls back to this when no
+    /// vocabulary is available. See issue #905.
+    public static let punctuationTokens: [Int] = [7883, 7956, 8020]
+
+    /// Sentence-final punctuation pieces resolved by text.
+    public static let sentenceFinalPunctuation: Set<String> = [".", "?", "!"]
+
+    /// Resolve the sentence-final punctuation token ids (`.` `?` `!`) from a
+    /// loaded vocabulary. A piece matches with or without a leading word
+    /// boundary (`▁` or the space it is normalized to).
+    public static func punctuationTokenIds(in vocabulary: [Int: String]) -> Set<Int> {
+        var ids: Set<Int> = []
+        for (id, piece) in vocabulary {
+            var core = Substring(piece)
+            if core.hasPrefix(sentencePieceWordBoundary) {
+                core = core.dropFirst(sentencePieceWordBoundary.count)
+            } else if core.hasPrefix(" ") {
+                core = core.dropFirst()
+            }
+            if sentenceFinalPunctuation.contains(String(core)) {
+                ids.insert(id)
+            }
+        }
+        return ids
+    }
 
     /// SentencePiece word-boundary marker (U+2581 LOWER ONE EIGHTH BLOCK).
     /// Prefixes tokens that begin a new word in BPE/Unigram tokenization.

--- a/Tests/FluidAudioTests/ASR/Parakeet/ASRConstantsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/ASRConstantsTests.swift
@@ -236,5 +236,12 @@ final class ASRConstantsTests: XCTestCase {
         // A vocabulary without punctuation (EOU) yields an empty set, so the
         // punctuation rules never fire instead of firing on random ids.
         XCTAssertTrue(ASRConstants.punctuationTokenIds(in: [7883: "abc", 7956: "▁xyz"]).isEmpty)
+
+        // Japanese (parakeet-0.6b-ja): `。` is token 1, `?` and `!` stay ASCII,
+        // `、` is a comma and must not count. Full-width `？` `！` resolve too.
+        let japanese: [Int: String] = [
+            0: "<unk>", 1: "。", 2: "▁", 8: "、", 25: "?", 27: "!", 40: "です", 41: "？", 42: "！",
+        ]
+        XCTAssertEqual(ASRConstants.punctuationTokenIds(in: japanese), [1, 25, 27, 41, 42])
     }
 }

--- a/Tests/FluidAudioTests/ASR/Parakeet/ASRConstantsTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/ASRConstantsTests.swift
@@ -214,4 +214,27 @@ final class ASRConstantsTests: XCTestCase {
             XCTAssertEqual(calculatedFrames, frameIndex, "Time -> Samples -> Frames should round-trip correctly")
         }
     }
+
+    // MARK: - Punctuation ids (#905)
+
+    /// The constant only matches the v3 vocabulary; runtime code resolves the
+    /// set from the loaded vocabulary so v2/110m/unified get their own ids and
+    /// non-punctuation pieces at the old v3-guess ids (7952 `й`, 7948 `ó`)
+    /// are never treated as sentence-final punctuation.
+    func testPunctuationTokenIdsResolveFromVocabularyByPieceText() {
+        let v3Shape: [Int: String] = [
+            7877: ",", 7883: ".", 7948: "ó", 7952: "й", 7956: "?", 8020: "!",
+            100: " the", 101: "ing", 102: " '", 103: "...",
+        ]
+        XCTAssertEqual(ASRConstants.punctuationTokenIds(in: v3Shape), [7883, 7956, 8020])
+        XCTAssertEqual(Set(ASRConstants.punctuationTokens), [7883, 7956, 8020])
+
+        // Word-boundary-marked variants resolve too, in both marker forms.
+        let marked: [Int: String] = [1: "▁.", 2: " ?", 3: "▁!", 4: "▁a", 5: "?x"]
+        XCTAssertEqual(ASRConstants.punctuationTokenIds(in: marked), [1, 2, 3])
+
+        // A vocabulary without punctuation (EOU) yields an empty set, so the
+        // punctuation rules never fire instead of firing on random ids.
+        XCTAssertTrue(ASRConstants.punctuationTokenIds(in: [7883: "abc", 7956: "▁xyz"]).isEmpty)
+    }
 }

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowFinalWindowRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowFinalWindowRegressionTests.swift
@@ -113,6 +113,15 @@ final class SlidingWindowFinalWindowRegressionTests: XCTestCase {
         return try await manager.finish()
     }
 
+    /// The shipped v3 vocabulary resolves `.` `?` `!` to 7883 / 7956 / 8020;
+    /// the ids the constant carried before #905 (7952, 7948) are `й` and `ó`.
+    func testPunctuationTokenIdsResolveAgainstShippedV3Vocabulary() async throws {
+        let models = try await loadModels()
+        XCTAssertEqual(ASRConstants.punctuationTokenIds(in: models.vocabulary), [7883, 7956, 8020])
+        XCTAssertEqual(models.vocabulary[7952], "й")
+        XCTAssertEqual(models.vocabulary[7948], "ó")
+    }
+
     func testFinalWindowKeepsTrailingWordsOnRealRecordings() async throws {
         let models = try await loadModels()
         for fixture in fixtures {

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderChunkTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderChunkTests.swift
@@ -256,7 +256,7 @@ final class TdtDecoderChunkTests: XCTestCase {
         var decoderState = try createMockDecoderState(lastToken: 7883, timeJump: 5)  // period token
 
         // Test punctuation token clearing logic
-        let punctuationTokens = [7883, 7952, 7948]  // period, question, exclamation
+        let punctuationTokens = ASRConstants.punctuationTokens  // v3: 7883 `.`, 7956 `?`, 8020 `!` (#905)
         let lastToken = decoderState.lastToken!
 
         XCTAssertTrue(punctuationTokens.contains(lastToken), "Test token should be punctuation")

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -9,11 +9,13 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
 
     // MARK: - AsrManager Token Deduplication Tests
 
-    /// Test punctuation deduplication (Stage 1)
+    /// Test punctuation deduplication (Stage 1). Ids are the v3 vocabulary's
+    /// `.` `?` `!` (7883 / 7956 / 8020); the pre-#905 constant carried 7952 (`й`)
+    /// and 7948 (`ó`) instead, so those must no longer count as punctuation.
     func testRemoveDuplicateTokenSequence_PunctuationDeduplication() async throws {
         let asrManager = AsrManager()
 
-        // Test case: Punctuation token (7883 = period) duplicated at boundary
+        // Period duplicated at the boundary (default fallback = v3 constant).
         let (deduped1, removed1) = asrManager.removeDuplicateTokenSequence(
             previous: [100, 101, 7883],
             current: [7883, 102, 103]
@@ -21,21 +23,43 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertEqual(deduped1, [102, 103], "Should remove duplicate punctuation token")
         XCTAssertEqual(removed1, 1, "Should report 1 removed token")
 
-        // Test case: Comma (7952) duplicated
+        // Question mark duplicated.
         let (deduped2, removed2) = asrManager.removeDuplicateTokenSequence(
-            previous: [200, 201, 7952],
-            current: [7952, 202, 203]
+            previous: [200, 201, 7956],
+            current: [7956, 202, 203]
         )
-        XCTAssertEqual(deduped2, [202, 203], "Should remove duplicate comma")
+        XCTAssertEqual(deduped2, [202, 203], "Should remove duplicate question mark")
         XCTAssertEqual(removed2, 1, "Should report 1 removed token")
 
-        // Test case: Question mark (7948) duplicated
+        // Exclamation mark duplicated.
         let (deduped3, removed3) = asrManager.removeDuplicateTokenSequence(
-            previous: [300, 301, 7948],
-            current: [7948, 302, 303]
+            previous: [300, 301, 8020],
+            current: [8020, 302, 303]
         )
-        XCTAssertEqual(deduped3, [302, 303], "Should remove duplicate question mark")
+        XCTAssertEqual(deduped3, [302, 303], "Should remove duplicate exclamation mark")
         XCTAssertEqual(removed3, 1, "Should report 1 removed token")
+
+        // The old guesses are letters in v3 (`й`, `ó`): a repeated one is not a
+        // punctuation duplicate. Stages 2/3 fall back to ID equality without
+        // timestamps, so use different ids around it to keep them out of play.
+        let (deduped4, removed4) = asrManager.removeDuplicateTokenSequence(
+            previous: [400, 401, 7952],
+            current: [7948, 402, 403]
+        )
+        XCTAssertEqual(deduped4, [7948, 402, 403])
+        XCTAssertEqual(removed4, 0)
+
+        // A vocabulary-resolved set (v2 ids: `.` 841, `?` 854, `!` 885) is
+        // honoured when passed explicitly; the v3 fallback would not match.
+        let v2 = ASRConstants.punctuationTokenIds(in: [841: ".", 854: "?", 885: "!", 7883: "▁the"])
+        XCTAssertEqual(v2, [841, 854, 885])
+        let (deduped5, removed5) = asrManager.removeDuplicateTokenSequence(
+            previous: [500, 501, 854],
+            current: [854, 502, 503],
+            punctuationTokens: v2
+        )
+        XCTAssertEqual(deduped5, [502, 503], "Should remove the v2 question mark")
+        XCTAssertEqual(removed5, 1)
     }
 
     /// Test suffix-prefix overlap (Stage 2)


### PR DESCRIPTION
Fixes #905.

## Problem

`ASRConstants.punctuationTokens` was `[7883, 7952, 7948]`. Against the shipped vocabularies:

| id | comment said | v3 |
|---|---|---|
| 7883 | `.` | `.` |
| 7952 | `?` | `й` |
| 7948 | `!` | `ó` |

The real v3 ids are `?` = 7956 and `!` = 8020, and every other shipped vocabulary uses different ids again (v2: 841/854/885, 110m: 986/1002/1016, unified: 962/977/1007, EOU has no punctuation pieces). So the two consumers, the `TdtDecoderV3` predictor-output clear after a sentence-final token and the dedup single-punctuation rule, never fired for `?`/`!` on v3, never fired at all on v2/110m, and would fire on a `й` or `ó` token.

## Change

- `ASRConstants.punctuationTokenIds(in:)` resolves the set from a loaded vocabulary by piece text (`.` `?` `!`, with or without a word-boundary marker).
- `AsrManager` caches the resolved set alongside `vocabulary` and passes it to both consumers: `TdtDecoderV3.decodeWithTimings` (all three model-version sites, `TdtDecoderV2` forwards it) and `removeDuplicateTokenSequence`.
- The constant is corrected to the v3 ids (`[7883, 7956, 8020]`) and documented as the fallback for callers without a vocabulary. Existing dedup tests that use 7883 without a vocabulary keep working through that fallback.
- Tests: resolver unit test (v3-shaped dictionary, boundary-marked variants, punctuation-free vocabulary yields an empty set) and an assertion against the shipped v3 vocabulary in the fixture test that already loads it. The decoder chunk test that hardcoded the old ids now reads the constant.

## Verification

Release build, M5 Pro, on the four public #855/#897 clips: v3 batch and streaming output at chunk sizes 7 / 10 / 11 is byte-identical to `main`. v2 streaming (the version that now gets punctuation handling for the first time) is also byte-identical to `main` on clips 01 and 02 at chunk sizes 7 / 10 / 11. The `?`-ending chunks in those clips already sit at window ends where the predictor state is reset, so the observable change is confined to seams that end in `?`/`!` mid-utterance.
