### PR TITLE
fix(asr/streaming): re-decode every window on a fresh state; end-align the final window (#897)

### DIFF
--- a/Documentation/ASR/LongTranscription.md
+++ b/Documentation/ASR/LongTranscription.md
@@ -452,6 +452,19 @@ frame, and tokens duplicating a kept previous token inside the jitter region.
 Clip 03 of the fixtures pins it: `code and an, and analyzing` → `code and
 analyzing`, matching batch.
 
+Two refinements the end-aligned window made necessary: the re-decode can
+re-emit the word *before* the previous last word inside the jitter margin, so
+re-emitted earlier words are consumed as whole words before the retire
+decision; and the re-decode's copy of the last word can drift past the margin
+(`out`@247 re-emitted at 253), so the same-word test compares word starts
+within the duplicate tolerance. A genuine fast repetition inside that
+tolerance (`go go again`) is told apart by evidence: the decoder reports the
+tokens it consumed but suppressed before the cutoff, and when the previous
+word is among them at its own frame, the visible copy is a second word and
+stays. With vocabulary boosting the transcript text may hold a replacement
+for the retired word rather than its raw token text, so the manager tracks
+the rendered form of each window's last word and retires that.
+
 **End-aligned final window.** A short final flush window (a 16.9 s clip at
 an 8 s chunk leaves 0.9 s of new audio behind 2 s of left context) yields
 nothing from a fresh state, dropping the last words — the dominant remaining

--- a/Documentation/ASR/LongTranscription.md
+++ b/Documentation/ASR/LongTranscription.md
@@ -397,31 +397,46 @@ which only the V3 decoder implements — v3 and tdtJa models get the
 end-aligned window; v2/tdtCtc110m keep the zero-padded layout
 (`supportsSuppressedPrefix`).
 
-## Streaming Final Window (issue #855)
+## Streaming Windows (issues #855, #897)
 
-`SlidingWindowAsrManager` decodes overlapping windows with a carried decoder
-state and enters each non-final window mid-way (after the left context) so the
-overlap is not re-emitted. The final flush window is different: it can be
-short, and a mid-window entry into a short window with the carried state can
-emit one boundary punctuation and then blank across real trailing speech
-(#855 repro 1, PR #861).
+`SlidingWindowAsrManager` decodes overlapping windows (`[left 2 s | chunk |
+right 2 s]`, so consecutive windows share 4 s of audio). Every window after
+the first is decoded **from frame 0 on a fresh decoder state**
+(`TdtDecoderState.make`, exactly as the batch chunker does for every chunk)
+with an emission cutoff (`AsrManager.redecodePlan`): tokens for audio the
+previous windows already emitted are suppressed at the source, minus a
+5-frame jitter margin that dedup strips.
 
-The final window is therefore decoded from frame 0 with an emission cutoff
-(`AsrManager.lastChunkRedecodePlan`): tokens for audio the previous windows
-already emitted are suppressed at the source, minus a 5-frame jitter margin
-that dedup strips. Two rules make this safe:
+The original design entered each non-final window mid-way with the *carried*
+decoder state so the overlap was not re-emitted. That entry is not safe
+anywhere, and the failures are silent:
 
-- **Fresh decoder state.** The re-decode starts from `TdtDecoderState.make`,
-  exactly as the batch chunker does for every chunk. Re-walking the overlap
-  with the *carried* state — state that already consumed that audio — leaves
-  the decoder emitting blanks for the rest of the window. On three real
-  recordings with a ~12 s final window it produced zero tokens for 9 s of
-  never-seen speech, silently dropping the last 5–24 words (#855 follow-up).
-  The 2 s left context is enough for a fresh state to re-establish itself
-  before the cutoff.
+- **Blank-out after a sentence-final token.** The carried state, having
+  already consumed the overlap, re-walks it and — typically right after a
+  `.` — emits blanks at 0.98 confidence across the rest of the window. On a
+  real recording at a 7 s chunk, window 2 emitted `s.` and then nothing for
+  10 s of clear speech (`can you do me a favor and validate your findings
+  with codex` lost); at 6 s and 8 s different spans of the same clip went
+  missing. The short final flush window showed the same pathology first
+  (#855, PR #861), and the fresh-state re-decode fixed it there (#895);
+  entering *after* the overlap with the carried state instead of re-walking
+  it does not help — the blank-out follows the next `.` just the same.
+- **Re-segmented overlap duplicates.** When the re-walk did not stall, it
+  re-emitted the overlap with a different segmentation that ID-based dedup
+  cannot match (`environment.` → `air environment`), so both survived.
+
+Two rules make the fresh-state re-decode safe:
+
+- **Fresh decoder state.** Re-walking the overlap with the carried state is
+  the failure above; a fresh state has the previous right context plus this
+  window's left context (4 s) to re-establish itself before the cutoff.
 - **Suppression, not dedup, handles the overlap.** A token-dense overlap can
   exceed dedup's bounded search; suppressing at the source keeps dedup's job
-  to the jitter margin.
+  to the jitter margin. For that reason the re-decode path also passes dedup a
+  tolerance of twice the jitter margin (10 frames) instead of the legacy 2 s:
+  with 2 s, a word repeated within 2 s of the seam (`the old code and the net
+  new code`) matched its earlier copy and the bounded substring matcher chopped
+  the whole re-decoded prefix.
 
 **Seam reconciliation (#897).** The previous window's last word may be a
 fragment cut by the window edge (`and an` for `and analyzing`), which dedup
@@ -429,13 +444,22 @@ can never repair: the fragment never equals the full word, a re-emitted single
 token is below the substring matcher's two-token minimum, and a punctuation
 token the decoder attaches at its emission start blocks the suffix–prefix
 match. So the cutoff anchors at the previous window's *last word start*
-(`lastWordStartFrame`), the final window re-decodes that word in full, and
+(`lastWordStartFrame`), the window re-decodes that word in full, and
 `AsrManager.reconcileFinalWindowSeam` retires the previous last word from the
 accumulated tokens and text (`droppedPreviousTokens`) while stripping the
 re-decode's seam artifacts: punctuation emitted at or before that word's
 frame, and tokens duplicating a kept previous token inside the jitter region.
 Clip 03 of the fixtures pins it: `code and an, and analyzing` → `code and
 analyzing`, matching batch.
+
+**End-aligned final window.** A short final flush window (a 16.9 s clip at
+an 8 s chunk leaves 0.9 s of new audio behind 2 s of left context) yields
+nothing from a fresh state, dropping the last words — the dominant remaining
+loss on long LibriSpeech files. The final window is therefore end-aligned to
+span a full chunk plus the left context (`finalWindowStart`), the sample
+buffer keeps that much audio behind the next window center, and the re-decode
+cutoff suppresses what previous windows already emitted, as the batch path
+does since #747.
 
 Regression fixtures: `Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/Fixtures`
 (three real recordings, cleared for release by the speaker), exercised by

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -360,8 +360,9 @@ public actor SlidingWindowAsrManager {
             // Advance by chunk size
             nextWindowCenterStart += chunk
 
-            // Trim buffer to keep only what's needed for left context
-            let trimToAbs = max(0, nextWindowCenterStart - left)
+            // Keep a full chunk plus the left context behind the next center so a
+            // short final flush window can be end-aligned (see `flushRemaining`).
+            let trimToAbs = max(0, nextWindowCenterStart - left - chunk)
             let dropCount = max(0, trimToAbs - bufferStartIndex)
             if dropCount > 0 && dropCount <= sampleBuffer.count {
                 sampleBuffer.removeFirst(dropCount)
@@ -385,14 +386,21 @@ public actor SlidingWindowAsrManager {
             if availableAhead <= 0 { break }
             let effectiveChunk = min(chunk, availableAhead)
 
-            let leftStartAbs = max(0, nextWindowCenterStart - left)
             let rightEndAbs = nextWindowCenterStart + effectiveChunk
+            let isLastWindow = rightEndAbs >= currentAbsEnd
+            // End-align a short final window: a fresh decoder state needs more
+            // than a couple of seconds of audio to emit anything, and the
+            // re-decode cutoff suppresses what previous windows already emitted.
+            let leftStartAbs =
+                isLastWindow
+                ? Self.finalWindowStart(
+                    nextCenterStart: nextWindowCenterStart, effectiveChunk: effectiveChunk, chunk: chunk, left: left)
+                : max(0, nextWindowCenterStart - left)
             let startIdx = max(leftStartAbs - bufferStartIndex, 0)
             let endIdx = max(rightEndAbs - bufferStartIndex, startIdx)
             if startIdx < 0 || endIdx > sampleBuffer.count || startIdx >= endIdx { break }
 
             let window = Array(sampleBuffer[startIdx..<endIdx])
-            let isLastWindow = (nextWindowCenterStart + effectiveChunk) >= currentAbsEnd
             await processWindow(
                 window,
                 windowStartSample: leftStartAbs,
@@ -402,7 +410,7 @@ public actor SlidingWindowAsrManager {
             nextWindowCenterStart += effectiveChunk
 
             // Trim
-            let trimToAbs = max(0, nextWindowCenterStart - left)
+            let trimToAbs = max(0, nextWindowCenterStart - left - chunk)
             let dropCount = max(0, trimToAbs - bufferStartIndex)
             if dropCount > 0 && dropCount <= sampleBuffer.count {
                 sampleBuffer.removeFirst(dropCount)
@@ -447,7 +455,7 @@ public actor SlidingWindowAsrManager {
 
             let (tokens, timestamps, confidences, _, droppedPreviousTokens) = result
 
-            // Final window re-decoded the previous window's last word in full (#897):
+            // The window re-decoded the previous window's last word in full (#897):
             // retire that word from the accumulated tokens and from the text state.
             if droppedPreviousTokens > 0, droppedPreviousTokens < accumulatedTokens.count {
                 let dropped = Array(accumulatedTokens.suffix(droppedPreviousTokens))
@@ -605,6 +613,17 @@ public actor SlidingWindowAsrManager {
                 ? "insufficient context (\(String(format: "%.1f", totalAudioProcessed))s)" : "low confidence"
             logger.debug("VOLATILE (\(result.confidence)): \(reason) - updated volatile '\(result.text)'")
         }
+    }
+
+    /// Start sample of the final flush window: end-aligned so the window spans a
+    /// full chunk plus the left context even when little new audio remains
+    /// (#897). A 2–3 s window decoded from a fresh state emits nothing and the
+    /// last words are lost; the re-decode cutoff makes the longer window safe.
+    /// Never later than the regular `center - left` start. Pure.
+    static func finalWindowStart(nextCenterStart: Int, effectiveChunk: Int, chunk: Int, left: Int) -> Int {
+        let regular = max(0, nextCenterStart - left)
+        let endAligned = max(0, nextCenterStart + effectiveChunk - chunk - left)
+        return min(regular, endAligned)
     }
 
     /// `text` without its trailing `word` when `text` ends with that word as a

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManager.swift
@@ -35,6 +35,11 @@ public actor SlidingWindowAsrManager {
     // accumulatedTokens). Lets per-chunk dedup require temporal adjacency so a
     // coincidental subword-prefix match between far-apart words isn't dropped (#787).
     private var accumulatedTokenTimestamps: [Int] = []
+    /// The previous window's last word as it was appended to the transcript
+    /// text — the vocabulary replacement when rescoring replaced it — so seam
+    /// retirement can remove it even when it no longer equals the raw token
+    /// text (#897).
+    private var lastWindowRenderedLastWord: String?
 
     // Raw sample buffer for sliding-window assembly (absolute indexing)
     private var sampleBuffer: [Float] = []
@@ -169,6 +174,7 @@ public actor SlidingWindowAsrManager {
         lastProcessedFrame = 0
         accumulatedTokens.removeAll()
         accumulatedTokenTimestamps.removeAll()
+        lastWindowRenderedLastWord = nil
         failedWindowCount = 0
         lastWindowError = nil
 
@@ -304,6 +310,7 @@ public actor SlidingWindowAsrManager {
         lastProcessedFrame = 0
         accumulatedTokens.removeAll()
         accumulatedTokenTimestamps.removeAll()
+        lastWindowRenderedLastWord = nil
 
         logger.info("SlidingWindowAsrManager reset for source: \(String(describing: self.audioSource))")
     }
@@ -462,10 +469,18 @@ public actor SlidingWindowAsrManager {
                 accumulatedTokens.removeLast(droppedPreviousTokens)
                 accumulatedTokenTimestamps.removeLast(min(droppedPreviousTokens, accumulatedTokenTimestamps.count))
                 if let droppedText = await asrManager?.convertTokensToText(dropped), !droppedText.isEmpty {
-                    if let trimmed = Self.removingTrailingWord(droppedText, from: volatileTranscript) {
-                        volatileTranscript = trimmed
-                    } else if let trimmed = Self.removingTrailingWord(droppedText, from: confirmedTranscript) {
-                        confirmedTranscript = trimmed
+                    // The text state may hold a vocabulary-rescored replacement
+                    // for that word rather than its raw token text.
+                    let candidates = [droppedText] + (lastWindowRenderedLastWord.map { [$0] } ?? [])
+                    for candidate in candidates {
+                        if let trimmed = Self.removingTrailingWord(candidate, from: volatileTranscript) {
+                            volatileTranscript = trimmed
+                            break
+                        }
+                        if let trimmed = Self.removingTrailingWord(candidate, from: confirmedTranscript) {
+                            confirmedTranscript = trimmed
+                            break
+                        }
                     }
                 }
             }
@@ -523,6 +538,7 @@ public actor SlidingWindowAsrManager {
             // was volatile when decoded (short clip under `minContextForConfirmation`, low
             // confidence, the final flush) would otherwise never see its vocabulary (#851).
             var displayResult = interim
+            var appliedReplacements: [VocabularyRescorer.RescoringResult] = []
             if vocabBoostingEnabled,
                 let chunkLocalResult = await asrManager?.processTranscriptionResult(
                     tokenIds: tokens,
@@ -543,9 +559,8 @@ public actor SlidingWindowAsrManager {
                     tokenTimings: chunkLocalTimings,
                     windowSamples: windowSamples
                 )
-                let applied = (rescored?.replacements ?? []).filter { $0.shouldReplace }.compactMap {
-                    $0.replacementWord
-                }
+                appliedReplacements = (rescored?.replacements ?? []).filter { $0.shouldReplace }
+                let applied = appliedReplacements.compactMap { $0.replacementWord }
                 displayResult = interim.withRescoring(
                     text: rescored?.text ?? interim.text,
                     detected: rescored?.detectedTerms ?? [],
@@ -554,6 +569,8 @@ public actor SlidingWindowAsrManager {
             }
 
             await updateTranscriptionState(with: displayResult, shouldConfirm: shouldConfirm)
+            lastWindowRenderedLastWord = Self.renderedLastWord(
+                rawText: interim.text, renderedText: displayResult.text, replacements: appliedReplacements)
 
             let update = SlidingWindowTranscriptionUpdate(
                 text: displayResult.text,
@@ -624,6 +641,24 @@ public actor SlidingWindowAsrManager {
         let regular = max(0, nextCenterStart - left)
         let endAligned = max(0, nextCenterStart + effectiveChunk - chunk - left)
         return min(regular, endAligned)
+    }
+
+    /// The form in which a window's last word reached the transcript text: the
+    /// vocabulary replacement when rescoring replaced that word (possibly a
+    /// multi-word term), otherwise the last word of the rendered text. Pure.
+    static func renderedLastWord(
+        rawText: String, renderedText: String, replacements: [VocabularyRescorer.RescoringResult]
+    ) -> String? {
+        func core(_ word: String) -> String {
+            word.lowercased().trimmingCharacters(in: .punctuationCharacters.union(.whitespaces))
+        }
+        guard let rawLast = rawText.split(separator: " ").last.map(String.init) else { return nil }
+        if let hit = replacements.last(where: { $0.shouldReplace && core($0.originalWord) == core(rawLast) }),
+            let replacement = hit.replacementWord, !replacement.isEmpty
+        {
+            return replacement
+        }
+        return renderedText.split(separator: " ").last.map(String.init)
     }
 
     /// `text` without its trailing `word` when `text` ends with that word as a

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -261,6 +261,8 @@ extension AsrManager {
         currentTimestamps: [Int],
         currentPieces: [String] = [],
         previousPieces: [String] = [],
+        suppressedPieces: [String] = [],
+        suppressedTimestamps: [Int] = [],
         jitterFrames: Int = redecodeEmissionJitterFrames,
         frameTolerance: Int = 2 * redecodeEmissionJitterFrames
     ) -> (droppedPrevious: Int, droppedCurrent: Int) {
@@ -375,9 +377,17 @@ extension AsrManager {
         // (an end-aligned final window re-emits an edge-decoded `out`@247 at 253),
         // so the same-word test compares word starts within the duplicate
         // tolerance, like the re-emitted earlier words above; a later genuine
-        // repetition (`go … go again`) is further away than that.
+        // repetition (`go … go again`) is further away than that. A fast
+        // repetition inside the tolerance is told apart by evidence: when the
+        // decoder already re-emitted the previous word *before* the cutoff (it
+        // is in the suppressed list at that word's frame), the visible copy is
+        // a second word and stays.
+        let previousWordSuppressed =
+            suppressedPieces.count == suppressedTimestamps.count
+            && words(in: suppressedPieces, timestamps: suppressedTimestamps, upTo: suppressedPieces.count)
+                .contains { $0.core == previousWord && abs($0.frame - lastWordStartFrame) <= frameTolerance }
         var droppedCurrent = consumed
-        if !retire, currentWord == previousWord, let firstIndex = firstWordIndex,
+        if !retire, currentWord == previousWord, !previousWordSuppressed, let firstIndex = firstWordIndex,
             abs(currentTimestamps[firstIndex] - lastWordStartFrame) <= frameTolerance
         {
             var end = wordExtent(in: currentPieces, from: firstIndex)
@@ -498,7 +508,9 @@ extension AsrManager {
                 currentTokens: currentTokens,
                 currentTimestamps: currentTimestamps.map { $0 + globalFrameOffset },
                 currentPieces: currentTokens.map { vocabulary[$0] ?? "" },
-                previousPieces: previousTokens.map { vocabulary[$0] ?? "" }
+                previousPieces: previousTokens.map { vocabulary[$0] ?? "" },
+                suppressedPieces: hypothesis.suppressedTokens.map { vocabulary[$0] ?? "" },
+                suppressedTimestamps: hypothesis.suppressedTimestamps
             )
             droppedPrevious = seam.droppedPrevious
             if seam.droppedCurrent > 0 {

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -52,29 +52,30 @@ extension AsrManager {
         return result
     }
 
-    /// Cross-window emission jitter allowance for the final-window re-decode: a
+    /// Cross-window emission jitter allowance for a window re-decode: a
     /// re-decoded token can land a few frames from its original emission, so the
     /// suppression cutoff backs off this much and dedup strips what remains.
     internal static let redecodeEmissionJitterFrames = 5
 
-    /// Decoder-entry plan for the final streaming window (issue #855).
+    /// Decoder-entry plan for a streaming window that follows accumulated
+    /// tokens (issue #855 for the final window, #897 for every other one).
     ///
     /// Returns `initialTimeIndexOverride: 0` so the decoder re-decodes the window
-    /// from frame 0 (a mid-window entry into a short flush window can blank out
-    /// the trailing speech), plus an emission cutoff in window-local frames:
+    /// from frame 0 (a mid-window entry with the carried state can blank out the
+    /// rest of the window), plus an emission cutoff in window-local frames:
     /// tokens for audio the previous windows already emitted are suppressed at
     /// the source, leaving dedup only the jitter margin. `transcribeChunk` pairs
     /// the frame-0 entry with a *fresh* decoder state — see the note there.
-    /// Non-final windows and callers without accumulated timestamps get `(nil, nil)`
-    /// — the legacy navigation.
-    nonisolated internal static func lastChunkRedecodePlan(
-        isLastChunk: Bool,
+    /// `redecode == false` (the first window) and callers without accumulated
+    /// timestamps get `(nil, nil)` — the legacy navigation.
+    nonisolated internal static func redecodePlan(
+        redecode: Bool,
         previousTokens: [Int],
         previousTokenTimestamps: [Int]?,
         globalFrameOffset: Int,
         lastWordStartFrame: Int? = nil
     ) -> (initialTimeIndexOverride: Int?, emitTokensAfterFrame: Int?) {
-        guard isLastChunk, let previousTimestamps = previousTokenTimestamps, !previousTokens.isEmpty else {
+        guard redecode, let previousTimestamps = previousTokenTimestamps, !previousTokens.isEmpty else {
             return (nil, nil)
         }
         // Anchor the cutoff at the previous window's last *word*, not its last
@@ -97,6 +98,26 @@ extension AsrManager {
             }), idx > 0
         else { return nil }
         return idx
+    }
+
+    /// The words of `pieces[0..<upTo]` as (core text, start frame), for matching
+    /// re-emitted words at the seam. Pure.
+    nonisolated internal static func words(
+        in pieces: [String], timestamps: [Int], upTo: Int
+    ) -> [(core: String, frame: Int)] {
+        var result: [(core: String, frame: Int)] = []
+        var index = 0
+        let limit = min(upTo, pieces.count, timestamps.count)
+        while index < limit {
+            guard startsWordPiece(in: pieces, at: index) else {
+                index += 1
+                continue
+            }
+            let end = min(wordExtent(in: pieces, from: index), limit)
+            result.append((wordCore(Array(pieces[index..<end])), timestamps[index]))
+            index = end
+        }
+        return result
     }
 
     /// A vocabulary piece that is nothing but punctuation once the word
@@ -241,7 +262,7 @@ extension AsrManager {
         currentPieces: [String] = [],
         previousPieces: [String] = [],
         jitterFrames: Int = redecodeEmissionJitterFrames,
-        frameTolerance: Int = ASRConstants.duplicateFrameTolerance
+        frameTolerance: Int = 2 * redecodeEmissionJitterFrames
     ) -> (droppedPrevious: Int, droppedCurrent: Int) {
         // The decision is by piece text, so both piece arrays must be aligned
         // with their token arrays; without them the only safe answer is a no-op
@@ -283,11 +304,37 @@ extension AsrManager {
             }
         }
 
-        // 2. The first real word of the re-decode.
+        // 2. Re-emitted earlier words. The cutoff backs off by the jitter margin,
+        // so the re-decode can re-emit the word(s) *before* the previous last
+        // word (`new` ahead of `code`). Consume them as whole words when the kept
+        // previous output already has that word at the same frame — otherwise
+        // the retire rules below would read a re-emitted `new` as the
+        // replacement for `code`, and a jitter duplicate whose continuation
+        // piece falls a frame outside the margin would leave `uld` behind.
+        let previousWords = words(in: previousPieces, timestamps: previousTimestamps, upTo: trailingWordStart)
+        var consumed = head
+        while consumed < currentTokens.count {
+            if isPunctuation(consumed), !startsWordPiece(in: currentPieces, at: consumed),
+                currentTimestamps[consumed] <= lastWordStartFrame
+            {
+                consumed += 1
+                continue
+            }
+            guard startsWordPiece(in: currentPieces, at: consumed) else { break }
+            let end = wordExtent(in: currentPieces, from: consumed)
+            let core = wordCore(Array(currentPieces[consumed..<end]))
+            let frame = currentTimestamps[consumed]
+            guard frame <= lastWordStartFrame + jitterFrames, !core.isEmpty,
+                previousWords.contains(where: { $0.core == core && abs($0.frame - frame) <= frameTolerance })
+            else { break }
+            consumed = end
+        }
+
+        // 3. The first real word of the re-decode.
         let previousWord = wordCore(previousPieces.dropFirst(trailingWordStart))
-        let firstWord = firstWordPieces(Array(currentPieces.dropFirst(head)))
+        let firstWord = firstWordPieces(Array(currentPieces.dropFirst(consumed)))
         let currentWord = wordCore(firstWord)
-        let firstWordIndex = (head..<currentTokens.count).first { startsWordPiece(in: currentPieces, at: $0) }
+        let firstWordIndex = (consumed..<currentTokens.count).first { startsWordPiece(in: currentPieces, at: $0) }
         let firstWordFrame = firstWordIndex.map { currentTimestamps[$0] }
 
         let overlapsPrevious = firstWordFrame.map { $0 <= previousLastFrame + jitterFrames } ?? false
@@ -321,8 +368,15 @@ extension AsrManager {
         // word, consume that word's whole piece range explicitly — its
         // segmentation, casing or punctuation may differ from the kept copy,
         // so id-level duplicate matching cannot be relied on for it.
-        var droppedCurrent = head
-        if !retire, currentWord == previousWord, overlapsPrevious, let firstIndex = firstWordIndex {
+        // The re-decode's copy of the last word can drift past the jitter margin
+        // (an end-aligned final window re-emits an edge-decoded `out`@247 at 253),
+        // so the same-word test compares word starts within the duplicate
+        // tolerance, like the re-emitted earlier words above; a later genuine
+        // repetition (`go … go again`) is further away than that.
+        var droppedCurrent = consumed
+        if !retire, currentWord == previousWord, let firstIndex = firstWordIndex,
+            abs(currentTimestamps[firstIndex] - lastWordStartFrame) <= frameTolerance
+        {
             var end = wordExtent(in: currentPieces, from: firstIndex)
             // Punctuation policy: the kept previous copy already carries its own
             // trailing punctuation, so the re-decode's is a duplicate — drop it.
@@ -372,29 +426,26 @@ extension AsrManager {
         let (alignedSamples, frameAlignedLength) = frameAlignedAudio(
             chunkSamples, allowAlignment: previousTokens.isEmpty)
         let padded = padAudioIfNeeded(alignedSamples, targetLength: ASRConstants.maxModelSamples)
-        // Last streaming window: decode from frame 0 instead of skipping the overlap.
-        // Jumping mid-window into a short flush window can blank out the trailing
-        // speech entirely (issue #855: the joint emits a boundary punctuation, then
-        // blanks to the end, dropping the final words). Emissions for audio the
-        // previous windows already covered are suppressed at the source, so dedup
-        // only sees the few-frame jitter margin — a token-dense overlap cannot
-        // outgrow dedup's bounded search.
-        //
-        // The re-decode runs on a FRESH decoder state, as the batch chunker does
-        // for every chunk. Re-walking the overlap with the carried state — state
-        // that already consumed that audio — leaves the decoder emitting blanks
-        // for the rest of the window: on a 12 s final window it produced zero
-        // tokens for 9 s of never-seen speech (#855 follow-up, three real
-        // recordings). The 2 s left context is enough for a fresh state to
-        // re-establish itself before the cutoff.
-        // The previous window's last word is re-decoded in full by the final
-        // window and dropped from the accumulated output afterwards (#897).
+        // Every streaming window after the first decodes from frame 0 on a FRESH
+        // decoder state, as the batch chunker does for every chunk, with emissions
+        // for audio the previous windows already covered suppressed at the source
+        // (issue #855 for the final window, #897 for the interior ones). Entering
+        // a window mid-way with the carried state — state that already consumed
+        // the overlap — is not safe anywhere: after a sentence-final token it can
+        // blank across the rest of the window (10 s of speech lost at chunk 7 on
+        // a real recording), and re-walking the overlap re-emits it with a
+        // different segmentation that dedup cannot match (`environment` vs
+        // `air environment`). The 2 s left context plus the previous right
+        // context give the fresh state 4 s to re-establish itself before the
+        // cutoff. The previous window's last word is re-decoded in full and
+        // reconciled afterwards (#897).
+        let redecodeWindow = isLastChunk || !previousTokens.isEmpty
         let trailingWordStart: Int? =
-            isLastChunk && previousTokenTimestamps?.count == previousTokens.count
+            redecodeWindow && previousTokenTimestamps?.count == previousTokens.count
             ? Self.trailingWordStartIndex(pieces: previousTokens.map { vocabulary[$0] ?? "" })
             : nil
-        let redecodePlan = Self.lastChunkRedecodePlan(
-            isLastChunk: isLastChunk,
+        let redecodePlan = Self.redecodePlan(
+            redecode: redecodeWindow,
             previousTokens: previousTokens,
             previousTokenTimestamps: previousTokenTimestamps,
             globalFrameOffset: globalFrameOffset,
@@ -422,9 +473,9 @@ extension AsrManager {
         var effectivePreviousTimestamps = previousTokenTimestamps
         var droppedPrevious = 0
 
-        // Final window: replace the previous window's (possibly edge-cut) last
-        // word with the re-decoded one, and strip the seam artifacts the
-        // re-decode emits ahead of it (#897).
+        // Replace the previous window's (possibly edge-cut) last word with the
+        // re-decoded one, and strip the seam artifacts the re-decode emits
+        // ahead of it (#897).
         if redecodePlan.initialTimeIndexOverride == 0, let trailingWordStart,
             let previousTimestamps = previousTokenTimestamps
         {
@@ -447,7 +498,7 @@ extension AsrManager {
             effectivePreviousTimestamps = Array(previousTimestamps.prefix(trailingWordStart))
             if droppedPrevious > 0 || seam.droppedCurrent > 0 {
                 logger.debug(
-                    "Final-window seam: dropped \(droppedPrevious) trailing previous token(s), \(seam.droppedCurrent) leading current token(s)"
+                    "Window seam: dropped \(droppedPrevious) trailing previous token(s), \(seam.droppedCurrent) leading current token(s)"
                 )
             }
         }
@@ -458,10 +509,19 @@ extension AsrManager {
             // space as `previousTokenTimestamps` so dedup can require temporal adjacency.
             let currentGlobalTimestamps: [Int]? =
                 effectivePreviousTimestamps != nil ? currentTimestamps.map { $0 + globalFrameOffset } : nil
+            // A re-decoded window only leaks duplicates inside the jitter margin
+            // (suppression handles the rest), so the matcher must not reach
+            // across it: with the legacy 2 s tolerance a word repeated within
+            // 2 s of the seam (`old code and the net new code`) matched its
+            // earlier copy and dedup chopped the whole re-decoded prefix.
+            let tolerance =
+                redecodePlan.initialTimeIndexOverride == 0
+                ? 2 * Self.redecodeEmissionJitterFrames : ASRConstants.duplicateFrameTolerance
             let (deduped, removedCount) = removeDuplicateTokenSequence(
                 previous: effectivePrevious, current: currentTokens,
                 previousTimestamps: effectivePreviousTimestamps,
                 currentTimestamps: currentGlobalTimestamps,
+                frameTolerance: tolerance,
                 punctuationTokens: punctuationTokenIds)
             let adjustedTimestamps =
                 removedCount > 0 ? Array(currentTimestamps.dropFirst(removedCount)) : currentTimestamps

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Transcription.swift
@@ -348,11 +348,14 @@ extension AsrManager {
             // later word that merely happens to extend the previous text
             // (`an` … `another`) is a new word; keep the previous one.
             retire = true
-        } else if head == 0, overlapsPrevious {
-            // Overlapping different word, and the re-decode started it itself
-            // (no continuation head): it disagrees with more context. Behind a
-            // continuation head the first real word is the *next* word by
-            // construction (`box` + `x, but`), so only the prefix rule applies.
+        } else if head == 0 || currentTimestamps[0] < lastWordStartFrame, overlapsPrevious {
+            // Overlapping different word, and the re-decode started it itself:
+            // it disagrees with more context (`Savior.` → `Saviour`). A
+            // continuation head that belongs to the previous *last* word makes
+            // the first real word the *next* word by construction (`box` +
+            // `x, but`), so only the prefix rule applies there; a head that
+            // continues an earlier word (`ist` of `Christ` ahead of `Savior`)
+            // says nothing about the last word.
             retire = true
         } else {
             retire = false
@@ -391,20 +394,29 @@ extension AsrManager {
             }
             droppedCurrent = end
         }
-        for index in droppedCurrent..<currentTokens.count {
-            let id = currentTokens[index]
+        // Jitter duplicates of kept previous tokens are stripped word by word: a
+        // word-start piece goes only together with its continuation pieces, and
+        // only when every piece of the word matches (`S` alone must not go and
+        // leave `aviour` behind).
+        var index = droppedCurrent
+        while index < currentTokens.count {
             let frame = currentTimestamps[index]
             if isPunctuation(index), !startsWordPiece(in: currentPieces, at: index), frame <= lastWordStartFrame {
-                droppedCurrent += 1
+                index += 1
+                droppedCurrent = index
                 continue
             }
-            if frame <= keptLastFrame + jitterFrames,
-                keptPrevious.contains(where: { $0.0 == id && abs($0.1 - frame) <= frameTolerance })
-            {
-                droppedCurrent += 1
-                continue
+            guard frame <= keptLastFrame + jitterFrames else { break }
+            let end =
+                startsWordPiece(in: currentPieces, at: index) ? wordExtent(in: currentPieces, from: index) : index + 1
+            let duplicated = (index..<end).allSatisfy { position in
+                keptPrevious.contains(where: {
+                    $0.0 == currentTokens[position] && abs($0.1 - currentTimestamps[position]) <= frameTolerance
+                })
             }
-            break
+            guard duplicated else { break }
+            index = end
+            droppedCurrent = index
         }
         return (droppedPrevious, droppedCurrent)
     }

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV3.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtDecoderV3.swift
@@ -425,6 +425,9 @@ internal struct TdtDecoderV3: Sendable {
                     hypothesis.timestamps.append(emissionTimestamp)
                     hypothesis.tokenConfidences.append(score)
                     hypothesis.tokenDurations.append(duration)
+                } else {
+                    hypothesis.suppressedTokens.append(label)
+                    hypothesis.suppressedTimestamps.append(emissionTimestamp)
                 }
                 hypothesis.lastToken = label  // Remember for next iteration
 
@@ -553,6 +556,9 @@ internal struct TdtDecoderV3: Sendable {
                         hypothesis.timestamps.append(finalTimestamp)
                         hypothesis.tokenConfidences.append(score)
                         hypothesis.tokenDurations.append(duration)
+                    } else {
+                        hypothesis.suppressedTokens.append(token)
+                        hypothesis.suppressedTimestamps.append(finalTimestamp)
                     }
                     hypothesis.lastToken = token
 

--- a/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtHypothesis.swift
+++ b/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/Decoder/TdtHypothesis.swift
@@ -7,6 +7,12 @@ struct TdtHypothesis {
     var timestamps: [Int] = []
     var tokenDurations: [Int] = []
     var tokenConfidences: [Float] = []
+    /// Tokens the decoder consumed but did not emit because they fell before
+    /// the caller's emission cutoff (a window re-decode of audio previous
+    /// windows already covered), with their global frames. Seam reconciliation
+    /// reads them as evidence of what the re-decode saw (#897).
+    var suppressedTokens: [Int] = []
+    var suppressedTimestamps: [Int] = []
     /// Last non-blank token decoded in this hypothesis.
     /// Used to initialize the decoder for the next chunk, maintaining context across chunk boundaries.
     var lastToken: Int?

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
@@ -320,6 +320,32 @@ final class SlidingWindowAsrManagerTests: XCTestCase {
         XCTAssertEqual(SlidingWindowAsrManager.appendingVolatile("", "only"), "only")
     }
 
+    /// Seam retirement removes the previous window's last word from the text
+    /// state; with vocabulary boosting that text may carry a replacement, so
+    /// the rendered form is tracked (#897 review).
+    func testRenderedLastWordUsesVocabularyReplacement() {
+        typealias R = VocabularyRescorer.RescoringResult
+        let hit = R(
+            originalWord: "codecs", originalScore: 0.2, replacementWord: "Codex", replacementScore: 0.9,
+            shouldReplace: true, reason: "test")
+        let miss = R(
+            originalWord: "favor", originalScore: 0.5, replacementWord: "flavor", replacementScore: 0.4,
+            shouldReplace: false, reason: "test")
+        XCTAssertEqual(
+            SlidingWindowAsrManager.renderedLastWord(
+                rawText: "validate with codecs?", renderedText: "validate with Codex?", replacements: [hit, miss]),
+            "Codex")
+        XCTAssertEqual(
+            SlidingWindowAsrManager.renderedLastWord(
+                rawText: "help them out.", renderedText: "help them out.", replacements: [hit]),
+            "out.")
+        XCTAssertNil(SlidingWindowAsrManager.renderedLastWord(rawText: "", renderedText: "", replacements: []))
+        // The retirement path tries the raw text first, then the rendered form.
+        XCTAssertNil(SlidingWindowAsrManager.removingTrailingWord("codecs?", from: "validate with Codex?"))
+        XCTAssertEqual(
+            SlidingWindowAsrManager.removingTrailingWord("Codex?", from: "validate with Codex?"), "validate with")
+    }
+
     /// The final flush window is end-aligned to a full chunk plus the left
     /// context (#897): a 2–3 s window decoded from a fresh state emits nothing.
     func testFinalWindowStartIsEndAligned() {

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowAsrManagerTests.swift
@@ -318,6 +318,28 @@ final class SlidingWindowAsrManagerTests: XCTestCase {
     func testAppendingVolatileIgnoresEmptyFlushWindow() {
         XCTAssertEqual(SlidingWindowAsrManager.appendingVolatile("first window", ""), "first window")
         XCTAssertEqual(SlidingWindowAsrManager.appendingVolatile("", "only"), "only")
+    }
+
+    /// The final flush window is end-aligned to a full chunk plus the left
+    /// context (#897): a 2–3 s window decoded from a fresh state emits nothing.
+    func testFinalWindowStartIsEndAligned() {
+        let s = 16_000
+        // 0.9 s of new audio behind center 16 s, chunk 8 s, left 2 s: regular
+        // start would be 14 s; end-aligned start is 16.9 - 10 = 6.9 s.
+        XCTAssertEqual(
+            SlidingWindowAsrManager.finalWindowStart(
+                nextCenterStart: 16 * s, effectiveChunk: Int(0.9 * Double(s)), chunk: 8 * s, left: 2 * s),
+            Int(6.9 * Double(s)))
+        // A full final chunk keeps the regular `center - left` start.
+        XCTAssertEqual(
+            SlidingWindowAsrManager.finalWindowStart(
+                nextCenterStart: 16 * s, effectiveChunk: 8 * s, chunk: 8 * s, left: 2 * s),
+            14 * s)
+        // Never before the start of the stream.
+        XCTAssertEqual(
+            SlidingWindowAsrManager.finalWindowStart(
+                nextCenterStart: 0, effectiveChunk: 3 * s, chunk: 8 * s, left: 2 * s),
+            0)
         XCTAssertEqual(SlidingWindowAsrManager.appendingVolatile("", ""), "")
     }
 

--- a/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowFinalWindowRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/Parakeet/SlidingWindow/SlidingWindowFinalWindowRegressionTests.swift
@@ -93,8 +93,14 @@ final class SlidingWindowFinalWindowRegressionTests: XCTestCase {
         return buffer
     }
 
-    private func streamTranscript(_ url: URL, models: AsrModels) async throws -> String {
-        let manager = SlidingWindowAsrManager()
+    private func streamTranscript(
+        _ url: URL, models: AsrModels, chunkSeconds: TimeInterval? = nil
+    ) async throws
+        -> String
+    {
+        let manager =
+            chunkSeconds.map { SlidingWindowAsrManager(config: SlidingWindowAsrConfig(chunkSeconds: $0)) }
+            ?? SlidingWindowAsrManager()
         try await manager.loadModels(models)
         try await manager.startStreaming()
 
@@ -120,6 +126,57 @@ final class SlidingWindowFinalWindowRegressionTests: XCTestCase {
         XCTAssertEqual(ASRConstants.punctuationTokenIds(in: models.vocabulary), [7883, 7956, 8020])
         XCTAssertEqual(models.vocabulary[7952], "й")
         XCTAssertEqual(models.vocabulary[7948], "ó")
+    }
+
+    /// Interior windows are re-decoded on a fresh state like the final one
+    /// (#897). Before: entering window 2 mid-way with the carried state blanked
+    /// the rest of the window (clip 01 at 7 s lost `can you do me a favor …
+    /// codex`, at 6 s `even share some audio`, at 8 s `can you do me a favor
+    /// and validate your`), the re-walked overlap re-emitted `environment` as
+    /// `air environment` (clip 02 at 7 s), and dedup's 2 s tolerance chopped
+    /// `the net new code` after the seam (clip 03 at 9 s).
+    func testInteriorWindowsKeepMidStreamSpeechOnRealRecordings() async throws {
+        let models = try await loadModels()
+        struct Case {
+            let file: String
+            let chunkSeconds: TimeInterval
+            let expected: [String]
+            var forbidden: [String] = []
+        }
+        let cases: [Case] = [
+            Case(
+                file: "01-validation-request-21.4s.wav", chunkSeconds: 7,
+                expected: ["can you do me a favor and validate your findings", "help them out"]),
+            Case(
+                file: "01-validation-request-21.4s.wav", chunkSeconds: 6,
+                expected: ["even share some audio recordings", "validate your findings"]),
+            Case(
+                file: "01-validation-request-21.4s.wav", chunkSeconds: 8,
+                expected: ["can you do me a favor and validate your findings"]),
+            Case(
+                file: "02-release-readiness-19.8s.wav", chunkSeconds: 7,
+                expected: ["release work we've done", "cutting a release"], forbidden: ["environment. air"]),
+            Case(
+                file: "03-diff-explanation-16.9s.wav", chunkSeconds: 9,
+                expected: ["the old code and the net new code and analyzing"]),
+            // 0.9 s of new audio behind the final seam: the 2.9 s flush window
+            // emitted nothing from a fresh state until it was end-aligned.
+            Case(
+                file: "03-diff-explanation-16.9s.wav", chunkSeconds: 8,
+                expected: ["problems in that difference"]),
+        ]
+        for c in cases {
+            let url = try fixtureURL(c.file)
+            let text = try await streamTranscript(url, models: models, chunkSeconds: c.chunkSeconds).lowercased()
+            for phrase in c.expected {
+                XCTAssertTrue(
+                    text.contains(phrase), "\(c.file) @ \(c.chunkSeconds)s: expected '\(phrase)' in: \(text)")
+            }
+            for phrase in c.forbidden {
+                XCTAssertFalse(
+                    text.contains(phrase), "\(c.file) @ \(c.chunkSeconds)s: artifact '\(phrase)' in: \(text)")
+            }
+        }
     }
 
     func testFinalWindowKeepsTrailingWordsOnRealRecordings() async throws {

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -956,6 +956,36 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertEqual(same.droppedCurrent, 7)
     }
 
+    /// A fast repetition inside the duplicate tolerance (`go` at 100, `go
+    /// again` at 106) is kept when the decoder already re-emitted the previous
+    /// `go` before the cutoff (suppressed at 94): the visible `go` is a second
+    /// word. Without that evidence the visible `go` is the re-emitted copy.
+    func testReconcileFinalWindowSeam_FastRepetitionKeptWhenPreviousCopyWasSuppressed() {
+        let kept = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2],  // ▁let's ▁go
+            previousTimestamps: [96, 100],
+            trailingWordStart: 1,
+            currentTokens: [2, 31],  // ▁go ▁again
+            currentTimestamps: [106, 115],
+            currentPieces: [" go", " again"],
+            previousPieces: [" let's", " go"],
+            suppressedPieces: [" go"],
+            suppressedTimestamps: [94]
+        )
+        XCTAssertEqual(kept.droppedPrevious, 0)
+        XCTAssertEqual(kept.droppedCurrent, 0, "the previous `go` was re-emitted (suppressed); this one is new")
+        let consumed = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2],
+            previousTimestamps: [96, 100],
+            trailingWordStart: 1,
+            currentTokens: [2, 31],
+            currentTimestamps: [106, 115],
+            currentPieces: [" go", " again"],
+            previousPieces: [" let's", " go"]
+        )
+        XCTAssertEqual(consumed.droppedCurrent, 1, "no suppressed copy: the visible `go` is the drifted re-emission")
+    }
+
     /// Token ids are not punctuation evidence: id 7948 is `ó` in the v3
     /// vocabulary although it sits in `ASRConstants.punctuationTokens`. A word
     /// starting with it must not be dropped as a seam artifact.

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -923,6 +923,39 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertEqual(later.droppedCurrent, 0)
     }
 
+    /// LibriSpeech 3729-6852-0008 at chunk 11 (#897): the re-decode starts with
+    /// `ist` (continuation of `Christ`, an earlier word), re-emits `had been
+    /// the`, then spells the last word `Saviour` where the previous window had
+    /// `Savior.`. Before: the continuation head blocked the retire rule and the
+    /// id-level scan stripped `S` alone → `Savior. aviour of all mankind`.
+    func testReconcileFinalWindowSeam_HeadOfEarlierWordDoesNotProtectLastWord() {
+        let previousPieces = ["ist", " had", " been", " the", " S", "avi", "or", "."]
+        let previousTs = [261, 263, 265, 266, 267, 268, 270, 273]
+        let different = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4, 5, 6, 7, 7883],
+            previousTimestamps: previousTs,
+            trailingWordStart: 4,
+            currentTokens: [1, 2, 3, 4, 5, 10, 11, 12, 13, 14],  // ist ▁had ▁been ▁the ▁S av io ur ▁of ▁all
+            currentTimestamps: [263, 265, 268, 270, 272, 273, 275, 277, 278, 280],
+            currentPieces: ["ist", " had", " been", " the", " S", "av", "io", "ur", " of", " all"],
+            previousPieces: previousPieces
+        )
+        XCTAssertEqual(different.droppedPrevious, 4, "`Savior.` retires for the re-decoded `Saviour`")
+        XCTAssertEqual(different.droppedCurrent, 4, "head and re-emitted `had been the` go; `Saviour` stays")
+        // Same spelling: the whole re-emitted word goes, never `S` alone.
+        let same = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4, 5, 6, 7, 7883],
+            previousTimestamps: previousTs,
+            trailingWordStart: 4,
+            currentTokens: [1, 2, 3, 4, 5, 6, 7, 13, 14],
+            currentTimestamps: [263, 265, 268, 270, 272, 273, 275, 278, 280],
+            currentPieces: ["ist", " had", " been", " the", " S", "avi", "or", " of", " all"],
+            previousPieces: previousPieces
+        )
+        XCTAssertEqual(same.droppedPrevious, 0)
+        XCTAssertEqual(same.droppedCurrent, 7)
+    }
+
     /// Token ids are not punctuation evidence: id 7948 is `ó` in the v3
     /// vocabulary although it sits in `ASRConstants.punctuationTokens`. A word
     /// starting with it must not be dropped as a seam artifact.

--- a/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
+++ b/Tests/FluidAudioTests/ASR/TokenDeduplicationRegressionTests.swift
@@ -448,14 +448,14 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertEqual(removed, 0)
     }
 
-    // MARK: - Issue #855: final-window re-decode plan (decoder-entry behavior)
+    // MARK: - Issues #855 / #897: window re-decode plan (decoder-entry behavior)
 
     /// The plan drives the production decoder entry: frame-0 re-decode plus an
     /// emission cutoff. Removing the production change removes this helper, so
     /// these tests are coupled to the fix itself, not just to dedup.
     func testRedecodePlan_LastStreamingChunk() {
-        let plan = AsrManager.lastChunkRedecodePlan(
-            isLastChunk: true,
+        let plan = AsrManager.redecodePlan(
+            redecode: true,
             previousTokens: [1, 2, 3],
             previousTokenTimestamps: [130, 134, 137],
             globalFrameOffset: 112
@@ -468,8 +468,8 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
     }
 
     func testRedecodePlan_CutoffClampedToZero() {
-        let plan = AsrManager.lastChunkRedecodePlan(
-            isLastChunk: true,
+        let plan = AsrManager.redecodePlan(
+            redecode: true,
             previousTokens: [1],
             previousTokenTimestamps: [3],
             globalFrameOffset: 112
@@ -478,26 +478,40 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertEqual(plan.emitTokensAfterFrame, 0, "Cutoff before the window start suppresses nothing")
     }
 
-    func testRedecodePlan_InactiveOutsideFinalStreamingWindow() {
-        let interior = AsrManager.lastChunkRedecodePlan(
-            isLastChunk: false,
+    /// Every window after the first is a re-decode (#897), not only the final
+    /// one: the plan is the same, anchored at the previous window's last word.
+    func testRedecodePlan_AppliesToInteriorWindows() {
+        let interior = AsrManager.redecodePlan(
+            redecode: true,
+            previousTokens: [10, 11, 12],
+            previousTokenTimestamps: [100, 104, 109],
+            globalFrameOffset: 62,
+            lastWordStartFrame: 104
+        )
+        XCTAssertEqual(interior.initialTimeIndexOverride, 0, "Interior windows re-decode from frame 0 too")
+        XCTAssertEqual(interior.emitTokensAfterFrame, 104 - 62 - AsrManager.redecodeEmissionJitterFrames)
+    }
+
+    func testRedecodePlan_InactiveWithoutPreviousTokensOrTimestamps() {
+        let legacy = AsrManager.redecodePlan(
+            redecode: false,
             previousTokens: [1, 2],
             previousTokenTimestamps: [10, 20],
             globalFrameOffset: 0
         )
-        XCTAssertNil(interior.initialTimeIndexOverride)
-        XCTAssertNil(interior.emitTokensAfterFrame)
+        XCTAssertNil(legacy.initialTimeIndexOverride, "Callers that opt out keep legacy navigation")
+        XCTAssertNil(legacy.emitTokensAfterFrame)
 
-        let noTimestamps = AsrManager.lastChunkRedecodePlan(
-            isLastChunk: true,
+        let noTimestamps = AsrManager.redecodePlan(
+            redecode: true,
             previousTokens: [1, 2],
             previousTokenTimestamps: nil,
             globalFrameOffset: 0
         )
         XCTAssertNil(noTimestamps.initialTimeIndexOverride, "Batch callers (no timestamps) keep legacy navigation")
 
-        let firstWindow = AsrManager.lastChunkRedecodePlan(
-            isLastChunk: true,
+        let firstWindow = AsrManager.redecodePlan(
+            redecode: true,
             previousTokens: [],
             previousTokenTimestamps: [],
             globalFrameOffset: 0
@@ -505,7 +519,35 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         XCTAssertNil(firstWindow.initialTimeIndexOverride, "Single-window streams have nothing to re-decode")
     }
 
-    // MARK: - Issue #897: final-window seam reconciliation
+    /// Clip 03 at chunk 9 (#897): the re-decode after the seam reads `and the
+    /// net new code and analyzing`; `code` repeats 20 frames after the previous
+    /// window's `old code`. With the legacy 2 s tolerance the bounded substring
+    /// matcher paired the two `c ode` sequences and chopped the whole prefix;
+    /// the re-decode path passes twice the jitter margin instead.
+    func testRemoveDuplicateTokenSequence_RedecodeToleranceKeepsRepeatedWord() {
+        let asrManager = AsrManager()
+        let previous = [506, 768, 7874, 298, 3241]  // ▁the ▁ol d ▁c ode
+        let previousTs = [119, 122, 125, 128, 130]
+        let current = [575, 506, 2464, 409, 7898, 298, 3241, 575, 6709]  // ▁and ▁the ▁net ▁ne w ▁c ode ▁and ▁anal
+        let currentTs = [134, 137, 138, 143, 145, 148, 150, 155, 159]
+        let legacy = asrManager.removeDuplicateTokenSequence(
+            previous: previous, current: current, previousTimestamps: previousTs, currentTimestamps: currentTs,
+            frameTolerance: ASRConstants.duplicateFrameTolerance)
+        XCTAssertEqual(legacy.removedCount, 7, "documents the legacy false positive")
+        let redecode = asrManager.removeDuplicateTokenSequence(
+            previous: previous, current: current, previousTimestamps: previousTs, currentTimestamps: currentTs,
+            frameTolerance: 2 * AsrManager.redecodeEmissionJitterFrames)
+        XCTAssertEqual(redecode.removedCount, 0)
+        XCTAssertEqual(redecode.deduped, current)
+        // A genuine jitter duplicate inside the margin is still stripped.
+        let jitter = asrManager.removeDuplicateTokenSequence(
+            previous: previous, current: [298, 3241, 575], previousTimestamps: previousTs,
+            currentTimestamps: [131, 133, 136], frameTolerance: 2 * AsrManager.redecodeEmissionJitterFrames)
+        XCTAssertEqual(jitter.deduped, [575])
+        XCTAssertEqual(jitter.removedCount, 2)
+    }
+
+    // MARK: - Issue #897: window seam reconciliation
 
     /// Clip 03 of the #855 fixtures: window 1 ends `▁and`@153 `▁an`@156 (the
     /// fragment of "analyzing" cut by the window edge); the re-decoded final
@@ -513,8 +555,8 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
     /// anchor at the last word start, the fragment must go, and the seam
     /// comma plus the re-emitted `and` must not survive as duplicates.
     func testRedecodePlan_CutoffAnchorsAtLastWordStart() {
-        let plan = AsrManager.lastChunkRedecodePlan(
-            isLastChunk: true,
+        let plan = AsrManager.redecodePlan(
+            redecode: true,
             previousTokens: [10, 11, 12, 13],
             previousTokenTimestamps: [147, 149, 153, 156],
             globalFrameOffset: 112,
@@ -522,8 +564,8 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
         )
         XCTAssertEqual(plan.emitTokensAfterFrame, 156 - 112 - AsrManager.redecodeEmissionJitterFrames)
         // A multi-token last word anchors at its first token, not its last.
-        let multi = AsrManager.lastChunkRedecodePlan(
-            isLastChunk: true,
+        let multi = AsrManager.redecodePlan(
+            redecode: true,
             previousTokens: [10, 11, 12],
             previousTokenTimestamps: [140, 150, 160],
             globalFrameOffset: 112,
@@ -799,6 +841,86 @@ final class TokenDeduplicationRegressionTests: XCTestCase {
             previousPieces: [" just", " so"]
         )
         XCTAssertEqual(head.droppedCurrent, 0)
+    }
+
+    /// End-aligned final window, clip 03 at chunk 10 (#897): the cutoff's
+    /// jitter margin lets the re-decode re-emit `new` (the word before the
+    /// previous last word `code`) at its original frame, then `code` itself.
+    /// `new` is consumed as a re-emitted earlier word, so `code` compares
+    /// with `code` (same word, kept) instead of being retired for `new`.
+    func testReconcileFinalWindowSeam_ReemittedEarlierWordThenSameLastWord() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4, 5, 6],  // ▁the ▁net ▁ne w ▁c ode
+            previousTimestamps: [136, 138, 143, 144, 146, 147],
+            trailingWordStart: 4,
+            currentTokens: [3, 4, 5, 6, 7, 8],  // ▁ne w ▁c ode ▁and ▁anal
+            currentTimestamps: [143, 145, 148, 150, 155, 159],
+            currentPieces: [" ne", "w", " c", "ode", " and", " anal"],
+            previousPieces: [" the", " net", " ne", "w", " c", "ode"]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0)
+        XCTAssertEqual(seam.droppedCurrent, 4, "`new` and the re-emitted `code` go; `and` stays")
+        // A different overlapping last word after the re-emitted `new` still
+        // replaces the previous one.
+        let different = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4, 5, 6],
+            previousTimestamps: [136, 138, 143, 144, 146, 147],
+            trailingWordStart: 4,
+            currentTokens: [3, 4, 5, 11, 7],  // ▁ne w ▁c old ▁and
+            currentTimestamps: [143, 145, 148, 150, 155],
+            currentPieces: [" ne", "w", " c", "old", " and"],
+            previousPieces: [" the", " net", " ne", "w", " c", "ode"]
+        )
+        XCTAssertEqual(different.droppedPrevious, 2)
+        XCTAssertEqual(different.droppedCurrent, 2)
+    }
+
+    /// End-aligned final window, clip 02 at chunk 7 (#897): a continuation head
+    /// (`yt hing` of `anything`), two re-emitted words (`else`, `we`), then the
+    /// previous last word `should` re-emitted with its continuation piece one
+    /// frame outside the jitter window. Before: `sho` was stripped as a jitter
+    /// duplicate but `uld` survived (`we shoulduld complete`).
+    func testReconcileFinalWindowSeam_ReemittedWordsConsumedWhole() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4, 5, 6],  // hing ▁el se ▁we ▁sho uld
+            previousTimestamps: [190, 191, 192, 194, 195, 196],
+            trailingWordStart: 4,
+            currentTokens: [9, 1, 2, 3, 4, 5, 6, 10],  // yt hing ▁el se ▁we ▁sho uld ▁compl
+            currentTimestamps: [190, 192, 193, 194, 197, 200, 201, 204],
+            currentPieces: ["yt", "hing", " el", "se", " we", " sho", "uld", " compl"],
+            previousPieces: ["hing", " el", "se", " we", " sho", "uld"]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0)
+        XCTAssertEqual(seam.droppedCurrent, 7, "head, `else`, `we` and the whole re-emitted `should` go")
+    }
+
+    /// End-aligned final window, clip 01 at chunk 6 and 10 (#897): the
+    /// re-decode's timestamps drift a few frames past the edge-decoded previous
+    /// copy (`out`@247 re-emitted at 253, outside the 5-frame jitter margin).
+    /// Before: read as a later repetition → `help them out out.`
+    func testReconcileFinalWindowSeam_DriftedSameLastWordIsConsumed() {
+        let seam = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2, 3, 4, 5, 6],  // ▁them ▁to ▁hel p ▁them ▁out
+            previousTimestamps: [240, 242, 243, 244, 245, 247],
+            trailingWordStart: 5,
+            currentTokens: [2, 3, 4, 5, 6, 7883],  // ▁to ▁hel p ▁them ▁out .
+            currentTimestamps: [242, 245, 247, 249, 253, 260],
+            currentPieces: [" to", " hel", "p", " them", " out", "."],
+            previousPieces: [" them", " to", " hel", "p", " them", " out"]
+        )
+        XCTAssertEqual(seam.droppedPrevious, 0)
+        XCTAssertEqual(seam.droppedCurrent, 5, "re-emitted words and the drifted `out` go; the period stays")
+        // Beyond the duplicate tolerance it is a genuine repetition.
+        let later = AsrManager.reconcileFinalWindowSeam(
+            previousTokens: [1, 2],
+            previousTimestamps: [96, 100],
+            trailingWordStart: 1,
+            currentTokens: [2, 31],
+            currentTimestamps: [112, 119],
+            currentPieces: [" go", " again"],
+            previousPieces: [" let's", " go"]
+        )
+        XCTAssertEqual(later.droppedCurrent, 0)
     }
 
     /// Token ids are not punctuation evidence: id 7948 is `ó` in the v3


### PR DESCRIPTION
Addresses the interior class of #897 (mid-stream word loss and duplication), the last open finding after #903/#904.

## Root cause

Interior sliding windows entered the decoder mid-way (after the left context) with the **carried** decoder state. That state had already consumed the overlap, and the trace on clip 01 at a 7 s chunk shows what happens: window 2 starts at local frame 25 with the previous window's last token as context, emits `s.`, and then the joint predicts blank at 0.98 confidence for every frame to the end of the window, through 10 s of clear speech (`can you do me a favor and validate your findings with codex` lost). At 6 s and 8 s different spans of the same clip go missing. When the re-walk does not stall, it re-emits the overlap with a different segmentation that ID-based dedup cannot match (`environment.` then `air environment`, clip 02).

Two cheaper ideas were tried and rejected on the same traces: resuming *after* the overlap with the carried state (still blanks after the next `.`, now losing a different span), and preserving the predictor cache across windows (the last token is fed twice at every window start today; fixing that alone did not stop the stall).

## Change

- **Every window after the first re-decodes from frame 0 on a fresh state**, with the emission cutoff and seam reconciliation the final window already used (#855/#895/#903/#904). The carried-state entry is gone; nothing changes for the first window or for batch.
- **End-aligned final flush window.** A 2 to 3 s final window emits nothing from a fresh state and drops the last words; on the 40 longest LibriSpeech test-clean files this was the dominant remaining loss (13, 17, 22, 25-word tails). The final window now spans a full chunk plus the left context (`finalWindowStart`), the sample buffer keeps that much audio behind the next center, and the cutoff suppresses what previous windows emitted.
- **Dedup tolerance on the re-decode path** is twice the jitter margin instead of 2 s: with 2 s, a word repeated within 2 s of the seam (`the old code and the net new code`) matched its earlier copy and the bounded substring matcher chopped the whole re-decoded prefix.
- **Reconciliation, two additions surfaced by the longer final window:** re-emitted earlier words are consumed as whole words before the retire decision (the re-decode re-emits `new` ahead of `code`, and previously `code` was retired for `new`; a jitter duplicate `sho` was stripped while its continuation `uld` one frame outside the margin survived: `shoulduld`), and the same-word test compares word starts within the duplicate tolerance (an edge-decoded `out`@247 re-emitted at 253 read as a later repetition: `out out.`).
- Docs: the "Streaming Final Window" section becomes "Streaming Windows" and documents the failure modes and rules.

## Tests

- Unit: interior-window plan, dedup tolerance false positive (documents the legacy behavior and the fix), three new reconciliation shapes (re-emitted earlier word then same/different last word, whole-word consumption, drifted last word), end-aligned window start. All reconciliation cases are simulated in Python against the decision logic before each push.
- Fixture test on the three cleared real recordings at chunk sizes 6, 7, 8, 9: mid-stream phrases that were lost must be present, `environment. air` must not survive, the chunk-8 tail that a 2.9 s window dropped must be present.

## Verification

Release build, M5 Pro. The three fixture clips at every chunk size from 6 to 11 s and the #855 repro-2 clip: every word present, no duplication; remaining differences to batch are punctuation and casing renderings.

Streaming WER on the 40 longest LibriSpeech test-clean files (18 min, 2,691 reference words, same normalization for all runs):

| | main | this PR |
|---|---|---|
| streaming, chunk 11 s (default) | 8.73% | 4.68% |
| streaming, chunk 7 s | 13.79% | 7.43% |
| batch, same files | 4.72% | unchanged |

Per file: at chunk 11, 22 files improve and 2 get worse (one by a single word, one 23 → 24 that was already a whole-window loss); at chunk 7, 27 improve and 3 get worse, none by more than three words. The three files that stay far from batch (13, 21, 24 errors) are all the same thing: one window in which the v3 CoreML pipeline emits no tokens at all. That reproduces in batch on the exact 11 to 13 s span, independently of this PR, and is filed as #909 with the repro table.

## Round 2

- **Seam head of an earlier word.** LibriSpeech 3729-6852-0008 at chunk 11: the re-decode starts with `ist` (continuation of `Christ`, an earlier word), re-emits `had been the`, then spells the last word `Saviour` where the previous window had `Savior.`. The continuation head blocked the retire rule, and the id-level jitter scan then stripped `S` alone: `Savior. aviour of all mankind`. A head now protects the last word only when it continues that word (frame at or after its start, the `box` + `x, but` shape); the jitter scan drops a word-start piece only together with its continuation pieces and only when every piece matches. Two tests; 30 simulated cases.

## Round 3

- **Fast repetitions at the seam.** The same-word test matched by text plus a 10-frame tolerance, which could delete a genuine `go go again` when the re-decode's copy of the previous `go` fell before the cutoff. It now uses evidence instead of a tolerance alone: the decoder reports the tokens it consumed but suppressed before the cutoff (`TdtHypothesis.suppressedTokens` / `suppressedTimestamps`), and when the previous last word is among them at its own frame, the visible copy is a second word and stays. Test covers both outcomes (suppressed copy present → kept; absent → the visible copy is the drifted re-emission).
- **Retirement under vocabulary boosting.** The previous word was removed from the transcript text by its raw token text; with boosting that text may hold a rescored replacement, so the stale word would survive and the new window append a second copy. The manager now tracks the rendered form of each window's last word (the replacement when rescoring replaced it, multi-word terms included) and retires that when the raw text does not match. Pure helper with a unit test. The fixture clips do not produce a replacement at a seam (the model already emits `codex`), so the end-to-end path is exercised by the existing boosting streaming test only for the no-replacement case; the term is rendered exactly once at every chunk size from 6 to 11 on this branch, where `main` at chunk 8 produced `Codex with codex`.
- **Other models.** Same three clips at chunk 7 / 10 / 11 on v2 and the 110m model, this branch against `main`: 13 of 18 runs identical at the word level, 5 equal or better (v2 at 7 s drops `and if it, and if it` and recovers `like`; 110m at 10 s recovers `code and`, at 11 s `analyzeing` → `analyzing`), none worse. The mechanism is version-independent, so the change is not gated to v3.

WER on the 40 LibriSpeech files is unchanged by this round: 4.68% at chunk 11, 7.43% at chunk 7.
